### PR TITLE
BATCH-2111: Java 8 / Upgrade to Spring 4

### DIFF
--- a/archetypes/simple-cli-javaconfig/pom.xml
+++ b/archetypes/simple-cli-javaconfig/pom.xml
@@ -14,10 +14,11 @@
         The ./bin/runJob.(sh|bat) script from the extracted deployment archive can be invoked to run the job.
     </description>
     <properties>
-        <spring.framework.version>3.2.7.RELEASE</spring.framework.version>
+        <spring.framework.version>4.0.2.RELEASE</spring.framework.version>
         <spring.batch.version>3.0.0.BUILD-SNAPSHOT</spring.batch.version>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <junit.version>4.10</junit.version>
+        <maven.compiler.plugin>3.1</maven.compiler.plugin>
         <compiler.target.version>1.6</compiler.target.version>
         <compiler.source.version>1.6</compiler.source.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -185,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>${maven.compiler.plugin}</version>
                 <configuration>
                     <source>${compiler.source.version}</source>
                     <target>${compiler.target.version}</target>

--- a/archetypes/simple-cli/pom.xml
+++ b/archetypes/simple-cli/pom.xml
@@ -14,10 +14,11 @@
         The ./bin/runJob.(sh|bat) script from the extracted deployment archive can be invoked to run the job.
     </description>
     <properties>
-        <spring.framework.version>3.2.7.RELEASE</spring.framework.version>
+        <spring.framework.version>4.0.2.RELEASE</spring.framework.version>
         <spring.batch.version>3.0.0.BUILD-SNAPSHOT</spring.batch.version>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <junit.version>4.10</junit.version>
+        <maven.compiler.plugin>3.1</maven.compiler.plugin>
         <compiler.target.version>1.6</compiler.target.version>
         <compiler.source.version>1.6</compiler.source.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -185,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>${maven.compiler.plugin}</version>
                 <configuration>
                     <source>${compiler.source.version}</source>
                     <target>${compiler.target.version}</target>

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +41,7 @@ import org.w3c.dom.NodeList;
 /**
  * @author Dave Syer
  * @author Michael Minella
+ * @author Chris Schaefer
  *
  */
 public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionParser {
@@ -119,7 +121,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 		parserContext.pushContainingComponent(compositeDef);
 
 		boolean stepExists = false;
-		Map<String, Set<String>> reachableElementMap = new HashMap<String, Set<String>>();
+		Map<String, Set<String>> reachableElementMap = new LinkedHashMap<String, Set<String>>();
 		String startElement = null;
 		NodeList children = element.getChildNodes();
 		for (int i = 0; i < children.getLength(); i++) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/scope/StepScopeProxyTargetClassOverrideIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/scope/StepScopeProxyTargetClassOverrideIntegrationTests.java
@@ -29,7 +29,7 @@ public class StepScopeProxyTargetClassOverrideIntegrationTests implements BeanFa
 	
 	private static final String JDK_PROXY_TO_STRING_REGEX = "class .*\\$Proxy\\d+";	
 	
-	private static final String CGLIB_PROXY_TO_STRING_REGEX = "class .*\\$EnhancerByCGLIB.*";
+	private static final String CGLIB_PROXY_TO_STRING_REGEX = "class .*\\$EnhancerBySpringCGLIB.*";
 
 	@Autowired
 	@Qualifier("simple")

--- a/spring-batch-integration/pom.xml
+++ b/spring-batch-integration/pom.xml
@@ -11,8 +11,8 @@
 		<relativePath>../spring-batch-parent</relativePath>
 	</parent>
 	<properties>
-		<spring.framework.version>4.0.0.RELEASE</spring.framework.version>
 		<spring.integration.version>4.0.0.M2</spring.integration.version>
+		<maven.compiler.plugin>3.1</maven.compiler.plugin>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -161,14 +161,6 @@
 	</dependencies>
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>com.springsource.bundlor</groupId>
 				<artifactId>com.springsource.bundlor.maven</artifactId>

--- a/spring-batch-parent/pom.xml
+++ b/spring-batch-parent/pom.xml
@@ -31,14 +31,22 @@
 			<name>Michael Minella</name>
 			<email>mminella@vmware.com</email>
 		</developer>
+		<developer>
+			<id>cschaefer</id>
+			<name>Chris Schaefer</name>
+			<email>cschaefer@gopivotal.com</email>
+		</developer>
 	</developers>
 	<properties>
-		<spring.framework.version>3.2.7.RELEASE</spring.framework.version>
+		<spring.framework.version>4.0.2.RELEASE</spring.framework.version>
 		<spring.amqp.version>1.1.2.RELEASE</spring.amqp.version>
 		<junit.version>4.10</junit.version>
 		<bundlor.version>1.0.0.RELEASE</bundlor.version>
+		<maven.compiler.plugin>3.1</maven.compiler.plugin>
 		<dependency.locations.enabled>false</dependency.locations.enabled>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<compiler.target.version>1.6</compiler.target.version>
+		<compiler.source.version>1.6</compiler.source.version>
 	</properties>
 	<profiles>
 		<profile>
@@ -279,10 +287,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>${maven.compiler.plugin}</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>${compiler.source.version}</source>
+					<target>${compiler.target.version}</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
- Upgrade Spring framework to 4.0.2.RELEASE
- Upgrade maven compiler plugin to 3.1
- Use LinkedHashMap to preseve ordering in AbstractFlowParser (found when upgrading to JDK 8)
- Match on EnhancerBySpringCGLIB in StepScopeProxyTargetClassOverrideIntegrationTests (SPR-11398)
