### PR TITLE
BATCH-1999: Initial commit of JSR parsing infrastructure

### DIFF
--- a/spring-batch-core/pom.xml
+++ b/spring-batch-core/pom.xml
@@ -19,6 +19,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+		    <groupId>javax.batch</groupId>
+		    <artifactId>javax.batch-api</artifactId>
+		    <version>1.0-b29</version>
+		</dependency>
+		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 		</dependency>
@@ -38,10 +43,6 @@
 			<optional>true</optional>
 			<scope>test</scope>
 		</dependency>
-<!-- 		<dependency> -->
-<!-- 			<groupId>org.easymock</groupId> -->
-<!-- 			<artifactId>easymock</artifactId> -->
-<!-- 		</dependency> -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.sql.DataSource;
+
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.configuration.support.ApplicationContextFactory;
 import org.springframework.batch.core.configuration.support.AutomaticJobRegistrar;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
@@ -211,7 +211,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 	 * @param reachableElementMap
 	 * @param accumulator a collection of reachable element names
 	 */
-	private void findAllReachableElements(String startElement, Map<String, Set<String>> reachableElementMap,
+	protected void findAllReachableElements(String startElement, Map<String, Set<String>> reachableElementMap,
 			Set<String> accumulator) {
 		Set<String> reachableIds = reachableElementMap.get(startElement);
 		accumulator.add(startElement);
@@ -233,7 +233,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 	 * {@link org.springframework.batch.core.job.flow.support.StateTransition}
 	 * references
 	 */
-	protected static Collection<BeanDefinition> getNextElements(ParserContext parserContext, BeanDefinition stateDef,
+	public static Collection<BeanDefinition> getNextElements(ParserContext parserContext, BeanDefinition stateDef,
 			Element element) {
 		return getNextElements(parserContext, null, stateDef, element);
 	}
@@ -248,7 +248,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 	 * {@link org.springframework.batch.core.job.flow.support.StateTransition}
 	 * references
 	 */
-	protected static Collection<BeanDefinition> getNextElements(ParserContext parserContext, String stepId,
+	public static Collection<BeanDefinition> getNextElements(ParserContext parserContext, String stepId,
 			BeanDefinition stateDef, Element element) {
 
 		Collection<BeanDefinition> list = new ArrayList<BeanDefinition>();
@@ -283,7 +283,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 		else if (hasNextAttribute) {
 			parserContext.getReaderContext().error(
 					"The <" + element.getNodeName() + "/> may not contain a '" + NEXT_ATTR
-							+ "' attribute and a transition element", element);
+					+ "' attribute and a transition element", element);
 		}
 
 		return list;
@@ -390,7 +390,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 	 * @return the BatchStatus corresponding to the transition name
 	 */
 	private static FlowExecutionStatus getBatchStatusFromEndTransitionName(String elementName) {
-        elementName = stripNamespace(elementName);
+		elementName = stripNamespace(elementName);
 		if (STOP_ELE.equals(elementName)) {
 			return FlowExecutionStatus.STOPPED;
 		}
@@ -405,17 +405,17 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 		}
 	}
 
-    /**
-     * Strip the namespace from the element name if it exists.
-     */
-    private static String stripNamespace(String elementName){
-        if(elementName.startsWith("batch:")){
-            return elementName.substring(6);
-        }
-        else{
-            return elementName;
-        }
-    }
+	/**
+	 * Strip the namespace from the element name if it exists.
+	 */
+	private static String stripNamespace(String elementName){
+		if(elementName.startsWith("batch:")){
+			return elementName.substring(6);
+		}
+		else{
+			return elementName;
+		}
+	}
 
 	/**
 	 * @param parserContext the parser context

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/CoreNamespaceUtils.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/CoreNamespaceUtils.java
@@ -47,7 +47,7 @@ public class CoreNamespaceUtils {
 
 	private static final String CORE_NAMESPACE_POST_PROCESSOR_CLASS_NAME = "org.springframework.batch.core.configuration.xml.CoreNamespacePostProcessor";
 
-	protected static void autoregisterBeansForNamespace(ParserContext parserContext, Object source) {
+	public static void autoregisterBeansForNamespace(ParserContext parserContext, Object source) {
 		checkForStepScope(parserContext, source);
 		addRangePropertyEditor(parserContext);
 		addCoreNamespacePostProcessor(parserContext);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/ExceptionElementParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/ExceptionElementParser.java
@@ -1,0 +1,41 @@
+package org.springframework.batch.core.configuration.xml;
+
+import java.util.List;
+
+import org.springframework.batch.core.step.item.ForceRollbackForWriteSkipException;
+import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.beans.factory.support.ManagedMap;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+
+public class ExceptionElementParser {
+
+	@SuppressWarnings("unchecked")
+	public ManagedMap parse(Element element, ParserContext parserContext, String exceptionListName) {
+		List<Element> children = DomUtils.getChildElementsByTagName(element, exceptionListName);
+		if (children.size() == 1) {
+			ManagedMap map = new ManagedMap();
+			Element exceptionClassesElement = children.get(0);
+			addExceptionClasses("include", true, exceptionClassesElement, map, parserContext);
+			addExceptionClasses("exclude", false, exceptionClassesElement, map, parserContext);
+			map.put(ForceRollbackForWriteSkipException.class, true);
+			return map;
+		}
+		else if (children.size() > 1) {
+			parserContext.getReaderContext().error(
+					"The <" + exceptionListName + "/> element may not appear more than once in a single <"
+							+ element.getNodeName() + "/>.", element);
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void addExceptionClasses(String elementName, boolean include, Element exceptionClassesElement,
+			ManagedMap map, ParserContext parserContext) {
+		for (Element child : DomUtils.getChildElementsByTagName(exceptionClassesElement, elementName)) {
+			String className = child.getAttribute("class");
+			map.put(new TypedStringValue(className, Class.class), include);
+		}
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/JobParserJobFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/JobParserJobFactoryBean.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @since 2.0.1
  */
-class JobParserJobFactoryBean implements SmartFactoryBean {
+public class JobParserJobFactoryBean implements SmartFactoryBean {
 
 	private String name;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SplitParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SplitParser.java
@@ -84,14 +84,13 @@ public class SplitParser {
 			stateBuilder.addPropertyValue("taskExecutor", taskExecutorRef);
 		}
 
-		@SuppressWarnings("unchecked")
 		List<Element> flowElements = DomUtils.getChildElementsByTagName(element, "flow");
 
 		if (flowElements.size() < 2) {
 			parserContext.getReaderContext().error("A <split/> must contain at least two 'flow' elements.", element);
 		}
 
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"rawtypes", "unchecked"})
 		Collection<Object> flows = new ManagedList();
 		int i = 0;
 		String prefix = idAttribute;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/BatchletParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/BatchletParser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import org.springframework.batch.core.configuration.xml.StepParserStepFactoryBean;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * Parser for the &lt;batchlet /&gt; tag defined in JSR-352.  The current state
+ * of this parser parses a batchlet element into a {@link Tasklet} (the ref
+ * attribute is expected to point to an implementation of Tasklet).
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class BatchletParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final String REF = "ref";
+
+	public void parseBatchlet(Element stepElement, Element taskletElement, AbstractBeanDefinition bd,
+			ParserContext parserContext) {
+
+		bd.setBeanClass(StepParserStepFactoryBean.class);
+		bd.setAttribute("isNamespaceStep", true);
+
+		String taskletRef = taskletElement.getAttribute(REF);
+
+		if (StringUtils.hasText(taskletRef)) {
+			bd.getPropertyValues().addPropertyValue("tasklet", new RuntimeBeanReference(taskletRef));
+		}
+
+		bd.setRole(BeanDefinition.ROLE_SUPPORT);
+		bd.setSource(parserContext.extractSource(taskletElement));
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/ChunkParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/ChunkParser.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import java.util.List;
+
+import org.springframework.batch.core.configuration.xml.ExceptionElementParser;
+import org.springframework.batch.core.configuration.xml.StepParserStepFactoryBean;
+import org.springframework.batch.core.step.item.ChunkOrientedTasklet;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.support.ManagedMap;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parser for the &lt;chunk /&gt; element as specified in JSR-352.  The current state
+ * parses a chunk element into it's related batch artifacts ({@link ChunkOrientedTasklet}, {@link ItemReader},
+ * {@link ItemProcessor}, and {@link ItemWriter}).
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ *
+ */
+public class ChunkParser {
+
+	private static final String TIME_LIMIT_ATTRIBUTE = "time-limit";
+	private static final String ITEM_COUNT_ATTRIBUTE = "item-count";
+	private static final String CHECKPOINT_ALGORITHM_ELEMENT = "checkpoint-algorithm";
+	private static final String CLASS_ATTRIBUTE = "class";
+	private static final String INCLUDE_ELEMENT = "include";
+	private static final String NO_ROLLBACK_EXCEPTION_CLASSES_ELEMENT = "no-rollback-exception-classes";
+	private static final String RETRYABLE_EXCEPTION_CLASSES_ELEMENT = "retryable-exception-classes";
+	private static final String SKIPPABLE_EXCEPTION_CLASSES_ELEMENT = "skippable-exception-classes";
+	private static final String WRITER_ELEMENT = "writer";
+	private static final String PROCESSOR_ELEMENT = "processor";
+	private static final String READER_ELEMENT = "reader";
+	private static final String REF_ATTRIBUTE = "ref";
+	private static final String RETRY_LIMIT_ATTRIBUTE = "retry-limit";
+	private static final String SKIP_LIMIT_ATTRIBUTE = "skip-limit";
+	private static final String CUSTOM_CHECKPOINT_POLICY = "custom";
+	private static final String ITEM_CHECKPOINT_POLICY = "item";
+	private static final String CHECKPOINT_POLICY_ATTRIBUTE = "checkpoint-policy";
+
+	public void parse(Element element, AbstractBeanDefinition bd, ParserContext parserContext) {
+		MutablePropertyValues propertyValues = bd.getPropertyValues();
+		bd.setBeanClass(StepParserStepFactoryBean.class);
+
+		propertyValues.addPropertyValue("hasChunkElement", Boolean.TRUE);
+
+		String checkpointPolicy = element.getAttribute(CHECKPOINT_POLICY_ATTRIBUTE);
+		if(StringUtils.hasText(checkpointPolicy)) {
+			if(checkpointPolicy.equals(ITEM_CHECKPOINT_POLICY)) {
+				parseSimpleAttribute(element, propertyValues, ITEM_COUNT_ATTRIBUTE, "commitInterval");
+				parseSimpleAttribute(element, propertyValues, TIME_LIMIT_ATTRIBUTE, "timeout");
+			} else if(checkpointPolicy.equals(CUSTOM_CHECKPOINT_POLICY)) {
+				parseCustomCheckpointAlgorithm(element, parserContext,
+						propertyValues);
+			}
+		}
+
+		parseSimpleAttribute(element, propertyValues, SKIP_LIMIT_ATTRIBUTE, "skipLimit");
+		parseSimpleAttribute(element, propertyValues, RETRY_LIMIT_ATTRIBUTE, "retryLimit");
+
+		NodeList children = element.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node nd = children.item(i);
+
+			parseChildElement(element, parserContext, propertyValues, nd);
+		}
+	}
+
+	private void parseSimpleAttribute(Element element,
+			MutablePropertyValues propertyValues, String attributeName, String propertyName) {
+		String skipLimit = element.getAttribute(attributeName);
+		if (StringUtils.hasText(skipLimit)) {
+			propertyValues.addPropertyValue(propertyName, skipLimit);
+		}
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private void parseChildElement(Element element,
+			ParserContext parserContext, MutablePropertyValues propertyValues,
+			Node nd) {
+		if (nd instanceof Element) {
+			Element nestedElement = (Element) nd;
+			String name = nestedElement.getLocalName();
+
+			String artifactName = nestedElement.getAttribute(REF_ATTRIBUTE);
+			if(name.equals(READER_ELEMENT)) {
+				if (StringUtils.hasText(artifactName)) {
+					propertyValues.addPropertyValue("itemReader", new RuntimeBeanReference(artifactName));
+				}
+			} else if(name.equals(PROCESSOR_ELEMENT)) {
+				if (StringUtils.hasText(artifactName)) {
+					propertyValues.addPropertyValue("itemProcessor", new RuntimeBeanReference(artifactName));
+				}
+			} else if(name.equals(WRITER_ELEMENT)) {
+				if (StringUtils.hasText(artifactName)) {
+					propertyValues.addPropertyValue("itemWriter", new RuntimeBeanReference(artifactName));
+				}
+			} else if(name.equals(SKIPPABLE_EXCEPTION_CLASSES_ELEMENT)) {
+				ManagedMap exceptionClasses = new ExceptionElementParser().parse(element, parserContext, SKIPPABLE_EXCEPTION_CLASSES_ELEMENT);
+				if(exceptionClasses != null) {
+					propertyValues.addPropertyValue("skippableExceptionClasses", exceptionClasses);
+				}
+			} else if(name.equals(RETRYABLE_EXCEPTION_CLASSES_ELEMENT)) {
+				ManagedMap exceptionClasses = new ExceptionElementParser().parse(element, parserContext, RETRYABLE_EXCEPTION_CLASSES_ELEMENT);
+				if(exceptionClasses != null) {
+					propertyValues.addPropertyValue("retryableExceptionClasses", exceptionClasses);
+				}
+			} else if(name.equals(NO_ROLLBACK_EXCEPTION_CLASSES_ELEMENT)) {
+				//TODO: Update to support excludes
+				ManagedList list = new ManagedList();
+
+				for (Element child : DomUtils.getChildElementsByTagName(nestedElement, INCLUDE_ELEMENT)) {
+					String className = child.getAttribute(CLASS_ATTRIBUTE);
+					list.add(new TypedStringValue(className, Class.class));
+				}
+
+				propertyValues.addPropertyValue("noRollbackExceptionClasses", list);
+			}
+		}
+	}
+
+	private void parseCustomCheckpointAlgorithm(Element element,
+			ParserContext parserContext, MutablePropertyValues propertyValues) {
+		List<Element> elements = DomUtils.getChildElementsByTagName(element, CHECKPOINT_ALGORITHM_ELEMENT);
+
+		if(elements.size() == 1) {
+			Element checkpointAlgorithmElement = elements.get(0);
+
+			String name = checkpointAlgorithmElement.getAttribute(REF_ATTRIBUTE);
+			if(StringUtils.hasText(name)) {
+				propertyValues.addPropertyValue("chunkCompletionPolicy", new RuntimeBeanReference(name));
+			}
+		} else if(elements.size() > 1){
+			parserContext.getReaderContext().error(
+					"The <checkpoint-algorithm/> element may not appear more than once in a single <"
+							+ element.getNodeName() + "/>.", element);
+		}
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/DecisionParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/DecisionParser.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import java.util.Collection;
+
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+
+/**
+ * Parser for the &lt;decision /&gt; element as specified in JSR-352.  The current state
+ * parses a decision element and assumes that it refers to a {@link JobExecutionDecider}
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class DecisionParser {
+
+	private static final String ID_ATTRIBUTE = "id";
+	private static final String REF_ATTRIBUTE = "ref";
+
+	public Collection<BeanDefinition> parse(Element element, ParserContext parserContext) {
+
+		String refAttribute = element.getAttribute(REF_ATTRIBUTE);
+		String idAttribute = element.getAttribute(ID_ATTRIBUTE);
+
+		BeanDefinitionBuilder stateBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition("org.springframework.batch.core.job.flow.support.state.DecisionState");
+		stateBuilder.addConstructorArgValue(new RuntimeBeanReference(refAttribute));
+		stateBuilder.addConstructorArgValue(idAttribute);
+		return FlowParser.getNextElements(parserContext, stateBuilder.getBeanDefinition(), element);
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/FlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/FlowParser.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.batch.core.configuration.xml.AbstractFlowParser;
+import org.springframework.batch.core.configuration.xml.SimpleFlowFactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parses flows as defined in JSR-352.  The current state parses a flow
+ * as it is within a regular Spring Batch job/flow.
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class FlowParser extends AbstractFlowParser {
+
+	private static final String DECISION_ELEMENT = "decision";
+	private static final String SPLIT_ELEMENT = "split";
+	private static final String STEP_ELEMENT = "step";
+	private StepParser stepParser = new StepParser();
+	private String flowName;
+
+	public FlowParser(String flowName) {
+		this.flowName = flowName;
+	}
+
+	@Override
+	protected Class<?> getBeanClass(Element element) {
+		return SimpleFlowFactoryBean.class;
+	}
+
+	@Override
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		builder.getRawBeanDefinition().setAttribute("flowName", flowName);
+		builder.addPropertyValue("name", flowName);
+
+		List<BeanDefinition> stateTransitions = new ArrayList<BeanDefinition>();
+
+		Map<String, Set<String>> reachableElementMap = new HashMap<String, Set<String>>();
+		String startElement = null;
+		NodeList children = element.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node node = children.item(i);
+			if (node instanceof Element) {
+				String nodeName = node.getLocalName();
+				Element child = (Element) node;
+				if (nodeName.equals(STEP_ELEMENT)) {
+					stateTransitions.addAll(stepParser.parse(child, parserContext, builder));
+				} else if(nodeName.equals(SPLIT_ELEMENT)) {
+					stateTransitions.addAll(new SplitParser().parse(child, parserContext));
+				} else if(nodeName.equals(DECISION_ELEMENT)) {
+					stateTransitions.addAll(new DecisionParser().parse(child, parserContext));
+				}
+			}
+		}
+
+		Set<String> allReachableElements = new HashSet<String>();
+		findAllReachableElements(startElement, reachableElementMap, allReachableElements);
+		for (String elementId : reachableElementMap.keySet()) {
+			if (!allReachableElements.contains(elementId)) {
+				parserContext.getReaderContext().error("The element [" + elementId + "] is unreachable", element);
+			}
+		}
+
+		ManagedList managedList = new ManagedList();
+		managedList.addAll(stateTransitions);
+		builder.addPropertyValue("stateTransitions", managedList);
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/JobParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/JobParser.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import org.springframework.batch.core.configuration.xml.CoreNamespaceUtils;
+import org.springframework.batch.core.configuration.xml.JobParserJobFactoryBean;
+import org.springframework.batch.core.listener.JobListenerFactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * Parses a &lt;job /&gt; tag as defined in JSR-352.  Current state parses into
+ * the standard Spring Batch artifacts.
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class JobParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final String RESTARTABLE_ATTRIBUTE = "restartable";
+	private static final String ID_ATTRIBUTE = "id";
+
+	@Override
+	protected Class<JobParserJobFactoryBean> getBeanClass(Element element) {
+		return JobParserJobFactoryBean.class;
+	}
+
+	@Override
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		CoreNamespaceUtils.autoregisterBeansForNamespace(parserContext, parserContext.extractSource(element));
+
+		String jobName = element.getAttribute(ID_ATTRIBUTE);
+		builder.addConstructorArgValue(jobName);
+
+		String restartableAttribute = element.getAttribute(RESTARTABLE_ATTRIBUTE);
+		if (StringUtils.hasText(restartableAttribute)) {
+			builder.addPropertyValue("restartable", restartableAttribute);
+		}
+
+		BeanDefinition flowDef = new FlowParser(jobName).parse(element, parserContext);
+		builder.addPropertyValue("flow", flowDef);
+
+		new ListnerParser(JobListenerFactoryBean.class, "jobExecutionListeners").parseListeners(element, parserContext, builder);
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/JsrNamespaceHandler.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/JsrNamespaceHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class JsrNamespaceHandler extends NamespaceHandlerSupport {
+
+	@Override
+	public void init() {
+		this.registerBeanDefinitionParser("job", new JobParser());
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/ListnerParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/ListnerParser.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import java.util.List;
+
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.parsing.CompositeComponentDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+
+/**
+ * Parses the various listeners defined in JSR-352.  Current state assumes
+ * the ref attributes point to implementations of Spring Batch interfaces
+ * and not JSR interfaces
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class ListnerParser {
+
+	private static final String REF_ATTRIBUTE = "ref";
+	private static final String LISTENER_ELEMENT = "listener";
+	private static final String LISTENERS_ELEMENT = "listeners";
+	@SuppressWarnings("rawtypes")
+	private Class listenerType;
+	private String propertyKey;
+
+	@SuppressWarnings("rawtypes")
+	public ListnerParser(Class listenerType, String propertyKey) {
+		this.listenerType = listenerType;
+		this.propertyKey = propertyKey;
+	}
+
+	public void parseListeners(Element element, ParserContext parserContext, AbstractBeanDefinition bd) {
+		ManagedList<AbstractBeanDefinition> listeners = parseListeners(element, parserContext);
+
+		if(listeners.size() > 0) {
+			bd.getPropertyValues().add(propertyKey, listeners);
+		}
+	}
+
+	public void parseListeners(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		ManagedList<AbstractBeanDefinition> listeners = parseListeners(element, parserContext);
+
+		if(listeners.size() > 0) {
+			builder.addPropertyValue(propertyKey, listeners);
+		}
+	}
+
+	private ManagedList<AbstractBeanDefinition> parseListeners(Element element, ParserContext parserContext) {
+
+		List<Element> listenersElements = DomUtils.getChildElementsByTagName(element, LISTENERS_ELEMENT);
+
+		ManagedList<AbstractBeanDefinition> listeners = new ManagedList<AbstractBeanDefinition>();
+
+		if (listenersElements.size() == 1) {
+			Element listenersElement = listenersElements.get(0);
+			CompositeComponentDefinition compositeDef = new CompositeComponentDefinition(listenersElement.getTagName(),
+					parserContext.extractSource(element));
+			parserContext.pushContainingComponent(compositeDef);
+			listeners.setMergeEnabled(false);
+			List<Element> listenerElements = DomUtils.getChildElementsByTagName(listenersElement, LISTENER_ELEMENT);
+			for (Element listenerElement : listenerElements) {
+				BeanDefinitionBuilder bd = BeanDefinitionBuilder.genericBeanDefinition(listenerType);
+				bd.addPropertyValue("delegate", new RuntimeBeanReference(listenerElement.getAttribute(REF_ATTRIBUTE)));
+				listeners.add(bd.getBeanDefinition());
+			}
+			parserContext.popAndRegisterContainingComponent();
+		}
+		else if (listenersElements.size() > 1) {
+			parserContext.getReaderContext().error(
+					"The '<listeners/>' element may not appear more than once in a single <job/>.", element);
+		}
+
+		return listeners;
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/SplitParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/SplitParser.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+
+/**
+ * Parses a &lt;split /&gt; element as defined in JSR-352.
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class SplitParser {
+
+	public Collection<BeanDefinition> parse(Element element, ParserContext parserContext) {
+
+		String idAttribute = element.getAttribute("id");
+
+		BeanDefinitionBuilder stateBuilder = BeanDefinitionBuilder
+				.genericBeanDefinition("org.springframework.batch.core.job.flow.support.state.SplitState");
+
+		List<Element> flowElements = DomUtils.getChildElementsByTagName(element, "flow");
+
+		if (flowElements.size() < 2) {
+			parserContext.getReaderContext().error("A <split/> must contain at least two 'flow' elements.", element);
+		}
+
+		Collection<Object> flows = new ManagedList<Object>();
+		int i = 0;
+		String prefix = idAttribute;
+		for (Element nextElement : flowElements) {
+			FlowParser flowParser = new FlowParser(prefix + "." + i);
+			flows.add(flowParser.parse(nextElement, parserContext));
+			i++;
+		}
+
+		stateBuilder.addConstructorArgValue(flows);
+		stateBuilder.addConstructorArgValue(prefix);
+
+		return FlowParser.getNextElements(parserContext, null, stateBuilder.getBeanDefinition(), element);
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/StepParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/StepParser.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import java.util.Collection;
+
+import org.springframework.batch.core.configuration.xml.StepParserStepFactoryBean;
+import org.springframework.batch.core.job.flow.support.state.StepState;
+import org.springframework.batch.core.listener.StepListenerFactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parser for the &lt;step /&gt; element defined by JSR-352.  Current state parses it
+ * into existing Spring Batch artifacts.
+ * 
+ * @author Michael Minella
+ * @since 3.0
+ */
+public class StepParser extends AbstractSingleBeanDefinitionParser {
+
+	private static final String CHUNK_ELEMENT = "chunk";
+	private static final String BATCHLET_ELEMENT = "batchlet";
+	private static final String ALLOW_START_IF_COMPLETE_ATTRIBUTE = "allow-start-if-complete";
+	private static final String START_LIMIT_ATTRIBUTE = "start-limit";
+	private static final String SPLIT_ID_ATTRIBUTE = "id";
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	protected Class<StepParserStepFactoryBean> getBeanClass(Element element) {
+		return StepParserStepFactoryBean.class;
+	}
+
+	protected Collection<BeanDefinition>  parse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		BeanDefinitionBuilder defBuilder = BeanDefinitionBuilder.genericBeanDefinition();
+		AbstractBeanDefinition bd = defBuilder.getRawBeanDefinition();
+
+		BeanDefinitionBuilder stateBuilder = BeanDefinitionBuilder.genericBeanDefinition(StepState.class);
+
+		String stepName = element.getAttribute(SPLIT_ID_ATTRIBUTE);
+		builder.addPropertyValue("name", stepName);
+		parserContext.registerBeanComponent(new BeanComponentDefinition(bd, stepName));
+		stateBuilder.addConstructorArgReference(stepName);
+
+		String startLimit = element.getAttribute(START_LIMIT_ATTRIBUTE);
+		if(StringUtils.hasText(startLimit)) {
+			builder.addPropertyValue("startLimit", startLimit);
+		}
+
+		String allowStartIfComplete = element.getAttribute(ALLOW_START_IF_COMPLETE_ATTRIBUTE);
+		if(StringUtils.hasText(allowStartIfComplete)) {
+			builder.addPropertyValue("allowStartIfComplete", allowStartIfComplete);
+		}
+
+		new ListnerParser(StepListenerFactoryBean.class, "listeners").parseListeners(element, parserContext, bd);
+
+		// look at all nested elements
+		NodeList children = element.getChildNodes();
+
+		for (int i = 0; i < children.getLength(); i++) {
+			Node nd = children.item(i);
+
+			if (nd instanceof Element) {
+				Element nestedElement = (Element) nd;
+				String name = nestedElement.getLocalName();
+
+				if(name.equalsIgnoreCase(BATCHLET_ELEMENT)) {
+					new BatchletParser().parseBatchlet(element, nestedElement, bd, parserContext);
+				} else if(name.equals(CHUNK_ELEMENT)) {
+					new ChunkParser().parse(nestedElement, bd, parserContext);
+				}
+			}
+		}
+
+		return FlowParser.getNextElements(parserContext, stepName, stateBuilder.getBeanDefinition(), element);
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -429,10 +429,8 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 	 * Register explicitly set item listeners and auto-register reader, processor and writer if applicable
 	 */
 	private void registerSkipListeners() {
-
 		// auto-register reader, processor and writer
 		for (Object itemHandler : new Object[] { getReader(), getWriter(), getProcessor() }) {
-
 			if (StepListenerFactoryBean.isListener(itemHandler)) {
 				StepListener listener = StepListenerFactoryBean.getListener(itemHandler);
 				if (listener instanceof SkipListener<?, ?>) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProvider.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProvider.java
@@ -16,8 +16,6 @@
 
 package org.springframework.batch.core.step.item;
 
-import org.springframework.classify.BinaryExceptionClassifier;
-import org.springframework.classify.Classifier;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.step.skip.LimitCheckingItemSkipPolicy;
 import org.springframework.batch.core.step.skip.NonSkippableReadException;
@@ -27,6 +25,8 @@ import org.springframework.batch.core.step.skip.SkipPolicy;
 import org.springframework.batch.core.step.skip.SkipPolicyFailedException;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.repeat.RepeatOperations;
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.classify.Classifier;
 
 /**
  * FaultTolerant implementation of the {@link ChunkProcessor} interface, that
@@ -53,7 +53,7 @@ public class FaultTolerantChunkProvider<I> extends SimpleChunkProvider<I> {
 	public FaultTolerantChunkProvider(ItemReader<? extends I> itemReader, RepeatOperations repeatOperations) {
 		super(itemReader, repeatOperations);
 	}
-	
+
 	/**
 	 * @param maxSkipsOnRead the maximum number of skips on read
 	 */
@@ -89,6 +89,7 @@ public class FaultTolerantChunkProvider<I> extends SimpleChunkProvider<I> {
 			catch (Exception e) {
 
 				if (shouldSkip(skipPolicy, e, contribution.getStepSkipCount())) {
+
 					// increment skip count and try again
 					contribution.incrementReadSkipCount();
 					chunk.skip(e);

--- a/spring-batch-core/src/main/resources/META-INF/spring.handlers
+++ b/spring-batch-core/src/main/resources/META-INF/spring.handlers
@@ -1,1 +1,2 @@
 http\://www.springframework.org/schema/batch=org.springframework.batch.core.configuration.xml.CoreNamespaceHandler
+http\://xmlns.jcp.org/xml/ns/javaee=org.springframework.batch.core.jsr.configuration.xml.JsrNamespaceHandler

--- a/spring-batch-core/src/main/resources/META-INF/spring.schemas
+++ b/spring-batch-core/src/main/resources/META-INF/spring.schemas
@@ -2,3 +2,4 @@ http\://www.springframework.org/schema/batch/spring-batch.xsd=/org/springframewo
 http\://www.springframework.org/schema/batch/spring-batch-2.2.xsd=/org/springframework/batch/core/configuration/xml/spring-batch-2.2.xsd
 http\://www.springframework.org/schema/batch/spring-batch-2.1.xsd=/org/springframework/batch/core/configuration/xml/spring-batch-2.1.xsd
 http\://www.springframework.org/schema/batch/spring-batch-2.0.xsd=/org/springframework/batch/core/configuration/xml/spring-batch-2.0.xsd
+http\://xmlns.jcp.org/xml/ns/javaee=/org/springframework/batch/core/jsr/configuration/xml/jobXML_1_0.xsd

--- a/spring-batch-core/src/main/resources/org/springframework/batch/core/jsr/configuration/xml/jobXML_1_0.xsd
+++ b/spring-batch-core/src/main/resources/org/springframework/batch/core/jsr/configuration/xml/jobXML_1_0.xsd
@@ -1,0 +1,435 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2012,2013 International Business Machines Corp. See the NOTICE 
+	file distributed with this work for additional information regarding copyright 
+	ownership. Licensed under the Apache License, Version 2.0 (the "License"); 
+	you may not use this file except in compliance with the License. You may 
+	obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+	Unless required by applicable law or agreed to in writing, software distributed 
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+	the specific language governing permissions and limitations under the License. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified" targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:jsl="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+
+	<xs:annotation>
+		<xs:documentation>
+			Job Specification Language (JSL) specifies a job,
+			its steps, and directs their execution.
+			JSL also can be referred to as "Job XML".
+		</xs:documentation>
+	</xs:annotation>
+
+	<xs:simpleType name="artifactRef">
+		<xs:annotation>
+			<xs:documentation>
+				This is a helper type. Though it is not otherwise
+				called out by this name
+				in the specification, it captures the fact
+				that the xs:string value refers
+				to a batch artifact, across numerous
+				other JSL type definitions.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
+	<xs:complexType name="Job">
+		<xs:annotation>
+			<xs:documentation>
+				The type of a job definition, whether concrete or
+				abstract. This is the type of the root element of any JSL document.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						The job-level properties, which are accessible
+						via the JobContext.getProperties() API in a batch artifact.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="listeners" type="jsl:Listeners"
+				minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Note that "listeners" sequence order in XML does
+						not imply order of execution by
+						the batch runtime, per the
+						specification.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="decision" type="jsl:Decision" />
+				<xs:element name="flow" type="jsl:Flow" />
+				<xs:element name="split" type="jsl:Split" />
+				<xs:element name="step" type="jsl:Step" />
+			</xs:choice>
+		</xs:sequence>
+        <xs:attribute name="version" use="required" type="xs:string" fixed="1.0" />
+		<xs:attribute name="id" use="required" type="xs:ID" />
+		<xs:attribute name="restartable" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:element name="job" type="jsl:Job">
+		<xs:annotation>
+			<xs:documentation>
+				The definition of an job, whether concrete or
+				abstract. This is the
+				type of the root element of any JSL document.
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+	<xs:complexType name="Listener">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="Split">
+		<xs:sequence>
+			<xs:element name="flow" type="jsl:Flow" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="id" use="required" type="xs:ID" />
+		<xs:attribute name="next" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:complexType name="Flow">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="decision" type="jsl:Decision" />
+				<xs:element name="flow" type="jsl:Flow" />
+				<xs:element name="split" type="jsl:Split" />
+				<xs:element name="step" type="jsl:Step" />
+			</xs:choice>
+			<xs:group ref="jsl:TransitionElements" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="id" use="required" type="xs:ID" />
+		<xs:attribute name="next" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:group name="TransitionElements">
+		<xs:annotation>
+			<xs:documentation>
+				This grouping provides allows for the reuse of the
+				'end', 'fail', 'next', 'stop' element sequences which
+				may appear at the end of a 'step', 'flow', 'split' or 'decision'.
+				The term 'TransitionElements' does not formally appear in the spec, it is
+				a schema convenience.			
+			</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="end" type="jsl:End" />
+			<xs:element name="fail" type="jsl:Fail" />
+			<xs:element name="next" type="jsl:Next" />
+			<xs:element name="stop" type="jsl:Stop" />
+		</xs:choice>
+	</xs:group>
+
+	<xs:complexType name="Decision">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+			<xs:group ref="jsl:TransitionElements" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="id" use="required" type="xs:ID" />
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:attributeGroup name="TerminatingAttributes">
+		<xs:attribute name="on" use="required" type="xs:string" />
+		<xs:attribute name="exit-status" use="optional" type="xs:string" />
+	</xs:attributeGroup>
+
+	<xs:complexType name="Fail">
+		<xs:attributeGroup ref="jsl:TerminatingAttributes" />
+	</xs:complexType>
+
+	<xs:complexType name="End">
+		<xs:attributeGroup ref="jsl:TerminatingAttributes" />
+	</xs:complexType>
+
+	<xs:complexType name="Stop">
+		<xs:attributeGroup ref="jsl:TerminatingAttributes" />
+		<xs:attribute name="restart" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:complexType name="Next">
+		<xs:attribute name="on" use="required" type="xs:string" />
+		<xs:attribute name="to" use="required" type="xs:string" />
+	</xs:complexType>
+
+	<xs:complexType name="CheckpointAlgorithm">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="ExceptionClassFilter">
+		<xs:sequence>
+			<xs:element name="include" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence />
+					<xs:attribute name="class" use="required" type="xs:string" />
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="exclude" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence />
+					<xs:attribute name="class" use="required" type="xs:string" />
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Step">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+			<xs:element name="listeners" type="jsl:Listeners"
+				minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Note that "listeners" sequence order in XML does
+						not imply order of execution by
+						the batch runtime, per the
+						specification.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0" maxOccurs="1"> 
+				<xs:element name="batchlet" type="jsl:Batchlet" />
+				<xs:element name="chunk" type="jsl:Chunk" />
+			</xs:choice>
+			<xs:element name="partition" type="jsl:Partition"
+				minOccurs="0" maxOccurs="1" />
+			<xs:group ref="jsl:TransitionElements" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="id" use="required" type="xs:ID" />
+		<xs:attribute name="start-limit" use="optional" type="xs:string" />
+		<xs:attribute name="allow-start-if-complete" use="optional"
+			type="xs:string" />
+		<xs:attribute name="next" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:complexType name="Batchlet">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="Chunk">
+		<xs:sequence>
+			<xs:element name="reader" type="jsl:ItemReader" />
+			<xs:element name="processor" type="jsl:ItemProcessor"
+				minOccurs="0" maxOccurs="1" />
+			<xs:element name="writer" type="jsl:ItemWriter" />
+			<xs:element name="checkpoint-algorithm" type="jsl:CheckpointAlgorithm"
+				minOccurs="0" maxOccurs="1" />
+			<xs:element name="skippable-exception-classes" type="jsl:ExceptionClassFilter"
+				minOccurs="0" maxOccurs="1" />
+			<xs:element name="retryable-exception-classes" type="jsl:ExceptionClassFilter"
+				minOccurs="0" maxOccurs="1" />
+			<xs:element name="no-rollback-exception-classes" type="jsl:ExceptionClassFilter"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="checkpoint-policy" use="optional"
+			type="xs:string">
+			<xs:annotation>
+				<xs:documentation>
+					Specifies the checkpoint policy that governs
+					commit behavior for this chunk.
+					Valid values are: "item" or
+					"custom". The "item" policy means the
+					chunk is checkpointed after a
+					specified number of items are
+					processed. The "custom" policy means
+					the chunk is checkpointed
+					according to a checkpoint algorithm
+					implementation. Specifying
+					"custom" requires that the
+					checkpoint-algorithm element is also
+					specified. It is an optional
+					attribute. The default policy is
+					"item". However, we chose not to define
+					a schema-specified default for this attribute.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="item-count" use="optional" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>
+					Specifies the number of items to process per chunk
+					when using the item
+					checkpoint policy. It must be valid XML integer.
+					It is an optional
+					attribute. The default is 10. The item-count
+					attribute is ignored
+					for "custom" checkpoint policy. However, to
+					make it easier for implementations to support JSL inheritance
+					we
+					abstain from defining a schema-specified default for this
+					attribute.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time-limit" use="optional" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>
+					Specifies the amount of time in seconds before
+					taking a checkpoint for the
+					item checkpoint policy. It must be valid
+					XML integer. It is an
+					optional attribute. The default is 0, which
+					means no limit. However, to
+					make it easier for implementations to
+					support JSL inheritance
+					we abstain from defining a schema-specified
+					default for this attribute.
+					When a value greater than zero is
+					specified, a checkpoint is taken when
+					time-limit is reached or
+					item-count items have been processed,
+					whichever comes first. The
+					time-limit attribute is ignored for
+					"custom" checkpoint policy.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="skip-limit" use="optional" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>
+					Specifies the number of exceptions a step will
+					skip if any configured
+					skippable exceptions are thrown by chunk
+					processing. It must be a
+					valid XML integer value. It is an optional
+					attribute. The default
+					is no limit.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="retry-limit" use="optional" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>
+					Specifies the number of times a step will retry if
+					any configured retryable
+					exceptions are thrown by chunk processing.
+					It must be a valid XML
+					integer value. It is an optional attribute.
+					The default is no
+					limit.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+
+	<xs:complexType name="ItemReader">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="ItemProcessor">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="ItemWriter">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="Property">
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="value" type="xs:string" use="required" />
+	</xs:complexType>
+
+	<xs:complexType name="Properties">
+		<xs:sequence>
+			<xs:element name="property" type="jsl:Property" maxOccurs="unbounded" minOccurs="0" />
+		</xs:sequence>
+		<xs:attribute name="partition" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:complexType name="Listeners">
+		<xs:sequence>
+			<xs:element name="listener" type="jsl:Listener" maxOccurs="unbounded" minOccurs="0" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Partition">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="1"> 
+				<xs:element name="mapper" type="jsl:PartitionMapper" />
+				<xs:element name="plan" type="jsl:PartitionPlan" />
+			</xs:choice>
+			<xs:element name="collector" type="jsl:Collector"
+				minOccurs="0" maxOccurs="1" />
+			<xs:element name="analyzer" type="jsl:Analyzer" minOccurs="0"
+				maxOccurs="1" />
+			<xs:element name="reducer" type="jsl:PartitionReducer"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="PartitionPlan">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+		<xs:attribute name="partitions" use="optional" type="xs:string" />
+		<xs:attribute name="threads" use="optional" type="xs:string" />
+	</xs:complexType>
+
+	<xs:complexType name="PartitionMapper">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="Collector">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="Analyzer">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+	<xs:complexType name="PartitionReducer">
+		<xs:sequence>
+			<xs:element name="properties" type="jsl:Properties"
+				minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+		<xs:attribute name="ref" use="required" type="jsl:artifactRef" />
+	</xs:complexType>
+
+</xs:schema>

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/InlineItemHandlerParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/InlineItemHandlerParserTests.java
@@ -92,7 +92,6 @@ public class InlineItemHandlerParserTests {
 		Map<String,ItemReader> readers = context.getBeansOfType(ItemReader.class);
 		// Should be 2 each (proxy and target) for the two readers in the steps defined
 		assertEquals(4, readers.size());
-		// System.err.println(readers);
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/DecisionParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/DecisionParsingTests.java
@@ -1,0 +1,44 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.job.flow.FlowExecutionStatus;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"DecisionParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DecisionParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Test
+	public void test() throws Exception {
+		JobExecution execution = jobLauncher.run(job, new JobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(2, execution.getStepExecutions().size());
+	}
+
+	public static class TestDecider implements JobExecutionDecider {
+
+		@Override
+		public FlowExecutionStatus decide(JobExecution jobExecution,
+				StepExecution stepExecution) {
+			return new FlowExecutionStatus("step2");
+		}
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/ExceptionHandlingParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/ExceptionHandlingParsingTests.java
@@ -1,0 +1,93 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"ExceptionHandlingParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ExceptionHandlingParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Test
+	public void testSkippable() throws Exception {
+		JobExecution execution1 = jobLauncher.run(job, new JobParametersBuilder().addLong("run", 1l).toJobParameters());
+		assertEquals(BatchStatus.FAILED, execution1.getStatus());
+		assertEquals(1, execution1.getStepExecutions().size());
+		assertEquals(1, execution1.getStepExecutions().iterator().next().getSkipCount());
+		assertTrue(execution1.getAllFailureExceptions().get(0).getMessage().contains("But don't skip me"));
+
+		JobExecution execution2 = jobLauncher.run(job, new JobParametersBuilder().addLong("run", 2l).toJobParameters());
+		assertEquals(BatchStatus.FAILED, execution2.getStatus());
+		assertEquals(2, execution2.getStepExecutions().size());
+		assertTrue(execution2.getAllFailureExceptions().get(0).getMessage().contains("But don't retry me"));
+
+		JobExecution execution3 = jobLauncher.run(job, new JobParametersBuilder().addLong("run", 3l).toJobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution3.getStatus());
+		assertEquals(3, execution3.getStepExecutions().size());
+
+		List<StepExecution> stepExecutions = new ArrayList<StepExecution>(execution3.getStepExecutions());
+		assertEquals(0, stepExecutions.get(2).getRollbackCount());
+
+		JobExecution execution4 = jobLauncher.run(job, new JobParametersBuilder().addLong("run", 4l).toJobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution4.getStatus());
+		assertEquals(3, execution4.getStepExecutions().size());
+	}
+
+	public static class ProblemProcessor implements ItemProcessor<String, String> {
+
+		private long runId = 0;
+		private boolean hasRetried = false;
+
+		public void setRunId(long id) {
+			this.runId = id;
+		}
+
+		@Override
+		public String process(String item) throws Exception {
+			throwException(item);
+			return item;
+		}
+
+		private void throwException(String item) throws Exception {
+			if(runId == 1) {
+				if(item.equals("One")) {
+					throw new Exception("skip me");
+				} else if(item.equals("Two")){
+					throw new RuntimeException("But don't skip me");
+				}
+			} else if(runId == 2) {
+				if(item.equals("Three") && !hasRetried) {
+					hasRetried = true;
+					throw new Exception("retry me");
+				} else if(item.equals("Four")){
+					throw new RuntimeException("But don't retry me");
+				}
+			} else if(runId == 3) {
+				if(item.equals("Five")) {
+					throw new Exception("Don't rollback on my account");
+				}
+			}
+		}
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/ItemSkipParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/ItemSkipParsingTests.java
@@ -1,0 +1,178 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.SkipListener;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"ItemSkipParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ItemSkipParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Autowired
+	public TestSkipListener skipListener;
+
+	@Test
+	public void test() throws Exception {
+		// Read skip and fail
+		JobExecution execution = jobLauncher.run(job, new JobParametersBuilder().toJobParameters());
+
+		assertEquals(BatchStatus.FAILED, execution.getStatus());
+		assertEquals(1, execution.getStepExecutions().iterator().next().getSkipCount());
+		assertEquals(1, skipListener.readSkips);
+		assertEquals(0, skipListener.processSkips);
+		assertEquals(0, skipListener.writeSkips);
+		assertEquals("read fail because of me", execution.getAllFailureExceptions().get(0).getCause().getMessage());
+
+		skipListener.resetCounts();
+
+		// Process skip and fail
+		execution = jobLauncher.run(job, new JobParametersBuilder().toJobParameters());
+
+		assertEquals(BatchStatus.FAILED, execution.getStatus());
+		assertEquals(1, execution.getStepExecutions().iterator().next().getSkipCount());
+		assertEquals(0, skipListener.readSkips);
+		assertEquals(1, skipListener.processSkips);
+		assertEquals(0, skipListener.writeSkips);
+		assertEquals("process fail because of me", execution.getAllFailureExceptions().get(0).getCause().getMessage());
+
+		skipListener.resetCounts();
+
+		// Write skip and fail
+		execution = jobLauncher.run(job, new JobParametersBuilder().toJobParameters());
+
+		assertEquals(BatchStatus.FAILED, execution.getStatus());
+		assertEquals(1, execution.getStepExecutions().iterator().next().getSkipCount());
+		assertEquals(0, skipListener.readSkips);
+		assertEquals(0, skipListener.processSkips);
+		assertEquals(1, skipListener.writeSkips);
+		assertEquals("write fail because of me", execution.getAllFailureExceptions().get(0).getCause().getMessage());
+
+		skipListener.resetCounts();
+
+		// Complete
+		execution = jobLauncher.run(job, new JobParametersBuilder().toJobParameters());
+
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(0, execution.getStepExecutions().iterator().next().getSkipCount());
+		assertEquals(0, skipListener.readSkips);
+		assertEquals(0, skipListener.processSkips);
+		assertEquals(0, skipListener.writeSkips);
+	}
+
+	public static class SkipErrorGeneratingReader implements ItemReader<String> {
+		private int count = 0;
+
+		@Override
+		public String read() throws Exception, UnexpectedInputException,
+		ParseException, NonTransientResourceException {
+			count++;
+
+			if(count == 1) {
+				throw new Exception("read skip me");
+			} else if (count == 2) {
+				return "item" + count;
+			} else if(count == 3) {
+				throw new RuntimeException("read fail because of me");
+			} else if(count < 15) {
+				return "item" + count;
+			} else {
+				return null;
+			}
+		}
+	}
+
+	public static class SkipErrorGeneratingProcessor implements ItemProcessor<String, String> {
+		private int count = 0;
+
+		@Override
+		public String process(String item) throws Exception {
+			count++;
+
+			if(count == 4) {
+				throw new Exception("process skip me");
+			} else if(count == 5) {
+				return item;
+			} else if(count == 6) {
+				throw new RuntimeException("process fail because of me");
+			} else {
+				return item;
+			}
+		}
+	}
+
+	public static class SkipErrorGeneratingWriter implements ItemWriter<String> {
+		private int count = 0;
+		protected List<String> writtenItems = new ArrayList<String>();
+		private List<String> skippedItems = new ArrayList<String>();
+
+		@Override
+		public void write(List<? extends String> items) throws Exception {
+			if(items.size() > 0 && !skippedItems.contains(items.get(0))) {
+				count++;
+			}
+
+			if(count == 7) {
+				skippedItems.addAll(items);
+				throw new Exception("write skip me");
+			} else if(count == 9) {
+				skippedItems = new ArrayList<String>();
+				throw new RuntimeException("write fail because of me");
+			} else {
+				writtenItems.addAll(items);
+			}
+		}
+	}
+
+	public static class TestSkipListener implements SkipListener<String, String> {
+
+		protected int readSkips = 0;
+		protected int processSkips = 0;
+		protected int writeSkips = 0;
+
+		@Override
+		public void onSkipInRead(Throwable t) {
+			readSkips++;
+		}
+
+		@Override
+		public void onSkipInWrite(String item, Throwable t) {
+			writeSkips++;
+		}
+
+		@Override
+		public void onSkipInProcess(String item, Throwable t) {
+			processSkips++;
+		}
+
+		public void resetCounts() {
+			readSkips = 0;
+			processSkips = 0;
+			writeSkips = 0;
+		}
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JobListenerParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JobListenerParsingTests.java
@@ -1,0 +1,58 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"JobListenerParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class JobListenerParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Autowired
+	public JobListener listener;
+
+	@Test
+	public void test() throws Exception {
+		assertNotNull(job);
+		assertEquals("job1", job.getName());
+
+		JobExecution execution = jobLauncher.run(job, new JobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(2, execution.getStepExecutions().size());
+		assertEquals(1, listener.countAfterJob);
+		assertEquals(1, listener.countBeforeJob);
+	}
+
+	public static class JobListener implements JobExecutionListener {
+
+		protected int countBeforeJob = 0;
+		protected int countAfterJob = 0;
+
+		@Override
+		public void beforeJob(JobExecution jobExecution) {
+			countBeforeJob++;
+		}
+
+		@Override
+		public void afterJob(JobExecution jobExecution) {
+			countAfterJob++;
+		}
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/SimpleItemBasedJobParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/SimpleItemBasedJobParsingTests.java
@@ -1,0 +1,90 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.repeat.CompletionPolicy;
+import org.springframework.batch.repeat.RepeatContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"SimpleItemBasedJobParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class SimpleItemBasedJobParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public Step step1;
+
+	@Autowired
+	public CountingItemProcessor processor;
+
+	@Autowired
+	public CountingCompletionPolicy policy;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Test
+	public void test() throws Exception {
+		assertNotNull(job);
+		assertEquals("job1", job.getName());
+		assertNotNull(step1);
+		assertEquals("step1", step1.getName());
+
+		JobExecution execution = jobLauncher.run(job, new JobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(3, execution.getStepExecutions().size());
+		assertEquals(2, processor.count);
+		assertEquals(3, policy.counter);
+	}
+
+	public static class CountingItemProcessor implements ItemProcessor<String, String>{
+		protected int count = 0;
+
+		@Override
+		public String process(String item) throws Exception {
+			count++;
+			return item;
+		}
+	}
+
+	public static class CountingCompletionPolicy implements CompletionPolicy {
+
+		protected int counter;
+
+		@Override
+		public boolean isComplete(RepeatContext context, RepeatStatus result) {
+			return counter == 3;
+		}
+
+		@Override
+		public boolean isComplete(RepeatContext context) {
+			return counter == 3;
+		}
+
+		@Override
+		public RepeatContext start(RepeatContext parent) {
+			counter = 0;
+			return parent;
+		}
+
+		@Override
+		public void update(RepeatContext context) {
+			counter++;
+		}
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/SimpleJobParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/SimpleJobParsingTests.java
@@ -1,0 +1,56 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"SimpleJobParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class SimpleJobParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	@Qualifier("step1")
+	public Step step1;
+
+	@Autowired
+	@Qualifier("step2")
+	public Step step2;
+
+	@Autowired
+	@Qualifier("step3")
+	public Step step3;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Test
+	public void test() throws Exception {
+		assertNotNull(job);
+		assertEquals("job1", job.getName());
+		assertNotNull(step1);
+		assertEquals("step1", step1.getName());
+		assertNotNull(step2);
+		assertEquals("step2", step2.getName());
+		assertNotNull(step3);
+		assertEquals("step3", step3.getName());
+
+		JobExecution execution = jobLauncher.run(job, new JobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(3, execution.getStepExecutions().size());
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/SplitParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/SplitParsingTests.java
@@ -1,0 +1,53 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"SplitParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class SplitParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void test() throws Exception {
+		JobExecution execution = jobLauncher.run(job, new JobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(5, execution.getStepExecutions().size());
+	}
+
+	@Test
+	public void testOneFlowInSplit() {
+		try {
+			new ClassPathXmlApplicationContext("/org/springframework/batch/core/jsr/configuration/xml/invalid-split-context.xml");
+		} catch (BeanDefinitionParsingException bdpe) {
+			assertTrue(bdpe.getMessage().indexOf("A <split/> must contain at least two 'flow' elements.") >= 0);
+			return;
+		}
+
+		fail("Expected exception was not thrown");
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/StepListenerParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/StepListenerParsingTests.java
@@ -1,0 +1,56 @@
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration({"StepListenerParsingTests-context.xml", "jsr-base-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class StepListenerParsingTests {
+
+	@Autowired
+	public Job job;
+
+	@Autowired
+	public JobLauncher jobLauncher;
+
+	@Autowired
+	public StepListener stepListener;
+
+	@Test
+	public void test() throws Exception {
+		JobExecution execution = jobLauncher.run(job, new JobParameters());
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(2, execution.getStepExecutions().size());
+		assertEquals(2, stepListener.countBeforeStep);
+		assertEquals(2, stepListener.countAfterStep);
+	}
+
+	public static class StepListener implements StepExecutionListener {
+		protected int countBeforeStep = 0;
+		protected int countAfterStep = 0;
+
+		@Override
+		public void beforeStep(StepExecution stepExecution) {
+			countBeforeStep++;
+		}
+
+		@Override
+		public ExitStatus afterStep(StepExecution stepExecution) {
+			countAfterStep++;
+			return null;
+		}
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletSupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletSupport.java
@@ -1,0 +1,15 @@
+package org.springframework.batch.core.step.tasklet;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+public class TaskletSupport implements Tasklet {
+
+	@Override
+	public RepeatStatus execute(StepContribution contribution,
+			ChunkContext chunkContext) throws Exception {
+		System.out.println("The tasklet was executed");
+		return RepeatStatus.FINISHED;
+	}
+}

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/DecisionParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/DecisionParsingTests-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="decider">
+		<batchlet ref="step1Ref" />
+	</step>
+	<decision ref="testDecider" id="decider">
+		<next on="step2" to="step2"/>
+		<end on="*"/>
+	</decision>
+	<step id="step2">
+		<batchlet ref="step1Ref" />
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/ExceptionHandlingParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/ExceptionHandlingParsingTests-context.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="step2">
+		<chunk item-count="5" skip-limit="2">
+			<reader ref="generatingItemReader1"/>
+			<processor ref="problemProcessor"/>
+			<writer ref="sysoutItemWriter"/>
+			<skippable-exception-classes>
+				<include class="java.lang.Exception"/>
+				<exclude class="java.lang.RuntimeException"/>
+			</skippable-exception-classes>
+		</chunk>
+	</step>
+ 	<step id="step2" next="step3">
+		<chunk item-count="5" retry-limit="2">
+			<reader ref="generatingItemReader2"/>
+			<processor ref="problemProcessor"/>
+			<writer ref="sysoutItemWriter"/>
+			<retryable-exception-classes>
+				<include class="java.lang.Exception"/>
+				<exclude class="java.lang.RuntimeException"/>
+			</retryable-exception-classes>
+		</chunk>
+	</step>
+	<step id="step3">
+		<chunk item-count="5">
+			<reader ref="generatingItemReader3"/>
+			<processor ref="problemProcessor"/>
+			<writer ref="sysoutItemWriter"/>
+			<no-rollback-exception-classes>
+				<include class="java.lang.Exception"/>
+			</no-rollback-exception-classes>
+		</chunk>
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/ItemSkipParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/ItemSkipParsingTests-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1">
+		<listeners>
+			<listener ref="skipListener"/>
+		</listeners>
+		<chunk checkpoint-policy="item" item-count="1" skip-limit="4">
+			<reader ref="skipErrorGeneratingReader"/>
+			<processor ref="skipErrorGeneratingProcessor"/>
+			<writer ref="skipErrorGeneratingWriter"/>
+			<skippable-exception-classes>
+				<include class="java.lang.Exception"/>
+				<exclude class="java.lang.RuntimeException"/>
+			</skippable-exception-classes>
+		</chunk>
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/JobListenerParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/JobListenerParsingTests-context.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<listeners>
+		<listener ref="jobListener"/>
+	</listeners>
+	<step id="step1" next="step2">
+		<batchlet ref="step1Ref" />
+	</step>
+	<step id="step2">
+		<batchlet ref="step1Ref" />
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/SimpleItemBasedJobParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/SimpleItemBasedJobParsingTests-context.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="step2">
+		<chunk checkpoint-policy="item" item-count="3">
+			<reader ref="generatingItemReader1"/>
+			<processor ref="countingItemProcessor"/>
+			<writer ref="sysoutItemWriter"/>
+		</chunk>
+	</step>
+	<step id="step2" next="step3">
+		<chunk checkpoint-policy="custom">
+			<reader ref="generatingItemReader1"/>
+			<processor ref="countingItemProcessor"/>
+			<writer ref="sysoutItemWriter"/>
+			<checkpoint-algorithm ref="testCompletionPolicy"/>
+		</chunk>
+	</step>
+	<step id="step3">
+		<chunk checkpoint-policy="item" item-count="3" time-limit="1">
+			<reader ref="generatingItemReader1"/>
+			<processor ref="countingItemProcessor"/>
+			<writer ref="sysoutItemWriter"/>
+			<checkpoint-algorithm ref="testCompletionPolicy"/>
+		</chunk>
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/SimpleJobParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/SimpleJobParsingTests-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="step2">
+		<batchlet ref="step1Ref" />
+	</step>
+	<step id="step2">
+		<batchlet ref="step1Ref" />
+		<next on="*" to="step3"/>
+	</step>
+	<step id="step3">
+		<batchlet ref="step1Ref" />
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/SplitParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/SplitParsingTests-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="step2">
+		<batchlet ref="step1Ref" />
+	</step>
+	<split id="step2" next="step3">
+		<flow id="step2a">
+			<step id="step2aStep1">
+				<batchlet ref="step1Ref" />
+			</step>
+		</flow>
+		<flow id="step2b">
+			<step id="step2bStep1" next="step2bStep2">
+				<batchlet ref="step1Ref" />
+			</step>
+			<step id="step2bStep2">
+				<chunk checkpoint-policy="item" item-count="3">
+					<reader ref="generatingItemReader1"/>
+					<processor ref="countingItemProcessor"/>
+					<writer ref="sysoutItemWriter"/>
+				</chunk>
+			</step>
+		</flow>
+	</split>
+	<step id="step3">
+		<batchlet ref="step1Ref" />
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/StepListenerParsingTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/StepListenerParsingTests-context.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="step2">
+		<listeners>
+			<listener ref="stepListener"/>
+		</listeners>
+		<batchlet ref="step1Ref" />
+	</step>
+	<step id="step2">
+		<listeners>
+			<listener ref="stepListener"/>
+		</listeners>
+		<batchlet ref="step1Ref" />
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/invalid-split-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/invalid-split-context.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" 
+	version="1.0">
+	<step id="step1" next="step2">
+		<batchlet ref="step1Ref" />
+	</step>
+	<split id="step2" next="step3">
+		<flow id="step2a">
+			<step id="step2aStep1">
+				<batchlet ref="step1Ref" />
+			</step>
+		</flow>
+	</split>
+	<step id="step3">
+		<batchlet ref="step1Ref" />
+	</step>
+</job>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/jsr-base-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/jsr-base-context.xml
@@ -1,0 +1,74 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+                    http://www.springframework.org/schema/beans/spring-beans.xsd
+   					http://www.springframework.org/schema/util
+					http://www.springframework.org/schema/util/spring-util.xsd">
+	                
+	<bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>
+	
+	<bean id="jobLauncher" class="org.springframework.batch.core.launch.support.SimpleJobLauncher">
+		<property name="jobRepository" ref="jobRepository"/>
+	</bean>
+	
+	<bean id="jobRepository" class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean"/>
+	
+	<bean id="step1Ref" class="org.springframework.batch.core.step.tasklet.TaskletSupport"/>
+	
+	<bean id="generatingItemReader1" class="org.springframework.batch.item.support.ListItemReader">
+		<constructor-arg>
+			<list>
+				<value>One</value>
+				<value>Two</value>
+			</list>
+		</constructor-arg>
+	</bean>
+	
+	<bean id="generatingItemReader2" class="org.springframework.batch.item.support.ListItemReader">
+		<constructor-arg>
+			<list>
+				<value>Three</value>
+				<value>Four</value>
+			</list>
+		</constructor-arg>
+	</bean>
+	
+	<bean id="generatingItemReader3" class="org.springframework.batch.item.support.ListItemReader">
+		<constructor-arg>
+			<list>
+				<value>Five</value>
+				<value>Six</value>
+			</list>
+		</constructor-arg>
+	</bean>
+	
+	<bean id="countingItemProcessor" class="org.springframework.batch.core.jsr.configuration.xml.SimpleItemBasedJobParsingTests.CountingItemProcessor"/>
+	
+	<bean id="sysoutItemWriter" class="org.springframework.batch.item.adapter.ItemWriterAdapter">
+		<property name="targetObject">
+			<util:constant static-field="java.lang.System.out"/>
+		</property>
+		<property name="targetMethod" value="println"/>
+	</bean>
+	
+	<bean id="jobListener" class="org.springframework.batch.core.jsr.configuration.xml.JobListenerParsingTests.JobListener"/>
+	
+	<bean id="stepListener" class="org.springframework.batch.core.jsr.configuration.xml.StepListenerParsingTests.StepListener"/>
+	
+	<bean id="problemProcessor" class="org.springframework.batch.core.jsr.configuration.xml.ExceptionHandlingParsingTests.ProblemProcessor" scope="step">
+		<property name="runId" value="#{jobParameters[run]}"/>
+	</bean>
+	
+	<bean id="testDecider" class="org.springframework.batch.core.jsr.configuration.xml.DecisionParsingTests.TestDecider"/>
+	
+	<bean id="testCompletionPolicy" class="org.springframework.batch.core.jsr.configuration.xml.SimpleItemBasedJobParsingTests.CountingCompletionPolicy"/>
+	
+	<bean id="skipErrorGeneratingReader" class="org.springframework.batch.core.jsr.configuration.xml.ItemSkipParsingTests.SkipErrorGeneratingReader"/>
+	
+	<bean id="skipErrorGeneratingProcessor" class="org.springframework.batch.core.jsr.configuration.xml.ItemSkipParsingTests.SkipErrorGeneratingProcessor"/>
+	
+	<bean id="skipErrorGeneratingWriter" class="org.springframework.batch.core.jsr.configuration.xml.ItemSkipParsingTests.SkipErrorGeneratingWriter"/>
+	
+	<bean id="skipListener" class="org.springframework.batch.core.jsr.configuration.xml.ItemSkipParsingTests.TestSkipListener"/>
+</beans>


### PR DESCRIPTION
- Added parsers for the JSR job's XML.  These parsers take the JSR Job XML and parse it into Spring Batch artifacts (no JSR interfaces/base classes are used).
- Fixed the JdbcTradeWriterTests that was failing intermittently with Java 7 due to autowiring ordering requirements.
