### PR TITLE
options.encoding='UTF-8'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,11 +107,13 @@ subprojects { subproject ->
     compileJava {
         sourceCompatibility=1.6
         targetCompatibility=1.6
+        options.encoding='UTF-8'
     }
 
     compileTestJava {
         sourceCompatibility=1.7
         targetCompatibility=1.7
+        options.encoding='UTF-8'
     }
 
 	eclipse {


### PR DESCRIPTION
configure source encoding in build.gradle (org.springframework.batch.support.transaction.TransactionAwareBufferedWriterTests.testBufferSizeInTransactionWithMultiByteCharacterUTF8 was failing on my machine, because my default encoding is not UTF-8)
