### PR TITLE
BATCH-2284: Improvement of AbstractJobRepositoryFactoryBean.getTarget()

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/AbstractJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/AbstractJobRepositoryFactoryBean.java
@@ -191,7 +191,7 @@ public abstract class AbstractJobRepositoryFactoryBean implements FactoryBean<Jo
 		initializeProxy();
 	}
 
-	private Object getTarget() throws Exception {
+	protected Object getTarget() throws Exception {
 		return new SimpleJobRepository(createJobInstanceDao(), createJobExecutionDao(), createStepExecutionDao(),
 				createExecutionContextDao());
 	}


### PR DESCRIPTION
"JobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean" class is "Factory Class" for JobRepository. I think this means that any JobRepository can be created. But, when I want to use CustomJobRepository(instead of SimpleJobRepository), I must make new CustomAbstractJobRepositoryFactoryBean. Because AbstractJobRepositoryFactoryBean.getTarget() is private method, so SimpleJobRepository is created certainly.

How about changing from "private getTarget()" to "protected getTarget()"?
