### PR TITLE
BATCH-2050: AbstractItemCountingItemStreamItemReader.read() shouldn't be final

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/StepScope.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/StepScope.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
  * }
  * </pre>
  *
- * <p>Marking a &#64;Bean as &#64;StepScope is equivalent to marking it as <code>&#64;Scope(value="step", proxyMode=INTERFACES)</code></p>
+ * <p>Marking a &#64;Bean as &#64;StepScope is equivalent to marking it as <code>&#64;Scope(value="step", proxyMode=TARGET_CLASS)</code></p>
  *
  * @author Dave Syer
  *

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
@@ -394,7 +394,7 @@ implements InitializingBean {
 	 * Execute the statement to open the cursor.
 	 */
 	@Override
-	protected final void doOpen() throws Exception {
+	protected void doOpen() throws Exception {
 
 		Assert.state(!initialized, "Stream is already initialized.  Close before re-opening.");
 		Assert.isNull(rs, "ResultSet still open!  Close before re-opening.");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateItemWriter.java
@@ -81,7 +81,7 @@ public class HibernateItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 *
 	 * @param sessionFactory session factory to be used by the writer
 	 */
-	public final void setSessionFactory(SessionFactory sessionFactory) {
+	public void setSessionFactory(SessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
 
@@ -101,7 +101,7 @@ public class HibernateItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 * @see org.springframework.batch.item.ItemWriter#write(java.util.List)
 	 */
 	@Override
-	public final void write(List<? extends T> items) {
+	public void write(List<? extends T> items) {
 		if(sessionFactory == null) {
 			doWrite(hibernateTemplate, items);
 			hibernateTemplate.flush();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaItemWriter.java
@@ -76,7 +76,7 @@ public class JpaItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 * @see org.springframework.batch.item.ItemWriter#write(java.util.List)
 	 */
 	@Override
-	public final void write(List<? extends T> items) {
+	public void write(List<? extends T> items) {
 		EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
 		if (entityManager == null) {
 			throw new DataAccessResourceFailureException("Unable to obtain a transactional EntityManager");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
@@ -117,7 +117,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer {
 	 *
 	 * @see #DEFAULT_QUOTE_CHARACTER
 	 */
-	public final void setQuoteCharacter(char quoteCharacter) {
+	public void setQuoteCharacter(char quoteCharacter) {
 		this.quoteCharacter = quoteCharacter;
 		this.quoteString = "" + quoteCharacter;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.java
@@ -75,7 +75,7 @@ public abstract class AbstractItemCountingItemStreamItemReader<T> extends Abstra
 	}
 
 	@Override
-	public final T read() throws Exception, UnexpectedInputException, ParseException {
+	public T read() throws Exception, UnexpectedInputException, ParseException {
 		if (currentItemCount >= maxItemCount) {
 			return null;
 		}


### PR DESCRIPTION
Removed final modifier from all methods of spring batch components that are likely to be used with @StepScope to prevent CGLIB proxying problems
