### PR TITLE
BATCH-2240 Call ItemStream open() and close() within a transaction

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -219,12 +219,20 @@ public class TaskletStepExceptionTests {
 		taskletStep.setTransactionManager(new ResourcelessTransactionManager() {
 			@Override
 			protected void doCommit(DefaultTransactionStatus status) throws TransactionException {
-				throw new RuntimeException("bar");
+				if ("chunk".equals(TransactionSynchronizationManager.getCurrentTransactionName())) {
+					throw new RuntimeException("bar");
+				} else {
+					super.doCommit(status);
+				}
 			}
 
 			@Override
 			protected void doRollback(DefaultTransactionStatus status) throws TransactionException {
-				throw new RuntimeException("foo");
+				if ("chunk".equals(TransactionSynchronizationManager.getCurrentTransactionName())) {
+					throw new RuntimeException("foo");
+				} else {
+					super.doRollback(status);
+				}
 			}
 		});
 
@@ -258,8 +266,12 @@ public class TaskletStepExceptionTests {
 		taskletStep.setTransactionManager(new ResourcelessTransactionManager() {
 			@Override
 			protected void doCommit(DefaultTransactionStatus status) throws TransactionException {
-				super.doRollback(status);
-				throw new UnexpectedRollbackException("bar");
+				if ("chunk".equals(TransactionSynchronizationManager.getCurrentTransactionName())) {
+					super.doRollback(status);
+					throw new UnexpectedRollbackException("bar");
+				} else {
+					super.doCommit(status);
+				}
 			}
 		});
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -180,10 +180,8 @@ public class TransactionAwareBufferedWriter extends Writer {
 	 */
 	@Override
 	public void close() throws IOException {
-		if (transactionActive()) {
-			if (getCurrentBuffer().length() > 0) {
-				TransactionSynchronizationManager.bindResource(closeKey, Boolean.TRUE);
-			}
+		if (transactionActive() && getCurrentBuffer().length() > 0) {
+			TransactionSynchronizationManager.bindResource(closeKey, Boolean.TRUE);
 			return;
 		}
 		closeCallback.run();


### PR DESCRIPTION
* Modify TaskletStep to call open() and close() of registered ItemStreams within a transaction
* Fix problem in TransactionAwareBufferedWriter where close callback was not being called if the transactional buffer was empty