### PR TITLE
fix JobOperatorTests.testJobOperatorGetRunningJobInstancesException TCK test

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/launch/JsrJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/launch/JsrJobOperator.java
@@ -342,6 +342,10 @@ public class JsrJobOperator implements JobOperator {
 
 		List<Long> results = new ArrayList<Long>(findRunningJobExecutions.size());
 
+		if(results.isEmpty()) {
+			throw new NoSuchJobException("Job name: " + name + " not found.");
+		}
+
 		for (org.springframework.batch.core.JobExecution jobExecution : findRunningJobExecutions) {
 			results.add(jobExecution.getId());
 		}


### PR DESCRIPTION
- Throw a NoSuchJobException in the event no running job executions are found when calling getRunningExecutions(String name)
