### PR TITLE
Explicitly specifying the type of input and output parameters to chunk method

### DIFF
--- a/archetypes/simple-cli-javaconfig/src/main/java/example/ModuleContext.java
+++ b/archetypes/simple-cli-javaconfig/src/main/java/example/ModuleContext.java
@@ -27,7 +27,7 @@ public class ModuleContext {
 	public Step step1(StepBuilderFactory stepBuilderFactory, ItemReader<Person> reader,
 			ItemWriter<Person> writer, ItemProcessor<Person, Person> processor) {
 		return stepBuilderFactory.get("step1")
-				.<Person, Person> chunk(10)
+				.chunk(10, Person.class, Person.class)
 				.reader(reader)
 				.processor(processor)
 				.writer(writer)

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilder.java
@@ -70,6 +70,24 @@ public class StepBuilder extends StepBuilderHelper<StepBuilder> {
 	}
 
 	/**
+	 * Build a step that processes items in chunks with the size provided. To extend the step to being fault tolerant,
+	 * call the {@link SimpleStepBuilder#faultTolerant()} method on the builder. In most cases you will want to
+	 * parameterize your call to this method, to preserve the type safety of your readers and writers, e.g.
+	 * 
+	 * <pre>
+	 * new StepBuilder(&quot;step1&quot;).chunk(100, Order.class, Ledger.class).reader(new OrderReader()).writer(new LedgerWriter())
+	 * // ... etc.
+	 * </pre>
+	 * 
+	 * @param chunkSize the chunk size (commit interval)
+	 * @return a {@link SimpleStepBuilder}
+	 * @param clazz1 the type of item to be processed as input
+	 * @param clazz2 the type of item to be output
+	 */
+	public <I, O> SimpleStepBuilder<I, O> chunk(int chunkSize, Class<I> clazz1, Class<O> clazz2) {
+		return chunk(chunkSize);
+	}	
+	/**
 	 * Build a step that processes items in chunks with the completion policy provided. To extend the step to being
 	 * fault tolerant, call the {@link SimpleStepBuilder#faultTolerant()} method on the builder. In most cases you will
 	 * want to parameterize your call to this method, to preserve the type safety of your readers and writers, e.g.
@@ -88,6 +106,24 @@ public class StepBuilder extends StepBuilderHelper<StepBuilder> {
 		return new SimpleStepBuilder<I, O>(this).chunk(completionPolicy);
 	}
 
+	/**
+	 * Build a step that processes items in chunks with the completion policy provided. To extend the step to being
+	 * fault tolerant, call the {@link SimpleStepBuilder#faultTolerant()} method on the builder. In most cases you will
+	 * want to parameterize your call to this method, to preserve the type safety of your readers and writers, e.g.
+	 * 
+	 * <pre>
+	 * new StepBuilder(&quot;step1&quot;).chunk(100, Order.class, Ledge.class).reader(new OrderReader()).writer(new LedgerWriter())
+	 * // ... etc.
+	 * </pre>
+	 * 
+	 * @param completionPolicy the completion policy to use to control chunk processing
+	 * @return a {@link SimpleStepBuilder}
+	 * @param clazz1 the type of item to be processed as input
+	 * @param clazz2 the type of item to be output *
+	 */
+	public <I, O> SimpleStepBuilder<I, O> chunk(CompletionPolicy completionPolicy, Class<I> clazz1, Class<O> clazz2) {
+		return chunk(completionPolicy);
+	}	
 	/**
 	 * Create a partition step builder for a remote (or local) step.
 	 * 


### PR DESCRIPTION
This is just a proposal - The chunk step builder currently depends on the input and output type as generic parameters:

```
stepBuilderFactory.get("step1").<Person, Person>chunk(10)
```

Instead, I think it is better from a users perspective to be explicit and have an overloaded version of chunk which accepts two more Class parameters and infers the type from that:

```
stepBuilderFactory.get("step1").chunk(10, Person.class, Person.class)
```
