### PR TITLE
pass jvm Xdoclint:none when using java8 w/ gradle to disable linting of javadocs and failing the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,14 @@ description = 'Spring Batch'
 apply plugin: 'base'
 apply plugin: 'idea'
 
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
 buildscript {
 	repositories {
 		maven { url 'http://repo.spring.io/plugins-release' }


### PR DESCRIPTION
apparently java 8 is "linting" javadocs and results in build failures on JDK8. found this snippet, and it appears to make grade install/build work for me. i suppose at some point we should cleanup the jdocs so we can remove this (and maybe it would keep the jdocs cleaner in the future).
