### PR TITLE
BATCH-1957: Add StaxEventItemWriter deleteIfEmpty property

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
@@ -455,7 +455,14 @@ public class FlatFileItemWriter<T> extends ExecutionContextUserSupport implement
 		 */
 		public void restoreFrom(ExecutionContext executionContext) {
 			lastMarkedByteOffsetPosition = executionContext.getLong(getKey(RESTART_DATA_NAME));
-			restarted = true;
+			linesWritten = executionContext.getLong(getKey(WRITTEN_STATISTICS_NAME));
+			if (shouldDeleteIfEmpty && linesWritten == 0) {
+				// previous execution deleted the output file because no items were written
+				restarted = false;
+				lastMarkedByteOffsetPosition = 0;
+			} else {
+				restarted = true;
+			}
 		}
 
 		/**
@@ -571,7 +578,6 @@ public class FlatFileItemWriter<T> extends ExecutionContextUserSupport implement
 			}
 
 			initialized = true;
-			linesWritten = 0;
 		}
 
 		public boolean isInitialized() {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -366,7 +366,14 @@ public class StaxEventItemWriter<T> extends ExecutionContextUserSupport implemen
 		if (executionContext.containsKey(getKey(RESTART_DATA_NAME))) {
 			startAtPosition = executionContext.getLong(getKey(RESTART_DATA_NAME));
 			currentRecordCount = executionContext.getLong(getKey(WRITE_STATISTICS_NAME));
-			restarted = true;			
+			restarted = true;
+			if (shouldDeleteIfEmpty && currentRecordCount == 0) {
+				// previous execution deleted the output file because no items were written
+				restarted = false;
+				startAtPosition = 0;
+			} else {
+				restarted = true;
+			}			
 		}
 
 		open(startAtPosition, restarted);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
@@ -323,8 +323,8 @@ public class FlatFileItemWriterTests {
 
 		assertEquals("footer", readLine());
 
-		// 3 lines were written to the file after restart
-		assertEquals(3, executionContext.getLong(ClassUtils.getShortName(FlatFileItemWriter.class) + ".written"));
+		// 8 lines were written to the file in total
+		assertEquals(8, executionContext.getLong(ClassUtils.getShortName(FlatFileItemWriter.class) + ".written"));
 
 	}
 
@@ -425,8 +425,8 @@ public class FlatFileItemWriterTests {
 
 		assertEquals("footer", readLine());
 
-		// 3 lines were written to the file after restart
-		assertEquals(3, executionContext.getLong(ClassUtils.getShortName(FlatFileItemWriter.class) + ".written"));
+		// 8 lines were written to the file in total
+		assertEquals(8, executionContext.getLong(ClassUtils.getShortName(FlatFileItemWriter.class) + ".written"));
 
 	}
 
@@ -595,6 +595,7 @@ public class FlatFileItemWriterTests {
 	public void testDeleteOnExitReopen() throws Exception {
 		writer.setShouldDeleteIfEmpty(true);
 		writer.open(executionContext);
+		writer.update(executionContext);
 		assertTrue(outputFile.exists());
 		writer.close();
 		assertFalse(outputFile.exists());
@@ -602,6 +603,30 @@ public class FlatFileItemWriterTests {
 		writer.write(Collections.singletonList("test2"));
 		assertEquals("test2", readLine());
 	}
+	
+	@Test
+	public void testWriteHeaderAndDeleteOnExitReopen() throws Exception {
+		writer.setHeaderCallback(new FlatFileHeaderCallback() {
+
+            @Override
+			public void writeHeader(Writer writer) throws IOException {
+				writer.write("a\nb");
+			}
+
+		});
+		writer.setShouldDeleteIfEmpty(true);
+		writer.open(executionContext);
+		writer.update(executionContext);
+		assertTrue(outputFile.exists());
+		writer.close();
+		assertFalse(outputFile.exists());
+
+		writer.open(executionContext);
+		writer.write(Collections.singletonList("test2"));
+		assertEquals("a", readLine());
+		assertEquals("b", readLine());
+		assertEquals("test2", readLine());
+	}	
 	
 	@Test
 	public void testDeleteOnExitNoRecordsWrittenAfterRestart() throws Exception {


### PR DESCRIPTION
Added shouldDeleteIfEmpty property to StaxEventItemWriter. I also encountered and fixed a bug: the currentRecordCount property was not being initialized from the ExecutionContext on restart.
