### PR TITLE
Ignore vi swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ com.springsource.sts.config.flow.prefs
 s3.properties
 .idea
 *.iml
+.*.swp


### PR DESCRIPTION
This is a trivial change for git to ignore vi swap files.
