### PR TITLE
Remove unique transition pattern check per JSR requirements

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/FlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/FlowParser.java
@@ -60,10 +60,18 @@ public class FlowParser extends AbstractFlowParser {
 	private static final String TO_ATTRIBUTE = "to";
 	private static final String RESTART_ATTRIBUTE = "restart";
 	private static final String EXIT_STATUS_ATTRIBUTE = "exit-status";
+	private static final List<String> TRANSITION_TYPES = new ArrayList<String>();
 
+	static {
+		TRANSITION_TYPES.add(NEXT_ATTRIBUTE);
+		TRANSITION_TYPES.add(STOP_ATTRIBUTE);
+		TRANSITION_TYPES.add(END_ATTRIBUTE);
+		TRANSITION_TYPES.add(FAIL_ATTRIBUTE);
+	}
+
+	private String flowName;
 	private String jobFactoryRef;
 	private StepParser stepParser = new StepParser();
-	private String flowName;
 
 	/**
 	 * @param flowName The name of the flow
@@ -157,12 +165,10 @@ public class FlowParser extends AbstractFlowParser {
 		}
 
 		boolean transitionElementExists = false;
-		List<String> patterns = new ArrayList<String>();
-		for (String transitionName : new String[] { NEXT_ATTRIBUTE, STOP_ATTRIBUTE, END_ATTRIBUTE, FAIL_ATTRIBUTE }) {
-			List<Element> transitionElements = DomUtils.getChildElementsByTagName(element, transitionName);
-			for (Element transitionElement : transitionElements) {
-				verifyUniquePattern(transitionElement, patterns, element, parserContext);
-				list.addAll(parseTransitionElement(transitionElement, stepId, stateDef, parserContext));
+		List<Element> childElements = DomUtils.getChildElements(element);
+		for(Element childElement : childElements) {
+			if(isChildElementTransitionElement(childElement)) {
+				list.addAll(parseTransitionElement(childElement, stepId, stateDef, parserContext));
 				transitionElementExists = true;
 			}
 		}
@@ -184,6 +190,17 @@ public class FlowParser extends AbstractFlowParser {
 		}
 
 		return list;
+	}
+
+	private static boolean isChildElementTransitionElement(Element childElement) {
+		boolean isTransitionElement = false;
+
+		if(TRANSITION_TYPES.contains(childElement.getLocalName())) {
+			int index = TRANSITION_TYPES.indexOf(childElement.getLocalName());
+			isTransitionElement = TRANSITION_TYPES.get(index) != null;
+		}
+
+		return isTransitionElement;
 	}
 
 	protected static Collection<BeanDefinition> parseTransitionElement(Element transitionElement, String stateId,

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/FlowParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/FlowParserTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.jsr.configuration.xml;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.batch.api.Batchlet;
+import javax.batch.runtime.context.StepContext;
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <p>
+ * Unit tests around {@link FlowParser}.
+ * </p>
+ *
+ * @author Chris Schaefer
+ * @since 3.0
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class FlowParserTests {
+	@Autowired
+	private Job job;
+
+	@Autowired
+	private JobLauncher jobLauncher;
+
+	@Test
+	public void testDuplicateTransitionPatternsAllowed() throws Exception {
+		JobExecution stoppedExecution = jobLauncher.run(job, new JobParameters());
+		assertEquals(ExitStatus.STOPPED.getExitCode(), stoppedExecution.getExitStatus().getExitCode());
+
+		JobExecution endedExecution = jobLauncher.run(job, new JobParameters());
+		assertEquals(ExitStatus.COMPLETED.getExitCode(), endedExecution.getExitStatus().getExitCode());
+
+		JobExecution failedExecution = jobLauncher.run(job, new JobParameters());
+		assertEquals(ExitStatus.FAILED.getExitCode(), failedExecution.getExitStatus().getExitCode());
+	}
+
+	public static class TestBatchlet implements Batchlet {
+		private static int CNT;
+
+		@Inject
+		private StepContext stepContext;
+
+		@Override
+		public String process() throws Exception {
+			String exitCode = "DISTINCT";
+
+			if("step3".equals(stepContext.getStepName())) {
+				exitCode = CNT % 2 == 0 ? "DISTINCT" : "RESTART";
+				CNT++;
+			}
+
+			return exitCode;
+		}
+
+		@Override
+		public void stop() throws Exception { }
+	}
+}

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/FlowParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/jsr/configuration/xml/FlowParserTests-context.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd">
+	<job id="job" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+		<step id="step1">
+			<batchlet ref="testBatchlet"/>
+			<next on="DISTINCT" to="step2"/>
+			<stop on="DISTINCT" restart="step1"/>
+			<end on="DISTINCT"/>
+			<fail on="DISTINCT"/>
+		</step>
+		<step id="step2">
+			<batchlet ref="testBatchlet"/>
+			<stop on="DISTINCT" restart="step3"/>
+			<next on="DISTINCT" to="step3"/>
+			<end on="DISTINCT"/>
+			<fail on="DISTINCT"/>
+		</step>
+		<step id="step3" allow-start-if-complete="true">
+			<batchlet ref="testBatchlet"/>
+			<end on="DISTINCT"/>
+			<next on="RESTART" to="step4"/>
+			<stop on="DISTINCT" restart="step3"/>
+			<fail on="DISTINCT"/>
+		</step>
+		<step id="step4">
+			<batchlet ref="testBatchlet"/>
+			<fail on="DISTINCT"/>
+			<next on="DISTINCT" to="step4"/>
+			<stop on="DISTINCT" restart="step2"/>
+			<end on="DISTINCT"/>
+		</step>
+	</job>
+
+	<bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>
+
+	<bean id="jobLauncher" class="org.springframework.batch.core.launch.support.SimpleJobLauncher"
+			p:jobRepository-ref="jobRepository"/>
+
+	<bean id="jobRepository" class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean"/>
+
+	<bean id="testBatchlet" class="org.springframework.batch.core.jsr.configuration.xml.FlowParserTests$TestBatchlet" scope="step"/>
+</beans>


### PR DESCRIPTION
Transitions are ordered based on their ordering in the job defintion XML document, so for example having an end and stop transition both with a pattern of "foo" is valid.
