### PR TITLE
use current classloader to get the proxied repository

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/AbstractJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/AbstractJobRepositoryFactoryBean.java
@@ -201,7 +201,7 @@ public abstract class AbstractJobRepositoryFactoryBean implements FactoryBean<Jo
 		if (proxyFactory == null) {
 			afterPropertiesSet();
 		}
-		return (JobRepository) proxyFactory.getProxy();
+		return (JobRepository) proxyFactory.getProxy(getClass().getClassLoader());
 	}
 
 }


### PR DESCRIPTION
The job repository factory always tries to get the proxied object with the system's classloader. If it has been loaded by a class loader that has a parent, the lookup will fail as the class is not visible from the parent class loader.