### PR TITLE
BATCH-2096: 'chunk-completion-policy' or 'commit-interval' with '#{jobParameters[...]}' is ignored when 'retry-limit' exists.

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBean.java
@@ -314,6 +314,7 @@ public class StepParserStepFactoryBean<I, O> implements FactoryBean, BeanNameAwa
 		if (commitInterval != null) {
 			builder.chunk(commitInterval);
 		}
+		builder.chunk(chunkCompletionPolicy);
 		enhanceTaskletStepBuilder(builder);
 
 		builder.reader(itemReader);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBeanTests.java
@@ -248,6 +248,10 @@ public class StepParserStepFactoryBeanTests {
 		assertEquals(new Integer(10), throttleLimit);
 		Object tasklet = ReflectionTestUtils.getField(step, "tasklet");
 		assertTrue(tasklet instanceof ChunkOrientedTasklet<?>);
+		Object chunkProvider = ReflectionTestUtils.getField(tasklet, "chunkProvider");
+		Object repeatOperations = ReflectionTestUtils.getField(chunkProvider, "repeatOperations");
+		Object completionPolicy = ReflectionTestUtils.getField(repeatOperations, "completionPolicy");
+		assertTrue(completionPolicy instanceof DummyCompletionPolicy);
 	}
 
 	@Test


### PR DESCRIPTION
This issue is described at [https://jira.springsource.org/browse/BATCH-2096].

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
The confirmation number is 63420130827123450.
