### PR TITLE
Expose createJobLauncher to sub-classes of DefaultBatchConfigurer

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -109,7 +109,7 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 		}
 	}
 
-	private JobLauncher createJobLauncher() throws Exception {
+	protected JobLauncher createJobLauncher() throws Exception {
 		SimpleJobLauncher jobLauncher = new SimpleJobLauncher();
 		jobLauncher.setJobRepository(jobRepository);
 		jobLauncher.afterPropertiesSet();


### PR DESCRIPTION
Looks like this is supposed to be an extension point and I'd like to use it in tests so I can use a `JobLauncher` with a `TaskExecutor` that's under my control. I want to do things like killing the `TaskExecutor` running the jobs and test recovery, test multi-threading, etc.