### PR TITLE
Unit test fixed

### DIFF
--- a/spring-batch-infrastructure-tests/pom.xml
+++ b/spring-batch-infrastructure-tests/pom.xml
@@ -130,11 +130,17 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.castor</groupId>
-			<artifactId>castor</artifactId>
-			<version>1.2</version>
+		      <groupId>org.codehaus.castor</groupId>
+		      <artifactId>castor-xml</artifactId>
+		      <version>1.3.2</version>
 			<scope>test</scope>
 		</dependency>
+	    <dependency>
+	      <groupId>commons-lang</groupId>
+	      <artifactId>commons-lang</artifactId>
+	      <version>2.5</version>
+	      <scope>test</scope>
+	    </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
The update to the newer version of Spring changed the dependency on oxm which depends on Castor.  To fix the tests, I updated the version of Castor the project depends on.
