### PR TITLE
BATCH-1884: JobLauncherIntegrationTests failing

### DIFF
--- a/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -91,8 +91,10 @@ public class DataSourceInitializer implements InitializingBean {
 	}
 
 	private void doExecuteScript(final Resource scriptResource) {
-		if (scriptResource == null || !scriptResource.exists())
-			return;
+        if (scriptResource == null || !scriptResource.exists()) {
+            throw new IllegalArgumentException("Script resource is null or does not exist");
+        }
+
 		TransactionTemplate transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
 		transactionTemplate.execute(new TransactionCallback() {
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/JobLauncherIntegrationTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/JobLauncherIntegrationTests-context.xml
@@ -21,7 +21,8 @@
 		<property name="dataSource" ref="dataSource" />
 		<property name="initScripts">
 			<list>
-				<value>schema-hsqldb.sql</value>
+				<value>org/springframework/batch/core/schema-drop-hsqldb.sql</value>
+				<value>org/springframework/batch/core/schema-hsqldb.sql</value>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
add path to schema-hsqldb.sql and throw exception if script resource does not exist to make error reporting more explicit rather than returning silently
