### PR TITLE
Fixes for stopping a partitioned step

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public class SimpleFlowFactoryBean implements FactoryBean, InitializingBean {
 		}
 		String stateName = prefix + oldName;
 		if (state instanceof StepState) {
-			return new StepState(stateName, ((StepState) state).getStep());
+			return new StepState(stateName, ((StepState) state).getStep(oldName));
 		}
 		return new DelegateState(stateName, state);
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.batch.core.StartLimitExceededException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.batch.core.step.StepLocator;
 
 /**
  * Simple implementation of {@link Job} interface providing the ability to run a
@@ -37,6 +38,7 @@ import org.springframework.batch.core.repository.JobRestartException;
  *
  * @author Lucas Ward
  * @author Dave Syer
+ * @author Michael Minella
  */
 public class SimpleJob extends AbstractJob {
 
@@ -77,6 +79,10 @@ public class SimpleJob extends AbstractJob {
 		List<String> names = new ArrayList<String>();
 		for (Step step : steps) {
 			names.add(step.getName());
+
+			if(step instanceof StepLocator) {
+				names.addAll(((StepLocator)step).getStepNames());
+			}
 		}
 		return names;
 	}
@@ -101,6 +107,11 @@ public class SimpleJob extends AbstractJob {
 		for (Step step : this.steps) {
 			if (step.getName().equals(stepName)) {
 				return step;
+			} else if(step instanceof StepLocator) {
+				Step result = ((StepLocator)step).getStep(stepName);
+				if(result != null) {
+					return result;
+				}
 			}
 		}
 		return null;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,12 @@ public class FlowJob extends AbstractJob {
 	private void findSteps(Flow flow, Map<String, Step> map) {
 
 		for (State state : flow.getStates()) {
-			if (state instanceof StepHolder) {
+			if (state instanceof StepLocator) {
+				StepLocator locator = (StepLocator) state;
+				for (String name : locator.getStepNames()) {
+					map.put(name, locator.getStep(name));
+				}
+			} else if (state instanceof StepHolder) {
 				Step step = ((StepHolder) state).getStep();
 				String name = step.getName();
 				stepMap.put(name, step);
@@ -101,12 +106,6 @@ public class FlowJob extends AbstractJob {
 			else if (state instanceof FlowHolder) {
 				for (Flow subflow : ((FlowHolder) state).getFlows()) {
 					findSteps(subflow, map);
-				}
-			}
-			else if (state instanceof StepLocator) {
-				StepLocator locator = (StepLocator) state;
-				for (String name : locator.getStepNames()) {
-					map.put(name, locator.getStep(name));
 				}
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/StepState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/StepState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,27 @@
 
 package org.springframework.batch.core.job.flow.support.state;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.flow.FlowExecutionStatus;
 import org.springframework.batch.core.job.flow.FlowExecutor;
 import org.springframework.batch.core.job.flow.State;
+import org.springframework.batch.core.step.NoSuchStepException;
 import org.springframework.batch.core.step.StepHolder;
+import org.springframework.batch.core.step.StepLocator;
 
 /**
  * {@link State} implementation that delegates to a {@link FlowExecutor} to
  * execute the specified {@link Step}.
  *
  * @author Dave Syer
+ * @author Michael Minella
  * @since 2.0
  */
-public class StepState extends AbstractState implements StepHolder {
+public class StepState extends AbstractState implements StepLocator, StepHolder {
 
 	private final Step step;
 
@@ -61,7 +68,7 @@ public class StepState extends AbstractState implements StepHolder {
 	}
 
 	/**
-	 * @return the step
+	 * @deprecated in favor of using {@link StepLocator#getStep(String)}.
 	 */
 	@Override
 	public Step getStep() {
@@ -76,4 +83,35 @@ public class StepState extends AbstractState implements StepHolder {
 		return false;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.batch.core.step.StepLocator#getStepNames()
+	 */
+	@Override
+	public Collection<String> getStepNames() {
+		List<String> names = new ArrayList<String>();
+
+		names.add(step.getName());
+
+		if(step instanceof StepLocator) {
+			names.addAll(((StepLocator)step).getStepNames());
+		}
+
+		return names;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.batch.core.step.StepLocator#getStep(java.lang.String)
+	 */
+	@Override
+	public Step getStep(String stepName) throws NoSuchStepException {
+		Step result = null;
+
+		if(step.getName().equals(stepName)) {
+			result = step;
+		} else if(step instanceof StepLocator) {
+			result = ((StepLocator) step).getStep(stepName);
+		}
+
+		return result;
+	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/job/flow/support/state/EndState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/job/flow/support/state/EndState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,22 +64,9 @@ public class EndState extends org.springframework.batch.core.job.flow.support.st
 	protected void setExitStatus(FlowExecutor executor, String code) {
 		StepExecution stepExecution = executor.getStepExecution();
 
-		if(!isNonDefaultExitStatus(code)) {
-			stepExecution.getJobExecution().setExitStatus(new ExitStatus(code));
+		ExitStatus status = new ExitStatus(code);
+		if(!ExitStatus.isNonDefaultExitStatus(status)) {
+			stepExecution.getJobExecution().setExitStatus(status);
 		}
-	}
-
-	/**
-	 * @param curStatus the exit code to be evaluated
-	 * @return true if the value matches a known exit code
-	 */
-	protected boolean isNonDefaultExitStatus(String curStatus) {
-		return curStatus == null ||
-				curStatus.equals(ExitStatus.COMPLETED.getExitCode()) ||
-				curStatus.equals(ExitStatus.EXECUTING.getExitCode()) ||
-				curStatus.equals(ExitStatus.FAILED.getExitCode()) ||
-				curStatus.equals(ExitStatus.NOOP.getExitCode()) ||
-				curStatus.equals(ExitStatus.STOPPED.getExitCode()) ||
-				curStatus.equals(ExitStatus.UNKNOWN.getExitCode());
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/step/PartitionStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/step/PartitionStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,13 @@ import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.jsr.partition.JsrPartitionHandler;
 import org.springframework.batch.core.jsr.partition.support.JsrStepExecutionAggregator;
 import org.springframework.batch.core.partition.PartitionHandler;
 import org.springframework.batch.core.partition.StepExecutionSplitter;
 import org.springframework.batch.core.partition.support.StepExecutionAggregator;
+import org.springframework.batch.core.step.NoSuchStepException;
+import org.springframework.batch.core.step.StepLocator;
 import org.springframework.batch.item.ExecutionContext;
 
 /**
@@ -38,7 +41,7 @@ import org.springframework.batch.item.ExecutionContext;
  * @author Michael Minella
  * @since 3.0
  */
-public class PartitionStep extends org.springframework.batch.core.partition.support.PartitionStep {
+public class PartitionStep extends org.springframework.batch.core.partition.support.PartitionStep implements StepLocator {
 
 	private PartitionReducer reducer;
 	private boolean hasReducer = false;
@@ -86,5 +89,28 @@ public class PartitionStep extends org.springframework.batch.core.partition.supp
 			reducer.beforePartitionedStepCompletion();
 			reducer.afterPartitionedStepCompletion(PartitionStatus.COMMIT);
 		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.batch.core.step.StepLocator#getStepNames()
+	 */
+	@Override
+	public Collection<String> getStepNames() {
+		return ((JsrPartitionHandler) getPartitionHandler()).getPartitionStepNames();
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.batch.core.step.StepLocator#getStep(java.lang.String)
+	 */
+	@Override
+	public Step getStep(String stepName) throws NoSuchStepException {
+		JsrPartitionHandler partitionHandler =  (JsrPartitionHandler) getPartitionHandler();
+		Collection<String> names = partitionHandler.getPartitionStepNames();
+
+		if(names.contains(stepName)) {
+			return partitionHandler.getStep();
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
- StepState now implements StepLocator so that the step it wraps can return slave steps in the case of a partitioned step
- FlowJob and SimpleJob now look for a StepLocator as they look for steps
- The JSR-352 version of PartitionStep implements StepLocator
