### PR TITLE
Use bean names to avoid key collision in in execution context

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkMonitor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkMonitor.java
@@ -58,10 +58,6 @@ public class ChunkMonitor extends ItemStreamSupport {
 
 	private ItemReader<?> reader;
 
-	public ChunkMonitor() {
-		this.setExecutionContextName(ChunkMonitor.class.getName());
-	}
-
 	/**
 	 * @param stream the stream to set
 	 */

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/partition/ExampleItemReader.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/partition/ExampleItemReader.java
@@ -6,7 +6,6 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
-import org.springframework.util.ClassUtils;
 
 /**
  * {@link ItemStreamReader} with hard-coded input data.
@@ -24,11 +23,7 @@ public class ExampleItemReader extends AbstractItemStreamItemReader<String> {
 	private int max = Integer.MAX_VALUE;
 
 	public static volatile boolean fail = false;
-
-        public ExampleItemReader() {
-                this.setExecutionContextName(ClassUtils.getShortName(this.getClass()));
-        }
-        
+      
 	/**
 	 * @param min the min to set
 	 */

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkMonitorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkMonitorTests.java
@@ -95,7 +95,7 @@ public class ChunkMonitorTests {
 	@Test
 	public void testOpen() {
 		ExecutionContext executionContext = new ExecutionContext();
-		executionContext.putInt(ChunkMonitor.class.getName() + ".OFFSET", 2);
+		executionContext.putInt(monitor.getExecutionContextKey("OFFSET"), 2);
 		monitor.open(executionContext);
 		assertEquals(2, count);
 		assertEquals(0, monitor.getOffset());
@@ -118,7 +118,7 @@ public class ChunkMonitorTests {
 			}
 		});
 		ExecutionContext executionContext = new ExecutionContext();
-		executionContext.putInt(ChunkMonitor.class.getName() + ".OFFSET", 2);
+		executionContext.putInt(monitor.getExecutionContextKey("OFFSET"), 2);
 		monitor.open(executionContext);
 	}
 
