### PR TITLE
BATCH-1783: Forcing step termination when ChunkListener fails

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleStepFactoryBean.java
@@ -590,15 +590,21 @@ public class SimpleStepFactoryBean<T, S> implements FactoryBean, BeanNameAware {
 					step.registerStepExecutionListener((StepExecutionListener) listener);
 				}
 				if (listener instanceof ChunkListener) {
-					step.registerChunkListener((ChunkListener) listener);
+					registerChunkListeners(step, listener);
 				}
 			}
 		}
 
 		step.setStepExecutionListeners(BatchListenerFactoryHelper.getListeners(listeners, StepExecutionListener.class)
 				.toArray(new StepExecutionListener[] {}));
-		step.setChunkListeners(BatchListenerFactoryHelper.getListeners(listeners, ChunkListener.class).toArray(
-				new ChunkListener[] {}));
+		
+		for(ChunkListener chunkListener: BatchListenerFactoryHelper.getListeners(listeners, ChunkListener.class)){
+			registerChunkListeners(step,chunkListener);
+		}
+	}
+
+	protected void registerChunkListeners(TaskletStep step, StepListener listener) {
+		step.registerChunkListener((ChunkListener) listener);
 	}
 
 	/**


### PR DESCRIPTION
Getting the ChunkListener to participate in retries and skips proved difficult as the context for retry and skips were not easily available. It can probably be done, but will require more extensive re-write of the step components. This change will at least fix the endless loop and the step will terminate if an exception is thrown in the ChunkListener (as is the default behavior for non-faulttolerant steps).
