### PR TITLE
Batch-1749: JdbcPagingItemReader now supports multi-column keys

### DIFF
--- a/spring-batch-infrastructure-tests/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderAsyncTests.java
+++ b/spring-batch-infrastructure-tests/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderAsyncTests.java
@@ -41,6 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -163,8 +164,8 @@ public class JdbcPagingItemReaderAsyncTests {
 		factory.setDataSource(dataSource);
 		factory.setSelectClause("select ID, NAME, VALUE");
 		factory.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("VALUE", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("VALUE", Order.ASCENDING);
 		factory.setSortKeys(sortKeys);
 		reader.setQueryProvider((PagingQueryProvider) factory.getObject());
 		reader.setRowMapper(new ParameterizedRowMapper<Foo>() {

--- a/spring-batch-infrastructure-tests/src/test/java/org/springframework/batch/item/database/JdbcPagingQueryIntegrationTests.java
+++ b/spring-batch-infrastructure-tests/src/test/java/org/springframework/batch/item/database/JdbcPagingQueryIntegrationTests.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
@@ -121,7 +122,7 @@ public class JdbcPagingQueryIntegrationTests {
 	private Map<String, Object> getStartAfterValues(
 			PagingQueryProvider queryProvider, List<Map<String, Object>> list) {
 		Map<String, Object> startAfterValues = new LinkedHashMap<String, Object>();
-		for (Map.Entry<String, Boolean> sortKey : queryProvider.getSortKeys().entrySet()) {
+		for (Map.Entry<String, Order> sortKey : queryProvider.getSortKeys().entrySet()) {
 			startAfterValues.put(sortKey.getKey(), list.get(pageSize - 1).get(sortKey.getKey()));
 		}
 		return startAfterValues;
@@ -154,8 +155,8 @@ public class JdbcPagingQueryIntegrationTests {
 		factory.setDataSource(dataSource);
 		factory.setSelectClause("select ID, NAME, VALUE");
 		factory.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("VALUE", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("VALUE", Order.ASCENDING);
 		factory.setSortKeys(sortKeys);
 		return (PagingQueryProvider) factory.getObject();
 

--- a/spring-batch-infrastructure-tests/src/test/java/org/springframework/batch/item/database/JdbcPagingRestartIntegrationTests.java
+++ b/spring-batch-infrastructure-tests/src/test/java/org/springframework/batch/item/database/JdbcPagingRestartIntegrationTests.java
@@ -25,7 +25,6 @@ import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import javax.sql.DataSource;
 
@@ -38,6 +37,7 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStream;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,8 +152,8 @@ public class JdbcPagingRestartIntegrationTests {
 		factory.setDataSource(dataSource);
 		factory.setSelectClause("select ID, NAME, VALUE");
 		factory.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new TreeMap<String, Boolean>();
-		sortKeys.put("VALUE", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("VALUE", Order.ASCENDING);
 		factory.setSortKeys(sortKeys);
 		reader.setQueryProvider((PagingQueryProvider) factory.getObject());
 		reader.setRowMapper(new ParameterizedRowMapper<Foo>() {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
@@ -31,6 +31,7 @@ import javax.sql.DataSource;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -326,7 +327,7 @@ public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> impleme
 	private class PagingRowMapper implements RowMapper {
 		public Object mapRow(ResultSet rs, int rowNum) throws SQLException {
 			startAfterValues = new LinkedHashMap<String, Object>();
-			for (Map.Entry<String, Boolean> sortKey : queryProvider.getSortKeys().entrySet()) {
+			for (Map.Entry<String, Order> sortKey : queryProvider.getSortKeys().entrySet()) {
 				startAfterValues.put(sortKey.getKey(), rs.getObject(sortKey.getKey()));
 			}
 			

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/PagingQueryProvider.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.springframework.batch.item.database.support.Order;
+
 /**
  * Interface defining the functionality to be provided for generating paging queries for use with Paging
  * Item Readers.
@@ -84,7 +86,7 @@ public interface PagingQueryProvider {
 	 *  
 	 * @return the sort keys used to order the query
 	 */
-	Map<String, Boolean> getSortKeys();
+	Map<String, Order> getSortKeys();
 	
 	/**
 	 * Returns either a String to be used as the named placeholder for a sort key value (based on the column name)

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -17,9 +17,9 @@
 package org.springframework.batch.item.database.support;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import javax.sql.DataSource;
 
@@ -57,7 +57,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 
 	private String whereClause;
 	
-	private Map<String, Boolean> sortKeys = new TreeMap<String, Boolean>();
+	private Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
 
 	private String groupClause;
 
@@ -136,7 +136,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	/**
 	 * @param sortKeys key to use to sort and limit page content
 	 */
-	public void setSortKeys(Map<String, Boolean> sortKeys) {
+	public void setSortKeys(Map<String, Order> sortKeys) {
 		this.sortKeys = sortKeys;
 	}
 
@@ -145,7 +145,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	 * 
 	 * @return sortKey key to use to sort and limit page content
 	 */
-	public Map<String, Boolean> getSortKeys() {
+	public Map<String, Order> getSortKeys() {
 		return sortKeys;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
@@ -54,7 +54,7 @@ public class OraclePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 		StringBuilder sql = new StringBuilder();
 		String prefix = "";
 		
-		for (Map.Entry<String, Boolean> sortKey : this.getSortKeys().entrySet()) {
+		for (Map.Entry<String, Order> sortKey : this.getSortKeys().entrySet()) {
 			sql.append(prefix);
 			prefix = ", ";
 			sql.append(sortKey.getKey());

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Order.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Order.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.database.support;
+
+/**
+ * The direction of the sort in an ORDER BY clause.
+ *  
+ * @author Michael Minella
+ */
+public enum Order {
+	ASCENDING, DESCENDING
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBean.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBean.java
@@ -18,8 +18,8 @@ package org.springframework.batch.item.database.support;
 import static org.springframework.batch.support.DatabaseType.DB2;
 import static org.springframework.batch.support.DatabaseType.DB2ZOS;
 import static org.springframework.batch.support.DatabaseType.DERBY;
-import static org.springframework.batch.support.DatabaseType.HSQL;
 import static org.springframework.batch.support.DatabaseType.H2;
+import static org.springframework.batch.support.DatabaseType.HSQL;
 import static org.springframework.batch.support.DatabaseType.MYSQL;
 import static org.springframework.batch.support.DatabaseType.ORACLE;
 import static org.springframework.batch.support.DatabaseType.POSTGRES;
@@ -27,6 +27,7 @@ import static org.springframework.batch.support.DatabaseType.SQLSERVER;
 import static org.springframework.batch.support.DatabaseType.SYBASE;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -46,6 +47,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Michael Minella
  */
+@SuppressWarnings("rawtypes")
 public class SqlPagingQueryProviderFactoryBean implements FactoryBean {
 
 	private DataSource dataSource;
@@ -60,9 +62,7 @@ public class SqlPagingQueryProviderFactoryBean implements FactoryBean {
 	
 	private String groupClause;
 
-	private Map<String, Boolean> sortKeys;
-
-	private boolean ascending = true;
+	private Map<String, Order> sortKeys;
 
 	private Map<DatabaseType, AbstractSqlPagingQueryProvider> providers = new HashMap<DatabaseType, AbstractSqlPagingQueryProvider>();
 
@@ -125,15 +125,17 @@ public class SqlPagingQueryProviderFactoryBean implements FactoryBean {
 	/**
 	 * @param sortKey the sortKey to set
 	 */
-	public void setSortKeys(Map<String, Boolean> sortKeys) {
+	public void setSortKeys(Map<String, Order> sortKeys) {
 		this.sortKeys = sortKeys;
 	}
-
-	/**
-	 * @param ascending
-	 */
-	public void setAscending(boolean ascending) {
-		this.ascending = ascending;	
+	
+	public void setSortKey(String key) {
+		Assert.doesNotContain(key, ",", "String setter is valid for a single ASC key only");
+		
+		Map<String, Order> keys = new LinkedHashMap<String, Order>();
+		keys.put(key, Order.ASCENDING);
+		
+		this.sortKeys = keys;
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
@@ -190,14 +190,14 @@ public class SqlPagingQueryUtils {
 		StringBuilder builder = new StringBuilder();
 		String prefix = "";
 		
-		for (Map.Entry<String, Boolean> sortKey : provider.getSortKeys().entrySet()) {
+		for (Map.Entry<String, Order> sortKey : provider.getSortKeys().entrySet()) {
 			builder.append(prefix);
 			
 			prefix = ", ";
 			
 			builder.append(sortKey.getKey());
 			
-			if(sortKey.getValue() != null && !sortKey.getValue()) {
+			if(sortKey.getValue() != null && sortKey.getValue() == Order.DESCENDING) {
 				builder.append(" DESC");
 			}
 			else {
@@ -216,7 +216,7 @@ public class SqlPagingQueryUtils {
 	 */
 	public static void buildSortConditions(
 			AbstractSqlPagingQueryProvider provider, StringBuilder sql) {
-		List<Map.Entry<String, Boolean>> keys = new ArrayList<Map.Entry<String,Boolean>>(provider.getSortKeys().entrySet());
+		List<Map.Entry<String, Order>> keys = new ArrayList<Map.Entry<String,Order>>(provider.getSortKeys().entrySet());
 		List<String> clauses = new ArrayList<String>();
 		
 		for(int i = 0; i < keys.size(); i++) {
@@ -226,7 +226,7 @@ public class SqlPagingQueryUtils {
 			for(int j = 0; j < i; j++) {
 				clause.append(prefix);
 				prefix = " AND ";
-				Entry<String, Boolean> entry = keys.get(j);
+				Entry<String, Order> entry = keys.get(j);
 				clause.append(entry.getKey());
 				clause.append(" = ");
 				clause.append(provider.getSortKeyPlaceHolder(entry.getKey()));
@@ -237,7 +237,7 @@ public class SqlPagingQueryUtils {
 			}
 			clause.append(keys.get(i).getKey());
 			
-			if(keys.get(i).getValue() != null && !keys.get(i).getValue()) {
+			if(keys.get(i).getValue() != null && keys.get(i).getValue() == Order.DESCENDING) {
 				clause.append(" < ");
 			}
 			else {
@@ -267,7 +267,7 @@ public class SqlPagingQueryUtils {
 		
 		String prefix = "";
 		
-		for (Map.Entry<String, Boolean> sortKey : provider.getSortKeys().entrySet()) {
+		for (Map.Entry<String, Order> sortKey : provider.getSortKeys().entrySet()) {
 			select.append(prefix);
 			
 			prefix = ", ";

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlWindowingPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlWindowingPagingQueryProvider.java
@@ -115,7 +115,7 @@ public class SqlWindowingPagingQueryProvider extends AbstractSqlPagingQueryProvi
 
 	private void buildSortKeySelect(StringBuilder sql) {
 		String prefix = "";
-		for (Map.Entry<String, Boolean> sortKey : getSortKeys().entrySet()) {
+		for (Map.Entry<String, Order> sortKey : getSortKeys().entrySet()) {
 			sql.append(prefix);
 			prefix = ", ";
 			sql.append(sortKey.getKey());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderAsyncTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderAsyncTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.batch.support.JdbcTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,8 +143,8 @@ public class JdbcPagingItemReaderAsyncTests {
 		HsqlPagingQueryProvider queryProvider = new HsqlPagingQueryProvider();
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		reader.setQueryProvider(queryProvider);
 		reader.setRowMapper(new ParameterizedRowMapper<Foo>() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderClassicParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderClassicParameterTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
 import org.springframework.test.context.ContextConfiguration;
@@ -46,8 +47,8 @@ public class JdbcPagingItemReaderClassicParameterTests extends AbstractPagingIte
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
 		queryProvider.setWhereClause("where VALUE >= ?");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		reader.setParameterValues(Collections.<String, Object>singletonMap("limit", 3));
 		reader.setQueryProvider(queryProvider);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests.java
@@ -27,6 +27,7 @@ import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
@@ -52,8 +53,8 @@ public class JdbcPagingItemReaderCommonTests extends AbstractItemStreamItemReade
 		HsqlPagingQueryProvider queryProvider = new HsqlPagingQueryProvider();
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		reader.setQueryProvider(queryProvider);
 		reader.setRowMapper(
@@ -82,8 +83,8 @@ public class JdbcPagingItemReaderCommonTests extends AbstractItemStreamItemReade
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
 		queryProvider.setWhereClause("where ID = -1");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		reader.setQueryProvider(queryProvider);
 		reader.setPageSize(3);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderIntegrationTests.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
 
@@ -40,8 +41,8 @@ public class JdbcPagingItemReaderIntegrationTests extends AbstractGenericDataSou
 		HsqlPagingQueryProvider queryProvider = new HsqlPagingQueryProvider();
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		inputSource.setQueryProvider(queryProvider);
 		inputSource.setRowMapper(

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderNamedParameterTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
 import org.springframework.test.context.ContextConfiguration;
@@ -45,8 +46,8 @@ public class JdbcPagingItemReaderNamedParameterTests extends AbstractPagingItemR
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
 		queryProvider.setWhereClause("where VALUE >= :limit");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		reader.setParameterValues(Collections.<String, Object>singletonMap("limit", 3));
 		reader.setQueryProvider(queryProvider);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderOrderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderOrderIntegrationTests.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
+import org.springframework.batch.item.database.support.Order;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
 
@@ -40,9 +41,9 @@ public class JdbcPagingItemReaderOrderIntegrationTests extends AbstractGenericDa
 		HsqlPagingQueryProvider queryProvider = new HsqlPagingQueryProvider();
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("VALUE", true);
-		sortKeys.put("NAME", false);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("VALUE", Order.ASCENDING);
+		sortKeys.put("NAME", Order.DESCENDING);
 		queryProvider.setSortKeys(sortKeys);
 		inputSource.setQueryProvider(queryProvider);
 		inputSource.setRowMapper(

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.database.support;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.LinkedHashMap;
@@ -42,8 +43,8 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 		pagingQueryProvider.setFromClause("foo");
 		pagingQueryProvider.setWhereClause("bar = 1");
 		
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("id", Order.ASCENDING);
 		pagingQueryProvider.setSortKeys(sortKeys);
 		pageSize = 100;
 
@@ -57,11 +58,51 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 
 	@Test
 	public void testQueryContainsSortKeyDesc(){
-		pagingQueryProvider.getSortKeys().put("id", false);
+		pagingQueryProvider.getSortKeys().put("id", Order.DESCENDING);
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize).toLowerCase();
 		assertTrue("Wrong query: "+s, s.contains("id desc"));		
 	}
 
+	@Test
+	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("name", Order.ASCENDING);
+		sortKeys.put("id", Order.DESCENDING);
+		pagingQueryProvider.setSortKeys(sortKeys);
+		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
+		assertEquals(getFirstPageSqlWithMultipleSortKeys(), s);
+	}
+
+	@Test
+	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("name", Order.ASCENDING);
+		sortKeys.put("id", Order.DESCENDING);
+		pagingQueryProvider.setSortKeys(sortKeys);
+		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
+		assertEquals(getRemainingSqlWithMultipleSortKeys(), s);
+	}
+
+	@Test
+	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("name", Order.ASCENDING);
+		sortKeys.put("id", Order.DESCENDING);
+		pagingQueryProvider.setSortKeys(sortKeys);
+		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
+		assertEquals(getJumpToItemQueryWithMultipleSortKeys(), s);
+	}
+
+	@Test
+	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("name", Order.ASCENDING);
+		sortKeys.put("id", Order.DESCENDING);
+		pagingQueryProvider.setSortKeys(sortKeys);
+		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
+		assertEquals(getJumpToItemQueryForFirstPageWithMultipleSortKeys(), s);
+	}
+	
 	@Test
 	public abstract void testGenerateFirstPageQuery();
 
@@ -86,15 +127,11 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 	@Test
 	public abstract void testGenerateJumpToItemQueryForFirstPageWithGroupBy();
 
-	@Test
-	public abstract void testGenerateFirstPageQueryWithMultipleSortKeys();
-
-	@Test
-	public abstract void testGenerateRemainingPagesQueryWithMultipleSortKeys();
-
-	@Test
-	public abstract void testGenerateJumpToItemQueryWithMultipleSortKeys();
-
-	@Test
-	public abstract void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys();
+	public abstract String getFirstPageSqlWithMultipleSortKeys();
+	
+	public abstract String getRemainingSqlWithMultipleSortKeys();
+	
+	public abstract String getJumpToItemQueryWithMultipleSortKeys();
+	
+	public abstract String getJumpToItemQueryForFirstPageWithMultipleSortKeys();
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/Db2PagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/Db2PagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -98,50 +95,22 @@ public class Db2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderT
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC FETCH FIRST 100 ROWS ONLY";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC FETCH FIRST 100 ROWS ONLY";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC FETCH FIRST 100 ROWS ONLY";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC FETCH FIRST 100 ROWS ONLY";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DerbyPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DerbyPagingQueryProviderTests.java
@@ -25,8 +25,6 @@ import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -132,7 +130,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	@Test
 	@Override
 	public void testQueryContainsSortKeyDesc() {
-		pagingQueryProvider.getSortKeys().put("id", false);
+		pagingQueryProvider.getSortKeys().put("id", Order.DESCENDING);
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize).toLowerCase();
 		assertTrue("Wrong query: " + s, s.contains("id desc"));
 	}
@@ -174,50 +172,22 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1  ORDER BY id ASC, name DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1  ORDER BY name ASC, id DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?))  ORDER BY id ASC, name DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?))  ORDER BY name ASC, id DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM ( SELECT id, name, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1  ORDER BY id ASC, name DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1  ORDER BY name ASC, id DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM ( SELECT id, name, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1  ORDER BY id ASC, name DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1  ORDER BY name ASC, id DESC) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -99,50 +96,22 @@ public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTe
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT LIMIT 99 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT LIMIT 99 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT LIMIT 0 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT LIMIT 0 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HsqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HsqlPagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -98,50 +95,22 @@ public class HsqlPagingQueryProviderTests extends AbstractSqlPagingQueryProvider
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?)) ORDER BY id ASC, name DESC";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT LIMIT 99 1 id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT LIMIT 99 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT LIMIT 0 1 id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT LIMIT 0 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/MySqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/MySqlPagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -98,50 +95,22 @@ public class MySqlPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC LIMIT 100";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC LIMIT 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?)) ORDER BY id ASC, name DESC LIMIT 100";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC LIMIT 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC LIMIT 99, 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC LIMIT 99, 1";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC LIMIT 0, 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC LIMIT 0, 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/OraclePagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/OraclePagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -102,54 +99,22 @@ public class OraclePagingQueryProviderTests extends AbstractSqlPagingQueryProvid
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT * FROM (SELECT id, name, age, ROWNUM as TMP_ROW_NUM FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC) WHERE ROWNUM <= 100";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
-		pagingQueryProvider.setWhereClause("");
-		String sql2 = "SELECT * FROM (SELECT id, name, age, ROWNUM as TMP_ROW_NUM FROM foo ORDER BY id ASC, name DESC) WHERE ROWNUM <= 100";
-		String s2 = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql2, s2);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT * FROM (SELECT id, name, age, ROWNUM as TMP_ROW_NUM FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC) WHERE ROWNUM <= 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT * FROM (SELECT id, name, age, ROWNUM as TMP_ROW_NUM FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?)) ORDER BY id ASC, name DESC) WHERE ROWNUM <= 100";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT * FROM (SELECT id, name, age, ROWNUM as TMP_ROW_NUM FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC) WHERE ROWNUM <= 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM (SELECT id, name, ROWNUM as TMP_ROW_NUM FROM (SELECT id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC)) WHERE TMP_ROW_NUM = 100";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM (SELECT name, id, ROWNUM as TMP_ROW_NUM FROM (SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC)) WHERE TMP_ROW_NUM = 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM (SELECT id, name, ROWNUM as TMP_ROW_NUM FROM (SELECT id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC)) WHERE TMP_ROW_NUM = 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM (SELECT name, id, ROWNUM as TMP_ROW_NUM FROM (SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC)) WHERE TMP_ROW_NUM = 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/PostgresPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/PostgresPagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -98,50 +95,22 @@ public class PostgresPagingQueryProviderTests extends AbstractSqlPagingQueryProv
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC LIMIT 100";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC LIMIT 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?)) ORDER BY id ASC, name DESC LIMIT 100";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC LIMIT 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC LIMIT 1 OFFSET 99";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals("Wrong SQL for jump to", sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC LIMIT 1 OFFSET 99";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC LIMIT 1 OFFSET 0";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals("Wrong SQL for first page", sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC LIMIT 1 OFFSET 0";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBeanTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBeanTests.java
@@ -43,8 +43,8 @@ public class SqlPagingQueryProviderFactoryBeanTests {
 		factory.setSelectClause("id, name, age");
 		factory.setFromClause("foo");
 		factory.setWhereClause("bar = 1");
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
+		Map<String, Order> sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("id", Order.ASCENDING);
 		factory.setSortKeys(sortKeys);
 		DataSource dataSource = DatabaseTypeTestUtils.getMockDataSource(DatabaseType.HSQL.getProductName(), "100.0.0");
 		factory.setDataSource(dataSource);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryUtilsTests.java
@@ -34,12 +34,12 @@ import org.springframework.util.StringUtils;
  */
 public class SqlPagingQueryUtilsTests {
 	
-	private Map<String, Boolean> sortKeys;
+	private Map<String, Order> sortKeys;
 	
 	@Before
 	public void setUp() {
-		sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("ID", true);
+		sortKeys = new LinkedHashMap<String, Order>();
+		sortKeys.put("ID", Order.ASCENDING);
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class SqlPagingQueryUtilsTests {
 
 	@Test
 	public void testGenerateTopSqlQueryDescending() {
-		sortKeys.put("ID", false);
+		sortKeys.put("ID", Order.DESCENDING);
 		AbstractSqlPagingQueryProvider qp = new TestSqlPagingQueryProvider("FOO", "BAR", sortKeys);
 		assertEquals("SELECT TOP 100 FOO FROM BAR ORDER BY ID DESC", SqlPagingQueryUtils.generateTopSqlQuery(qp, false,
 				"TOP 100"));
@@ -113,7 +113,7 @@ public class SqlPagingQueryUtilsTests {
 
 	@Test
 	public void testGenerateRowNumSqlQueryDescending() {
-		sortKeys.put("ID", false);
+		sortKeys.put("ID", Order.DESCENDING);
 		AbstractSqlPagingQueryProvider qp = new TestSqlPagingQueryProvider("FOO", "BAR", sortKeys);
 		assertEquals(
 				"SELECT * FROM (SELECT FOO, ROWNUM as TMP_ROW_NUM FROM BAR ORDER BY ID DESC) WHERE ROWNUMBER <= 100",
@@ -152,7 +152,7 @@ public class SqlPagingQueryUtilsTests {
 
 	@Test
 	public void testGenerateTopJumpQueryDescending() {
-		sortKeys.put("ID", false);
+		sortKeys.put("ID", Order.DESCENDING);
 		AbstractSqlPagingQueryProvider qp = new TestSqlPagingQueryProvider("FOO", "BAR", sortKeys);
 		String query = SqlPagingQueryUtils.generateTopJumpToQuery(qp, "TOP 100, 1");
 		assertTrue("Wrong query: " + query, query.contains("ID DESC"));
@@ -164,7 +164,7 @@ public class SqlPagingQueryUtilsTests {
 
 	@Test
 	public void testGenerateLimitJumpQueryDescending() {
-		sortKeys.put("ID", false);
+		sortKeys.put("ID", Order.DESCENDING);
 		AbstractSqlPagingQueryProvider qp = new TestSqlPagingQueryProvider("FOO", "BAR", sortKeys);
 		String query = SqlPagingQueryUtils.generateLimitJumpToQuery(qp, "LIMIT 100, 1");
 		assertTrue("Wrong query: " + query, query.contains("ID DESC"));
@@ -176,7 +176,7 @@ public class SqlPagingQueryUtilsTests {
 
 	private static class TestSqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 
-		public TestSqlPagingQueryProvider(String select, String from, Map<String, Boolean> sortKeys) {
+		public TestSqlPagingQueryProvider(String select, String from, Map<String, Order> sortKeys) {
 			setSelectClause(select);
 			setFromClause(from);
 			setSortKeys(sortKeys);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -98,50 +95,22 @@ public class SqlServerPagingQueryProviderTests extends AbstractSqlPagingQueryPro
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC, name DESC";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals(sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?)) ORDER BY id ASC, name DESC";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals(sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM ( SELECT id, name, ROW_NUMBER() OVER ( ORDER BY id ASC, name DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM ( SELECT id, name, ROW_NUMBER() OVER ( ORDER BY id ASC, name DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals(sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlWindowingPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlWindowingPagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -98,50 +95,22 @@ public class SqlWindowingPagingQueryProviderTests extends AbstractSqlPagingQuery
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER ( ORDER BY id ASC, name DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals("", sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER ( ORDER BY id ASC, name DESC) AS ROW_NUMBER FROM foo WHERE bar = 1 AND ((id > ?) OR (id = ? AND name < ?))) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals("", sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT * FROM ( SELECT id, name, age, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?))) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM ( SELECT id, name, ROW_NUMBER() OVER ( ORDER BY id ASC, name DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals("", sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("id", true);
-		sortKeys.put("name", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT id, name FROM ( SELECT id, name, ROW_NUMBER() OVER ( ORDER BY id ASC, name DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		Assert.assertEquals("", sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SybasePagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SybasePagingQueryProviderTests.java
@@ -17,9 +17,6 @@ package org.springframework.batch.item.database.support;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Test;
 
 /**
@@ -98,50 +95,22 @@ public class SybasePagingQueryProviderTests extends AbstractSqlPagingQueryProvid
 	}
 
 	@Override
-	@Test
-	public void testGenerateFirstPageQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
-		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals("", sql, s);
+	public String getFirstPageSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateRemainingPagesQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
-		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals("", sql, s);
+	public String getRemainingSqlWithMultipleSortKeys() {
+		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) WHERE ROW_NUMBER = 100";
-		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals("", sql, s);
+	public String getJumpToItemQueryWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) WHERE ROW_NUMBER = 100";
 	}
 
 	@Override
-	@Test
-	public void testGenerateJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		Map<String, Boolean> sortKeys = new LinkedHashMap<String, Boolean>();
-		sortKeys.put("name", true);
-		sortKeys.put("id", false);
-		pagingQueryProvider.setSortKeys(sortKeys);
-		String sql = "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) WHERE ROW_NUMBER = 1";
-		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals("", sql, s);
+	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
+		return "SELECT name, id FROM ( SELECT name, id, ROW_NUMBER() OVER ( ORDER BY name ASC, id DESC) AS ROW_NUMBER FROM foo WHERE bar = 1) WHERE ROW_NUMBER = 1";
 	}
 }

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderConfigTests-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderConfigTests-context.xml
@@ -23,8 +23,8 @@
         		<property name="fromClause" value="foo"/>
         		<property name="sortKeys">
         			<map>
-        				<entry key="id" value="true"/>
-        				<entry key="name" value="false"/>
+        				<entry key="id" value="ASCENDING"/>
+        				<entry key="name" value="DESCENDING"/>
         			</map>
         		</property>
         	</bean>

--- a/spring-batch-samples/src/main/resources/jobs/iosample/jdbcPaging.xml
+++ b/spring-batch-samples/src/main/resources/jobs/iosample/jdbcPaging.xml
@@ -18,7 +18,7 @@
 				<property name="dataSource" ref="dataSource" />
 				<property name="sortKeys">
 					<map>
-						<entry key="id" value="true"/>
+						<entry key="id" value="ASCENDING"/>
 					</map>
 				</property>
 				<!-- Intentionally put sort key second in the query list as a test -->

--- a/spring-batch-samples/src/main/resources/jobs/partitionJdbcJob.xml
+++ b/spring-batch-samples/src/main/resources/jobs/partitionJdbcJob.xml
@@ -46,7 +46,7 @@
 				<property name="selectClause" value="ID,NAME,CREDIT"/>
 				<property name="sortKeys">
 					<map>
-						<entry key="ID" value="true"/>
+						<entry key="ID" value="ASCENDING"/>
 					</map>
 				</property>
 				<property name="whereClause" value="ID &gt;= :minId and ID &lt;= :maxId"/>


### PR DESCRIPTION
- Implemented the ability to page using multiple column sort keys

This is the same as the previously closed pull request #65 with the following additions:
- Implemented the Order enum to be more clear on intent for sorting direction
- Added back the getSortKey(String) method to provide a quick way for a user to provide a single column to be sorted ASC.
