### PR TITLE
Improved Concurrency Support for MemoryJob* classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ com.springsource.sts.config.flow.prefs
 s3.properties
 .idea
 *.iml
+.*.swp

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clone the git repository using the URL on the Github home page:
     $ cd spring-batch
 
 ## Command Line
-Use Maven 2.2.* (might work with 3.0, but we don't test it), then on the command line:
+Use Maven 2.2 or 3.0, then on the command line:
 
     $ mvn install
 
@@ -27,7 +27,7 @@ In STS (or any Eclipse distro or other IDE with Maven support), import the modul
 
   This is the quickest way to get started.  It requires an internet connection for download, and access to a Maven repository (remote or local).
 
-* Download STS version 2.5.* (or better) from the [SpringSource website](http://www.springsource.com/products/sts).  STS is a free Eclipse bundle with many features useful for Spring developers.
+* Download STS version 2.5 (or better) from the [SpringSource website](http://www.springsource.com/products/sts).  STS is a free Eclipse bundle with many features useful for Spring developers.
 * Go to `File->New->Spring Template Project` from the menu bar (in the Spring perspective).
 * The wizard has a drop down with a list of template projects.  One of them is a "Simple Spring Batch Project".  Select it and follow the wizard.
 * A project is created with all dependencies and a simple input/output job configuration.  It can be run using a unit test, or on the command line (see instructions in the pom.xml).

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapExecutionContextDao.java
@@ -16,7 +16,10 @@
 
 package org.springframework.batch.core.repository.dao;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.Map;
+
+import java.io.Serializable;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
@@ -32,15 +35,61 @@ import org.springframework.batch.support.transaction.TransactionAwareProxyFactor
  */
 public class MapExecutionContextDao implements ExecutionContextDao {
 
-	private Map<Long, ExecutionContext> contextsByStepExecutionId = TransactionAwareProxyFactory
+	private final ConcurrentMap<ContextKey, ExecutionContext> contexts = TransactionAwareProxyFactory
 			.createAppendOnlyTransactionalMap();
 
-	private Map<Long, ExecutionContext> contextsByJobExecutionId = TransactionAwareProxyFactory
-			.createAppendOnlyTransactionalMap();
+	private static final class ContextKey implements Comparable<ContextKey>, Serializable {
 
-	public void clear() {
-		contextsByJobExecutionId.clear();
-		contextsByStepExecutionId.clear();
+		private static enum Type { STEP, JOB; }
+
+		private final Type type;
+		private final long id;
+
+		private ContextKey(Type type, long id) {
+			if(type == null) throw new IllegalStateException("Need a non-null type for a context");
+			this.type = type;
+			this.id = id;
+		}
+
+		@Override
+		public int compareTo(ContextKey them) {
+			if(them == null) return 1;
+			final int idCompare = Long.compare(this.id, them.id);
+			if(idCompare != 0) return idCompare;
+			final int typeCompare = this.type.compareTo(them.type);
+			if(typeCompare != 0) return typeCompare;
+			return 0;
+		}
+
+		@Override
+		public boolean equals(Object them) {
+			if(them == null) return false;
+			if(them instanceof ContextKey) return this.equals((ContextKey)them);
+			return false;
+		}
+
+		public boolean equals(ContextKey them) {
+			if(them == null) return false;
+			return this.id == them.id && this.type.equals(them.type);
+		}
+
+		@Override
+		public int hashCode() {
+			int value = (int)(id^(id>>>32));
+			switch(type) {
+				case STEP: return value;
+				case JOB: return ~value;
+				default: throw new IllegalStateException("Unknown type encountered in switch: " + type);
+			}
+		}
+
+		public static ContextKey step(long id) { return new ContextKey(Type.STEP, id); }
+
+		public static ContextKey job(long id) { return new ContextKey(Type.JOB, id); }
+	}
+
+	public void clear() {	
+		contexts.clear();
 	}
 
 	private static ExecutionContext copy(ExecutionContext original) {
@@ -48,24 +97,24 @@ public class MapExecutionContextDao implements ExecutionContextDao {
 	}
 
 	public ExecutionContext getExecutionContext(StepExecution stepExecution) {
-		return copy(contextsByStepExecutionId.get(stepExecution.getId()));
+		return copy(contexts.get(ContextKey.step(stepExecution.getId())));
 	}
 
 	public void updateExecutionContext(StepExecution stepExecution) {
 		ExecutionContext executionContext = stepExecution.getExecutionContext();
 		if (executionContext != null) {
-			contextsByStepExecutionId.put(stepExecution.getId(), copy(executionContext));
+			contexts.put(ContextKey.step(stepExecution.getId()), copy(executionContext));
 		}
 	}
 
 	public ExecutionContext getExecutionContext(JobExecution jobExecution) {
-		return copy(contextsByJobExecutionId.get(jobExecution.getId()));
+		return copy(contexts.get(ContextKey.job(jobExecution.getId())));
 	}
 
 	public void updateExecutionContext(JobExecution jobExecution) {
 		ExecutionContext executionContext = jobExecution.getExecutionContext();
 		if (executionContext != null) {
-			contextsByJobExecutionId.put(jobExecution.getId(), copy(executionContext));
+			contexts.put(ContextKey.job(jobExecution.getId()), copy(executionContext));
 		}
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapJobExecutionDao.java
@@ -23,7 +23,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -36,9 +38,9 @@ import org.springframework.util.Assert;
  */
 public class MapJobExecutionDao implements JobExecutionDao {
 
-	private Map<Long, JobExecution> executionsById = new ConcurrentHashMap<Long, JobExecution>();
+	private final ConcurrentMap<Long, JobExecution> executionsById = new ConcurrentSkipListMap<Long, JobExecution>();
 
-	private long currentId = 0;
+	private final AtomicLong currentId = new AtomicLong(0L);
 
 	public void clear() {
 		executionsById.clear();
@@ -51,7 +53,7 @@ public class MapJobExecutionDao implements JobExecutionDao {
 
 	public void saveJobExecution(JobExecution jobExecution) {
 		Assert.isTrue(jobExecution.getId() == null);
-		Long newId = currentId++;
+		Long newId = currentId.getAndIncrement();
 		jobExecution.setId(newId);
 		jobExecution.incrementVersion();
 		executionsById.put(newId, copy(jobExecution));

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapJobInstanceDao.java
@@ -21,7 +21,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -33,9 +34,9 @@ import org.springframework.util.Assert;
  */
 public class MapJobInstanceDao implements JobInstanceDao {
 
-	private Collection<JobInstance> jobInstances = new CopyOnWriteArraySet<JobInstance>();
+	private final Collection<JobInstance> jobInstances = new ConcurrentSkipListSet<JobInstance>();
 
-	private long currentId = 0;
+	private final AtomicLong currentId = new AtomicLong(0L);
 
 	public void clear() {
 		jobInstances.clear();
@@ -45,7 +46,7 @@ public class MapJobInstanceDao implements JobInstanceDao {
 
 		Assert.state(getJobInstance(jobName, jobParameters) == null, "JobInstance must not already exist");
 
-		JobInstance jobInstance = new JobInstance(currentId++, jobParameters, jobName);
+		JobInstance jobInstance = new JobInstance(currentId.getAndIncrement(), jobParameters, jobName);
 		jobInstance.incrementVersion();
 		jobInstances.add(jobInstance);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/MapJobExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/MapJobExecutionDaoTests.java
@@ -1,6 +1,14 @@
 package org.springframework.batch.core.repository.dao;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CountDownLatch;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.SortedSet;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +51,65 @@ public class MapJobExecutionDaoTests extends AbstractJobExecutionDaoTests {
 		jobExecution.setEndTime(new Date());
 		assertNull(retrieved.getEndTime());
 		
+	}
+
+	/**
+	* Verify that the ids are properly generated even under heavy concurrent load
+	*/
+	@Test
+	public void testConcurrentSaveJobExecution() throws Exception {
+		final int iterations = 5000;
+
+		// Object under test
+		final JobExecutionDao tested = new MapJobExecutionDao();
+
+		// Support objects for this testing
+		final CountDownLatch latch = new CountDownLatch(1);
+		final SortedSet<Long> ids = new ConcurrentSkipListSet<Long>();
+		final AtomicReference<Exception> exception = new AtomicReference<Exception>(null);
+
+		// Implementation of the high-concurrency code
+		final Runnable codeUnderTest = new Runnable() {
+			public void run() {
+				try {
+					JobExecution jobExecution = new JobExecution(new JobInstance((long) -1, new JobParameters(), "mapJob"));
+					latch.await();
+					tested.saveJobExecution(jobExecution);
+					ids.add(jobExecution.getId());
+				} catch(Exception e) {
+					exception.set(e);
+				}
+			}
+		};
+
+		// Create the threads
+		final Thread[] threads = new Thread[iterations];
+		for(int i = 0; i < iterations; i++) {
+			Thread t = new Thread(codeUnderTest, "Map Job Thread #" + (i+1));
+			t.setPriority(Thread.MAX_PRIORITY);
+			t.setDaemon(true);
+			t.start();
+			Thread.yield();
+			threads[i] = t;
+		}
+
+		// Let the high concurrency abuse begin!
+		do { latch.countDown(); } while(latch.getCount() > 0);
+		for(Thread t : threads) { t.join(); }
+
+		// Ensure no general exceptions arose
+		if(exception.get() != null) throw new RuntimeException("Excepion occurred under high concurrency usage", exception.get());
+
+		// Validate the ids: we'd expect one of these three things to fail
+		if(ids.size() < iterations) {
+			fail("Duplicate id generated during high concurrency usage");	
+		}
+		if(ids.first() < 0) {
+			fail("Generated an id less than zero during high concurrency usage: " + ids.first());
+		}
+		if(ids.last() > iterations) {
+			fail("Generated an id larger than expected during high concurrency usage: " + ids.last());
+		}
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -165,8 +166,8 @@ public class TransactionAwareProxyFactory<T> {
 		return (Map<K, V>) new TransactionAwareProxyFactory<ConcurrentHashMap<K, V>>(new ConcurrentHashMap<K, V>(map)).createInstance();
 	}
 
-	public static <K, V> Map<K, V> createAppendOnlyTransactionalMap() {
-		return (Map<K, V>) new TransactionAwareProxyFactory<ConcurrentHashMap<K, V>>(new ConcurrentHashMap<K, V>(), true).createInstance();
+	public static <K, V> ConcurrentMap<K, V> createAppendOnlyTransactionalMap() {
+		return new TransactionAwareProxyFactory<ConcurrentHashMap<K, V>>(new ConcurrentHashMap<K, V>(), true).createInstance();
 	}
 
 	public static <T> Set<T> createAppendOnlyTransactionalSet() {


### PR DESCRIPTION
Some updates to support running multiple jobs simultaneously: First of all, longs cannot be incremented (++) safely. Second, no reason to use external synchronization when the ConcurrentMap API gives you the functionality we are looking for. Finally, since we often are adding to the end (higher keys), a ConcurrentSkipListMap should be more performant than any other kind of concurrent map.