@@ -129,7 +129,7 @@ public class ChunkMonitorTests {
 		monitor.update(executionContext);
 		assertEquals(0, executionContext.size());
 
-		executionContext.put(ChunkMonitor.class.getName() + ".OFFSET", 3);
+		executionContext.put(monitor.getExecutionContextKey("OFFSET"), 3);
 		monitor.update(executionContext);
 		assertEquals(0, executionContext.size());
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemStreamSupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemStreamSupport.java
@@ -16,6 +16,8 @@
 package org.springframework.batch.item;
 
 import org.springframework.batch.item.util.ExecutionContextUserSupport;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.util.ClassUtils;
 
 /**
  * Empty method implementation of {@link ItemStream}.
@@ -24,9 +26,17 @@ import org.springframework.batch.item.util.ExecutionContextUserSupport;
  * @author Dean de Bree
  *
  */
-public abstract class ItemStreamSupport implements ItemStream {
+public abstract class ItemStreamSupport implements ItemStream, BeanNameAware {
 
 	private final ExecutionContextUserSupport executionContextUserSupport = new ExecutionContextUserSupport();
+	
+	private final String defaultName = ClassUtils.getShortName(getClass());
+	
+	private String name;
+	
+	public ItemStreamSupport() {
+		setName(defaultName);
+	}
 
 	/**
 	 * No-op.
@@ -54,21 +64,38 @@ public abstract class ItemStreamSupport implements ItemStream {
 	
 	/**
 	 * The name of the component which will be used as a stem for keys in the
-	 * {@link ExecutionContext}. Subclasses should provide a default value, e.g.
-	 * the short form of the class name.
+	 * {@link ExecutionContext}. By default, the short form of the class name is used.
+	 * If this component is a spring bean, the name of the bean will be used as default.
+	 * Setting this property explicitly overrides this default behavior.
 	 * 
 	 * @param name the name for the component
 	 */
 	public void setName(String name) {
 		this.setExecutionContextName(name);
 	}
+	
+	/**
+	 * Set the name of the bean in the bean factory that created this bean.
+	 * The bean name will only be used as name of the component in case it hasn't 
+	 * already been explicitly set to a value other than the default. 
+	 * 
+	 * {@link #setName(String)}
+	 * @see BeanNameAware#setBeanName(String)
+	 */
+	@Override
+	public void setBeanName(String name) {
+		if (defaultName.equals(this.name)) { 			
+			setName(name);
+		}
+	}
 
 	protected void setExecutionContextName(String name) {
+		this.name = name;
 		executionContextUserSupport.setName(name);
 	}
 
 	public String getExecutionContextKey(String key) {
 		return executionContextUserSupport.getKey(key);
 	}
-
+		
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemReader.java
@@ -77,11 +77,6 @@ public class MongoItemReader<T> extends AbstractPaginatedDataItemReader<T> imple
 	private String fields;
 	private List<Object> parameterValues;
 
-	public MongoItemReader() {
-		super();
-		setName(ClassUtils.getShortName(MongoItemReader.class));
-	}
-
 	/**
 	 * Used to perform operations against the MongoDB instance.  Also
 	 * handles the mapping of documents to objects.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/Neo4jItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/Neo4jItemReader.java
@@ -81,10 +81,6 @@ InitializingBean {
 
 	private ResultConverter resultConverter;
 
-	public Neo4jItemReader() {
-		setName(ClassUtils.getShortName(Neo4jItemReader.class));
-	}
-
 	/**
 	 * The start segment of the cypher query.  START is prepended
 	 * to the statement provided and should <em>not</em> be

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
@@ -84,10 +84,6 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 
 	private String methodName;
 
-	public RepositoryItemReader() {
-		setName(ClassUtils.getShortName(RepositoryItemReader.class));
-	}
-
 	/**
 	 * Arguments to be passed to the data providing method.
 	 *

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
@@ -56,10 +56,6 @@ public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingIt
 
 	private Object lock = new Object();
 
-	public AbstractPagingItemReader() {
-		setName(ClassUtils.getShortName(AbstractPagingItemReader.class));
-	}
-
 	/**
 	 * The current page number.
 	 * @return the current page

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateCursorItemReader.java
@@ -59,10 +59,6 @@ public class HibernateCursorItemReader<T> extends AbstractItemCountingItemStream
 
 	private HibernateItemReaderHelper<T> helper = new HibernateItemReaderHelper<T>();
 
-	public HibernateCursorItemReader() {
-		setName(ClassUtils.getShortName(HibernateCursorItemReader.class));
-	}
-
 	private ScrollableResults cursor;
 
 	private boolean initialized = false;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernatePagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernatePagingItemReader.java
@@ -66,11 +66,7 @@ public class HibernatePagingItemReader<T> extends AbstractPagingItemReader<T>
 	private Map<String, Object> parameterValues;
 
 	private int fetchSize;
-
-	public HibernatePagingItemReader() {
-		setName(ClassUtils.getShortName(HibernatePagingItemReader.class));
-	}
-
+	
 	/**
 	 * The parameter values to apply to a query (map of name:value).
 	 *

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/IbatisPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/IbatisPagingItemReader.java
@@ -100,10 +100,6 @@ public class IbatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
 
 	private DataSource dataSource;
 
-	public IbatisPagingItemReader() {
-		setName(ClassUtils.getShortName(IbatisPagingItemReader.class));
-	}
-
 	public void setDataSource(DataSource dataSource) {
 		this.dataSource = dataSource;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
@@ -61,11 +61,6 @@ public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
 	RowMapper rowMapper;
 
-	public JdbcCursorItemReader() {
-		super();
-		setName(ClassUtils.getShortName(JdbcCursorItemReader.class));
-	}
-
 	/**
 	 * Set the RowMapper to be used for all calls to read().
 	 *

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
@@ -99,10 +99,6 @@ public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> impleme
 
 	private int fetchSize = VALUE_NOT_SET;
 
-	public JdbcPagingItemReader() {
-		setName(ClassUtils.getShortName(JdbcPagingItemReader.class));
-	}
-
 	public void setDataSource(DataSource dataSource) {
 		this.dataSource = dataSource;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
@@ -99,10 +99,6 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 	
 	private boolean transacted = true;//default value
 
-	public JpaPagingItemReader() {
-		setName(ClassUtils.getShortName(JpaPagingItemReader.class));
-	}
-
 	/**
 	 * Create a query using an appropriate query provider (entityManager OR
 	 * queryProvider).

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
@@ -74,11 +74,6 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 
 	private int refCursorPosition = 0;
 
-	public StoredProcedureItemReader() {
-		super();
-		setName(ClassUtils.getShortName(StoredProcedureItemReader.class));
-	}
-
 	/**
 	 * Set the RowMapper to be used for all calls to read().
 	 *

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
@@ -73,10 +73,6 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 
 	private BufferedReaderFactory bufferedReaderFactory = new DefaultBufferedReaderFactory();
 
-	public FlatFileItemReader() {
-		setName(ClassUtils.getShortName(FlatFileItemReader.class));
-	}
-
 	/**
 	 * In strict mode the reader will throw an exception on
 	 * {@link #open(org.springframework.batch.item.ExecutionContext)} if the input resource does not exist.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
@@ -96,10 +96,6 @@ InitializingBean {
 
 	private boolean append = false;
 
-	public FlatFileItemWriter() {
-		this.setExecutionContextName(ClassUtils.getShortName(FlatFileItemWriter.class));
-	}
-
 	/**
 	 * Assert that mandatory properties (lineAggregator) are set.
 	 * 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemReader.java
@@ -30,7 +30,6 @@ import org.springframework.batch.item.UnexpectedInputException;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * Reads items from multiple resources sequentially - resource list is given by {@link #setResources(Resource[])}, the
@@ -82,10 +81,6 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 		}
 
 	};
-
-	public MultiResourceItemReader() {
-		this.setExecutionContextName(ClassUtils.getShortName(MultiResourceItemReader.class));
-	}
 
 	/**
 	 * Reads the next item, jumping to next resource if necessary.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemWriter.java
@@ -19,13 +19,13 @@ package org.springframework.batch.item.file;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.support.AbstractItemStreamItemWriter;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * Wraps a {@link ResourceAwareItemWriterItemStream} and creates a new output
@@ -62,10 +62,6 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 	private boolean saveState = true;
 
 	private boolean opened = false;
-
-	public MultiResourceItemWriter() {
-		this.setExecutionContextName(ClassUtils.getShortName(MultiResourceItemWriter.class));
-	}
 
     @Override
 	public void write(List<? extends T> items) throws Exception {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/ResourcesItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/ResourcesItemReader.java
@@ -35,13 +35,6 @@ public class ResourcesItemReader extends AbstractItemStreamItemReader<Resource> 
 
 	private AtomicInteger counter = new AtomicInteger(0);
 
-        public ResourcesItemReader() {
-		/*
-		 * Initialize the name for the key in the execution context.
-		 */
-		this.setExecutionContextName(getClass().getName());
-	}
-
 	/**
 	 * The resources to serve up as items. Hint: use a pattern to configure.
 	 * 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
@@ -75,10 +75,6 @@ ResourceAwareItemReaderItemStream<T>, InitializingBean {
 
 	private boolean strict = true;
 
-	public StaxEventItemReader() {
-		setName(ClassUtils.getShortName(StaxEventItemReader.class));
-	}
-
 	/**
 	 * In strict mode the reader will throw an exception on
 	 * {@link #open(org.springframework.batch.item.ExecutionContext)} if the input resource does not exist.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -55,7 +55,6 @@ import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.XmlMappingException;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -155,10 +154,6 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 	
 	// List holding the QName of elements that were opened in the header callback, but not closed
 	private List<QName> unclosedHeaderCallbackElements = Collections.EMPTY_LIST;
-
-	public StaxEventItemWriter() {
-		setExecutionContextName(ClassUtils.getShortName(StaxEventItemWriter.class));
-	}
 
 	/**
 	 * Set output file.

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ItemStreamSupportTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ItemStreamSupportTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2006-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.aop.framework.ProxyFactoryBean;
+
+/**
+ * @author Jimmy Praet
+ */
+public class ItemStreamSupportTests {
+	
+	private SimpleItemStreamSupport itemStream = new SimpleItemStreamSupport();
+	
+	@Test
+	public void testDefaultName() {
+		assertEquals("ItemStreamSupportTests.SimpleItemStreamSupport.foo", itemStream.getExecutionContextKey("foo"));
+	}
+	
+	@Test
+	public void testDefaultNameForCglibProxy() {
+		ProxyFactoryBean proxyFactoryBean = new ProxyFactoryBean();
+		proxyFactoryBean.setProxyTargetClass(true);
+		proxyFactoryBean.setTarget(itemStream);
+		itemStream = (SimpleItemStreamSupport) proxyFactoryBean.getObject();
+		assertEquals("ItemStreamSupportTests.SimpleItemStreamSupport.foo", itemStream.getExecutionContextKey("foo"));		
+	}
+	
+	@Test
+	public void testSetName() {
+		itemStream.setName("name");
+		assertEquals("name.foo", itemStream.getExecutionContextKey("foo"));
+	}
+
+	@Test
+	public void testSetExecutionContextName() {
+		itemStream.setExecutionContextName("name");
+		assertEquals("name.foo", itemStream.getExecutionContextKey("foo"));
+	}
+
+	@Test
+	public void testBeanName() {
+		itemStream.setBeanName("beanName");
+		assertEquals("beanName.foo", itemStream.getExecutionContextKey("foo"));
+	}
+
+	@Test
+	public void testExplicitNameTakesPrecedenceOverBeanName() {
+		itemStream.setName("explicitName");
+		itemStream.setBeanName("beanName");
+		assertEquals("explicitName.foo", itemStream.getExecutionContextKey("foo"));
+	}
+	
+	public static class SimpleItemStreamSupport extends ItemStreamSupport {
+	}
+	
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Dave Syer
@@ -61,11 +62,13 @@ public class ItemCountingItemStreamItemReaderTests {
 		assertTrue(reader.closeCalled);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
-	public void testOpenWithoutName() {
+	@Test
+	public void testOpenWithDefaultName() {
 		reader = new ItemCountingItemStreamItemReader();
 		reader.open(new ExecutionContext());
-		assertFalse(reader.openCalled);
+		assertTrue(reader.openCalled);
+		assertEquals("ItemCountingItemStreamItemReaderTests.ItemCountingItemStreamItemReader.foo", 
+				reader.getExecutionContextKey("foo"));
 	}
 
 	@Test
@@ -151,7 +154,7 @@ public class ItemCountingItemStreamItemReaderTests {
 			}
 			return items.next();
 		}
-
+		
 	}
 
 }


### PR DESCRIPTION
Change ItemStreamSupport to implement BeanNameAware. The default name (in case the object is instantiated outside of a spring bean factory) is still the short form of the class name. The name property can still be explicitly configured by the user. When the user didn't configure the name, the BeanNameAware.setBeanName callback will initialize the name property to the bean name.
