### PR TITLE
stop job execution if an exception is thrown in an after step

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -344,11 +344,11 @@ InitializingBean {
 
 				try {
 					listener.afterJob(execution);
-				} catch (Exception e) {
-					logger.error("Exception encountered in afterStep callback", e);
-execution.setExitStatus(getDefaultExitStatusForFailure(e, execution));
-			execution.setStatus(BatchStatus.FAILED);
-			execution.addFailureException(e);
+				} catch (Throwable t) {
+					logger.error("Exception encountered in afterStep callback", t);
+					execution.setExitStatus(getDefaultExitStatusForFailure(t, execution));
+					execution.setStatus(BatchStatus.FAILED);
+					execution.addFailureException(t);
 				}
 
 				jobRepository.update(execution);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -346,6 +346,9 @@ InitializingBean {
 					listener.afterJob(execution);
 				} catch (Exception e) {
 					logger.error("Exception encountered in afterStep callback", e);
+execution.setExitStatus(getDefaultExitStatusForFailure(e, execution));
+			execution.setStatus(BatchStatus.FAILED);
+			execution.addFailureException(e);
 				}
 
 				jobRepository.update(execution);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
@@ -234,8 +234,11 @@ public abstract class AbstractStep implements Step, InitializingBean, BeanNameAw
 				stepExecution.setExitStatus(exitStatus);
 				exitStatus = exitStatus.and(getCompositeListener().afterStep(stepExecution));
 			}
-			catch (Exception e) {
-				logger.error(String.format("Exception in afterStep callback in step %s in job %s", name, stepExecution.getJobExecution().getJobInstance().getJobName()), e);
+			catch (Throwable t) {
+				logger.error(String.format("Exception in afterStep callback in step %s in job %s", name, stepExecution.getJobExecution().getJobInstance().getJobName()), t);
+				stepExecution.upgradeStatus(determineBatchStatus(t));
+				exitStatus = exitStatus.and(getDefaultExitStatusForFailure(t));
+				stepExecution.addFailureException(t);
 			}
 
 			try {


### PR DESCRIPTION
This pull request will stop the job if an exception is thrown in an after step.
This way we won't go into the next with a potential weird state due to an incomplete after step.
This way the developer can easily throw exception in the after step. If exception are non blocking he can just catch them and that's it.