### PR TITLE
Batch 2399 - JSON ItemReader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ allprojects {
 		javaMailVersion = '1.4.7'
 		javaxBatchApiVersion = '1.0'
 		javaxInjectVersion = '1'
+		javaxJson = '1.0.4'
 		jbatchTckSpi = '1.0'
 		jettisonVersion = '1.2'
 		jtdsVersion = '1.2.4'
@@ -347,6 +348,7 @@ project('spring-batch-infrastructure') {
         optional "org.springframework.ldap:spring-ldap-core:$springLdapVersion"
         optional "org.springframework.ldap:spring-ldap-core-tiger:$springLdapVersion"
         optional "org.springframework.ldap:spring-ldap-ldif-core:$springLdapVersion"
+        optional "org.glassfish:javax.json:$javaxJson"
 	}
 }
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonStreamItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonStreamItemReader.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.json;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import javax.json.Json;
+import javax.json.stream.JsonParser;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
+import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.io.Resource;
+import org.springframework.ojm.Unmarshaller;
+import org.springframework.util.Assert;
+
+public class JsonStreamItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> 
+	implements ResourceAwareItemReaderItemStream<T>, InitializingBean {
+
+	private static final Log logger = LogFactory.getLog(JsonStreamItemReader.class);
+	private boolean strict = true;
+	private boolean noInput;
+
+	private Resource resource;
+	private InputStream inputStream;
+	private JsonParser jsonParser;
+
+	private String keyName;
+	
+	private Unmarshaller<T> unmarshaller;
+	private Class<T> targetClass;
+
+	public void setKeyName(String keyName) {
+		this.keyName = keyName;
+	}
+
+	public void setUnmarshaller(Unmarshaller<T> unmarshaller) {
+		this.unmarshaller = unmarshaller;
+	}
+
+	public void setTargetClass(Class<T> targetClass) {
+		this.targetClass = targetClass;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(unmarshaller, "The Unmarshaller must not be null.");
+		Assert.notNull(keyName, "The keyName may be empty, but it cannot be null.");
+	}
+
+	@Override
+	public void setResource(Resource resource) {
+		this.resource = resource;		
+	}
+
+	@Override
+	protected T doRead() throws Exception {
+		if (noInput) {
+			return null;
+		}
+
+		try {
+			int nestingLevel = 0;
+			StringBuilder json = new StringBuilder();
+			JsonParser.Event nextEvent;
+
+			while (true) {
+				nextEvent = jsonParser.next();
+				switch (nextEvent) {
+				/* If we hit the end of an array/object, there will always be an 
+				 * excess comma from the other switch statement.  Remove it before 
+				 * closing the array/object.
+				 */
+				case END_ARRAY: 
+					if (0 == nestingLevel) {
+						noInput = true;
+						return null;
+					} else {
+						json = json.deleteCharAt(json.length() - 1).append(']');
+						nestingLevel--;
+						break;						
+					}
+				case END_OBJECT: 
+					// empty object corner case
+					if (1 < json.length()) {
+						json = json.deleteCharAt(json.length() - 1);
+					}
+					json = json.append('}');
+					/* we need to track the nesting level.  only the end of the root 
+					 * object should the json be unmarshalled.  otherwise, we should continue 
+					 * to build the object.
+					 */
+					if (1 == nestingLevel) {
+						T item = unmarshaller.unmarshal(new ByteArrayInputStream(json.toString().getBytes()), targetClass);
+						return item;
+					} else {
+						nestingLevel--;
+						break;
+					}
+				case KEY_NAME: 
+					json = json.append('"').append(jsonParser.getString()).append('"').append(":");
+					break;
+				case START_ARRAY: 
+					json = json.append('[');
+					nestingLevel++;
+					break;
+				case START_OBJECT: 
+					json = json.append('{');
+					nestingLevel++;
+					break;
+				case VALUE_FALSE: 
+					json = json.append("false");
+					break;
+				case VALUE_NULL: 
+					json = json.append("null");
+					break;
+				case VALUE_TRUE: 
+					json = json.append("true");
+					break;
+				case VALUE_STRING: 
+					json = json.append('"').append(jsonParser.getString().replaceAll("\"", "\\\\\"")).append('"');
+					break;
+				case VALUE_NUMBER: 
+					if (jsonParser.isIntegralNumber()) {
+						json = json.append(jsonParser.getLong());
+					} else {
+						json = json.append(jsonParser.getBigDecimal());
+					}
+					break;
+				}
+
+				/* For any value inside an object/array, we need to add a comma.
+				 * This will create a problem with the last element, but we can remove 
+				 * the extra comma at that time. 
+				 */
+				switch (nextEvent) {
+				case END_ARRAY:
+				case END_OBJECT:
+				case VALUE_FALSE: 
+				case VALUE_NULL: 
+				case VALUE_TRUE: 
+				case VALUE_STRING: 
+				case VALUE_NUMBER:
+					json = json.append(",");
+					break;
+				default: 
+					break;
+				}
+			}
+		} catch (Exception e) {
+			// Prevent caller from retrying indefinitely since this is fatal
+			noInput = true;
+			throw e;			
+		}
+	}
+
+	@Override
+	protected void doOpen() throws Exception {
+		noInput = true;
+		if (!resource.exists()) {
+			if (strict) {
+				throw new IllegalStateException("Input resource must exist (reader is in 'strict' mode)");
+			}
+			logger.warn("Input resource does not exist " + resource.getDescription());
+			return;
+		}
+		if (!resource.isReadable()) {
+			if (strict) {
+				throw new IllegalStateException("Input resource must be readable (reader is in 'strict' mode)");
+			}
+			logger.warn("Input resource is not readable " + resource.getDescription());
+			return;
+		}
+
+		inputStream = resource.getInputStream();
+		jsonParser = Json.createParser(inputStream);
+		noInput = false;
+
+		// move the cursor to the start of the input.  ignore everything before that.
+		while (jsonParser.hasNext()) {
+			JsonParser.Event nextEvent = jsonParser.next();
+			if (JsonParser.Event.KEY_NAME == nextEvent && jsonParser.getString().equals(keyName)) {
+				// A JSON array is expected, otherwise it's a format error.
+				nextEvent = jsonParser.next();
+				Assert.isTrue(JsonParser.Event.START_ARRAY == nextEvent
+					, "Value at element with key '" + keyName + "' must be an array."
+				);
+				return;
+			}
+		}
+	}
+
+	@Override
+	protected void doClose() throws Exception {
+		try {
+			if (null != jsonParser) {
+				jsonParser.close();
+			}
+			if (null != inputStream) {
+				inputStream.close();
+			}
+		}
+		finally {
+			jsonParser = null;
+			inputStream = null;
+		}
+	}
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonStreamItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonStreamItemReader.java
@@ -61,7 +61,6 @@ public class JsonStreamItemReader<T> extends AbstractItemCountingItemStreamItemR
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.notNull(unmarshaller, "The Unmarshaller must not be null.");
-		Assert.notNull(keyName, "The keyName may be empty, but it cannot be null.");
 	}
 
 	@Override
