### PR TITLE
BATCH-2018

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
@@ -46,15 +46,14 @@ import org.springframework.util.StringUtils;
  */
 public class MongoItemWriter<T> implements ItemWriter<T>, InitializingBean {
 
-	private static final String BUFFER_KEY_PREFIX = MongoItemWriter.class.getName() + ".BUFFER_KEY";
 	private MongoOperations template;
-	private final String bufferKey;
+	private final Object bufferKey;
 	private String collection;
 	private boolean delete = false;
 
 	public MongoItemWriter() {
 		super();
-		this.bufferKey = BUFFER_KEY_PREFIX + "." + hashCode();
+		this.bufferKey = new Object();
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -37,13 +37,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  */
 public class TransactionAwareBufferedWriter extends Writer {
 
-	private static final String BUFFER_KEY_PREFIX = TransactionAwareBufferedWriter.class.getName() + ".BUFFER_KEY";
+	private final Object bufferKey;
 
-	private static final String CLOSE_KEY_PREFIX = TransactionAwareBufferedWriter.class.getName() + ".CLOSE_KEY";
-
-	private final String bufferKey;
-
-	private final String closeKey;
+	private final Object closeKey;
 
 	private FileChannel channel;
 
@@ -66,8 +62,8 @@ public class TransactionAwareBufferedWriter extends Writer {
 		super();
 		this.channel = channel;
 		this.closeCallback = closeCallback;
-		this.bufferKey = BUFFER_KEY_PREFIX + "." + hashCode();
-		this.closeKey = CLOSE_KEY_PREFIX + "." + hashCode();
+		this.bufferKey = new Object();
+		this.closeKey = new Object();
 	}
 
 	public void setEncoding(String encoding) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
@@ -2,17 +2,28 @@ package org.springframework.batch.item.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.batch.support.transaction.TransactionAwareBufferedWriter;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -232,4 +243,52 @@ public class MongoItemWriterTests {
 		verify(template).remove(items.get(0), "collection");
 		verify(template).remove(items.get(1), "collection");
 	}
+	
+	// BATCH-2018
+	@Test
+	public void testResourceKeyCollision() throws Exception {
+		final int limit = 5000;
+		final MongoItemWriter<String>[] writers = new MongoItemWriter[limit];
+		final String[] results = new String[limit];
+		for(int i = 0; i< limit; i++) {
+			final int index = i;
+			MongoOperations mongoOperations = mock(MongoOperations.class);
+			
+			doAnswer(new Answer<Void>() {
+				@Override
+				public Void answer(InvocationOnMock invocation)
+						throws Throwable {
+					String val = (String) invocation.getArguments()[0];
+					if(results[index] == null) {
+						results[index] = val;
+					} else {
+						results[index] += val;
+					}
+					return null;
+				}
+			}).when(mongoOperations).save(any(String.class));
+			writers[i] = new MongoItemWriter<String>();
+			writers[i].setTemplate(mongoOperations);
+		}
+		
+		new TransactionTemplate(transactionManager).execute(new TransactionCallback() {
+            @Override
+			public Object doInTransaction(TransactionStatus status) {
+				try {
+					for(int i=0; i< limit; i++) {
+						writers[i].write(Collections.singletonList(String.valueOf(i)));
+					}
+				}
+				catch (Exception e) {
+					throw new IllegalStateException("Unexpected Exception", e);
+				}
+				return null;
+			}
+		});		
+		
+		for(int i=0; i< limit; i++) {
+			assertEquals(String.valueOf(i), results[i]);
+		}				
+	}
+	
 }


### PR DESCRIPTION
BATCH-2018 fix for TransactionSynchronizationManager resource key collision in TransactionAwareBufferedWriter and MongoItemWriter
