### PR TITLE
ItemStreamSupport component name collision detection

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ItemStreamSupportTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ItemStreamSupportTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Jimmy Praet
+ */
+public class ItemStreamSupportTests {
+	
+	private ItemStreamSupport itemStreamSupport;
+	
+	private ExecutionContext executionContext;
+	
+	@Before
+	public void setUp() {
+		itemStreamSupport = new TestItemStreamSupport();
+		executionContext = new ExecutionContext();
+	}
+	
+	@Test
+	public void testGetExecutionContextKey() {
+		Assert.assertEquals("TestItemStreamSupport.foo", itemStreamSupport.getExecutionContextKey("foo"));
+	}
+	
+	@Test
+	public void testOpen() {
+		itemStreamSupport.open(executionContext);
+		Assert.assertEquals(1, executionContext.size());
+	}
+
+	@Test
+	public void testUpdateBeforeOpen() {
+		itemStreamSupport.update(executionContext);
+		Assert.assertEquals(0, executionContext.size());
+	}
+
+	@Test
+	public void testUpdateAfterOpen() {
+		itemStreamSupport.open(executionContext);
+		itemStreamSupport.update(executionContext);
+		Assert.assertEquals(1, executionContext.size());
+	}
+	
+	@Test(expected=IllegalStateException.class)
+	public void testExecutionContextKeyCollision() {
+		ItemStreamSupport other = new TestItemStreamSupport();
+		itemStreamSupport.open(executionContext);
+		other.open(executionContext);
+		itemStreamSupport.update(executionContext);
+		other.update(executionContext);
+	}
+
+	@Test
+	public void testExecutionContextNoKeyCollision() {
+		ItemStreamSupport other = new TestItemStreamSupport();
+		other.setName("unique_name");
+		itemStreamSupport.open(executionContext);
+		other.open(executionContext);
+		itemStreamSupport.update(executionContext);
+		other.update(executionContext);
+	}
+
+	private static final class TestItemStreamSupport extends ItemStreamSupport {
+		
+		public TestItemStreamSupport() {
+			setName("TestItemStreamSupport");
+		}
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -564,7 +564,7 @@ public class FlatFileItemWriterTests {
 		writer.open(executionContext);
 		writer.update(executionContext);
 		assertNotNull(executionContext);
-		assertEquals(2, executionContext.entrySet().size());
+		assertEquals(3, executionContext.entrySet().size());
 		assertEquals(0, executionContext.getLong(ClassUtils.getShortName(FlatFileItemWriter.class) + ".current.count"));
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemStreamTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemStreamTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ public class CompositeItemStreamTests extends TestCase {
 	private CompositeItemStream manager = new CompositeItemStream();
 
 	private List<String> list = new ArrayList<String>();
+	
+	private ExecutionContext executionContext = new ExecutionContext();
 
 	public void testRegisterAndOpen() {
 		ItemStreamSupport stream = new ItemStreamSupport() {
@@ -44,7 +46,7 @@ public class CompositeItemStreamTests extends TestCase {
 			}
 		};
 		manager.register(stream);
-		manager.open(null);
+		manager.open(executionContext);
 		assertEquals(1, list.size());
 	}
 
@@ -58,7 +60,7 @@ public class CompositeItemStreamTests extends TestCase {
 		};
 		manager.register(stream);
 		manager.register(stream);
-		manager.open(null);
+		manager.open(executionContext);
 		assertEquals(1, list.size());
 	}
 
@@ -70,7 +72,7 @@ public class CompositeItemStreamTests extends TestCase {
 				list.add("bar");
 			}
 		});
-		manager.update(null);
+		manager.update(executionContext);
 		assertEquals(1, list.size());
 	}
 
@@ -94,9 +96,9 @@ public class CompositeItemStreamTests extends TestCase {
 				list.add("bar");
 			}
 		} });
-		manager.open(null);
+		manager.open(executionContext);
 		manager.close();
-		manager.open(null);
+		manager.open(executionContext);
 		assertEquals(2, list.size());
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ public class ItemCountingItemStreamItemReaderTests {
 		context.putInt("foo.read.count.max", 1);
 		reader.open(context);
 		reader.update(context);
-		assertEquals(2, context.size());
+		assertEquals(3, context.size());
 	}
 
 	private static class ItemCountingItemStreamItemReader extends AbstractItemCountingItemStreamItemReader<String> {


### PR DESCRIPTION
Alternative approach for https://github.com/spring-projects/spring-batch/pull/292.

Instead of trying to prevent ExecutionContext key collisions using
BeanNameAware, this PR throws an exception on update() when a duplicate
component name is detected.
