### PR TITLE
Allow compilation w/ JDK 8 on 2.2

### DIFF
--- a/archetypes/simple-cli/pom.xml
+++ b/archetypes/simple-cli/pom.xml
@@ -13,7 +13,7 @@
         The ./bin/runJob.(sh|bat) script from the extracted deployment archive can be invoked to run the job.
     </description>
     <properties>
-        <spring.framework.version>3.2.0.RELEASE</spring.framework.version>
+        <spring.framework.version>3.2.7.RELEASE</spring.framework.version>
         <spring.batch.version>2.2.7.BUILD-SNAPSHOT</spring.batch.version>
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <junit.version>4.10</junit.version>

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -118,7 +119,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 		parserContext.pushContainingComponent(compositeDef);
 
 		boolean stepExists = false;
-		Map<String, Set<String>> reachableElementMap = new HashMap<String, Set<String>>();
+		Map<String, Set<String>> reachableElementMap = new LinkedHashMap<String, Set<String>>();
 		String startElement = null;
 		NodeList children = element.getChildNodes();
 		for (int i = 0; i < children.getLength(); i++) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/PooledEmbeddedDataSource.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/PooledEmbeddedDataSource.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+
+/**
+ * As of Spring 3.2, when a context is closed, the shutdown method is
+ * called on any beans that are registered.  With an embedded database
+ * that uses a connection pool, this can leave the connection pool open
+ * with stale connections.  This wraps an {@link EmbeddedDatabase} and
+ * ignores calls to {@link EmbeddedDatabase#shutdown()}.
+ *
+ * @author Phil Webb
+ * @since 3.0
+ */
+public class PooledEmbeddedDataSource implements EmbeddedDatabase {
+
+	private final EmbeddedDatabase dataSource;
+
+	/**
+	 * @param dataSource The database to be wrapped
+	 */
+	public PooledEmbeddedDataSource(EmbeddedDatabase dataSource) {
+		this.dataSource = dataSource;
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.sql.DataSource#getConnection()
+	 */
+	@Override
+	public Connection getConnection() throws SQLException {
+		return this.dataSource.getConnection();
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.sql.DataSource#getConnection(java.lang.String, java.lang.String)
+	 */
+	@Override
+	public Connection getConnection(String username, String password) throws SQLException {
+		return this.dataSource.getConnection(username, password);
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.sql.CommonDataSource#getLogWriter()
+	 */
+	@Override
+	public PrintWriter getLogWriter() throws SQLException {
+		return this.dataSource.getLogWriter();
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.sql.CommonDataSource#setLogWriter(java.io.PrintWriter)
+	 */
+	@Override
+	public void setLogWriter(PrintWriter out) throws SQLException {
+		this.dataSource.setLogWriter(out);
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.sql.CommonDataSource#getLoginTimeout()
+	 */
+	@Override
+	public int getLoginTimeout() throws SQLException {
+		return this.dataSource.getLoginTimeout();
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.sql.CommonDataSource#setLoginTimeout(int)
+	 */
+	@Override
+	public void setLoginTimeout(int seconds) throws SQLException {
+		this.dataSource.setLoginTimeout(seconds);
+	}
+
+	/* (non-Javadoc)
+	 * @see java.sql.Wrapper#unwrap(java.lang.Class)
+	 */
+	@Override
+	public <T> T unwrap(Class<T> iface) throws SQLException {
+		return this.dataSource.unwrap(iface);
+	}
+
+	/* (non-Javadoc)
+	 * @see java.sql.Wrapper#isWrapperFor(java.lang.Class)
+	 */
+	@Override
+	public boolean isWrapperFor(Class<?> iface) throws SQLException {
+		return this.dataSource.isWrapperFor(iface);
+	}
+
+	public Logger getParentLogger() {
+		return Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.jdbc.datasource.embedded.EmbeddedDatabase#shutdown()
+	 */
+	@Override
+	public void shutdown() {
+	}
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.batch.core.configuration.annotation;
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
+import org.springframework.batch.core.PooledEmbeddedDataSource;
 import org.springframework.batch.core.Step;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -48,7 +49,7 @@ public class DataSourceConfiguration {
 	
 	@Bean
 	public DataSource dataSource() {
-		return new EmbeddedDatabaseFactory().getDatabase();
+		return new PooledEmbeddedDataSource(new EmbeddedDatabaseFactory().getDatabase());
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/RegisterMultiListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/RegisterMultiListenerTests.java
@@ -15,6 +15,7 @@ import org.springframework.batch.core.ItemWriteListener;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.PooledEmbeddedDataSource;
 import org.springframework.batch.core.SkipListener;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
@@ -184,11 +185,11 @@ public class RegisterMultiListenerTests {
 
 		@Bean
 		public DataSource dataSource(){
-			return new EmbeddedDatabaseBuilder()
+			return new PooledEmbeddedDataSource(new EmbeddedDatabaseBuilder()
 			.addScript("classpath:org/springframework/batch/core/schema-drop-hsqldb.sql")
 			.addScript("classpath:org/springframework/batch/core/schema-hsqldb.sql")
 			.setType(EmbeddedDatabaseType.HSQL)
-			.build();
+			.build());
 		}
 
 		@Override
@@ -214,11 +215,11 @@ public class RegisterMultiListenerTests {
 
 		@Bean
 		public DataSource dataSource(){
-			return new EmbeddedDatabaseBuilder()
+			return new PooledEmbeddedDataSource(new EmbeddedDatabaseBuilder()
 			.addScript("classpath:org/springframework/batch/core/schema-drop-hsqldb.sql")
 			.addScript("classpath:org/springframework/batch/core/schema-hsqldb.sql")
 			.setType(EmbeddedDatabaseType.HSQL)
-			.build();
+			.build());
 		}
 
 		@Override

--- a/spring-batch-parent/pom.xml
+++ b/spring-batch-parent/pom.xml
@@ -33,7 +33,7 @@
 		</developer>
 	</developers>
 	<properties>
-		<spring.framework.version>3.2.0.RELEASE</spring.framework.version>
+		<spring.framework.version>3.2.7.RELEASE</spring.framework.version>
 		<spring.amqp.version>1.1.2.RELEASE</spring.amqp.version>
 		<junit.version>4.10</junit.version>
 		<bundlor.version>1.0.0.RELEASE</bundlor.version>


### PR DESCRIPTION
With 2.2 being the current version and JDK 8 released, one should be able to compile with a 1.8 JDK.
- Upgrade spring from 3.2.0 to 3.2.7 (ASM handling changes for 1.8)
- Preseve ordering of reacheable elements (plucked from ef0823)
- Added the PooledEmbeddedDataSource to address the issue outlined in SPR-11372 (plucked from b27823)
