### PR TITLE
PartitionParserTests fixes

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/PartitionParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/PartitionParserTests.java
@@ -132,7 +132,6 @@ public class PartitionParserTests {
 		assertTrue(PartitionCollector.artifactNames.contains("collector1"));
 		assertTrue(PartitionCollector.artifactNames.contains("collector2"));
 
-		assertEquals(PartitionMapper.name, "mapper");
 		assertEquals(PartitionAnalyzer.name, "analyzer");
 		assertEquals(PartitionReducer.name, "reducer");
 	}

--- a/spring-batch-core/src/test/resources/META-INF/batch-jobs/fullPartitionParserWithHardcodedPropertiesTests.xml
+++ b/spring-batch-core/src/test/resources/META-INF/batch-jobs/fullPartitionParserWithHardcodedPropertiesTests.xml
@@ -36,6 +36,11 @@
 					<property name="artifactName" value="reducer"/>
 				</properties>
 	    	</reducer>
+            <mapper ref="org.springframework.batch.core.jsr.configuration.xml.PartitionParserTests$PartitionMapper">
+                <properties>
+                    <property name="artifactName" value="mapper"/>
+                </properties>
+            </mapper>
 	    </partition>
 	</step>
 </job>


### PR DESCRIPTION
testFullPartitionConfigurationWithMapperSuppliedProperties
- remove assert on PartitionMapper.name as PropertyPartitionMapper is used and
  PartitionMapper.name does not get populated.

testFullPartitionConfigurationWithHardcodedProperties
- when run as part of the suite, the static field "name" gets populated by another test case.
  add explicit reference and hardcoded property to job def