@@ -193,17 +192,20 @@ public class JsonStreamItemReader<T> extends AbstractItemCountingItemStreamItemR
 		noInput = false;
 
 		// move the cursor to the start of the input.  ignore everything before that.
-		while (jsonParser.hasNext()) {
-			JsonParser.Event nextEvent = jsonParser.next();
-			if (JsonParser.Event.KEY_NAME == nextEvent && jsonParser.getString().equals(keyName)) {
-				// A JSON array is expected, otherwise it's a format error.
+		JsonParser.Event nextEvent;
+		if (null != keyName && !"".equals(keyName)) {
+			while (jsonParser.hasNext()) {
 				nextEvent = jsonParser.next();
-				Assert.isTrue(JsonParser.Event.START_ARRAY == nextEvent
-					, "Value at element with key '" + keyName + "' must be an array."
-				);
-				return;
+				if (JsonParser.Event.KEY_NAME == nextEvent && jsonParser.getString().equals(keyName)) {
+					break;
+				}
 			}
 		}
+		// A JSON array is expected, otherwise it's a format error.
+		nextEvent = jsonParser.next();
+		Assert.isTrue(JsonParser.Event.START_ARRAY == nextEvent
+			, "Value at element with key '" + keyName + "' must be an array."
+		);		
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonStreamItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonStreamItemReader.java
@@ -43,14 +43,14 @@ public class JsonStreamItemReader<T> extends AbstractItemCountingItemStreamItemR
 
 	private String keyName;
 	
-	private Unmarshaller<T> unmarshaller;
+	private Unmarshaller unmarshaller;
 	private Class<T> targetClass;
 
 	public void setKeyName(String keyName) {
 		this.keyName = keyName;
 	}
 
-	public void setUnmarshaller(Unmarshaller<T> unmarshaller) {
+	public void setUnmarshaller(Unmarshaller unmarshaller) {
 		this.unmarshaller = unmarshaller;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/ojm/Unmarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/ojm/Unmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/ojm/Unmarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/ojm/Unmarshaller.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ojm;
+
+import java.io.InputStream;
+
+public interface Unmarshaller<T> {
+
+	public T unmarshal(InputStream inputStream, Class<T> _class) throws Exception;
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/ojm/Unmarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/ojm/Unmarshaller.java
@@ -17,7 +17,7 @@ package org.springframework.ojm;
 
 import java.io.InputStream;
 
-public interface Unmarshaller<T> {
+public interface Unmarshaller {
 
-	public T unmarshal(InputStream inputStream, Class<T> _class) throws Exception;
+	public <T> T unmarshal(InputStream inputStream, Class<T> _class) throws Exception;
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/ojm/jackson/JacksonUnmarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/ojm/jackson/JacksonUnmarshaller.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.ojm.Unmarshaller;
 
-public class JacksonUnmarshaller<T> implements Unmarshaller<T> {
+public class JacksonUnmarshaller implements Unmarshaller {
 
 	private ObjectMapper objectMapper;
 
@@ -29,7 +29,7 @@ public class JacksonUnmarshaller<T> implements Unmarshaller<T> {
 	}
 
 	@Override
-	public T unmarshal(InputStream inputStream, Class<T> _class) throws Exception {
+	public <T> T unmarshal(InputStream inputStream, Class<T> _class) throws Exception {
 		return objectMapper.readValue(inputStream, _class);
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/ojm/jackson/JacksonUnmarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/ojm/jackson/JacksonUnmarshaller.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ojm.jackson;
+
+import java.io.InputStream;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.springframework.ojm.Unmarshaller;
+
+public class JacksonUnmarshaller<T> implements Unmarshaller<T> {
+
+	private ObjectMapper objectMapper;
+
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public T unmarshal(InputStream inputStream, Class<T> _class) throws Exception {
+		return objectMapper.readValue(inputStream, _class);
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
@@ -1,0 +1,98 @@
+package org.springframework.batch.item.json;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.ojm.jackson.JacksonUnmarshaller;
+
+public class JsonStreamItemReaderTests {
+
+	public static class TestObject {
+		private Integer id;
+		private String string;
+		private Double doubleValue;
+		private Boolean booleanValue;
+		private List<TestObject> nestedTestObjectList;
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return this.id;
+		}
+
+		public void getString(String string) {
+			this.string = string;
+		}
+
+		public String getString() {
+			return this.string;
+		}
+
+		public void setDoubleValue(Double doubleValue) {
+			this.doubleValue = doubleValue;
+		}
+
+		public Double getDoubleValue() {
+			return this.doubleValue;
+		}
+
+		public void setBooleanValue(Boolean booleanValue) {
+			this.booleanValue = booleanValue;
+		}
+
+		public Boolean getBooleanValue() {
+			return this.booleanValue;
+		}
+
+		public void setNestedTestObjectList(List<TestObject> nestedTestObjectList) {
+			this.nestedTestObjectList = nestedTestObjectList;
+		}
+
+		public List<TestObject> getNestedTestObjectList() {
+			return this.nestedTestObjectList;
+		}
+	}
+
+	@Test
+	public void keyName() throws Exception {
+		JacksonUnmarshaller<JsonStreamItemReaderTests.TestObject> unmarshaller = new JacksonUnmarshaller<JsonStreamItemReaderTests.TestObject>();
+		unmarshaller.setObjectMapper(new ObjectMapper());
+		JsonStreamItemReader<JsonStreamItemReaderTests.TestObject> itemReader = new JsonStreamItemReader<JsonStreamItemReaderTests.TestObject>();
+		itemReader.setResource(new InputStreamResource(
+			ClassLoader.class.getResourceAsStream("/org/springframework/batch/item/json/keyName.json")
+		));
+		itemReader.setTargetClass(JsonStreamItemReaderTests.TestObject.class);
+		itemReader.setUnmarshaller(unmarshaller);
+		itemReader.setKeyName("arrayOfObjects");
+		itemReader.afterPropertiesSet();
+		itemReader.doOpen();
+
+		TestObject testObject = itemReader.read();
+		assertEquals(new Integer(1), testObject.getId());
+		assertEquals("a", testObject.getString());
+		assertEquals(new Double(0.012), testObject.getDoubleValue());
+		assertEquals(true, testObject.getBooleanValue());
+		List<TestObject> nestedTestObjects = testObject.getNestedTestObjectList();
+		assertEquals(1, nestedTestObjects.size());
+		TestObject nestedTestObject0 = nestedTestObjects.get(0);
+		assertEquals(null, nestedTestObject0.getId());
+		assertEquals("nested-a", nestedTestObject0.getString());
+		assertEquals(null, nestedTestObject0.getDoubleValue());
+		assertEquals(null, nestedTestObject0.getBooleanValue());
+
+		testObject = itemReader.read();
+		assertEquals("\"b", testObject.getString());
+		assertEquals(false, testObject.getBooleanValue());
+		assertEquals(null, testObject.getNestedTestObjectList());
+
+		testObject = itemReader.read();
+		assertEquals(null, testObject.getBooleanValue());
+		assertEquals(null, testObject.getNestedTestObjectList());
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
@@ -60,7 +60,7 @@ public class JsonStreamItemReaderTests {
 	}
 
 	private void testTemplate(String resourceString, String keyName) throws Exception {
-		JacksonUnmarshaller<JsonStreamItemReaderTests.TestObject> unmarshaller = new JacksonUnmarshaller<JsonStreamItemReaderTests.TestObject>();
+		JacksonUnmarshaller unmarshaller = new JacksonUnmarshaller();
 		unmarshaller.setObjectMapper(new ObjectMapper());
 		JsonStreamItemReader<JsonStreamItemReaderTests.TestObject> itemReader = new JsonStreamItemReader<JsonStreamItemReaderTests.TestObject>();
 		itemReader.setResource(new InputStreamResource(

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
@@ -59,17 +59,16 @@ public class JsonStreamItemReaderTests {
 		}
 	}
 
-	@Test
-	public void keyName() throws Exception {
+	private void testTemplate(String resourceString, String keyName) throws Exception {
 		JacksonUnmarshaller<JsonStreamItemReaderTests.TestObject> unmarshaller = new JacksonUnmarshaller<JsonStreamItemReaderTests.TestObject>();
 		unmarshaller.setObjectMapper(new ObjectMapper());
 		JsonStreamItemReader<JsonStreamItemReaderTests.TestObject> itemReader = new JsonStreamItemReader<JsonStreamItemReaderTests.TestObject>();
 		itemReader.setResource(new InputStreamResource(
-			ClassLoader.class.getResourceAsStream("/org/springframework/batch/item/json/keyName.json")
+			ClassLoader.class.getResourceAsStream(resourceString)
 		));
 		itemReader.setTargetClass(JsonStreamItemReaderTests.TestObject.class);
 		itemReader.setUnmarshaller(unmarshaller);
-		itemReader.setKeyName("arrayOfObjects");
+		itemReader.setKeyName(keyName);
 		itemReader.afterPropertiesSet();
 		itemReader.doOpen();
 
@@ -94,5 +93,20 @@ public class JsonStreamItemReaderTests {
 		testObject = itemReader.read();
 		assertEquals(null, testObject.getBooleanValue());
 		assertEquals(null, testObject.getNestedTestObjectList());
+	}
+
+	@Test
+	public void keyName() throws Exception {
+		testTemplate("/org/springframework/batch/item/json/keyName.json", "arrayOfObjects");
+	}
+
+	@Test
+	public void noKeyName() throws Exception {
+		testTemplate("/org/springframework/batch/item/json/noKeyName.json", null);		
+	}
+
+	@Test
+	public void emptyKeyName() throws Exception {
+		testTemplate("/org/springframework/batch/item/json/noKeyName.json", "");		
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonStreamItemReaderTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.item.json;
 
 import static org.junit.Assert.assertEquals;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/ojm/jackson/JacksonUnmarshallerTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/ojm/jackson/JacksonUnmarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/test/java/org/springframework/ojm/jackson/JacksonUnmarshallerTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/ojm/jackson/JacksonUnmarshallerTest.java
@@ -83,7 +83,7 @@ public class JacksonUnmarshallerTest {
 	@Test
 	public void simpleObject() throws Exception {
 		String json = "{'stringValue' : '123'}";
-		JacksonUnmarshaller<SimpleObject> unmarshaller = new JacksonUnmarshaller<SimpleObject>();
+		JacksonUnmarshaller unmarshaller = new JacksonUnmarshaller();
 		SimpleObject simpleObject = unmarshaller.unmarshal(new ByteArrayInputStream(json.getBytes()), SimpleObject.class);
 		assertThat(simpleObject.getStringValue(), equals("123"));
 	}
@@ -91,7 +91,7 @@ public class JacksonUnmarshallerTest {
 	@Test
 	public void compositeObject() throws Exception {
 		String json = "'stringValue' : '321', 'arrayOfIntegers' : [1, 2], 'simpleObject' : {'stringValue' : '123'}";
-		JacksonUnmarshaller<CompositeObject> unmarshaller = new JacksonUnmarshaller<CompositeObject>();
+		JacksonUnmarshaller unmarshaller = new JacksonUnmarshaller();
 		CompositeObject simpleObject = unmarshaller.unmarshal(new ByteArrayInputStream(json.getBytes()), CompositeObject.class);
 		assertThat(simpleObject.getStringValue(), equals("321"));
 		assertThat(simpleObject.getArrayOfIntegers(), hasItems(1, 2));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/ojm/jackson/JacksonUnmarshallerTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/ojm/jackson/JacksonUnmarshallerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ojm.jackson;
+
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Suppressed "unused" warnings on setter methods of test objects.  They are not used 
+ * locally but they are used by Jackson through reflection.
+ * 
+ * @author Matthew Ouyang
+ * @since 3.1
+ */
+public class JacksonUnmarshallerTest {
+
+	private static class SimpleObject {
+
+		private String stringValue;
+
+		public String getStringValue() {
+			return stringValue;
+		}
+
+		@SuppressWarnings("unused")
+		public void setStringValue(String stringValue) {
+			this.stringValue = stringValue;
+		}
+	}
+
+	private static class CompositeObject {
+
+		private String stringValue;
+		private List<Integer> arrayOfIntegers;
+		private SimpleObject simpleObject;
+
+		public String getStringValue() {
+			return stringValue;
+		}
+
+		@SuppressWarnings("unused")
+		public void setStringValue(String stringValue) {
+			this.stringValue = stringValue;
+		}
+
+		public List<Integer> getArrayOfIntegers() {
+			return arrayOfIntegers;
+		}
+
+		@SuppressWarnings("unused")
+		public void setArrayOfIntegers(List<Integer> arrayOfIntegers) {
+			this.arrayOfIntegers = arrayOfIntegers;
+		}
+
+		public SimpleObject getSimpleObject() {
+			return simpleObject;
+		}
+
+		@SuppressWarnings("unused")
+		public void setSimpleObject(SimpleObject simpleObject) {
+			this.simpleObject = simpleObject;
+		}
+	}
+
+	@Test
+	public void simpleObject() throws Exception {
+		String json = "{'stringValue' : '123'}";
+		JacksonUnmarshaller<SimpleObject> unmarshaller = new JacksonUnmarshaller<SimpleObject>();
+		SimpleObject simpleObject = unmarshaller.unmarshal(new ByteArrayInputStream(json.getBytes()), SimpleObject.class);
+		assertThat(simpleObject.getStringValue(), equals("123"));
+	}
+
+	@Test
+	public void compositeObject() throws Exception {
+		String json = "'stringValue' : '321', 'arrayOfIntegers' : [1, 2], 'simpleObject' : {'stringValue' : '123'}";
+		JacksonUnmarshaller<CompositeObject> unmarshaller = new JacksonUnmarshaller<CompositeObject>();
+		CompositeObject simpleObject = unmarshaller.unmarshal(new ByteArrayInputStream(json.getBytes()), CompositeObject.class);
+		assertThat(simpleObject.getStringValue(), equals("321"));
+		assertThat(simpleObject.getArrayOfIntegers(), hasItems(1, 2));
+		assertThat(simpleObject.getSimpleObject().getStringValue(), equals("123"));
+	}
+}

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/json/keyName.json
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/json/keyName.json
@@ -1,0 +1,17 @@
+{
+    "beforeArrayOfObjects" : {}, 
+    "arrayOfObjects" : [{
+        "id" : 1, 
+        "string" : "a", 
+        "doubleValue" : 0.012, 
+        "booleanValue" : true, 
+        "nestedTestObjectList" : [{
+            "string" : "nested-a"
+        }]
+    },{
+        "string" : "\"b", 
+        "booleanValue" : false
+    },{
+    }], 
+    "afterArrayOfObjects" : {}
+}

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/json/noKeyName.json
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/json/noKeyName.json
@@ -1,0 +1,13 @@
+[{
+        "id" : 1, 
+        "string" : "a", 
+        "doubleValue" : 0.012, 
+        "booleanValue" : true, 
+        "nestedTestObjectList" : [{
+            "string" : "nested-a"
+        }]
+    },{
+        "string" : "\"b", 
+        "booleanValue" : false
+    },{
+    }]


### PR DESCRIPTION
Overview
* more direct support for JSON
* added Unmarshaller interface for JSON similar to what is there for XML.  used Jackson as initial implementation.
* used JSR-353 to grab items one at a time and pass it off to Unmarshaller
* Handles reading from an array starting from a particular key name, or when the input is entirely an array (similar to StaxEventItemReader)

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.