### PR TITLE
Force allow start if complete on DecisionStep

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/DecisionStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/DecisionStepFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  * {@link FactoryBean} for creating a {@link DecisionStep}.
  *
  * @author Michael Minella
+ * @author Chris Schaefer
  * @since 3.0
  */
 public class DecisionStepFactoryBean implements FactoryBean<Step>, InitializingBean {
@@ -65,10 +66,10 @@ public class DecisionStepFactoryBean implements FactoryBean<Step>, InitializingB
 	 */
 	@Override
 	public Step getObject() throws Exception {
-
 		DecisionStep decisionStep = new DecisionStep(jsrDecider);
 		decisionStep.setName(name);
 		decisionStep.setJobRepository(jobRepository);
+		decisionStep.setAllowStartIfComplete(true);
 
 		return decisionStep;
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/step/DecisionStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/step/DecisionStepTests.java
@@ -2,8 +2,11 @@ package org.springframework.batch.core.jsr.step;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.springframework.batch.core.jsr.JsrTestUtils.restartJob;
+import static org.springframework.batch.core.jsr.JsrTestUtils.runJob;
 
 import java.util.List;
+import java.util.Properties;
 
 import javax.batch.api.Decider;
 import javax.batch.runtime.StepExecution;
@@ -115,6 +118,17 @@ public class DecisionStepTests {
 	@Test
 	@Ignore("Splits are not implemented yet as part of our JSR implementation")
 	public void testDecisionAfterSplit() {
+	}
+
+	@Test
+	public void testDecisionOnRestart() throws Exception {
+		javax.batch.runtime.JobExecution jobExecution = runJob("DecisionStepTests-executeDecisionOnRestart", new Properties(), 10000l);
+		assertEquals("next", jobExecution.getExitStatus());
+		assertEquals(javax.batch.runtime.BatchStatus.FAILED, jobExecution.getBatchStatus());
+
+		javax.batch.runtime.JobExecution restartedJobExecution = restartJob(jobExecution.getExecutionId(), new Properties(), 10000l);
+		assertEquals("next", restartedJobExecution.getExitStatus());
+		assertEquals(javax.batch.runtime.BatchStatus.FAILED, jobExecution.getBatchStatus());
 	}
 
 	public static class NextDecider implements Decider {

--- a/spring-batch-core/src/test/resources/META-INF/batch-jobs/DecisionStepTests-executeDecisionOnRestart.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch-jobs/DecisionStepTests-executeDecisionOnRestart.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd">
+	<job id="job1" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+		<step id="step1" next="decision1" allow-start-if-complete="true">
+			<batchlet ref="doSomethingBatchlet"/>
+		</step>
+		<decision ref="nextDecider" id="decision1">
+			<fail on="*"/>
+		</decision>
+	</job>
+
+	<bean id="nextDecider" class="org.springframework.batch.core.jsr.step.DecisionStepTests$NextDecider"/>
+	<bean id="doSomethingBatchlet" class="org.springframework.batch.core.jsr.step.batchlet.BatchletSupport"/>
+</beans>


### PR DESCRIPTION
Force allow start if complete on DecisionStep. Fixes TCK tests:

testDeciderTransitionFromStepAndAllowRestart
testDeciderTransitionFromStepWithinFlowAndAllowRestart
testDeciderTransitionFromFlowAndAllowRestart
