### PR TITLE
BATCH-2407 Use StringBuilder instead of StringBuffer

### DIFF
--- a/spring-batch-core-tests/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-core-tests/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -137,10 +137,10 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 	}
 
 	private String stripComments(List<String> list) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (String line : list) {
 			if (!line.startsWith("//") && !line.startsWith("--")) {
-				buffer.append(line + "\n");
+				buffer.append(line).append("\n");
 			}
 		}
 		return buffer.toString();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/DefaultJobKeyGenerator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/DefaultJobKeyGenerator.java
@@ -43,14 +43,14 @@ public class DefaultJobKeyGenerator implements JobKeyGenerator<JobParameters> {
 	public String generateKey(JobParameters source) {
 
 		Map<String, JobParameter> props = source.getParameters();
-		StringBuffer stringBuffer = new StringBuffer();
+		StringBuilder stringBuffer = new StringBuilder();
 		List<String> keys = new ArrayList<String>(props.keySet());
 		Collections.sort(keys);
 		for (String key : keys) {
 			JobParameter jobParameter = props.get(key);
 			if(jobParameter.isIdentifying()) {
 				String value = jobParameter.getValue()==null ? "" : jobParameter.toString();
-				stringBuffer.append(key + "=" + value + ";");
+				stringBuffer.append(key).append("=").append(value).append(";");
 			}
 		}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
@@ -242,7 +242,7 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	 * description
 	 */
 	public ExitStatus addExitDescription(String description) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		boolean changed = StringUtils.hasText(description) && !exitDescription.equals(description);
 		if (StringUtils.hasText(exitDescription)) {
 			buffer.append(exitDescription);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
@@ -157,9 +157,9 @@ public class JobParametersTests {
 	public void testToStringOrder() {
 
 		Map<String, JobParameter> props = parameters.getParameters();
-		StringBuffer stringBuilder = new StringBuffer();
+		StringBuilder stringBuilder = new StringBuilder();
 		for (Entry<String, JobParameter> entry : props.entrySet()) {
-			stringBuilder.append(entry.toString() + ";");
+			stringBuilder.append(entry.toString()).append(";");
 		}
 
 		String string1 = stringBuilder.toString();
@@ -177,9 +177,9 @@ public class JobParametersTests {
 		JobParameters testProps = new JobParameters(parameterMap);
 
 		props = testProps.getParameters();
-		stringBuilder = new StringBuffer();
+		stringBuilder = new StringBuilder();
 		for (Entry<String, JobParameter> entry : props.entrySet()) {
-			stringBuilder.append(entry.toString() + ";");
+			stringBuilder.append(entry.toString()).append(";");
 		}
 		String string2 = stringBuilder.toString();
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDaoTests.java
@@ -79,7 +79,7 @@ public class JdbcJobInstanceDaoTests extends AbstractJobInstanceDaoTests {
 	public void testHexing() throws Exception {
 		MessageDigest digest = MessageDigest.getInstance("MD5");
 		byte[] bytes = digest.digest("f78spx".getBytes("UTF-8"));
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		for (byte bite : bytes) {
 			output.append(String.format("%02x", bite));
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDaoTests.java
@@ -49,7 +49,7 @@ public class JdbcStepExecutionDaoTests extends AbstractStepExecutionDaoTests {
 	@Test
 	public void testTruncateExitDescription() {
 
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < 100; i++) {
 			sb.append("too long exit description");
 		}

--- a/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -135,10 +135,10 @@ public class DataSourceInitializer implements InitializingBean {
 	}
 
 	private String stripComments(List<String> list) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (String line : list) {
 			if (!line.startsWith("//") && !line.startsWith("--")) {
-				buffer.append(line + "\n");
+				buffer.append(line).append("\n");
 			}
 		}
 		return buffer.toString();

--- a/spring-batch-infrastructure-tests/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-infrastructure-tests/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -140,10 +140,10 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 	}
 
 	private String stripComments(List<String> list) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (String line : list) {
 			if (!line.startsWith("//") && !line.startsWith("--")) {
-				buffer.append(line + "\n");
+				buffer.append(line).append("\n");
 			}
 		}
 		return buffer.toString();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PropertyMatches.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PropertyMatches.java
@@ -99,7 +99,7 @@ final class PropertyMatches {
 	 * indicating the possible property matches.
 	 */
 	public String buildErrorMessage() {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		buf.append("Bean property '");
 		buf.append(this.propertyName);
 		buf.append("' is not writable or has an invalid setter method. ");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditor.java
@@ -98,7 +98,7 @@ public class RangeArrayPropertyEditor extends PropertyEditorSupport {
 	public String getAsText() {
 		Range[] ranges = (Range[])getValue();
 		
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 
 		for (int i = 0; i < ranges.length; i++) {
 			if(i>0) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/SpringValidator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/SpringValidator.java
@@ -59,7 +59,7 @@ public class SpringValidator<T> implements Validator<T>, InitializingBean {
 	 * @return string of field errors followed by global errors.
 	 */
 	private String errorsToString(Errors errors) {
-		StringBuffer builder = new StringBuffer();
+		StringBuilder builder = new StringBuilder();
 
 		appendCollection(errors.getFieldErrors(), builder);
 		appendCollection(errors.getGlobalErrors(), builder);
@@ -71,7 +71,7 @@ public class SpringValidator<T> implements Validator<T>, InitializingBean {
 	 * Append the string representation of elements of the collection (separated
 	 * by new lines) to the given StringBuilder.
 	 */
-	private void appendCollection(Collection<?> collection, StringBuffer builder) {
+	private void appendCollection(Collection<?> collection, StringBuilder builder) {
 		for (Object value : collection) {
 			builder.append("\n");
 			builder.append(value.toString());

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
@@ -151,7 +151,7 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 	 */
     @Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer("SynchronizedAttributeAccessor: [");
+		StringBuilder buffer = new StringBuilder("SynchronizedAttributeAccessor: [");
 		synchronized (support) {
 			String[] names = attributeNames();
 			for (int i = 0; i < names.length; i++) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodInvokerUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodInvokerUtils.java
@@ -70,7 +70,7 @@ public class MethodInvokerUtils {
 	 * @return String
 	 */
 	public static String getParamTypesString(Class<?>... paramTypes) {
-		StringBuffer paramTypesList = new StringBuffer("(");
+		StringBuilder paramTypesList = new StringBuilder("(");
 		for (int i = 0; i < paramTypes.length; i++) {
 			paramTypesList.append(paramTypes[i].getSimpleName());
 			if (i + 1 < paramTypes.length) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -88,11 +88,11 @@ public class TransactionAwareBufferedWriter extends Writer {
 	/**
 	 * @return
 	 */
-	private StringBuffer getCurrentBuffer() {
+	private StringBuilder getCurrentBuffer() {
 
 		if (!TransactionSynchronizationManager.hasResource(bufferKey)) {
 
-			TransactionSynchronizationManager.bindResource(bufferKey, new StringBuffer());
+			TransactionSynchronizationManager.bindResource(bufferKey, new StringBuilder());
 
 			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
 				@Override
@@ -113,7 +113,7 @@ public class TransactionAwareBufferedWriter extends Writer {
 				}
 
 				private void complete() throws IOException {
-					StringBuffer buffer = (StringBuffer) TransactionSynchronizationManager.getResource(bufferKey);
+					StringBuilder buffer = (StringBuilder) TransactionSynchronizationManager.getResource(bufferKey);
 					if (buffer != null) {
 						String string = buffer.toString();
 						byte[] bytes = string.getBytes(encoding);
@@ -145,7 +145,7 @@ public class TransactionAwareBufferedWriter extends Writer {
 
 		}
 
-		return (StringBuffer) TransactionSynchronizationManager.getResource(bufferKey);
+		return (StringBuilder) TransactionSynchronizationManager.getResource(bufferKey);
 
 	}
 
@@ -222,7 +222,7 @@ public class TransactionAwareBufferedWriter extends Writer {
 			return;
 		}
 
-		StringBuffer buffer = getCurrentBuffer();
+		StringBuilder buffer = getCurrentBuffer();
 		buffer.append(cbuf, off, len);
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/FormatterLineAggregatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/FormatterLineAggregatorTests.java
@@ -132,7 +132,7 @@ public class FormatterLineAggregatorTests {
 				for (int i = 0; i < strings.length; i++) {
 					strings[i] = item[i];
 					if (item[i].length() < widths[i]) {
-						StringBuffer buffer = new StringBuffer(strings[i]);
+						StringBuilder buffer = new StringBuilder(strings[i]);
 						for (int j = 0; j < (widths[i] - item[i].length() + 1) / 2; j++) {
 							buffer.append(" ");
 						}
@@ -167,7 +167,7 @@ public class FormatterLineAggregatorTests {
 				for (int i = 0; i < strings.length; i++) {
 					strings[i] = item[i];
 					if (item[i].length() < widths[i]) {
-						StringBuffer buffer = new StringBuffer(strings[i]);
+						StringBuilder buffer = new StringBuilder(strings[i]);
 						for (int j = 0; j < widths[i] - item[i].length(); j++) {
 							buffer.append(".");
 						}

--- a/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -173,10 +173,10 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 	}
 
 	private String stripComments(List<String> list) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (String line : list) {
 			if (!line.startsWith("//") && !line.startsWith("--")) {
-				buffer.append(line + "\n");
+				buffer.append(line).append("\n");
 			}
 		}
 		return buffer.toString();

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
@@ -157,10 +157,10 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 	}
 
 	private String stripComments(List<String> list) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (String line : list) {
 			if (!line.startsWith("//") && !line.startsWith("--")) {
-				buffer.append(line + "\n");
+				buffer.append(line).append("\n");
 			}
 		}
 		return buffer.toString();

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/common/LogAdvice.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/common/LogAdvice.java
@@ -36,7 +36,7 @@ public class LogAdvice {
      */
     public void doBasicLogging(JoinPoint pjp) throws Throwable {
     	Object[] args = pjp.getArgs();
-    	StringBuffer output = new StringBuffer();
+    	StringBuilder output = new StringBuilder();
 
 		output.append(pjp.getTarget().getClass().getName()).append(": ");
 		output.append(pjp.toShortString()).append(": ");


### PR DESCRIPTION
With Java 1.5 StringBuilder is preferred over StringBuffer for single
threaded access as is has less overhead.

This is evidenced by the class comment of StringBuffer and Effective
Java 2nd Edition Item 67: Avoid excessive synchronization.

> The StringBuilder class should generally be used in preference to
> this one, as it supports all of the same operations but it is faster,
> as it performs no synchronization.

 - replace StringBuffer with StringBuilder where possible

Issue: BATCH-2407