### PR TITLE
BATCH-1972: StaxEventItemReader fails when restarted at end of file

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
@@ -17,6 +17,7 @@
 package org.springframework.batch.item.xml;
 
 import java.io.InputStream;
+import java.util.NoSuchElementException;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -247,8 +248,18 @@ public class StaxEventItemReader<T> extends AbstractItemCountingItemStreamItemRe
 	@Override
 	protected void jumpToItem(int itemIndex) throws Exception {
 		for (int i = 0; i < itemIndex; i++) {
-			readToStartFragment();
-			readToEndFragment();
+			try {
+				readToStartFragment();
+				readToEndFragment();
+			} catch (NoSuchElementException e) {
+				if (itemIndex == (i + 1)) {
+					// we can presume a NoSuchElementException on the last item means the EOF was reached on the last run
+					return;
+				} else {
+					// if NoSuchElementException occurs on an item other than the last one, this indicates a problem
+					throw e;
+				}
+			}
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -223,6 +223,26 @@ public class StaxEventItemReaderTests {
 
 	}
 
+	/**
+	 * Test restart at end of file.
+	 */
+	@Test
+	public void testRestartAtEndOfFile() throws Exception {
+
+		source.open(executionContext);
+		assertNotNull(source.read());
+		assertNotNull(source.read());
+		assertNull(source.read());
+		source.update(executionContext);
+		source.close();
+		
+		assertEquals(3, executionContext.getInt(ClassUtils.getShortName(StaxEventItemReader.class) + ".read.count"));
+		
+		source = createNewInputSouce();
+		source.open(executionContext);
+		assertNull(source.read());
+	}
+	
 	@Test
 	public void testRestoreWorksFromClosedStream() throws Exception {
 		source.close();


### PR DESCRIPTION
Ignoring java.util.NoSuchElementException for last item index in org.springframework.batch.item.xml.StaxEventItemReader.jumpToItem(int).
