### PR TITLE
Fix TCK test JobOperatorTests.testJobOperatorRestartJobAlreadyAbandoned

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/step/batchlet/FailingBatchlet.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/step/batchlet/FailingBatchlet.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.step.batchlet;
+
+import javax.batch.api.Batchlet;
+
+/**
+ * <p>
+ * Test batchlet that always fails..
+ * </p>
+ *
+ * @author Chris Schaefer
+ */
+public class FailingBatchlet implements Batchlet {
+	@Override
+	public String process() throws Exception {
+		throw new RuntimeException("process failed");
+	}
+
+	@Override
+	public void stop() throws Exception {
+	}
+}

--- a/spring-batch-core/src/test/resources/META-INF/batch-jobs/jsrJobOperatorTestRestartAbandonJob.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch-jobs/jsrJobOperatorTestRestartAbandonJob.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<job id="failingJob" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+    <step id="step1" >
+        <batchlet ref="failingBatchlet" />
+    </step>
+</job>

--- a/spring-batch-core/src/test/resources/META-INF/batch.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch.xml
@@ -1,4 +1,5 @@
 <batch-artifacts xmlns="http://xmlns.jcp.org/xml/ns/javaee">
 	<ref id="testBatchlet" class="org.springframework.batch.core.jsr.step.batchlet.BatchletSupport" />
-	<ref id="restartBatchlet" class="org.springframework.batch.core.jsr.step.batchlet.RestartBatchlet" />
+    <ref id="restartBatchlet" class="org.springframework.batch.core.jsr.step.batchlet.RestartBatchlet" />
+    <ref id="failingBatchlet" class="org.springframework.batch.core.jsr.step.batchlet.FailingBatchlet" />
 </batch-artifacts>


### PR DESCRIPTION
- On restart if a previous JobExecution has a status of ABANDONED, throw a JobRestartException
- Ensure any previous JobParameters are merged with new parameters when creating a new job execution on restart
