### PR TITLE
BATCH-2409 OracleLobHandler is deprecated

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java
@@ -37,7 +37,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.lob.LobHandler;
-import org.springframework.jdbc.support.lob.OracleLobHandler;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -181,10 +180,6 @@ public class JobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean i
 		if (databaseType == null) {
 			databaseType = DatabaseType.fromMetaData(dataSource).name();
 			logger.info("No database type set, using meta data indicating: " + databaseType);
-		}
-
-		if (lobHandler == null && databaseType.equalsIgnoreCase(DatabaseType.ORACLE.toString())) {
-			lobHandler = new OracleLobHandler();
 		}
 
 		if(serializer == null) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
@@ -15,6 +15,20 @@
  */
 package org.springframework.batch.core.repository.support;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Types;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,23 +45,9 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
-import org.springframework.jdbc.support.lob.OracleLobHandler;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.Types;
-import java.util.Map;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Lucas Ward
@@ -97,24 +97,6 @@ public class JobRepositoryFactoryBeanTests {
 
 		factory.afterPropertiesSet();
 		factory.getObject();
-
-	}
-
-	@Test
-	public void testOracleLobHandler() throws Exception {
-
-		factory.setDatabaseType("ORACLE");
-
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
-		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
-		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
-		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ")).thenReturn(new StubIncrementer());
-		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "STEP_EXECUTION_SEQ")).thenReturn(new StubIncrementer());
-		factory.setIncrementerFactory(incrementerFactory);
-
-		factory.afterPropertiesSet();
-		LobHandler lobHandler = (LobHandler) ReflectionTestUtils.getField(factory, "lobHandler");
-		assertTrue(lobHandler instanceof OracleLobHandler);
 
 	}
 


### PR DESCRIPTION
Spring has deprecated OracleLobHandler in favor of DefaultLobHandler
for the Oracle 10g driver and higher and recommends using that driver
even against 9i databases. Extended Support for Oracle 9.2 ended in
July 2010.

 - switch OracleLobHandler to DefaultLobHandler

Issue: BATCH-2409