### PR TITLE
BATCH-1930: Adding PostWriteHeaderCallback

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Writer;
+import java.io.FileWriter;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.UnsupportedCharsetException;
@@ -87,6 +88,8 @@ public class FlatFileItemWriter<T> extends ExecutionContextUserSupport implement
 	private String encoding = OutputState.DEFAULT_CHARSET;
 
 	private FlatFileHeaderCallback headerCallback;
+
+	private FlatFilePostWriteHeaderCallback postWriteHeaderCallback;
 
 	private FlatFileFooterCallback footerCallback;
 
@@ -218,6 +221,15 @@ public class FlatFileItemWriter<T> extends ExecutionContextUserSupport implement
 	}
 
 	/**
+	 * postWriteHeaderCallback will be called after file is written to the disk.
+	 * It will store header in a separate file then merge both files.
+	 * Newline will be automatically appended after the header is written.
+	 */
+	public void setPostWriteHeaderCallback(FlatFilePostWriteHeaderCallback headerCallback) {
+		this.postWriteHeaderCallback = headerCallback;
+	}
+
+	/**
 	 * footerCallback will be called after writing the last item to file, but
 	 * before the file is closed.
 	 */
@@ -277,6 +289,7 @@ public class FlatFileItemWriter<T> extends ExecutionContextUserSupport implement
 	 * @see ItemStream#close()
 	 */
 	public void close() {
+		long totalLines = state.linesWritten;
 		if (state != null) {
 			try {
 				if (footerCallback != null && state.outputBufferedWriter != null) {
@@ -298,6 +311,25 @@ public class FlatFileItemWriter<T> extends ExecutionContextUserSupport implement
 					}
 				}
 				state = null;
+			}
+
+			try{
+				if(postWriteHeaderCallback != null){
+					Resource temporary = resource.createRelative("./.temporary");
+					File postWriteHeader = temporary.getFile();
+					postWriteHeader.delete();
+					postWriteHeader.createNewFile();
+					File original = resource.getFile();
+					Writer postWriteHeaderWriter = new BufferedWriter(new FileWriter(postWriteHeader));
+					postWriteHeaderCallback.writeHeader(postWriteHeaderWriter, original, totalLines);
+					postWriteHeaderWriter.write(System.getProperty("line.separator"));
+					postWriteHeaderWriter.close();
+					FileUtils.mergeFiles(original, postWriteHeader);
+					postWriteHeader.renameTo(original);
+				}
+			}
+			catch(IOException e){
+				throw new ItemStreamException("Failed to write Post Write Header", e);
 			}
 		}
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFilePostWriteHeaderCallback.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFilePostWriteHeaderCallback.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2006-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.item.file;
+
+import java.io.File;
+import java.io.Writer;
+import java.io.IOException;
+import org.springframework.batch.item.file.FlatFileHeaderCallback;
+
+/**
+ * Callback interface for writing to a header to a file after the file has been written
+ * 
+ * @author Juzer Ali
+ */
+public interface FlatFilePostWriteHeaderCallback {
+
+	/**
+	 * Write contents to a file using the supplied {@link Writer} after all the data
+	 * has been written on the disk. Uses file merge. It is not
+	 * required to flush the writer inside this method.
+	 * @param file handle to file which has been written
+	 * @param lineCount Number of lines in the file
+	 */
+	void writeHeader(Writer writer, File file, long lineCount) throws IOException;
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/FileUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/FileUtils.java
@@ -16,7 +16,11 @@
 
 package org.springframework.batch.item.util;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 
 import org.springframework.batch.item.ItemStreamException;
@@ -123,6 +127,32 @@ public final class FileUtils {
 			}
 		}
 
+	}
+
+	/**
+	 * Merges two files
+	 * 
+	 * @param source the file which needs to be copied
+	 * @param destination file to copy into
+	 */
+	public static boolean mergeFiles(File source, File destination) throws IOException {
+		try{
+			BufferedReader sourceReader = new BufferedReader(new FileReader(source));
+			BufferedWriter destWriter = new BufferedWriter(new FileWriter(destination, true));
+
+			String line = "";
+
+			while((line = sourceReader.readLine()) != null){
+				destWriter.append(line);
+				destWriter.newLine();
+			}
+			sourceReader.close();
+			destWriter.close();
+		}
+		catch(IOException e){
+			throw new ItemStreamException("Failed while merging two files");
+		}
+		return true;
 	}
 
 }


### PR DESCRIPTION
So that header can be written after the batch data has been written so that number of lines and content hash can be written in header. Added PostWriteHeaderCallback Interface, changed FlatFileItemWriter to write header inside close(), Added FileUtils#mergeFiles.

*This is hacky currently.
