### PR TITLE
BATCH-1994: Add protected DAO getters to SimpleJobExplorer

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/SimpleJobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/SimpleJobExplorer.java
@@ -191,4 +191,19 @@ public class SimpleJobExplorer implements JobExplorer {
 		}
 	}
 
+    protected JobInstanceDao getJobInstanceDao() {
+        return jobInstanceDao;
+    }
+
+    protected JobExecutionDao getJobExecutionDao() {
+        return jobExecutionDao;
+    }
+
+    protected StepExecutionDao getStepExecutionDao() {
+        return stepExecutionDao;
+    }
+
+    protected ExecutionContextDao getEcDao() {
+        return ecDao;
+    }
 }


### PR DESCRIPTION
Added getters for DAOs used in SimpleJobExplorer, to allow the class to be extended more easily.

Since I'm trying to get a feel of the development process with my first PR to Spring Batch, I might be wrong in my assumption to make this change off of the 2.1.9 tag and make a PR to 2.1.x only, for this ticket with an affected version of 2.1.9. Please let me know if this is not the correct approach. Thanks.
