### PR TITLE
BATCH-2050: Added doUpdate method and made update methods final

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/StepScope.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/StepScope.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
  * }
  * </pre>
  *
- * <p>Marking a &#64;Bean as &#64;StepScope is equivalent to marking it as <code>&#64;Scope(value="step", proxyMode=INTERFACES)</code></p>
+ * <p>Marking a &#64;Bean as &#64;StepScope is equivalent to marking it as <code>&#64;Scope(value="step", proxyMode=TARGET_CLASS)</code></p>
  *
  * @author Dave Syer
  *

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
@@ -337,7 +337,7 @@ public class FaultTolerantStepFactoryBeanRetryTests {
 			}
 
 			@Override
-			protected void doOpen() throws Exception {
+			protected void doOpen(ExecutionContext context) throws Exception {
 				reader = new ListItemReader<String>(Arrays.asList("a", "b",
 						"c", "d", "e", "f"));
 			}
@@ -345,6 +345,10 @@ public class FaultTolerantStepFactoryBeanRetryTests {
 			@Override
 			protected String doRead() throws Exception {
 				return reader.read();
+			}
+
+			@Override
+			protected void doUpdate(ExecutionContext context) throws Exception {
 			}
 
 		};

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractPaginatedDataItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractPaginatedDataItemReader.java
@@ -2,6 +2,7 @@ package org.springframework.batch.item.data;
 
 import java.util.Iterator;
 
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
@@ -75,8 +76,11 @@ AbstractItemCountingItemStreamItemReader<T> {
 	protected abstract Iterator<T> doPageRead();
 
 	@Override
-	protected void doOpen() throws Exception {
+	protected void doOpen(ExecutionContext context) throws Exception {
 	}
+
+	@Override
+	protected void doUpdate(ExecutionContext context) {}
 
 	@Override
 	protected void doClose() throws Exception {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
@@ -210,7 +210,7 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 	}
 
 	@Override
-	protected void doOpen() throws Exception {
+	protected void doOpen(ExecutionContext context) throws Exception {
 	}
 
 	@Override
@@ -259,5 +259,9 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 		invoker.setTargetObject(targetObject);
 		invoker.setTargetMethod(targetMethod);
 		return invoker;
+	}
+
+	@Override
+	protected void doUpdate(ExecutionContext context) throws Exception {
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
@@ -394,7 +394,7 @@ implements InitializingBean {
 	 * Execute the statement to open the cursor.
 	 */
 	@Override
-	protected final void doOpen() throws Exception {
+	protected final void doOpen(ExecutionContext context) throws Exception {
 
 		Assert.state(!initialized, "Stream is already initialized.  Close before re-opening.");
 		Assert.isNull(rs, "ResultSet still open!  Close before re-opening.");
@@ -404,6 +404,9 @@ implements InitializingBean {
 		initialized = true;
 
 	}
+
+	@Override
+	protected void doUpdate(ExecutionContext context){}
 
 	protected void initializeConnection() {
 		Assert.state(getDataSource() != null, "DataSource must not be null.");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -39,8 +40,8 @@ import org.springframework.util.ClassUtils;
  * @author Dave Syer
  * @since 2.0
  */
-public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> 
-        implements InitializingBean {
+public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
+implements InitializingBean {
 
 	protected Log logger = LogFactory.getLog(getClass());
 
@@ -128,12 +129,15 @@ public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingIt
 	abstract protected void doReadPage();
 
 	@Override
-	protected void doOpen() throws Exception {
+	protected void doOpen(ExecutionContext context) throws Exception {
 
 		Assert.state(!initialized, "Cannot open an already opened ItemReader, call close first");
 		initialized = true;
 
 	}
+
+	@Override
+	protected void doUpdate(ExecutionContext context){}
 
 	@Override
 	protected void doClose() throws Exception {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateCursorItemReader.java
@@ -22,8 +22,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.database.orm.HibernateQueryProvider;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
@@ -54,8 +54,8 @@ import org.springframework.util.ClassUtils;
  * @author Robert Kasanicky
  * @author Dave Syer
  */
-public class HibernateCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> 
-        implements InitializingBean {
+public class HibernateCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
+implements InitializingBean {
 
 	private HibernateItemReaderHelper<T> helper = new HibernateItemReaderHelper<T>();
 
@@ -180,7 +180,7 @@ public class HibernateCursorItemReader<T> extends AbstractItemCountingItemStream
 	 * Open hibernate session and create a forward-only cursor for the query.
 	 */
 	@Override
-	protected void doOpen() throws Exception {
+	protected void doOpen(ExecutionContext context) throws Exception {
 		Assert.state(!initialized, "Cannot open an already opened ItemReader, call close first");
 		cursor = helper.getForwardOnlyCursor(fetchSize, parameterValues);
 		initialized = true;
@@ -193,8 +193,7 @@ public class HibernateCursorItemReader<T> extends AbstractItemCountingItemStream
 	 * @throws ItemStreamException if there is a problem
 	 */
 	@Override
-	public void update(ExecutionContext executionContext) throws ItemStreamException {
-		super.update(executionContext);
+	public void doUpdate(ExecutionContext executionContext) throws ItemStreamException {
 		helper.clear();
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernatePagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernatePagingItemReader.java
@@ -23,7 +23,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.database.orm.HibernateQueryProvider;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -58,8 +57,8 @@ import org.springframework.util.ClassUtils;
  *
  * @since 2.1
  */
-public class HibernatePagingItemReader<T> extends AbstractPagingItemReader<T> 
-                implements InitializingBean {
+public class HibernatePagingItemReader<T> extends AbstractPagingItemReader<T>
+implements InitializingBean {
 
 	private HibernateItemReaderHelper<T> helper = new HibernateItemReaderHelper<T>();
 
@@ -152,8 +151,8 @@ public class HibernatePagingItemReader<T> extends AbstractPagingItemReader<T>
 	}
 
 	@Override
-	protected void doOpen() throws Exception {
-		super.doOpen();
+	protected void doOpen(ExecutionContext context) throws Exception {
+		super.doOpen(context);
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
@@ -228,8 +228,7 @@ public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> impleme
 	}
 
 	@Override
-	public void update(ExecutionContext executionContext) throws ItemStreamException {
-		super.update(executionContext);
+	public void doUpdate(ExecutionContext executionContext) throws ItemStreamException {
 		if (isSaveState() && startAfterValues != null) {
 			executionContext.put(getExecutionContextKey(START_AFTER_VALUE), startAfterValues);
 		}
@@ -237,7 +236,8 @@ public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> impleme
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void open(ExecutionContext executionContext) {
+	public void doOpen(ExecutionContext executionContext) throws Exception {
+		super.doOpen(executionContext);
 		if (isSaveState()) {
 			startAfterValues = (Map<String, Object>) executionContext.get(getExecutionContextKey(START_AFTER_VALUE));
 
@@ -245,8 +245,6 @@ public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> impleme
 				startAfterValues = new LinkedHashMap<String, Object>();
 			}
 		}
-
-		super.open(executionContext);
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
@@ -96,7 +96,7 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 	private JpaQueryProvider queryProvider;
 
 	private Map<String, Object> parameterValues;
-	
+
 	private boolean transacted = true;//default value
 
 	public JpaPagingItemReader() {
@@ -129,18 +129,18 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 	public void setParameterValues(Map<String, Object> parameterValues) {
 		this.parameterValues = parameterValues;
 	}
-	
+
 	/**
-	 * By default (true) the EntityTransaction will be started and committed around the read.  
-	 * Can be overridden (false) in cases where the JPA implementation doesn't support a 
-	 * particular transaction.  (e.g. Hibernate with a JTA transaction).  NOTE: may cause 
+	 * By default (true) the EntityTransaction will be started and committed around the read.
+	 * Can be overridden (false) in cases where the JPA implementation doesn't support a
+	 * particular transaction.  (e.g. Hibernate with a JTA transaction).  NOTE: may cause
 	 * problems in guaranteeing the object consistency in the EntityManagerFactory.
 	 * 
 	 * @param transacted
 	 */
 	public void setTransacted(boolean transacted) {
 		this.transacted = transacted;
-	}	
+	}
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
@@ -171,8 +171,8 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 	}
 
 	@Override
-	protected void doOpen() throws Exception {
-		super.doOpen();
+	protected void doOpen(ExecutionContext context) throws Exception {
+		super.doOpen(context);
 
 		entityManager = entityManagerFactory.createEntityManager(jpaPropertyMap);
 		if (entityManager == null) {
@@ -191,11 +191,11 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 	protected void doReadPage() {
 
 		EntityTransaction tx = null;
-		
+
 		if (transacted) {
 			tx = entityManager.getTransaction();
 			tx.begin();
-			
+
 			entityManager.flush();
 			entityManager.clear();
 		}//end if
@@ -214,7 +214,7 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 		else {
 			results.clear();
 		}
-		
+
 		if (!transacted) {
 			List<T> queryResult = query.getResultList();
 			for (T entity : queryResult) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ReaderNotOpenException;
 import org.springframework.batch.item.file.separator.RecordSeparatorPolicy;
@@ -42,7 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Robert Kasanicky
  */
 public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements
-		ResourceAwareItemReaderItemStream<T>, InitializingBean {
+ResourceAwareItemReaderItemStream<T>, InitializingBean {
 
 	private static final Log logger = LogFactory.getLog(FlatFileItemReader.class);
 
@@ -145,7 +146,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 	/**
 	 * Public setter for the input resource.
 	 */
-    @Override
+	@Override
 	public void setResource(Resource resource) {
 		this.resource = resource;
 	}
@@ -241,7 +242,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 	}
 
 	@Override
-	protected void doOpen() throws Exception {
+	protected void doOpen(ExecutionContext context) throws Exception {
 		Assert.notNull(resource, "Input resource must be set");
 		Assert.notNull(recordSeparatorPolicy, "RecordSeparatorPolicy must be set");
 
@@ -273,7 +274,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 		noInput = false;
 	}
 
-    @Override
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.notNull(lineMapper, "LineMapper is required");
 	}
@@ -313,4 +314,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 
 	}
 
+	@Override
+	protected void doUpdate(ExecutionContext context) throws Exception {
+	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
@@ -29,6 +29,7 @@ import javax.xml.stream.events.XMLEvent;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.NonTransientResourceException;
 import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
@@ -178,7 +179,7 @@ ResourceAwareItemReaderItemStream<T>, InitializingBean {
 	}
 
 	@Override
-	protected void doOpen() throws Exception {
+	protected void doOpen(ExecutionContext context) throws Exception {
 		Assert.notNull(resource, "The Resource must not be null.");
 
 		noInput = true;
@@ -291,5 +292,9 @@ ResourceAwareItemReaderItemStream<T>, InitializingBean {
 				return;
 			}
 		}
+	}
+
+	@Override
+	protected void doUpdate(ExecutionContext context) throws Exception {
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
@@ -34,7 +34,7 @@ import org.springframework.batch.item.ExecutionContext;
 public class ItemCountingItemStreamItemReaderTests {
 
 	private ItemCountingItemStreamItemReader reader = new ItemCountingItemStreamItemReader();
-	
+
 	@Before
 	public void setUp() {
 		reader.setName("foo");
@@ -89,6 +89,7 @@ public class ItemCountingItemStreamItemReaderTests {
 		reader.update(context);
 		assertEquals(1, context.size());
 		assertEquals(1, context.getInt("foo.read.count"));
+		assertEquals(1, reader.updateCalled);
 	}
 
 	@Test
@@ -98,6 +99,7 @@ public class ItemCountingItemStreamItemReaderTests {
 		ExecutionContext context = new ExecutionContext();
 		reader.update(context);
 		assertEquals(1, context.getInt("bar.read.count"));
+		assertEquals(1, reader.updateCalled);
 	}
 
 	@Test
@@ -106,6 +108,7 @@ public class ItemCountingItemStreamItemReaderTests {
 		ExecutionContext context = new ExecutionContext();
 		reader.update(context);
 		assertEquals(1, context.size());
+		assertEquals(1, reader.updateCalled);
 	}
 
 	@Test
@@ -124,6 +127,7 @@ public class ItemCountingItemStreamItemReaderTests {
 		reader.open(context);
 		reader.update(context);
 		assertEquals(2, context.size());
+		assertEquals(1, reader.updateCalled);
 	}
 
 	private static class ItemCountingItemStreamItemReader extends AbstractItemCountingItemStreamItemReader<String> {
@@ -131,6 +135,8 @@ public class ItemCountingItemStreamItemReaderTests {
 		private boolean closeCalled = false;
 
 		private boolean openCalled = false;
+
+		private int updateCalled = 0;
 
 		private Iterator<String> items = Arrays.asList("a", "b", "c").iterator();
 
@@ -140,7 +146,7 @@ public class ItemCountingItemStreamItemReaderTests {
 		}
 
 		@Override
-		protected void doOpen() throws Exception {
+		protected void doOpen(ExecutionContext context) throws Exception {
 			openCalled = true;
 		}
 
@@ -152,6 +158,10 @@ public class ItemCountingItemStreamItemReaderTests {
 			return items.next();
 		}
 
+		@Override
+		protected void doUpdate(ExecutionContext context) throws Exception {
+			updateCalled++;
+		}
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SingleItemPeekableItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SingleItemPeekableItemReaderTests.java
@@ -28,9 +28,9 @@ import org.springframework.batch.item.ExecutionContext;
  *
  */
 public class SingleItemPeekableItemReaderTests {
-	
+
 	private SingleItemPeekableItemReader<String> reader = new SingleItemPeekableItemReader<String>();
-	
+
 	/**
 	 * Test method for {@link org.springframework.batch.item.support.SingleItemPeekableItemReader#read()}.
 	 */
@@ -66,7 +66,7 @@ public class SingleItemPeekableItemReaderTests {
 		reader.update(executionContext);
 		reader.close();
 		reader.open(executionContext);
-		assertEquals("b", reader.read());		
+		assertEquals("b", reader.read());
 	}
 
 	/**
@@ -81,7 +81,7 @@ public class SingleItemPeekableItemReaderTests {
 		reader.update(executionContext);
 		reader.close();
 		reader.open(executionContext);
-		assertEquals("b", reader.read());		
+		assertEquals("b", reader.read());
 	}
 
 	@Test
@@ -93,20 +93,20 @@ public class SingleItemPeekableItemReaderTests {
 		reader.update(executionContext);
 		reader.close();
 		reader.open(executionContext);
-		assertEquals("b", reader.read());		
+		assertEquals("b", reader.read());
 		assertEquals("c", reader.peek());
 		reader.update(executionContext);
 		reader.close();
 		reader.open(executionContext);
-		assertEquals("c", reader.read());		
+		assertEquals("c", reader.read());
 	}
 
 	public static class CountingListItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> {
-		
+
 		private final List<T> list;
-		
+
 		private int counter = 0;
-		
+
 		public CountingListItemReader(List<T> list) {
 			this.list = list;
 			setName("foo");
@@ -118,7 +118,7 @@ public class SingleItemPeekableItemReaderTests {
 		}
 
 		@Override
-		protected void doOpen() throws Exception {
+		protected void doOpen(ExecutionContext context) throws Exception {
 			counter = 0;
 		}
 
@@ -129,7 +129,9 @@ public class SingleItemPeekableItemReaderTests {
 			}
 			return list.get(counter++);
 		}
-		
-	}
 
+		@Override
+		protected void doUpdate(ExecutionContext context) throws Exception {
+		}
+	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -605,8 +605,8 @@ public class StaxEventItemReaderTests {
 		private boolean openCalled = false;
 
 		@Override
-		public void open(ExecutionContext executionContext) {
-			super.open(executionContext);
+		public void doOpen(ExecutionContext executionContext) throws Exception {
+			super.doOpen(executionContext);
 			openCalled = true;
 		}
 


### PR DESCRIPTION
As of 2.2.0.RELEASE, CGLIB became the default for the step scope.  In order for the state of the ItemReaders to be consistent across ItemReader#read(), ItemStream#open, ItemStream#update, and ItemStream#close they must be either final or not.  To enforce this, the implementations of these methods have been made final with a do\* for each method.
