### PR TITLE
Removed serialisable check on ExecutionContext entries

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/DefaultExecutionContextSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/DefaultExecutionContextSerializer.java
@@ -18,6 +18,7 @@ package org.springframework.batch.core.repository.dao;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.Map;
 
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
@@ -54,6 +55,9 @@ public class DefaultExecutionContextSerializer implements ExecutionContextSerial
 		Assert.notNull(context);
 		Assert.notNull(out);
 
+		for(Object value : context.values()) {
+			Assert.isInstanceOf(Serializable.class, value, "Value: [ " + value + "must be serializable.");
+		}
 		serializer.serialize(context, out);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/DefaultExecutionContextSerializerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/DefaultExecutionContextSerializerTests.java
@@ -60,6 +60,14 @@ public class DefaultExecutionContextSerializerTests {
 		compareContexts(m1, m2);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testSerializeNonSerializable() throws Exception {
+		Map<String, Object> m1 = new HashMap<String, Object>();
+		m1.put("object1", new Object());
+
+		serializer.serialize(m1, new ByteArrayOutputStream());
+	}
+
 	@Test
 	public void testComplexObject() throws Exception {
 		Map<String, Object> m1 = new HashMap<String, Object>();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
@@ -117,15 +117,14 @@ public class ExecutionContext implements Serializable {
 	}
 
 	/**
-	 * Add an Object value to the context (must be Serializable). Putting
-	 * <code>null</code> value for a given key removes the key.
+	 * Add an Object value to the context. Putting <code>null</code>
+	 * value for a given key removes the key.
 	 *
 	 * @param key Key to add to context
 	 * @param value Value to associate with key
 	 */
 	public void put(String key, Object value) {
 		if (value != null) {
-			Assert.isInstanceOf(Serializable.class, value, "Value: [ " + value + "must be serializable.");
 			Object result = map.put(key, value);
 			dirty = result==null || result!=null && !result.equals(value);
 		}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
@@ -124,18 +124,6 @@ public class ExecutionContextTests {
 		assertTrue(tempContext.equals(context));
 	}
 
-	@Test
-	public void testSerializationCheck() {
-		// adding a non serializable object should cause an error.
-		try {
-			context.put("1", new Object());
-			fail();
-		}
-		catch (IllegalArgumentException ex) {
-			// expected
-		}
-	}
-
 	/**
 	 * Putting null value is equivalent to removing the entry for the given key.
 	 */


### PR DESCRIPTION
The serialisation/deserialisation implementation is injectable, so it does not make sense to enforce the presence of this interface

JIRA issue [here](https://jira.spring.io/browse/BATCH-2208)
