### PR TITLE
fix NPE and testInvokeJobWithUncaughtExceptionFailAndRestart

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/FlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/FlowParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,12 +147,6 @@ public class FlowParser extends AbstractFlowParser {
 
 		Collection<BeanDefinition> list = new ArrayList<BeanDefinition>();
 
-		String shortNextAttribute = element.getAttribute(NEXT_ATTRIBUTE);
-		boolean hasNextAttribute = StringUtils.hasText(shortNextAttribute);
-		if (hasNextAttribute) {
-			list.add(getStateTransitionReference(parserContext, stateDef, null, shortNextAttribute));
-		}
-
 		boolean transitionElementExists = false;
 		List<Element> childElements = DomUtils.getChildElements(element);
 		for(Element childElement : childElements) {
@@ -161,6 +155,9 @@ public class FlowParser extends AbstractFlowParser {
 				transitionElementExists = true;
 			}
 		}
+
+		String shortNextAttribute = element.getAttribute(NEXT_ATTRIBUTE);
+		boolean hasNextAttribute = StringUtils.hasText(shortNextAttribute);
 
 		if (!transitionElementExists) {
 			list.addAll(createTransition(FlowExecutionStatus.FAILED, FlowExecutionStatus.FAILED.getName(), null, null,
@@ -171,6 +168,10 @@ public class FlowParser extends AbstractFlowParser {
 				list.addAll(createTransition(FlowExecutionStatus.COMPLETED, FlowExecutionStatus.COMPLETED.getName(), null, null, stateDef, parserContext,
 						false));
 			}
+		}
+
+		if (hasNextAttribute) {
+			list.add(getStateTransitionReference(parserContext, stateDef, null, shortNextAttribute));
 		}
 
 		return list;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/launch/JsrJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/launch/JsrJobOperatorTests.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import javax.batch.api.AbstractBatchlet;
 import javax.batch.api.Batchlet;
 import javax.batch.operations.JobExecutionIsRunningException;
 import javax.batch.operations.JobOperator;
@@ -425,6 +426,14 @@ public class JsrJobOperatorTests {
 	}
 
 	@Test(expected = JobRestartException.class)
+	public void testNonRestartableJob() throws Exception {
+		javax.batch.runtime.JobExecution jobExecutionStart = runJob("jsrJobOperatorTestNonRestartableJob", new Properties(), TIMEOUT);
+		assertEquals(BatchStatus.FAILED, jobExecutionStart.getBatchStatus());
+
+		restartJob(jobExecutionStart.getExecutionId(), null, TIMEOUT);
+	}
+
+	@Test(expected = JobRestartException.class)
 	public void testRestartAbandoned() throws Exception {
 		jsrJobOperator = BatchRuntime.getJobOperator();
 		javax.batch.runtime.JobExecution execution = runJob("jsrJobOperatorTestRestartAbandonJob", null, TIMEOUT);
@@ -532,6 +541,13 @@ public class JsrJobOperatorTests {
 		@Override
 		public void stop() throws Exception {
 			stopped = true;
+		}
+	}
+
+	public static class FailingBatchlet extends AbstractBatchlet {
+		@Override
+		public String process() throws Exception {
+			throw new RuntimeException("blah");
 		}
 	}
 }

--- a/spring-batch-core/src/test/resources/META-INF/batch-jobs/FlowParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch-jobs/FlowParserTests-context.xml
@@ -2,7 +2,6 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:p="http://www.springframework.org/schema/p"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 						http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd">
 	<job id="job" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">

--- a/spring-batch-core/src/test/resources/META-INF/batch-jobs/FlowParserTestsWildcardAndNextAttrJob.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch-jobs/FlowParserTestsWildcardAndNextAttrJob.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd">
+	<job id="job" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+		<step id="step1" next="step2">
+			<batchlet ref="testBatchlet"/>
+		</step>
+		<step id="step2">
+			<batchlet ref="testBatchlet"/>
+		</step>
+	</job>
+
+	<bean id="testBatchlet" class="org.springframework.batch.core.jsr.configuration.xml.FlowParserTests$FailingTestBatchlet" scope="step"/>
+</beans>

--- a/spring-batch-core/src/test/resources/META-INF/batch-jobs/jsrJobOperatorTestNonRestartableJob.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch-jobs/jsrJobOperatorTestNonRestartableJob.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<job id="nonRestartableJob" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0" restartable="false">
+	<step id="step1">
+		<batchlet ref="org.springframework.batch.core.jsr.launch.JsrJobOperatorTests$FailingBatchlet" />
+	</step>
+</job>


### PR DESCRIPTION
- Update copyright year
- Move addition of state transition for elements with a next transition to be last
- Move restartable check into run method on restart to avoid NPE in factory bean due to null JobExecution.

Transition shuffle fixes TCK test testInvokeJobWithUncaughtExceptionFailAndRestart, NPE fix contributes to other tests but does not fix completely.
