### PR TITLE
BATCH-2054: StaxEventItemWriter fails on a NullPointerException with Spring OXM 3.2.x.

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -658,7 +658,7 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 		finally {
 
 			try {
-				eventWriter.close();
+				delegateEventWriter.close();
 			}
 			catch (XMLStreamException e) {
 				log.error("Unable to close file resource: [" + resource + "] " + e);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentStreamWriter.java
@@ -39,4 +39,10 @@ public class NoStartEndDocumentStreamWriter extends AbstractEventWriterWrapper {
 			wrappedEventWriter.add(event);
 		}
 	}
+    
+    // prevents OXM Marshallers from closing the XMLEventWriter
+    @Override
+    public void close() throws XMLStreamException {
+    	flush();
+    }
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
@@ -726,6 +726,32 @@ public class StaxEventItemWriterTests {
 		assertEquals("Wrong content: " + content,
 				"<foo:root xmlns:foo=\"urn:org.test.foo\" xmlns:ns=\"http://www.springframework.org/test\"><ns:item/><ns:item/></foo:root>", content);
 	}
+	
+	/**
+	 * Test with OXM Marshaller that closes the XMLEventWriter. 
+	 */
+	// BATCH-2054
+	@Test
+	public void testMarshallingClosingEventWriter() throws Exception {
+		writer.setMarshaller(new SimpleMarshaller() {
+			@Override
+			public void marshal(Object graph, Result result) throws XmlMappingException, IOException {
+				super.marshal(graph, result);
+				try {
+					StaxUtils.getXmlEventWriter(result).close();
+				} catch (Exception e) {
+					throw new RuntimeException("Exception while writing to output file", e);
+				}
+			}
+
+		});
+		writer.afterPropertiesSet();
+
+		writer.open(executionContext);
+
+		writer.write(items);
+		writer.write(items);
+	}	
 
 	/**
 	 * Writes object's toString representation as XML comment.

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentWriterTests.java
@@ -7,6 +7,9 @@ import javax.xml.stream.events.XMLEvent;
 import junit.framework.TestCase;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests for {@link NoStartEndDocumentStreamWriter}
@@ -43,5 +46,15 @@ public class NoStartEndDocumentWriterTests extends TestCase {
 		writer.add(event);
 		writer.add(eventFactory.createEndDocument());
 
+	}
+	
+	/**
+	 * Close is not delegated to the wrapped writer. Instead, the wrapped writer is flushed.
+	 */
+	public void testClose() throws Exception {
+		writer.close();
+		
+		verify(wrappedWriter, times(1)).flush();
+		verify(wrappedWriter, never()).close();
 	}
 }


### PR DESCRIPTION
Prevents OXM Marshallers from closing StaxEventItemWriter's internal XMLEventWriter
