### PR TITLE
Make use of current working dir explicit for compatibility with H2 1.4

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeIntegrationTests.java
@@ -31,7 +31,7 @@ public class DatabaseTypeIntegrationTests {
 	@Test
 	public void testH2() throws Exception {
 		DataSource dataSource = DatabaseTypeTestUtils.getDataSource(org.h2.Driver.class,
-				"jdbc:h2:file:build/data/sample");
+				"jdbc:h2:file:./build/data/sample");
 		assertEquals(DatabaseType.H2, DatabaseType.fromMetaData(dataSource));
 		dataSource.getConnection();
 	}


### PR DESCRIPTION
H2 1.4 requires that file paths that are relative to the current working directory declare this explicitly, i.e. the path file:/some-dir must now be file:./some-dir.

This commit updates DatabaseTypeIntegrationTests to meet the above-described requirement, thereby allowing the tests to pass when run against H2 1.4.x.
