### PR TITLE
Add ProcessErrorListener for AsyncItemProcessor to allow notification of async processing failures

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ItemProcessListenerSupport.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ItemProcessListenerSupport.java
@@ -13,23 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.batch.integration.async;
+package org.springframework.batch.core;
 
+import org.springframework.batch.item.ItemProcessor;
 
 /**
- * Implementations of this interface will be notified in the event of any
- * exceptions thrown by the async processor.
+ * Interface to mark {@link ItemProcessor} which support injection of a {@link ItemProcessListener}.
  * 
  * @author Dominik Bartholdi
  *
  */
-public interface ProcessErrorListener<I> {
+public interface ItemProcessListenerSupport<I, O> {
 
-	/**
-	 * Called if an exception was thrown from {@link AsyncItemProcessor#process(Object)}.
-	 * 
-	 * @param item attempted to be processed
-	 * @param e - exception thrown during processing.
-	 */
-	void onProcessError(I item, Exception e);
+	public void setItemProcessListener(ItemProcessListener<I, O> itemProcessListener);
+
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
@@ -18,6 +18,8 @@ package org.springframework.batch.core.step.item;
 
 import java.util.List;
 
+import org.springframework.batch.core.ItemProcessListenerSupport;
+import org.springframework.batch.core.ItemProcessListener;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepListener;
 import org.springframework.batch.core.listener.MulticasterBatchListener;
@@ -99,6 +101,9 @@ public class SimpleChunkProcessor<I, O> implements ChunkProcessor<I>, Initializi
 	 */
 	public void registerListener(StepListener listener) {
 		this.listener.register(listener);
+		if((itemProcessor instanceof ItemProcessListenerSupport) && (listener instanceof ItemProcessListener)){
+			((ItemProcessListenerSupport)itemProcessor).setItemProcessListener((ItemProcessListener)listener);
+		}
 	}
 
 	/**

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/ProcessErrorListener.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/ProcessErrorListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.integration.async;
+
+
+/**
+ * Implementations of this interface will be notified in the event of any
+ * exceptions thrown by the async processor.
+ * 
+ * @author Dominik Bartholdi
+ *
+ */
+public interface ProcessErrorListener<I> {
+
+	/**
+	 * Called if an exception was thrown from {@link AsyncItemProcessor#process(Object)}.
+	 * 
+	 * @param item attempted to be processed
+	 * @param e - exception thrown during processing.
+	 */
+	void onProcessError(I item, Exception e);
+}


### PR DESCRIPTION
As mention in BATCH-2371, ItemProcessListener.onProcessError() is not called in parallel processing. This is quite a big drawback, as there is no fine grained way to react on processing errors anymore.

This PR adds a new Interface `ProcessErrorListener` which can be set on `AsyncItemProcessor`. If it is set, then `ProcessErrorListener` is called in case of an exception.
