### PR TITLE
BATCH-2205: MethodInvokingTaskletAdaper does not support primitive arguments.

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.MethodInvoker;
 
 /**
@@ -167,7 +168,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 						if (arguments[j] == null) {
 							continue;
 						}
-						if (!(params[j].isAssignableFrom(arguments[j].getClass()))) {
+						if (!(ClassUtils.isAssignableValue(params[j], arguments[j]))) {
 							argumentsMatchParameters = false;
 						}
 					}

--- a/spring-batch-samples/src/main/resources/jobs/taskletJob.xml
+++ b/spring-batch-samples/src/main/resources/jobs/taskletJob.xml
@@ -27,6 +27,13 @@
 		class="org.springframework.batch.core.step.tasklet.MethodInvokingTaskletAdapter">
 		<property name="targetObject" ref="value" />
 		<property name="targetMethod" value="execute" />
+		<property name="arguments">
+			<list>
+      			<value>foo2</value>
+      			<value type="int">3</value>
+      			<value type="double">3.14</value>
+   			</list>
+		</property>
 	</bean>
 
 	<bean id="value"

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/TaskletJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/TaskletJobFunctionalTests.java
@@ -50,8 +50,11 @@ public class TaskletJobFunctionalTests {
 			this.value = value;
 		}
 
-		public void execute() {
+		public void execute(String strValue, Integer integerValue, double doubleValue) {
 			assertEquals("foo", value);
+			assertEquals("foo2", strValue);
+			assertEquals(3, integerValue.intValue());
+			assertEquals(3.14, doubleValue, 0.01);
 		}
 	}
 


### PR DESCRIPTION
MethodInvokingTaskletAdaper does not support primitive arguments.
Because "isAssignableFrom(..)" method was used in AbstractMethodInvokingDelegator.targetClassDeclaresTargetMethod().

The original source are correct when Object[] are used as parameters.
(ex. public static class TestBean {
		public void execute(Integer integerValue) {
                    ...
		}
	}
)

But I think, using a primitive type parameter can be supported.
(ex. public static class TestBean {
		public void execute(int integerValue) {
                    ...
		}
	}
)