### PR TITLE
BATCH-1908. 

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
@@ -187,11 +187,11 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter, Initi
 			boolean startable = getStartable(currentStepExecution, context.getValue());
 
 			if (startable) {
-				jobRepository.add(currentStepExecution);
 				set.add(currentStepExecution);
 			}
-
 		}
+		
+		jobRepository.addAll(set);
 
 		return set;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/JobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/JobRepository.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.core.repository;
 
+import java.util.Collection;
+
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -39,6 +41,7 @@ import org.springframework.transaction.annotation.Isolation;
  * @author Lucas Ward
  * @author Dave Syer
  * @author Robert Kasanicky
+ * @author David Turanski
  */
 public interface JobRepository {
 
@@ -114,6 +117,17 @@ public interface JobRepository {
 	 * @param stepExecution
 	 */
 	void add(StepExecution stepExecution);
+
+	/**
+	 * Save a collection of {@link StepExecution}s and each {@link ExecutionContext}. The 
+	 * StepExecution ID will be assigned - it is not permitted that an ID be assigned before calling
+	 * this method. Instead, it should be left blank, to be assigned by {@link JobRepository}.
+	 * 
+	 * Preconditions: {@link StepExecution} must have a valid {@link Step}.
+	 * 
+	 * @param stepExecution
+	 */
+	void addAll(Collection<StepExecution> stepExecutions);
 
 	/**
 	 * Update the {@link StepExecution} (but not its {@link ExecutionContext}).

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/ExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/ExecutionContextDao.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.core.repository.dao;
 
+import java.util.Collection;
+
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
@@ -24,6 +26,7 @@ import org.springframework.batch.item.ExecutionContext;
  * DAO interface for persisting and retrieving {@link ExecutionContext}s.
  * 
  * @author Robert Kasanicky
+ * @author David Turanski
  */
 public interface ExecutionContextDao {
 
@@ -52,6 +55,13 @@ public interface ExecutionContextDao {
 	 * @param stepExecution
 	 */
 	void saveExecutionContext(final StepExecution stepExecution);
+	
+	/**
+	 * Persist the execution context associated with each stepExecution in a given collection,
+	 * persistent entry for the context should not exist yet.
+	 * @param stepExecution
+	 */
+	void saveExecutionContexts(final Collection<StepExecution> stepExecutions);
 
 	/**
 	 * Persist the updates of execution context associated with the given

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapExecutionContextDao.java
@@ -17,6 +17,7 @@
 package org.springframework.batch.core.repository.dao;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
 import org.springframework.batch.core.JobExecution;
@@ -24,12 +25,14 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.support.SerializationUtils;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
+import org.springframework.util.Assert;
 
 /**
  * In-memory implementation of {@link ExecutionContextDao} backed by maps.
  *
  * @author Robert Kasanicky
  * @author Dave Syer
+ * @author David Turanski
  */
 @SuppressWarnings("serial")
 public class MapExecutionContextDao implements ExecutionContextDao {
@@ -143,6 +146,15 @@ public class MapExecutionContextDao implements ExecutionContextDao {
 	@Override
 	public void saveExecutionContext(StepExecution stepExecution) {
 		updateExecutionContext(stepExecution);
+	}
+
+	 
+	@Override
+	public void saveExecutionContexts(Collection<StepExecution> stepExecutions) {
+		Assert.notNull(stepExecutions,"Attempt to save a nulk collection of step executions");
+		for (StepExecution stepExecution: stepExecutions) {
+			saveExecutionContext(stepExecution);
+		}
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapStepExecutionDao.java
@@ -17,6 +17,7 @@ package org.springframework.batch.core.repository.dao;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -136,5 +137,13 @@ public class MapStepExecutionDao implements StepExecutionDao {
 			copy.add(copy(exec));
 		}
 		jobExecution.addStepExecutions(copy);
+	}
+
+	@Override
+	public void saveStepExecutions(Collection<StepExecution> stepExecutions) {
+		Assert.notNull(stepExecutions,"Attempt to save an null collect of step executions");
+		for (StepExecution stepExecution: stepExecutions) {
+			saveStepExecution(stepExecution);
+		}
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.core.repository.dao;
 
+import java.util.Collection;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
@@ -34,6 +35,17 @@ public interface StepExecutionDao {
 	void saveStepExecution(StepExecution stepExecution);
 
 	/**
+	 * Save the given collection of StepExecution as a batch.
+	 * 
+	 * Preconditions: StepExecution Id must be null.
+	 * 
+	 * Postconditions: StepExecution Id will be set to a unique Long.
+	 * 
+	 * @param stepExecutions
+	 */
+	void saveStepExecutions(Collection<StepExecution> stepExecutions);
+
+	/**
 	 * Update the given StepExecution
 	 * 
 	 * Preconditions: Id must not be null.
@@ -50,7 +62,7 @@ public interface StepExecutionDao {
 	 * @return a {@link StepExecution}
 	 */
 	StepExecution getStepExecution(JobExecution jobExecution, Long stepExecutionId);
-	
+
 	/**
 	 * Retrieve all the {@link StepExecution} for the parent {@link JobExecution}.
 	 * 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/DummyJobRepository.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/DummyJobRepository.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.core.configuration.xml;
 
+import java.util.Collection;
+
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
@@ -27,6 +29,7 @@ import org.springframework.beans.factory.BeanNameAware;
 
 /**
  * @author Dan Garrette
+ * @author David Turanski
  * @since 2.0.1
  */
 public class DummyJobRepository implements JobRepository, BeanNameAware {
@@ -86,6 +89,10 @@ public class DummyJobRepository implements JobRepository, BeanNameAware {
 
 	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
+	}
+
+	@Override
+	public void addAll(Collection<StepExecution> stepExecutions) {
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.core.step;
 
+import java.util.Collection;
+
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
@@ -23,6 +25,7 @@ import org.springframework.batch.core.repository.JobRepository;
 
 /**
  * @author Dave Syer
+ * @author David Turanski
  *
  */
 public class JobRepositorySupport implements JobRepository {
@@ -94,6 +97,10 @@ public class JobRepositorySupport implements JobRepository {
 
 	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
+	}
+
+	@Override
+	public void addAll(Collection<StepExecution> stepExecutions) {
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -11,6 +11,8 @@ import static org.springframework.batch.core.BatchStatus.FAILED;
 import static org.springframework.batch.core.BatchStatus.STOPPED;
 import static org.springframework.batch.core.BatchStatus.UNKNOWN;
 
+import java.util.Collection;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.batch.core.ExitStatus;
@@ -45,6 +47,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  *
  * @author Lucas Ward
  * @author Dave Syer
+ * @author David Turanski
  *
  */
 public class TaskletStepExceptionTests {
@@ -466,6 +469,10 @@ public class TaskletStepExceptionTests {
 
 		@Override
 		public void updateExecutionContext(JobExecution jobExecution) {
+		}
+
+		@Override
+		public void addAll(Collection<StepExecution> stepExecutions) {
 		}
 	}
 


### PR DESCRIPTION
Added batch inserts to JdbcExecutionContextDao and JdbcStepExecutionDao. 
Added JobRepository.addAll(Collection<StepExecution>).  SimpleStepExecutionSplitter calls this method now.  

Note: This change is not backward compatible since any existing JobRepository implementations must implement addAll() now.  

Also did some refactoring in JdbcStepExecutionDao since there are 17 parameter values and corresponding types in the Insert statement, I wanted to avoid duplication. It's not as clean as I would like, but I haven't thought of a better way to do it. 
