### PR TITLE
onWriteError is called when items fail in recovery mode

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProcessor.java
@@ -529,6 +529,7 @@ public class FaultTolerantChunkProcessor<I, O> extends SimpleChunkProcessor<I, O
 			outputIterator.remove();
 		}
 		catch (Exception e) {
+			doOnWriteError(e, items);
 			if (!shouldSkip(itemWriteSkipPolicy, e, -1) && !rollbackClassifier.classify(e)) {
 				inputIterator.remove();
 				outputIterator.remove();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
@@ -151,7 +151,7 @@ public class SimpleChunkProcessor<I, O> implements ChunkProcessor<I>, Initializi
 			doAfterWrite(items);
 		}
 		catch (Exception e) {
-			listener.onWriteError(e, items);
+			doOnWriteError(e, items);
 			throw e;
 		}
 
@@ -164,6 +164,9 @@ public class SimpleChunkProcessor<I, O> implements ChunkProcessor<I>, Initializi
 	 */
 	protected final void doAfterWrite(List<O> items) {
 		listener.afterWrite(items);
+	}
+	protected final void doOnWriteError(Exception e, List<O> items) {
+		listener.onWriteError(e, items);
 	}
 
 	protected void writeItems(List<O> items) throws Exception {


### PR DESCRIPTION
The scan method in the FaultTolerantChunkProcessor did not invoke the onWriteError when items failed during write. As a result listener was only invoked in the initial attempt to write a chunk.
