### PR TITLE
BATCH-1728: Added repository based ItemReader/ItemWriter implementations

### DIFF
--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -4,8 +4,8 @@
 	<artifactId>spring-batch-infrastructure</artifactId>
 	<packaging>jar</packaging>
 	<name>Infrastructure</name>
-	<description><![CDATA[The Spring Batch Infrastructure is a set of 
-	low-level components, interfaces and tools for batch processing 
+	<description><![CDATA[The Spring Batch Infrastructure is a set of
+	low-level components, interfaces and tools for batch processing
 	applications and optimisations.]]>
 	</description>
 	<url>http://static.springframework.org/spring-batch/${project.artifactId}</url>
@@ -213,6 +213,11 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			 <groupId>org.springframework.data</groupId>
+			 <artifactId>spring-data-commons-core</artifactId>
+			 <optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.woodstox</groupId>

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.data;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.adapter.AbstractMethodInvokingDelegator.InvocationTargetThrowableWrapper;
+import org.springframework.batch.item.adapter.DynamicMethodInvocationException;
+import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.MethodInvoker;
+
+/**
+ * <p>
+ * A {@link org.springframework.batch.item.ItemReader} that reads records utilizing
+ * a {@link org.springframework.data.repository.PagingAndSortingRepository}.
+ * </p>
+ *
+ * <p>
+ * Performance of the reader is dependent on the repository implementation, however
+ * setting a reasonably large page size and matching that to the commit interval should
+ * yield better performance.
+ * </p>
+ *
+ * <p>
+ * The reader must be configured with a {@link org.springframework.data.repository.PagingAndSortingRepository},
+ * a {@link org.springframework.data.domain.Sort}, and a pageSize greater than 0.
+ * </p>
+ *
+ * <p>
+ * This implementation is thread safe between calls to {@link #open(ExecutionContext)}, but remember to use
+ * <code>saveState=false</code> if used in a multi-threaded client (no restart available).
+ * </p>
+ *
+ * @author Michael Minella
+ * @since 2.2
+ */
+@SuppressWarnings("rawtypes")
+public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements InitializingBean {
+
+	protected Log logger = LogFactory.getLog(getClass());
+
+	private PagingAndSortingRepository repository;
+
+	private Sort sort;
+
+	private volatile int page = 0;
+
+	private int pageSize = 10;
+
+	private volatile int current = 0;
+
+	private List arguments;
+
+	private volatile List<T> results;
+
+	private Object lock = new Object();
+
+	private String methodName;
+
+	public RepositoryItemReader() {
+		setName(ClassUtils.getShortName(RepositoryItemReader.class));
+	}
+
+	public void setArguments(List arguments) {
+		this.arguments = arguments;
+	}
+
+	/**
+	 * Provides ordering of the results so that order is maintained between paged queries
+	 *
+	 * @param sort the fields to sort by and the directions
+	 */
+	public void setSort(Sort sort) {
+		this.sort = sort;
+	}
+
+	/**
+	 * @param pageSize The number of items to retrieve per page.
+	 */
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	/**
+	 * The {@link org.springframework.data.repository.PagingAndSortingRepository}
+	 * implementation used to read input from.
+	 *
+	 * @param repository underlying repository for input to be read from.
+	 */
+	public void setRepository(PagingAndSortingRepository repository) {
+		this.repository = repository;
+	}
+
+	/**
+	 * Specifies what method on the repository to call.  This method must take
+	 * {@link org.springframework.data.domain.Pageable} as the <em>last</em> argument.
+	 *
+	 * @param methodName
+	 */
+	public void setMethodName(String methodName) {
+		this.methodName = methodName;
+	}
+
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(repository, "A PagingAndSortingRepository is required");
+		Assert.isTrue(pageSize > 0, "Page size must be greater than 0");
+		Assert.notNull(sort, "A sort is required");
+	}
+
+	@Override
+	protected T doRead() throws Exception {
+
+		synchronized (lock) {
+			if(results == null || current >= results.size()) {
+
+				if (logger.isDebugEnabled()) {
+					logger.debug("Reading page " + page);
+				}
+
+				results = doPageRead();
+
+				current = 0;
+				page ++;
+
+				if(results.size() <= 0) {
+					return null;
+				}
+			}
+
+			if(current < results.size()) {
+				T curLine = results.get(current);
+				current++;
+				return curLine;
+			}
+			else {
+				return null;
+			}
+		}
+	}
+
+	@Override
+	protected void jumpToItem(int itemLastIndex) throws Exception {
+		synchronized (lock) {
+			page = itemLastIndex / pageSize;
+			current = itemLastIndex % pageSize;
+
+			results = doPageRead();
+		}
+	}
+
+	/**
+	 * Performs the actual reading of a page via the repository.
+	 * Available for overriding as needed.
+	 *
+	 * @return the list of items that make up the page
+	 * @throws Exception
+	 */
+	@SuppressWarnings("unchecked")
+	protected List<T> doPageRead() throws Exception {
+		Pageable pageRequest = new PageRequest(page, pageSize, sort);
+
+		MethodInvoker invoker = createMethodInvoker(repository, methodName);
+
+		List parameters = new ArrayList();
+
+		if(arguments != null && arguments.size() > 0) {
+			parameters.addAll(arguments);
+		}
+
+		parameters.add(pageRequest);
+
+		invoker.setArguments(parameters.toArray());
+
+		Page curPage = (Page) doInvoke(invoker);
+
+		return curPage.getContent();
+	}
+
+	@Override
+	protected void doOpen() throws Exception {
+	}
+
+	@Override
+	protected void doClose() throws Exception {
+	}
+
+	private Object doInvoke(MethodInvoker invoker) throws Exception{
+		try {
+			invoker.prepare();
+		}
+		catch (ClassNotFoundException e) {
+			throw new DynamicMethodInvocationException(e);
+		}
+		catch (NoSuchMethodException e) {
+			throw new DynamicMethodInvocationException(e);
+		}
+
+		try {
+			return invoker.invoke();
+		}
+		catch (InvocationTargetException e) {
+			if (e.getCause() instanceof Exception) {
+				throw (Exception) e.getCause();
+			}
+			else {
+				throw new InvocationTargetThrowableWrapper(e.getCause());
+			}
+		}
+		catch (IllegalAccessException e) {
+			throw new DynamicMethodInvocationException(e);
+		}
+	}
+
+	private MethodInvoker createMethodInvoker(Object targetObject, String targetMethod) {
+		MethodInvoker invoker = new MethodInvoker();
+		invoker.setTargetObject(targetObject);
+		invoker.setTargetMethod(targetMethod);
+		return invoker;
+	}
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.data;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.util.Assert;
+
+/**
+ * <p>
+ * A {@link org.springframework.batch.item.ItemReader} wrapper for a
+ * {@link org.springframework.data.repository.CrudRepository} from Spring Data.
+ * </p>
+ *
+ * <p>
+ * It depends on {@link org.springframework.data.repository.CrudRepository#save(Iterable)}
+ * method to store the items for the chunk.  Performance will be determined by that
+ * implementation more than this writer.
+ * </p>
+ *
+ * <p>
+ * As long as the repository provided is thread-safe, this writer is also thread-safe once
+ * properties are set (normal singleton behavior), so it can be used in multiple concurrent
+ * transactions.
+ * </p>
+ *
+ * @author Michael Minella
+ * @since 2.2
+ */
+@SuppressWarnings("rawtypes")
+public class RepositoryItemWriter implements ItemWriter, InitializingBean {
+
+	protected static final Log logger = LogFactory.getLog(RepositoryItemWriter.class);
+
+	private CrudRepository repository;
+
+	/**
+	 * Set the {@link org.springframework.data.repository.CrudRepository} implementation
+	 * for persistence
+	 *
+	 * @param repository the Spring Data repository to be set
+	 */
+	public void setRepository(CrudRepository repository) {
+		this.repository = repository;
+	}
+
+	/**
+	 * Write all items to the data store via a Spring Data repository.
+	 *
+	 * @see org.springframework.batch.item.ItemWriter#write(java.util.List)
+	 */
+	public void write(List items) throws Exception {
+		if(items != null && !items.isEmpty()) {
+			doWrite(items);
+		}
+	}
+
+	/**
+	 * Performs the actual write to the repository.  This can be overriden by
+	 * a subclass if necessary.
+	 *
+	 * @param items the list of items to be persisted.
+	 */
+	@SuppressWarnings("unchecked")
+	protected void doWrite(List items) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Writing to the repository with " + items.size() + " items.");
+		}
+
+		repository.save(items);
+	}
+
+	/**
+	 * Check mandatory properties - there must be a repository.
+	 */
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(repository, "A CRUDRepository is required");
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTest.java
@@ -1,0 +1,216 @@
+package org.springframework.batch.item.data;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+
+import org.easymock.Capture;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.item.adapter.DynamicMethodInvocationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+@SuppressWarnings("rawtypes")
+public class RepositoryItemReaderTest {
+
+	private RepositoryItemReader reader;
+	private PagingAndSortingRepository repository;
+	private Sort sort;
+
+	@Before
+	public void setUp() throws Exception {
+		repository = createMock(PagingAndSortingRepository.class);
+		sort = new Sort(Direction.ASC, "id");
+		reader = new RepositoryItemReader();
+		reader.setRepository(repository);
+		reader.setPageSize(1);
+		reader.setSort(sort);
+		reader.setMethodName("findAll");
+	}
+
+	@Test
+	public void testAfterPropertiesSet() throws Exception {
+		try {
+			new RepositoryItemReader().afterPropertiesSet();
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			reader = new RepositoryItemReader();
+			reader.setRepository(repository);
+			reader.afterPropertiesSet();
+			fail();
+		} catch (IllegalArgumentException iae) {
+		}
+
+		try {
+			reader = new RepositoryItemReader();
+			reader.setRepository(repository);
+			reader.setPageSize(-1);
+			reader.afterPropertiesSet();
+			fail();
+		} catch (IllegalArgumentException iae) {
+		}
+
+		try {
+			reader = new RepositoryItemReader();
+			reader.setRepository(repository);
+			reader.setPageSize(1);
+			reader.afterPropertiesSet();
+			fail();
+		} catch (IllegalArgumentException iae) {
+		}
+
+		reader = new RepositoryItemReader();
+		reader.setRepository(repository);
+		reader.setPageSize(1);
+		reader.setSort(new Sort(Direction.ASC, "name"));
+		reader.afterPropertiesSet();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testDoReadFirstReadNoResults() throws Exception {
+		Capture<PageRequest> pageRequestContainer = new Capture<PageRequest>();
+		expect(repository.findAll(capture(pageRequestContainer))).andReturn(new PageImpl(new ArrayList()));
+
+		replay(repository);
+
+		assertNull(reader.doRead());
+
+		verify(repository);
+
+		Pageable pageRequest = pageRequestContainer.getValue();
+		assertEquals(0, pageRequest.getOffset());
+		assertEquals(0, pageRequest.getPageNumber());
+		assertEquals(1, pageRequest.getPageSize());
+		assertEquals(sort, pageRequest.getSort());
+	}
+
+	@Test
+	@SuppressWarnings({"serial", "unchecked"})
+	public void testDoReadFirstReadResults() throws Exception {
+		Capture<PageRequest> pageRequestContainer = new Capture<PageRequest>();
+		final Object result = new Object();
+
+		expect(repository.findAll(capture(pageRequestContainer))).andReturn(new PageImpl(new ArrayList(){{
+			add(result);
+		}}));
+
+		replay(repository);
+
+		assertEquals(result, reader.doRead());
+
+		verify(repository);
+
+		Pageable pageRequest = pageRequestContainer.getValue();
+		assertEquals(0, pageRequest.getOffset());
+		assertEquals(0, pageRequest.getPageNumber());
+		assertEquals(1, pageRequest.getPageSize());
+		assertEquals(sort, pageRequest.getSort());
+	}
+
+	@Test
+	@SuppressWarnings({"serial", "unchecked"})
+	public void testDoReadFirstReadSecondPage() throws Exception {
+		Capture<PageRequest> pageRequestContainer = new Capture<PageRequest>();
+		final Object result = new Object();
+		expect(repository.findAll((Pageable)anyObject())).andReturn(new PageImpl(new ArrayList(){{
+			add(new Object());
+		}}));
+		expect(repository.findAll(capture(pageRequestContainer))).andReturn(new PageImpl(new ArrayList(){{
+			add(result);
+		}}));
+
+		replay(repository);
+
+		assertFalse(reader.doRead() == result);
+		assertEquals(result, reader.doRead());
+
+		verify(repository);
+
+		Pageable pageRequest = pageRequestContainer.getValue();
+		assertEquals(1, pageRequest.getOffset());
+		assertEquals(1, pageRequest.getPageNumber());
+		assertEquals(1, pageRequest.getPageSize());
+		assertEquals(sort, pageRequest.getSort());
+	}
+
+	@Test
+	@SuppressWarnings({"serial", "unchecked"})
+	public void testDoReadFirstReadExhausted() throws Exception {
+		Capture<PageRequest> pageRequestContainer = new Capture<PageRequest>();
+		final Object result = new Object();
+		expect(repository.findAll((Pageable)anyObject())).andReturn(new PageImpl(new ArrayList(){{
+			add(new Object());
+		}}));
+		expect(repository.findAll(capture(pageRequestContainer))).andReturn(new PageImpl(new ArrayList(){{
+			add(result);
+		}}));
+		expect(repository.findAll(capture(pageRequestContainer))).andReturn(new PageImpl(new ArrayList()));
+
+		replay(repository);
+
+		assertFalse(reader.doRead() == result);
+		assertEquals(result, reader.doRead());
+		assertNull(reader.doRead());
+
+		verify(repository);
+
+		Pageable pageRequest = pageRequestContainer.getValue();
+		assertEquals(2, pageRequest.getOffset());
+		assertEquals(2, pageRequest.getPageNumber());
+		assertEquals(1, pageRequest.getPageSize());
+		assertEquals(sort, pageRequest.getSort());
+	}
+
+	@Test
+	@SuppressWarnings({"serial", "unchecked"})
+	public void testJumpToItem() throws Exception {
+		reader.setPageSize(100);
+		Capture<PageRequest> pageRequestContainer = new Capture<PageRequest>();
+		expect(repository.findAll(capture(pageRequestContainer))).andReturn(new PageImpl(new ArrayList(){{
+			add(new Object());
+		}}));
+
+		replay(repository);
+
+		reader.jumpToItem(485);
+
+		verify(repository);
+
+		Pageable pageRequest = pageRequestContainer.getValue();
+		assertEquals(400, pageRequest.getOffset());
+		assertEquals(4, pageRequest.getPageNumber());
+		assertEquals(100, pageRequest.getPageSize());
+		assertEquals(sort, pageRequest.getSort());
+	}
+
+	@Test
+	public void testInvalidMethodName() throws Exception {
+		reader.setMethodName("thisMethodDoesNotExist");
+
+		try {
+			reader.doPageRead();
+			fail();
+		} catch (DynamicMethodInvocationException dmie) {
+			assertTrue(dmie.getCause() instanceof NoSuchMethodException);
+		}
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTest.java
@@ -1,0 +1,74 @@
+package org.springframework.batch.item.data;
+
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.repository.CrudRepository;
+
+@SuppressWarnings("rawtypes")
+public class RepositoryItemWriterTest {
+
+	private CrudRepository repository;
+
+	private RepositoryItemWriter writer;
+
+	@Before
+	public void setUp() throws Exception {
+		repository = createStrictMock(CrudRepository.class);
+		writer = new RepositoryItemWriter();
+		writer.setRepository(repository);
+	}
+
+	@Test
+	public void testAfterPropertiesSet() throws Exception {
+		writer.afterPropertiesSet();
+
+		writer.setRepository(null);
+
+		try {
+			writer.afterPropertiesSet();
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+	}
+
+	@Test
+	@SuppressWarnings({"serial", "unchecked"})
+	public void testWriteNoItems() throws Exception {
+		replay(repository);
+		writer.write(null);
+
+		writer.write(new ArrayList());
+
+		try {
+			writer.write(new ArrayList(){{add(new Object());}});
+		} catch (AssertionError e) {
+			assertTrue(e.getMessage().contains("CrudRepository.save("));
+		}
+	}
+
+	@Test
+	@SuppressWarnings({"serial", "unchecked"})
+	public void testWriteItems() throws Exception {
+		List<Object> items = new ArrayList<Object>() {{
+			add(new Object());
+		}};
+
+		expect(repository.save(items)).andReturn(null);
+
+		replay(repository);
+
+		writer.write(items);
+
+		verify(repository);
+	}
+}

--- a/spring-batch-parent/pom.xml
+++ b/spring-batch-parent/pom.xml
@@ -27,10 +27,16 @@
 			<name>Dave Syer</name>
 			<email>david.syer@springsource.com</email>
 		</developer>
+		<developer>
+			<id>mminella</id>
+			<name>Michael Minella</name>
+			<email>mminella@vmware.com</email>
+		</developer>
 	</developers>
 	<properties>
 		<spring.framework.version>3.1.2.RELEASE</spring.framework.version>
 		<spring.amqp.version>1.1.2.RELEASE</spring.amqp.version>
+		<spring.data.version>1.2.0.RELEASE</spring.data.version>
 		<junit.version>4.10</junit.version>
 		<bundlor.version>1.0.0.RELEASE</bundlor.version>
 		<dependency.locations.enabled>false</dependency.locations.enabled>
@@ -687,6 +693,11 @@
 				<groupId>org.springframework.amqp</groupId>
 				<artifactId>spring-rabbit</artifactId>
 				<version>${spring.amqp.version}</version>
+			</dependency>
+			<dependency>
+				 <groupId>org.springframework.data</groupId>
+				 <artifactId>spring-data-commons-core</artifactId>
+				 <version>${spring.data.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Spring Data supports a generic data access concept called a Repository.  This ItemReader/ItemWriter combination allows a user to utilize existing Repository implementations as input/output sources for their batch jobs.
