### PR TITLE
Improvement(exception process) of SimpleMethodInvoker.invokeMethod(Object...)

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import org.springframework.aop.framework.Advised;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Simple implementation of the {@link MethodInvoker} interface that invokes a
@@ -81,7 +82,6 @@ public class SimpleMethodInvoker implements MethodInvoker {
 	 * org.springframework.batch.core.configuration.util.MethodInvoker#invokeMethod
 	 * (java.lang.Object[])
 	 */
-    @Override
 	public Object invokeMethod(Object... args) {
 
 		Class<?>[] parameterTypes = method.getParameterTypes();
@@ -106,9 +106,9 @@ public class SimpleMethodInvoker implements MethodInvoker {
 			return method.invoke(target, invokeArgs);
 		}
 		catch (Exception e) {
-			throw new IllegalArgumentException("Unable to invoke method: [" + method + "] on object: [" + object
-					+ "] with arguments: [" + Arrays.toString(args) + "]", e);
+			ReflectionUtils.handleReflectionException(e);
 		}
+		return null;
 	}
 
 	private Object extractTarget(Object target, Method method) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SimpleMethodInvokerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SimpleMethodInvokerTests.java
@@ -118,7 +118,13 @@ public class SimpleMethodInvokerTests {
 		assertEquals(methodInvoker, methodInvoker2);
 	}
 	
-	@SuppressWarnings("unused")
+	@Test(expected=RuntimeException.class)
+	public void testMethodWithLogicalException() throws Exception{
+		MethodInvoker methodInvoker = new SimpleMethodInvoker(testClass, "logicalExceptionTest");
+		methodInvoker.invokeMethod(new Object());
+		assertTrue(testClass.argumentTestCalled);
+	}
+	
 	private class TestClass{
 		
 		boolean beforeCalled = false;
@@ -139,6 +145,10 @@ public class SimpleMethodInvokerTests {
 		public void argumentTest(Object object){
 			Assert.notNull(object);
 			argumentTestCalled = true;
+		}
+		
+		public void logicalExceptionTest(){
+			throw new RuntimeException("Logical Exception.");
 		}
 	}
 }


### PR DESCRIPTION
If a exception was occurred after the method.invoke(target, invokeArgs) was executed In SimpleMethodInvoker.invokeMethod(Object...), the exception(IllegalAccessException, IllegalArgumentException and InvocationTargetException) is wrapped a IllegalArgumentException. So, it is more efficient that using ReflectionUtils.handleReflectionException(e). Because the InvocationTargetException or IllegalAccessException is not the IllegalArgumentException actually.

Issue: BATCH-2213
