### PR TITLE
General cleanup etc around properties and substitution

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/JobContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/JobContext.java
@@ -33,19 +33,18 @@ import org.springframework.util.Assert;
  * @since 3.0
  */
 public class JobContext implements javax.batch.runtime.context.JobContext {
-
 	private Object transientUserData;
-    private Properties properties;
-    private JobExecution jobExecution;
+	private Properties properties;
+	private JobExecution jobExecution;
 
-    /**
+	/**
 	 * @param jobExecution for the related job
 	 */
 	public JobContext(JobExecution jobExecution, Properties properties) {
 		Assert.notNull(jobExecution, "A JobExecution is required");
 
-        this.properties = properties;
-        this.jobExecution = jobExecution;
+		this.jobExecution = jobExecution;
+		this.properties = properties != null ? properties : new Properties();
 	}
 
 	/* (non-Javadoc)
@@ -93,7 +92,7 @@ public class JobContext implements javax.batch.runtime.context.JobContext {
 	 */
 	@Override
 	public Properties getProperties() {
-		return properties != null ? properties : new Properties();
+		return properties;
 	}
 
 	/* (non-Javadoc)

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/StepContextFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/StepContextFactoryBean.java
@@ -41,9 +41,7 @@ public class StepContextFactoryBean implements FactoryBean<StepContext> {
 	public StepContext getObject() throws Exception {
 		org.springframework.batch.core.scope.context.StepContext stepContext = StepSynchronizationManager.getContext();
 
-		String stepName = stepContext.getStepName();
-		String jobName = stepContext.getStepExecution().getJobExecution().getJobInstance().getJobName();
-		Properties properties = batchPropertyContext.getStepLevelProperties(jobName + "." + stepName);
+		Properties properties = batchPropertyContext.getStepProperties(stepContext.getStepName());
 
 		return new StepContext(stepContext.getStepExecution(), properties);
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/BatchArtifact.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/BatchArtifact.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.support;
+
+import javax.batch.api.Batchlet;
+import javax.batch.api.Decider;
+import javax.batch.api.chunk.CheckpointAlgorithm;
+import javax.batch.api.chunk.ItemProcessor;
+import javax.batch.api.chunk.ItemReader;
+import javax.batch.api.chunk.ItemWriter;
+import javax.batch.api.chunk.listener.ChunkListener;
+import javax.batch.api.chunk.listener.ItemProcessListener;
+import javax.batch.api.chunk.listener.ItemReadListener;
+import javax.batch.api.chunk.listener.ItemWriteListener;
+import javax.batch.api.chunk.listener.RetryProcessListener;
+import javax.batch.api.chunk.listener.RetryReadListener;
+import javax.batch.api.chunk.listener.RetryWriteListener;
+import javax.batch.api.chunk.listener.SkipProcessListener;
+import javax.batch.api.chunk.listener.SkipReadListener;
+import javax.batch.api.chunk.listener.SkipWriteListener;
+import javax.batch.api.listener.JobListener;
+import javax.batch.api.listener.StepListener;
+import javax.batch.api.partition.PartitionAnalyzer;
+import javax.batch.api.partition.PartitionCollector;
+import javax.batch.api.partition.PartitionMapper;
+import javax.batch.api.partition.PartitionPlan;
+import javax.batch.api.partition.PartitionReducer;
+
+/**
+ * <p>
+ * Simple enum representing metadata about batch artifacts and types.
+ * </p>
+ *
+ * @author Chris Schaefer
+ */
+public enum BatchArtifact {
+	ITEM_READER(ItemReader.class),
+	ITEM_WRITER(ItemWriter.class),
+	ITEM_PROCESSOR(ItemProcessor.class),
+	CHECKPOINT_ALGORITHM(CheckpointAlgorithm.class),
+	BATCHLET(Batchlet.class),
+	ITEM_READ_LISTENER(ItemReadListener.class),
+	ITEM_PROCESS_LISTENER(ItemProcessListener.class),
+	ITEM_WRITE_LISTENER(ItemWriteListener.class),
+	JOB_LISTENER(JobListener.class),
+	STEP_LISTENER(StepListener.class),
+	CHUNK_LISTENER(ChunkListener.class),
+	SKIP_READ_LISTENER(SkipReadListener.class),
+	SKIP_PROCESS_LISTENER(SkipProcessListener.class),
+	SKIP_WRITER_LISTENER(SkipWriteListener.class),
+	RETRY_READ_LISTENER(RetryReadListener.class),
+	RETRY_PROCESS_LISTENER(RetryProcessListener.class),
+	RETRY_WRITE_LISTENER(RetryWriteListener.class),
+	PARTITION_MAPPER(PartitionMapper.class),
+	PARTITION_REDUCER(PartitionReducer.class),
+	PARTITION_COLLECTOR(PartitionCollector.class),
+	PARTITION_ANALYZER(PartitionAnalyzer.class),
+	PARTITION_PLAN(PartitionPlan.class),
+	DECIDER(Decider.class);
+
+	private Class<?> clazz;
+
+	private BatchArtifact(Class<?> clazz) {
+		this.clazz = clazz;
+	}
+
+	private Class<?> getBatchArtifactClass() {
+		return clazz;
+	}
+
+	/**
+	 * <p>
+	 * Determines if the provided artifact is a JSR-352 batch artifact.
+	 * </p>
+	 *
+	 * @param artifact the artifact to check
+	 * @return boolean answer based on check
+	 */
+	public static boolean isBatchArtifact(Object artifact) {
+		for (BatchArtifact batchArtifactType : BatchArtifact.values()) {
+			if (batchArtifactType.getBatchArtifactClass().isInstance(artifact)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * <p>
+	 * Enum to identify batch artifact types.
+	 * </p>
+	 *
+	 * @author Chris Schaefer
+	 * @since 3.0
+	 */
+	public enum BatchArtifactType {
+		STEP,
+		STEP_ARTIFACT,
+		ARTIFACT,
+		JOB
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/JobParameterResolvingBeanFactoryPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/JobParameterResolvingBeanFactoryPostProcessor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.support;
+
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionVisitor;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.expression.StandardBeanExpressionResolver;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.util.StringValueResolver;
+
+/**
+ * <p>
+ * This post processor will resolve values in bean definitions that represent #{jobParameter['key']}
+ * expressions prior to the standard SPeL resolution if they correspond with an entry in the user
+ * provided {@link java.util.Properties} to the start or restart methods of the
+ * {@link org.springframework.batch.core.jsr.launch.JsrJobOperator}. This allows jobProperty replacements
+ * to occur for elements that require resolution prior to context initialization and are not step scoped.
+ * </p>
+ *
+ * @author Chris Schaefer
+ * @since 3.0
+ */
+public class JobParameterResolvingBeanFactoryPostProcessor implements BeanFactoryPostProcessor, PriorityOrdered {
+	private Properties properties;
+	private JobParameterResolver jobParameterResolver;
+	private static final Pattern JOB_PARAMETERS_KEY_PATTERN = Pattern.compile("'([^']*?)'");
+	private static final Pattern JOB_PARAMETERS_PATTERN = Pattern.compile("(#\\{jobParameters[^}]+\\})");
+
+	public JobParameterResolvingBeanFactoryPostProcessor(Properties properties) {
+		this.properties = properties;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.beans.factory.config.BeanFactoryPostProcessor#postProcessBeanFactory(org.springframework.beans.factory.config.ConfigurableListableBeanFactory)
+	 */
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		if (jobParameterResolver == null) {
+			this.jobParameterResolver = new JobParameterResolver(beanFactory, properties);
+		}
+
+		String[] beanNames = beanFactory.getBeanDefinitionNames();
+
+		for (String curName : beanNames) {
+			jobParameterResolver.visitBeanDefinition(beanFactory.getBeanDefinition(curName));
+		}
+	}
+
+	/**
+	 * Sets this {@link BeanFactoryPostProcessor} to the lowest precedence so that
+	 * it is executed as late as possible in the chain of {@link BeanFactoryPostProcessor}s
+	 */
+	@Override
+	public int getOrder() {
+		return PriorityOrdered.LOWEST_PRECEDENCE;
+	}
+
+	protected class JobParameterResolver {
+		private Properties properties;
+		private JsrExpressionParser jsrExpressionParser;
+		private BeanDefinitionVisitor beanDefinitionVisitor;
+
+		public JobParameterResolver(ConfigurableListableBeanFactory beanFactory, Properties properties) {
+			this.properties = properties;
+			this.jsrExpressionParser = new JsrExpressionParser(new StandardBeanExpressionResolver(), new BeanExpressionContext(beanFactory, null));
+			this.beanDefinitionVisitor = new BeanDefinitionVisitor(new JobParameterStringValueResolver());
+		}
+
+		public void visitBeanDefinition(BeanDefinition beanDefinition) {
+			if (properties != null && ! properties.isEmpty() && ! "step".equals(beanDefinition.getScope())) {
+				beanDefinitionVisitor.visitBeanDefinition(beanDefinition);
+			}
+		}
+
+		protected class JobParameterStringValueResolver implements StringValueResolver {
+			private static final String NULL = "null";
+
+			@Override
+			public String resolveStringValue(String value) {
+				if (value != null && ! "".equals(value)) {
+					String resolvedString = resolveJobProperties(value);
+
+					if (!"".equals(resolvedString)) {
+						return jsrExpressionParser.parseExpression(resolvedString);
+					}
+				}
+
+				return value;
+			}
+
+			private String resolveJobProperties(String value) {
+				StringBuffer valueBuffer = new StringBuffer();
+				Matcher jobParameterMatcher = JOB_PARAMETERS_PATTERN.matcher(value);
+
+				while (jobParameterMatcher.find()) {
+					Matcher jobParameterKeyMatcher = JOB_PARAMETERS_KEY_PATTERN.matcher(jobParameterMatcher.group(1));
+
+					if (jobParameterKeyMatcher.find()) {
+						String extractedProperty = jobParameterKeyMatcher.group(1);
+
+						if (properties.containsKey(extractedProperty)) {
+							String resolvedProperty = properties.getProperty(extractedProperty);
+							jobParameterMatcher.appendReplacement(valueBuffer, resolvedProperty);
+						} else {
+							jobParameterMatcher.appendReplacement(valueBuffer, NULL);
+						}
+					}
+				}
+
+				jobParameterMatcher.appendTail(valueBuffer);
+
+				return valueBuffer.toString();
+			}
+		}
+	}
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/ThreadLocalClassloaderBeanPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/ThreadLocalClassloaderBeanPostProcessor.java
@@ -15,14 +15,10 @@
  */
 package org.springframework.batch.core.jsr.configuration.support;
 
-import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.BeanDefinitionVisitor;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -30,7 +26,6 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.PriorityOrdered;
-import org.springframework.util.StringValueResolver;
 
 /**
  * After the {@link BeanFactory} is created, this post processor will evaluate to see
@@ -38,26 +33,10 @@ import org.springframework.util.StringValueResolver;
  * to class names instead of bean names.  If this is the case, a new {@link BeanDefinition}
  * is added with the name of the class as the bean name.
  *
- * This post processor will also resolve values in bean definitions that represent
- * #{jobParameter['key']} expressions prior to the standard SPeL resolution if they correspond
- * with an entry in the user provided {@link Properties} to the start or restart methods of the
- * {@link org.springframework.batch.core.jsr.launch.JsrJobOperator}. This allows jobProperty
- * replacements to occur for elements that require resolution prior to context initialization
- * and are not step scoped.
- *
  * @author Michael Minella
- * @author Chris Schaefer
  * @since 3.0
  */
 public class ThreadLocalClassloaderBeanPostProcessor implements BeanFactoryPostProcessor, PriorityOrdered {
-	private JobParameterResolver jobParameterResolver;
-	private static final Pattern JOB_PARAMETERS_KEY_PATTERN = Pattern.compile("'([^']*?)'");
-	private static final Pattern JOB_PARAMETERS_PATTERN = Pattern.compile("(#\\{jobParameters[^}]+\\})");
-
-	public ThreadLocalClassloaderBeanPostProcessor(Properties properties) {
-		this.jobParameterResolver = new JobParameterResolver(properties);
-	}
-
 	/* (non-Javadoc)
 	 * @see org.springframework.beans.factory.config.BeanFactoryPostProcessor#postProcessBeanFactory(org.springframework.beans.factory.config.ConfigurableListableBeanFactory)
 	 */
@@ -81,8 +60,6 @@ public class ThreadLocalClassloaderBeanPostProcessor implements BeanFactoryPostP
 					}
 				}
 			}
-
-			jobParameterResolver.visitBeanDefinition(beanDefinition);
 		}
 	}
 
@@ -93,58 +70,5 @@ public class ThreadLocalClassloaderBeanPostProcessor implements BeanFactoryPostP
 	@Override
 	public int getOrder() {
 		return PriorityOrdered.LOWEST_PRECEDENCE;
-	}
-
-	protected class JobParameterResolver {
-		private Properties properties;
-		private BeanDefinitionVisitor beanDefinitionVisitor;
-
-		public JobParameterResolver(Properties properties) {
-			this.properties = properties;
-			this.beanDefinitionVisitor = new BeanDefinitionVisitor(new JobParameterStringValueResolver());
-		}
-
-		public void visitBeanDefinition(BeanDefinition beanDefinition) {
-			if (properties != null && ! properties.isEmpty() && ! "step".equals(beanDefinition.getScope())) {
-				beanDefinitionVisitor.visitBeanDefinition(beanDefinition);
-			}
-		}
-
-		protected class JobParameterStringValueResolver implements StringValueResolver {
-			@Override
-			public String resolveStringValue(String value) {
-				if (value != null && ! "".equals(value)) {
-					String resolvedString = resolveJobProperties(value);
-
-					if (!"".equals(resolvedString)) {
-						return resolvedString;
-					}
-				}
-
-				return value;
-			}
-
-			private String resolveJobProperties(String value) {
-				StringBuffer valueBuffer = new StringBuffer();
-				Matcher jobParameterMatcher = JOB_PARAMETERS_PATTERN.matcher(value);
-
-				while (jobParameterMatcher.find()) {
-					Matcher jobParameterKeyMatcher = JOB_PARAMETERS_KEY_PATTERN.matcher(jobParameterMatcher.group(1));
-
-					if (jobParameterKeyMatcher.find()) {
-						String extractedProperty = jobParameterKeyMatcher.group(1);
-
-						if (properties.containsKey(extractedProperty)) {
-							String resolvedProperty = properties.getProperty(extractedProperty);
-							jobParameterMatcher.appendReplacement(valueBuffer, resolvedProperty);
-						}
-					}
-				}
-
-				jobParameterMatcher.appendTail(valueBuffer);
-
-				return valueBuffer.toString();
-			}
-		}
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/BatchletParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/BatchletParser.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.jsr.configuration.xml;
 
+import org.springframework.batch.core.jsr.configuration.support.BatchArtifact;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -36,7 +37,7 @@ import org.w3c.dom.Element;
 public class BatchletParser extends AbstractSingleBeanDefinitionParser {
 	private static final String REF = "ref";
 
-	public void parseBatchlet(Element batchletElement, AbstractBeanDefinition bd, ParserContext parserContext) {
+	public void parseBatchlet(Element batchletElement, AbstractBeanDefinition bd, ParserContext parserContext, String stepName) {
 		bd.setBeanClass(StepFactoryBean.class);
 		bd.setAttribute("isNamespaceStep", false);
 
@@ -49,6 +50,6 @@ public class BatchletParser extends AbstractSingleBeanDefinitionParser {
 		bd.setRole(BeanDefinition.ROLE_SUPPORT);
 		bd.setSource(parserContext.extractSource(batchletElement));
 
-		new PropertyParser(taskletRef, parserContext).parseProperties(batchletElement);
+		new PropertyParser(taskletRef, parserContext, BatchArtifact.BatchArtifactType.STEP_ARTIFACT, stepName).parseProperties(batchletElement);
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/DecisionParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/DecisionParser.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import org.springframework.batch.core.job.flow.JobExecutionDecider;
 import org.springframework.batch.core.job.flow.support.state.StepState;
+import org.springframework.batch.core.jsr.configuration.support.BatchArtifact;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
@@ -50,8 +51,6 @@ public class DecisionParser {
 
 		String idAttribute = element.getAttribute(ID_ATTRIBUTE);
 
-		PropertyParser.pushPath(idAttribute);
-
 		parserContext.registerBeanComponent(new BeanComponentDefinition(factoryDefinition, idAttribute));
 		stateBuilder.addConstructorArgReference(idAttribute);
 
@@ -63,12 +62,8 @@ public class DecisionParser {
 			factoryDefinition.setAttribute("jobParserJobFactoryBeanRef", jobFactoryRef);
 		}
 
-		new PropertyParser(refAttribute, parserContext).parseProperties(element);
+		new PropertyParser(refAttribute, parserContext, BatchArtifact.BatchArtifactType.STEP_ARTIFACT, idAttribute).parseProperties(element);
 
-		Collection<BeanDefinition> nextElements = FlowParser.getNextElements(parserContext, stateBuilder.getBeanDefinition(), element);
-
-		PropertyParser.popPath();
-
-		return nextElements;
+		return FlowParser.getNextElements(parserContext, stateBuilder.getBeanDefinition(), element);
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/ListnerParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/ListnerParser.java
@@ -17,6 +17,7 @@ package org.springframework.batch.core.jsr.configuration.xml;
 
 import java.util.List;
 
+import org.springframework.batch.core.jsr.configuration.support.BatchArtifact;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.parsing.CompositeComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -48,8 +49,8 @@ public class ListnerParser {
 		this.listenerType = listenerType;
 	}
 
-	public void parseListeners(Element element, ParserContext parserContext, AbstractBeanDefinition bd) {
-		ManagedList<AbstractBeanDefinition> listeners = parseListeners(element, parserContext);
+	public void parseListeners(Element element, ParserContext parserContext, AbstractBeanDefinition bd, String stepName) {
+		ManagedList<AbstractBeanDefinition> listeners = parseListeners(element, parserContext, stepName);
 
 		if(listeners.size() > 0) {
 			bd.getPropertyValues().add(propertyKey, listeners);
@@ -57,14 +58,14 @@ public class ListnerParser {
 	}
 
 	public void parseListeners(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
-		ManagedList<AbstractBeanDefinition> listeners = parseListeners(element, parserContext);
+		ManagedList<AbstractBeanDefinition> listeners = parseListeners(element, parserContext, "");
 
 		if(listeners.size() > 0) {
 			builder.addPropertyValue(propertyKey, listeners);
 		}
 	}
 
-	private ManagedList<AbstractBeanDefinition> parseListeners(Element element, ParserContext parserContext) {
+	private ManagedList<AbstractBeanDefinition> parseListeners(Element element, ParserContext parserContext, String stepName) {
 		List<Element> listenersElements = DomUtils.getChildElementsByTagName(element, LISTENERS_ELEMENT);
 
 		ManagedList<AbstractBeanDefinition> listeners = new ManagedList<AbstractBeanDefinition>();
@@ -84,7 +85,7 @@ public class ListnerParser {
 
 				listeners.add(bd.getBeanDefinition());
 
-				new PropertyParser(beanName, parserContext).parseProperties(listenerElement);
+				new PropertyParser(beanName, parserContext, getBatchArtifactType(stepName), stepName).parseProperties(listenerElement);
 			}
 			parserContext.popAndRegisterContainingComponent();
 		}
@@ -94,5 +95,10 @@ public class ListnerParser {
 		}
 
 		return listeners;
+	}
+
+	private BatchArtifact.BatchArtifactType getBatchArtifactType(String stepName) {
+		return (stepName != null && !"".equals(stepName)) ? BatchArtifact.BatchArtifactType.STEP_ARTIFACT
+			: BatchArtifact.BatchArtifactType.ARTIFACT;
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/launch/JsrJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/launch/JsrJobOperator.java
@@ -47,7 +47,7 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.jsr.JobContext;
 import org.springframework.batch.core.jsr.JsrJobParametersConverter;
 import org.springframework.batch.core.jsr.configuration.support.BatchPropertyContext;
-import org.springframework.batch.core.jsr.configuration.support.ThreadLocalClassloaderBeanPostProcessor;
+import org.springframework.batch.core.jsr.configuration.support.JobParameterResolvingBeanFactoryPostProcessor;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.access.BeanFactoryLocator;
@@ -452,7 +452,7 @@ public class JsrJobOperator implements JobOperator, InitializingBean {
 			batchContext.load(jobXml);
 		}
 
-		batchContext.addBeanFactoryPostProcessor(new ThreadLocalClassloaderBeanPostProcessor(params));
+		batchContext.addBeanFactoryPostProcessor(new JobParameterResolvingBeanFactoryPostProcessor(params));
 		batchContext.setParent(baseContext);
 		batchContext.refresh();
 
@@ -476,7 +476,7 @@ public class JsrJobOperator implements JobOperator, InitializingBean {
 			ConfigurableListableBeanFactory factory = batchContext.getBeanFactory();
 
 			BatchPropertyContext batchPropertyContext = factory.getBean(BATCH_PROPERTY_CONTEXT_BEAN_NAME, BatchPropertyContext.class);
-			Properties properties = batchPropertyContext.getBatchProperties("job-" + job.getName());
+			Properties properties = batchPropertyContext.getJobProperties();
 
 			factory.registerSingleton(job.getName() + "_" + jobExecution.getId() + "_jobContext", new JobContext(jobExecution, properties));
 
@@ -553,7 +553,7 @@ public class JsrJobOperator implements JobOperator, InitializingBean {
 			batchContext.load(jobXml);
 		}
 
-		batchContext.addBeanFactoryPostProcessor(new ThreadLocalClassloaderBeanPostProcessor(params));
+		batchContext.addBeanFactoryPostProcessor(new JobParameterResolvingBeanFactoryPostProcessor(params));
 		batchContext.setParent(baseContext);
 		batchContext.refresh();
 
@@ -575,7 +575,7 @@ public class JsrJobOperator implements JobOperator, InitializingBean {
 			ConfigurableListableBeanFactory factory = batchContext.getBeanFactory();
 
 			BatchPropertyContext batchPropertyContext = factory.getBean(BATCH_PROPERTY_CONTEXT_BEAN_NAME, BatchPropertyContext.class);
-			Properties properties = batchPropertyContext.getBatchProperties("job-" + job.getName());
+			Properties properties = batchPropertyContext.getJobProperties();
 
 			factory.registerSingleton(job.getName() + "_" + jobExecution.getId() + "_jobContext", new JobContext(jobExecution, properties));
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/support/BatchPropertyContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/support/BatchPropertyContextTests.java
@@ -16,13 +16,12 @@
 package org.springframework.batch.core.jsr.configuration.support;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * <p>
@@ -32,7 +31,10 @@ import static org.junit.Assert.assertTrue;
  * @author Chris Schaefer
  */
 public class BatchPropertyContextTests {
-	private List<BatchPropertyContext.BatchPropertyContextEntry> entries = new ArrayList<BatchPropertyContext.BatchPropertyContextEntry>();
+	private List<BatchPropertyContext.BatchPropertyContextEntry> jobProperties = new ArrayList<BatchPropertyContext.BatchPropertyContextEntry>();
+	private List<BatchPropertyContext.BatchPropertyContextEntry> stepProperties = new ArrayList<BatchPropertyContext.BatchPropertyContextEntry>();
+	private List<BatchPropertyContext.BatchPropertyContextEntry> artifactProperties = new ArrayList<BatchPropertyContext.BatchPropertyContextEntry>();
+	private List<BatchPropertyContext.BatchPropertyContextEntry> stepArtifactProperties = new ArrayList<BatchPropertyContext.BatchPropertyContextEntry>();
 
 	@Before
 	public void setUp() {
@@ -41,83 +43,55 @@ public class BatchPropertyContextTests {
 		Properties step1Properties = new Properties();
 		step1Properties.setProperty("step1PropertyName1", "step1PropertyValue1");
 		step1Properties.setProperty("step1PropertyName2", "step1PropertyValue2");
-		entries.add(batchPropertyContext.new BatchPropertyContextEntry("job1.step1", step1Properties));
+		stepProperties.add(batchPropertyContext.new BatchPropertyContextEntry("step1", step1Properties, BatchArtifact.BatchArtifactType.STEP));
 
 		Properties step2Properties = new Properties();
 		step2Properties.setProperty("step2PropertyName1", "step2PropertyValue1");
 		step2Properties.setProperty("step2PropertyName2", "step2PropertyValue2");
-		entries.add(batchPropertyContext.new BatchPropertyContextEntry("job1.step2", step2Properties));
+		stepProperties.add(batchPropertyContext.new BatchPropertyContextEntry("step2", step2Properties, BatchArtifact.BatchArtifactType.STEP));
 
 		Properties jobProperties = new Properties();
 		jobProperties.setProperty("jobProperty1", "jobProperty1value");
 		jobProperties.setProperty("jobProperty2", "jobProperty2value");
-		entries.add(batchPropertyContext.new BatchPropertyContextEntry("job1.job-job1", jobProperties));
+		this.jobProperties.add(batchPropertyContext.new BatchPropertyContextEntry("job1", jobProperties, BatchArtifact.BatchArtifactType.JOB));
+
+		Properties artifactProperties = new Properties();
+		artifactProperties.setProperty("deciderProperty1", "deciderProperty1value");
+		artifactProperties.setProperty("deciderProperty2", "deciderProperty2value");
+		this.artifactProperties.add(batchPropertyContext.new BatchPropertyContextEntry("decider1", artifactProperties, BatchArtifact.BatchArtifactType.ARTIFACT));
+
+		Properties stepArtifactProperties = new Properties();
+		stepArtifactProperties.setProperty("readerProperty1", "readerProperty1value");
+		stepArtifactProperties.setProperty("readerProperty2", "readerProperty2value");
+
+		BatchPropertyContext.BatchPropertyContextEntry batchPropertyContextEntry =
+				batchPropertyContext.new BatchPropertyContextEntry("reader", stepArtifactProperties, BatchArtifact.BatchArtifactType.STEP_ARTIFACT);
+		batchPropertyContextEntry.setStepName("step1");
+
+		this.stepArtifactProperties.add(batchPropertyContextEntry);
 	}
 
 	@Test
-	public void testAddBatchContextEntries() {
+	public void testStepLevelProperties() {
 		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
-		batchPropertyContext.setBatchContextEntries(entries);
+		batchPropertyContext.setJobPropertiesContextEntry(jobProperties);
+		batchPropertyContext.setStepPropertiesContextEntry(stepProperties);
 
-		Properties step1BatchProperties = batchPropertyContext.getBatchProperties("job1.step1");
-		assertEquals(4, step1BatchProperties.size());
-		assertEquals("step1PropertyValue1", step1BatchProperties.getProperty("step1PropertyName1"));
-		assertEquals("step1PropertyValue2", step1BatchProperties.getProperty("step1PropertyName2"));
-		assertEquals("jobProperty1value", step1BatchProperties.getProperty("jobProperty1"));
-		assertEquals("jobProperty2value", step1BatchProperties.getProperty("jobProperty2"));
+		Properties step1Properties = batchPropertyContext.getStepProperties("step1");
+		assertEquals(2, step1Properties.size());
+		assertEquals("step1PropertyValue1", step1Properties.getProperty("step1PropertyName1"));
+		assertEquals("step1PropertyValue2", step1Properties.getProperty("step1PropertyName2"));
 
-		Properties step2BatchProperties = batchPropertyContext.getBatchProperties("job1.step2");
-		assertEquals(4, step2BatchProperties.size());
-		assertEquals("step2PropertyValue1", step2BatchProperties.getProperty("step2PropertyName1"));
-		assertEquals("step2PropertyValue2", step2BatchProperties.getProperty("step2PropertyName2"));
-		assertEquals("jobProperty1value", step2BatchProperties.getProperty("jobProperty1"));
-		assertEquals("jobProperty2value", step2BatchProperties.getProperty("jobProperty2"));
-
-		Properties jobProperties = batchPropertyContext.getBatchProperties("job1.job-job1");
-		assertEquals(2, jobProperties.size());
-		assertEquals("jobProperty1value", jobProperties.getProperty("jobProperty1"));
-		assertEquals("jobProperty2value", jobProperties.getProperty("jobProperty2"));
+		Properties step2Properties = batchPropertyContext.getStepProperties("step2");
+		assertEquals(2, step2Properties.size());
+		assertEquals("step2PropertyValue1", step2Properties.getProperty("step2PropertyName1"));
+		assertEquals("step2PropertyValue2", step2Properties.getProperty("step2PropertyName2"));
 	}
 
 	@Test
-	public void testAddBatchContextEntriesToExistingArtifact() {
+	public void testJobLevelProperties() {
 		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
-
-		Properties step1properties = new Properties();
-		step1properties.setProperty("newStep1PropertyName", "newStep1PropertyValue");
-		entries.add(batchPropertyContext.new BatchPropertyContextEntry("job1.step1", step1properties));
-
-		batchPropertyContext.setBatchContextEntries(entries);
-
-		Properties bean2 = batchPropertyContext.getBatchProperties("job1.step1");
-		assertEquals(5, bean2.size());
-		assertEquals("step1PropertyValue1", bean2.getProperty("step1PropertyName1"));
-		assertEquals("step1PropertyValue2", bean2.getProperty("step1PropertyName2"));
-		assertEquals("newStep1PropertyValue", bean2.getProperty("newStep1PropertyName"));
-		assertEquals("jobProperty1value", bean2.getProperty("jobProperty1"));
-		assertEquals("jobProperty2value", bean2.getProperty("jobProperty2"));
-	}
-
-	@Test
-	public void testGetStepLevelProperties() {
-		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
-		batchPropertyContext.setBatchContextEntries(entries);
-
-		Properties bean1 = batchPropertyContext.getStepLevelProperties("job1.step1");
-		assertEquals(2, bean1.size());
-		assertEquals("step1PropertyValue1", bean1.getProperty("step1PropertyName1"));
-		assertEquals("step1PropertyValue2", bean1.getProperty("step1PropertyName2"));
-
-		Properties bean2 = batchPropertyContext.getStepLevelProperties("job1.step2");
-		assertEquals(2, bean2.size());
-		assertEquals("step2PropertyValue1", bean2.getProperty("step2PropertyName1"));
-		assertEquals("step2PropertyValue2", bean2.getProperty("step2PropertyName2"));
-	}
-
-	@Test
-	public void testJobProperties() {
-		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
-		batchPropertyContext.setBatchContextEntries(entries);
+		batchPropertyContext.setJobPropertiesContextEntry(jobProperties);
 
 		Properties jobProperties = batchPropertyContext.getJobProperties();
 		assertEquals(2, jobProperties.size());
@@ -126,56 +100,83 @@ public class BatchPropertyContextTests {
 	}
 
 	@Test
-	public void testJobNonOverridingJobProperties() {
+	public void testAddPropertiesToExistingStep() {
 		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
+		batchPropertyContext.setJobPropertiesContextEntry(jobProperties);
+		batchPropertyContext.setStepPropertiesContextEntry(stepProperties);
 
-		Properties jobProperties = new Properties();
-		jobProperties.setProperty("step1PropertyName1", "step1PropertyOverride");
-		entries.add(batchPropertyContext.new BatchPropertyContextEntry("job1.job-job1", jobProperties));
+		Properties step1 = batchPropertyContext.getStepProperties("step1");
+		assertEquals(2, step1.size());
+		assertEquals("step1PropertyValue1", step1.getProperty("step1PropertyName1"));
+		assertEquals("step1PropertyValue2", step1.getProperty("step1PropertyName2"));
 
-		batchPropertyContext.setBatchContextEntries(entries);
+		Properties step1properties = new Properties();
+		step1properties.setProperty("newStep1PropertyName", "newStep1PropertyValue");
 
-		Properties bean1 = batchPropertyContext.getBatchProperties("job1.step1");
-		assertEquals(4, bean1.size());
-		assertEquals("step1PropertyValue1", bean1.getProperty("step1PropertyName1"));
-		assertEquals("step1PropertyValue2", bean1.getProperty("step1PropertyName2"));
-		assertEquals("jobProperty1value", bean1.getProperty("jobProperty1"));
-		assertEquals("jobProperty2value", bean1.getProperty("jobProperty2"));
+		batchPropertyContext.setStepPropertiesContextEntry(
+				Collections.singletonList(batchPropertyContext.new BatchPropertyContextEntry("step1", step1properties, BatchArtifact.BatchArtifactType.STEP)));
 
-		Properties testJobBean = batchPropertyContext.getBatchProperties("job1.job-job1");
-		assertEquals(3, testJobBean.size());
-		assertEquals("step1PropertyOverride", testJobBean.getProperty("step1PropertyName1"));
-		assertEquals("jobProperty1value", testJobBean.getProperty("jobProperty1"));
-		assertEquals("jobProperty2value", testJobBean.getProperty("jobProperty2"));
+		Properties step1updated = batchPropertyContext.getStepProperties("step1");
+		assertEquals(3, step1updated.size());
+		assertEquals("step1PropertyValue1", step1updated.getProperty("step1PropertyName1"));
+		assertEquals("step1PropertyValue2", step1updated.getProperty("step1PropertyName2"));
+		assertEquals("newStep1PropertyValue", step1updated.getProperty("newStep1PropertyName"));
 	}
 
 	@Test
-	public void testJobLevelPropertiesWithPath() {
-		List<BatchPropertyContext.BatchPropertyContextEntry> entries = new ArrayList<BatchPropertyContext.BatchPropertyContextEntry>();
-
+	public void testNonStepLevelArtifactProperties() {
 		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
+		batchPropertyContext.setJobPropertiesContextEntry(jobProperties);
+		batchPropertyContext.setArtifactPropertiesContextEntry(artifactProperties);
+		batchPropertyContext.setStepPropertiesContextEntry(stepProperties);
 
-		Properties jobProperties = new Properties();
-		jobProperties.setProperty("readerName", "testJobreaderName");
-
-		entries.add(batchPropertyContext.new BatchPropertyContextEntry("job1.job-job1.itemReader", jobProperties));
-
-		batchPropertyContext.setBatchContextEntries(entries);
-
-		Properties props = batchPropertyContext.getJobProperties();
-		assertEquals(1, props.size());
-		assertEquals("testJobreaderName", props.getProperty("readerName"));
+		Properties artifactProperties = batchPropertyContext.getArtifactProperties("decider1");
+		assertEquals(4, artifactProperties.size());
+		assertEquals("deciderProperty1value", artifactProperties.getProperty("deciderProperty1"));
+		assertEquals("deciderProperty2value", artifactProperties.getProperty("deciderProperty2"));
+		assertEquals("jobProperty1value", artifactProperties.getProperty("jobProperty1"));
+		assertEquals("jobProperty2value", artifactProperties.getProperty("jobProperty2"));
 	}
 
 	@Test
-	public void testJobLevelComponentPath() {
+	public void testStepLevelArtifactProperties() {
 		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
-		assertTrue(batchPropertyContext.isJobLevelComponentPath("myJob.job-myJob"));
-		assertTrue(batchPropertyContext.isJobLevelComponentPath("myJob.job-myJob.myReader"));
-		assertTrue(batchPropertyContext.isJobLevelComponentPath("myJob.job-myJob.myReader.something"));
-		assertFalse(batchPropertyContext.isJobLevelComponentPath("myJob"));
-		assertFalse(batchPropertyContext.isJobLevelComponentPath("job-myJob"));
-		assertFalse(batchPropertyContext.isJobLevelComponentPath(null));
-		assertFalse(batchPropertyContext.isJobLevelComponentPath("myJob."));
+		batchPropertyContext.setJobPropertiesContextEntry(jobProperties);
+		batchPropertyContext.setArtifactPropertiesContextEntry(artifactProperties);
+		batchPropertyContext.setStepPropertiesContextEntry(stepProperties);
+		batchPropertyContext.setStepArtifactPropertiesContextEntry(stepArtifactProperties);
+
+		Properties artifactProperties = batchPropertyContext.getStepArtifactProperties("step1", "reader");
+		assertEquals(4, artifactProperties.size());
+		assertEquals("readerProperty1value", artifactProperties.getProperty("readerProperty1"));
+		assertEquals("readerProperty2value", artifactProperties.getProperty("readerProperty2"));
+		assertEquals("step1PropertyValue1", artifactProperties.getProperty("step1PropertyName1"));
+		assertEquals("step1PropertyValue2", artifactProperties.getProperty("step1PropertyName2"));
+	}
+
+	@Test
+	public void testArtifactNonOverridingJobProperties() {
+		BatchPropertyContext batchPropertyContext = new BatchPropertyContext();
+		batchPropertyContext.setJobPropertiesContextEntry(jobProperties);
+		batchPropertyContext.setArtifactPropertiesContextEntry(artifactProperties);
+
+		Properties jobProperties = new Properties();
+		jobProperties.setProperty("deciderProperty1", "decider1PropertyOverride");
+
+		batchPropertyContext.setJobPropertiesContextEntry(
+				Collections.singletonList(batchPropertyContext.new BatchPropertyContextEntry("job1", jobProperties, BatchArtifact.BatchArtifactType.JOB)));
+
+		Properties step1 = batchPropertyContext.getArtifactProperties("decider1");
+		assertEquals(4, step1.size());
+		assertEquals("deciderProperty1value", step1.getProperty("deciderProperty1"));
+		assertEquals("deciderProperty2value", step1.getProperty("deciderProperty2"));
+		assertEquals("jobProperty1value", step1.getProperty("jobProperty1"));
+		assertEquals("jobProperty2value", step1.getProperty("jobProperty2"));
+
+		Properties job = batchPropertyContext.getJobProperties();
+		assertEquals(3, job.size());
+		assertEquals("decider1PropertyOverride", job.getProperty("deciderProperty1"));
+		assertEquals("jobProperty1value", job.getProperty("jobProperty1"));
+		assertEquals("jobProperty2value", job.getProperty("jobProperty2"));
 	}
 }

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/JobPropertyTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/JobPropertyTests-context.xml
@@ -69,7 +69,7 @@
                 <property name="annotationNamedDeciderPropertyName" value="annotationNamedDeciderPropertyValue"/>
                 <property name="nonexistentDeciderPropertyName" value="nonexistentDeciderPropertyValue"/>
             </properties>
-            <next on="*" to="#{jobProperties['step2name']}"/>
+            <next on="*" to="#{jobParameters['unresolving.prop']}?:#{jobProperties['step2name']};"/>
 		</decision>
 		<step id="step2">
             <!-- JSR Section 8.2.3 -->
@@ -132,7 +132,7 @@
     <bean id="injectTestObj" class="org.springframework.batch.core.jsr.configuration.xml.JobPropertyTests$InjectTestObj"
         c:name="Chris"/>
 
-    <bean id="threadLocalClassloaderBeanPostProcessor" class="org.springframework.batch.core.jsr.configuration.support.ThreadLocalClassloaderBeanPostProcessor">
+    <bean id="jobParameterResolvingBeanFactoryPostProcessor" class="org.springframework.batch.core.jsr.configuration.support.JobParameterResolvingBeanFactoryPostProcessor">
         <constructor-arg>
             <props>
                 <prop key="allow.start.if.complete">true</prop>


### PR DESCRIPTION
- Move pre-context init of JobParameters support out of ThreadLocalClassloaderBeanPostProcessor
- General cleanup in BatchPropertyBeanPostProcessor, move artifact type checking into classifer class, minor naming updates
- Refactor BatchPropertyContext to use different data structures for different types of properties and provide named accessors
- Remove path based artifact scoping support
- Make sure expressions are parsed when resolving properties directly from XML
- Update property tests
- Move registration of jobProperties bean into the JsrNamespaceUtils
