### PR TITLE
BATCH-2213 Improvement of SimpleMethodInvoker.invokeMethod(Object... args)

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import org.springframework.aop.framework.Advised;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Simple implementation of the {@link MethodInvoker} interface that invokes a
@@ -106,9 +107,9 @@ public class SimpleMethodInvoker implements MethodInvoker {
 			return method.invoke(target, invokeArgs);
 		}
 		catch (Exception e) {
-			throw new IllegalArgumentException("Unable to invoke method: [" + method + "] on object: [" + object
-					+ "] with arguments: [" + Arrays.toString(args) + "]", e);
+			ReflectionUtils.handleReflectionException(e);
 		}
+		return null;
 	}
 
 	private Object extractTarget(Object target, Method method) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SimpleMethodInvokerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SimpleMethodInvokerTests.java
@@ -118,6 +118,20 @@ public class SimpleMethodInvokerTests {
 		assertEquals(methodInvoker, methodInvoker2);
 	}
 	
+	@Test
+	public void testMethodWithLogicalException() throws Exception{
+		try {
+			MethodInvoker methodInvoker = new SimpleMethodInvoker(testClass, "logicalExceptionTest");
+			methodInvoker.invokeMethod(new Object());
+			assertTrue(testClass.argumentTestCalled);
+		} catch(IllegalArgumentException ie) {
+			assertFalse(true);
+		} catch(RuntimeException e) {
+			assertEquals("Logical Exception.", e.getMessage());
+		}
+	 	
+	 }
+	
 	@SuppressWarnings("unused")
 	private class TestClass{
 		
@@ -139,6 +153,10 @@ public class SimpleMethodInvokerTests {
 		public void argumentTest(Object object){
 			Assert.notNull(object);
 			argumentTestCalled = true;
+		}
+		
+		public void logicalExceptionTest(){
+			throw new RuntimeException("Logical Exception.");
 		}
 	}
 }


### PR DESCRIPTION
If a exception was occurred after the method.invoke(target, invokeArgs) was executed In SimpleMethodInvoker.invokeMethod(Object...), the exception(IllegalAccessException, IllegalArgumentException and InvocationTargetException) is wrapped a IllegalArgumentException. So, it is more efficient that using ReflectionUtils.handleReflectionException(e). Because the InvocationTargetException or IllegalAccessException is not the IllegalArgumentException actually.

Issue: BATCH-2213
