### PR TITLE
BATCH-2227: Allow multiple configs (xmls, java-files, packages) to be loaded in ApplicationContextFactory

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AbstractApplicationContextFactory.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AbstractApplicationContextFactory.java
@@ -172,7 +172,7 @@ public abstract class AbstractApplicationContextFactory implements ApplicationCo
 	}
 
 	protected abstract ConfigurableApplicationContext createApplicationContext(ConfigurableApplicationContext parent,
-			Object[] resources);
+			Object... resources);
 
 	/**
 	 * Extension point for special subclasses that want to do more complex things with the context prior to refresh. The

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactory.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactory.java
@@ -53,11 +53,11 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 	}
 
 	/**
-	 * @see AbstractApplicationContextFactory#createApplicationContext(ConfigurableApplicationContext, Object)
+	 * @see AbstractApplicationContextFactory#createApplicationContext(ConfigurableApplicationContext, Object...)
 	 */
 	@Override
 	protected ConfigurableApplicationContext createApplicationContext(ConfigurableApplicationContext parent,
-			Object[] resources) {
+			Object... resources) {
 		if (allObjectsOfType(resources, Resource.class)) {
 			return new ResourceXmlApplicationContext(parent, resources);
 		}
@@ -91,7 +91,7 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 		private final ConfigurableApplicationContext parent;
 
 		public ApplicationContextHelper(ConfigurableApplicationContext parent, GenericApplicationContext context,
-				Object[] configs) {
+				Object... configs) {
 			this.parent = parent;
 			if (parent != null) {
 				Assert.isTrue(parent.getBeanFactory() instanceof DefaultListableBeanFactory,
@@ -107,9 +107,9 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 			prepareContext(parent, context);
 		}
 
-		protected abstract String generateId(Object[] configs);
+		protected abstract String generateId(Object... configs);
 
-		protected abstract void loadConfiguration(Object[] configs);
+		protected abstract void loadConfiguration(Object... configs);
 
 		protected void prepareBeanFactory(ConfigurableListableBeanFactory beanFactory) {
 			if (parentBeanFactory != null) {
@@ -131,15 +131,15 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 		/**
 		 * @param parent
 		 */
-		public ResourceXmlApplicationContext(ConfigurableApplicationContext parent, Object[] resources) {
+		public ResourceXmlApplicationContext(ConfigurableApplicationContext parent, Object... resources) {
 			helper = new ApplicationContextHelper(parent, this, resources) {
 				@Override
-				protected String generateId(Object[] configs) {
+				protected String generateId(Object... configs) {
 					Resource[] resources = Arrays.copyOfRange(configs, 0, configs.length, Resource[].class);
 					try {
 						List<String> uris = new ArrayList<String>();
-						for (Resource rsrc : resources) {
-							uris.add(rsrc.getURI().toString());
+						for (Resource resource : resources) {
+							uris.add(resource.getURI().toString());
 						}
 						return StringUtils.collectionToCommaDelimitedString(uris);
 					}
@@ -148,7 +148,7 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 					}
 				}
 				@Override
-				protected void loadConfiguration(Object[] configs) {
+				protected void loadConfiguration(Object... configs) {
 					Resource[] resources = Arrays.copyOfRange(configs, 0, configs.length, Resource[].class);
 					load(resources);
 				}
@@ -173,10 +173,10 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 
 		private final ApplicationContextHelper helper;
 
-		public ResourceAnnotationApplicationContext(ConfigurableApplicationContext parent, Object[] resources) {
+		public ResourceAnnotationApplicationContext(ConfigurableApplicationContext parent, Object... resources) {
 			helper = new ApplicationContextHelper(parent, this, resources) {
 				@Override
-				protected String generateId(Object[] configs) {
+				protected String generateId(Object... configs) {
 					if (allObjectsOfType(configs, Class.class)) {
 						Class<?>[] types = Arrays.copyOfRange(configs, 0, configs.length, Class[].class);
 						List<String> names = new ArrayList<String>();
@@ -190,7 +190,7 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 					}
 				}
 				@Override
-				protected void loadConfiguration(Object[] configs) {
+				protected void loadConfiguration(Object... configs) {
 					if (allObjectsOfType(configs, Class.class)) {
 						Class<?>[] types = Arrays.copyOfRange(configs, 0, configs.length, Class[].class);
 						register(types);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactoryTests.java
@@ -21,7 +21,11 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.JobSupport;
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.support.AbstractBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.io.ClassPathResource;
@@ -131,6 +135,40 @@ public class GenericApplicationContextFactoryTests {
 		GenericApplicationContextFactory other = new GenericApplicationContextFactory(resource);
 		assertEquals(other, factory);
 		assertEquals(other.hashCode(), factory.hashCode());
+	}
+
+	@Test
+	public void testEqualsMultileConfigs() throws Exception {
+		Resource resource1 = new ClassPathResource(ClassUtils.addResourcePathToPackagePath(getClass(),
+				"abstract-context.xml"));
+		Resource resource2 = new ClassPathResource(ClassUtils.addResourcePathToPackagePath(getClass(),
+				"child-context-with-abstract-job.xml"));
+		GenericApplicationContextFactory factory = new GenericApplicationContextFactory(resource1, resource2);
+		GenericApplicationContextFactory other = new GenericApplicationContextFactory(resource1, resource2);
+		assertEquals(other, factory);
+		assertEquals(other.hashCode(), factory.hashCode());
+	}
+
+	@Test
+	public void testParentConfigurationInheritedMultipleConfigs() {
+		Resource resource1 = new ClassPathResource(ClassUtils.addResourcePathToPackagePath(getClass(),
+				"abstract-context.xml"));
+		Resource resource2 = new ClassPathResource(ClassUtils.addResourcePathToPackagePath(getClass(),
+				"child-context-with-abstract-job.xml"));
+		GenericApplicationContextFactory factory = new GenericApplicationContextFactory(resource1, resource2);
+		ConfigurableApplicationContext context = factory.createApplicationContext();
+		assertEquals("concrete-job", context.getBeanNamesForType(Job.class)[0]);
+		assertEquals("bar", context.getBean("concrete-job", Job.class).getName());
+		assertEquals(4, context.getBean("foo", Foo.class).values[1], 0.01);
+		assertNotNull(context.getBean("concrete-job", JobSupport.class).getStep("step31"));
+		assertNotNull(context.getBean("concrete-job", JobSupport.class).getStep("step32"));
+		boolean autowiredFound = false;
+		for (BeanPostProcessor postProcessor : ((AbstractBeanFactory)context.getBeanFactory()).getBeanPostProcessors()) {
+			if (postProcessor instanceof AutowiredAnnotationBeanPostProcessor) {
+				autowiredFound = true;
+			}
+		}
+		assertTrue(autowiredFound);
 	}
 
 	public static class Foo {

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/abstract-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/abstract-context.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop"
+	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:p="http://www.springframework.org/schema/p" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<context:annotation-config />
+
+	<bean id="abstract-job" abstract="true" class="org.springframework.batch.core.job.JobSupport">
+		<property name="name" value="${foo}" />
+		<property name="steps">
+            <list>
+                <bean id="step31" class="org.springframework.batch.core.step.StepSupport"/>
+                <bean id="step32" class="org.springframework.batch.core.step.StepSupport"/>
+            </list>
+        </property>
+	</bean>
+
+	<bean id="foo" class="org.springframework.batch.core.configuration.support.GenericApplicationContextFactoryTests$Foo">
+		<property name="values" value="1,4" />
+	</bean>
+	
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="properties" value="foo=bar" />
+		<property name="order" value="1"/>
+	</bean>
+
+	<bean class="org.springframework.beans.factory.config.CustomEditorConfigurer">
+		<property name="customEditors">
+			<map>
+				<entry key="double[]" value="org.springframework.batch.support.IntArrayPropertyEditor"/>
+			</map>
+		</property>
+	</bean>
+
+</beans>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/child-context-with-abstract-job.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/child-context-with-abstract-job.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop"
+	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:p="http://www.springframework.org/schema/p" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd">
+
+	<bean id="concrete-job" parent="abstract-job">
+	</bean>
+
+</beans>


### PR DESCRIPTION
With the ApplicationContextFactory it is not possible to load a Job context from multiple resources. 

At the moment you can only give one Resource (i.e. XML file) to the GenericApplicationContextFactory constructor to load beans from it. With this, it is not possible to use a separate XML file for abstract behaviour (abstract steps and jobs) without importing it explicitly into the job XML. I have the usecase, that I want do add abstract job and step definitions globally and I don't want to force any Job XML provider to import it.

I found that the GenericXmlApplicationContext that is used inside the GenericApplicationContextFactory is already able to load from multiple resources. So I extended the AbstractApplicationContextFactory and GenericApplicationContextFactory, that an array of resources is allowed to be put into the constructor of GenericApplicationContextFactory.

With the use of Var-Args the new implementation is backward compatible with the old one as Java just creates an one-element-array if you put only one resource into the constructor.

What do you think about it?
