### PR TITLE
BATCH-2410 junit.framework.Assert is deprecated

### DIFF
--- a/spring-batch-core-tests/src/test/java/org/springframework/batch/core/test/ldif/LdifReaderTests.java
+++ b/spring-batch-core-tests/src/test/java/org/springframework/batch/core/test/ldif/LdifReaderTests.java
@@ -15,11 +15,16 @@
  */
 package org.springframework.batch.core.test.ldif;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.net.MalformedURLException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -34,15 +39,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.Assert;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.net.MalformedURLException;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "/simple-job-launcher-context.xml", "/applicationContext-test1.xml"})
 public class LdifReaderTests {
-	private static Logger log = LoggerFactory.getLogger(LdifReaderTests.class);
 
 	private Resource expected;
 	private Resource actual;
@@ -95,12 +94,11 @@ public class LdifReaderTests {
 			int lineNum = 1;
 			for (String expectedLine = null; (expectedLine = expectedReader.readLine()) != null; lineNum++) {
 				String actualLine = actualReader.readLine();
-				junit.framework.Assert.assertEquals("Line number " + lineNum + " does not match.", expectedLine, actualLine);
+				assertEquals("Line number " + lineNum + " does not match.", expectedLine, actualLine);
 			}
 
 			String actualLine = actualReader.readLine();
-			junit.framework.Assert.assertEquals("More lines than expected.  There should not be a line number " + lineNum + ".", null,
-					actualLine);
+			assertEquals("More lines than expected.  There should not be a line number " + lineNum + ".", null, actualLine);
 		}
 		finally {
 			expectedReader.close();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/MapJobRepositoryConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/MapJobRepositoryConfigurationTests.java
@@ -15,6 +15,10 @@
  */
 package org.springframework.batch.core.configuration.annotation;
 
+import static org.junit.Assert.assertEquals;
+
+import javax.sql.DataSource;
+
 import org.junit.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -35,10 +39,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.stereotype.Component;
-
-import javax.sql.DataSource;
-
-import static junit.framework.Assert.assertEquals;
 
 public class MapJobRepositoryConfigurationTests {
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/MapStepRegistryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/MapStepRegistryTests.java
@@ -15,6 +15,12 @@
  */
 package org.springframework.batch.core.configuration.support;
 
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.batch.core.Step;
@@ -23,12 +29,6 @@ import org.springframework.batch.core.configuration.StepRegistry;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.step.NoSuchStepException;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-
-import static junit.framework.Assert.fail;
 
 /**
  * @author Sebastien Gerard

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/JobExecutionListenerMethodAttributeParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/JobExecutionListenerMethodAttributeParserTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.core.configuration.xml;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/JobExecutionListenerParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/JobExecutionListenerParserTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.core.configuration.xml;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.batch.core.explore.support;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import javax.sql.DataSource;
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JobPropertyTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JobPropertyTests.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.batch.core.jsr.configuration.xml;
 
-import org.junit.Test;
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.jsr.AbstractJsrTestCase;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.repeat.RepeatStatus;
+import static org.junit.Assert.assertEquals;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Properties;
 
 import javax.batch.api.BatchProperty;
 import javax.batch.api.Batchlet;
@@ -34,11 +33,13 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
-import java.io.Serializable;
-import java.util.List;
-import java.util.Properties;
 
-import static junit.framework.Assert.assertEquals;
+import org.junit.Test;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.jsr.AbstractJsrTestCase;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
 
 /**
  * <p>

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrBeanDefinitionDocumentReaderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrBeanDefinitionDocumentReaderTests.java
@@ -15,6 +15,17 @@
  */
 package org.springframework.batch.core.jsr.configuration.xml;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import javax.batch.api.Batchlet;
+import javax.batch.runtime.JobExecution;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
@@ -29,16 +40,6 @@ import org.springframework.util.xml.SimpleSaxErrorHandler;
 import org.w3c.dom.Document;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
-
-import javax.batch.api.Batchlet;
-import javax.batch.runtime.JobExecution;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
 
 /**
  * <p>

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrXmlApplicationContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrXmlApplicationContextTests.java
@@ -15,13 +15,15 @@
  */
 package org.springframework.batch.core.jsr.configuration.xml;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Properties;
+
 import org.junit.Test;
 import org.springframework.beans.factory.config.BeanDefinition;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
 
 /**
  * <p>

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/JobListenerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/JobListenerFactoryBeanTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.core.listener;
 
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.batch.core.listener.JobListenerMetaData.AFTER_JOB;
 
 import java.util.HashMap;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/StepListenerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/StepListenerFactoryBeanTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.core.listener;
 
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.batch.core.listener.StepListenerMetaData.AFTER_STEP;
 import static org.springframework.batch.core.listener.StepListenerMetaData.AFTER_WRITE;
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
@@ -15,6 +15,20 @@
  */
 package org.springframework.batch.core.repository.support;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Types;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -35,19 +49,6 @@ import org.springframework.jdbc.support.lob.OracleLobHandler;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.Types;
-import java.util.Map;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Lucas Ward

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderXmlTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderXmlTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.item.file;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.Comparator;
 
@@ -23,10 +25,8 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.transform.Source;
 
-import junit.framework.Assert;
-
-import org.junit.runners.JUnit4;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -56,7 +56,7 @@ public class MultiResourceItemReaderXmlTests extends AbstractItemStreamItemReade
 				Attribute attr;
 				try {
 					XMLEventReader eventReader = StaxUtils.getXmlEventReader(source );
-					Assert.assertTrue(eventReader.nextEvent().isStartDocument());
+					assertTrue(eventReader.nextEvent().isStartDocument());
 					StartElement event = eventReader.nextEvent().asStartElement();
 					attr = (Attribute) event.getAttributes().next();
 				}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapperTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item.file.mapping;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractorTests.java
@@ -16,9 +16,9 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.springframework.beans.NotReadablePropertyException;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PassThroughFieldExtractorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PassThroughFieldExtractorTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.file.transform;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizerTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriterTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.xml.stax;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -29,8 +30,6 @@ import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
-
-import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -104,7 +103,7 @@ public class UnopenedElementClosingEventWriterTests {
     	verify(wrappedWriter).add(endElement);
     	
     	// only internal list should be modified
-    	Assert.assertEquals(2, unopenedElements.size());    	
+    	assertEquals(2, unopenedElements.size());    	
     }    
     
     @Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PatternMatcherTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PatternMatcherTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.support;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/AssertFile.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/AssertFile.java
@@ -16,11 +16,11 @@
 
 package org.springframework.batch.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
-
-import junit.framework.Assert;
 
 import org.springframework.core.io.Resource;
 
@@ -39,11 +39,11 @@ public abstract class AssertFile {
 			int lineNum = 1;
 			for (String expectedLine = null; (expectedLine = expectedReader.readLine()) != null; lineNum++) {
 				String actualLine = actualReader.readLine();
-				Assert.assertEquals("Line number " + lineNum + " does not match.", expectedLine, actualLine);
+				assertEquals("Line number " + lineNum + " does not match.", expectedLine, actualLine);
 			}
 
 			String actualLine = actualReader.readLine();
-			Assert.assertEquals("More lines than expected.  There should not be a line number " + lineNum + ".", null,
+			assertEquals("More lines than expected.  There should not be a line number " + lineNum + ".", null,
 					actualLine);
 		}
 		finally {
@@ -53,7 +53,7 @@ public abstract class AssertFile {
 	}
 
 	public static void assertFileEquals(Resource expected, Resource actual) throws Exception {
-		AssertFile.assertFileEquals(expected.getFile(), actual.getFile());
+		assertFileEquals(expected.getFile(), actual.getFile());
 	}
 
 	public static void assertLineCount(int expectedLineCount, File file) throws Exception {
@@ -63,7 +63,7 @@ public abstract class AssertFile {
 			while (expectedReader.readLine() != null) {
 				lineCount++;
 			}
-			Assert.assertEquals(expectedLineCount, lineCount);
+			assertEquals(expectedLineCount, lineCount);
 		}
 		finally {
 			expectedReader.close();
@@ -71,6 +71,6 @@ public abstract class AssertFile {
 	}
 
 	public static void assertLineCount(int expectedLineCount, Resource resource) throws Exception {
-		AssertFile.assertLineCount(expectedLineCount, resource.getFile());
+		assertLineCount(expectedLineCount, resource.getFile());
 	}
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/AssertFileTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/AssertFileTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.batch.test;
 
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import junit.framework.AssertionFailedError;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.springframework.core.io.FileSystemResource;
 
@@ -42,7 +42,7 @@ public class AssertFileTests {
 			executeAssertEquals("input1.txt", "input2.txt");
 			fail();
 		}
-		catch (AssertionFailedError e) {
+		catch (ComparisonFailure e) {
 			assertTrue(e.getMessage().startsWith("Line number 3 does not match."));
 		}
 	}
@@ -53,7 +53,7 @@ public class AssertFileTests {
 			executeAssertEquals("input3.txt", "input1.txt");
 			fail();
 		}
-		catch (AssertionFailedError e) {
+		catch (AssertionError e) {
 			assertTrue(e.getMessage().startsWith("More lines than expected.  There should not be a line number 4."));
 		}
 	}
@@ -64,7 +64,7 @@ public class AssertFileTests {
 			executeAssertEquals("input1.txt", "input3.txt");
 			fail();
 		}
-		catch (AssertionFailedError e) {
+		catch (AssertionError e) {
 			assertTrue(e.getMessage().startsWith("Line number 4 does not match."));
 		}
 	}
@@ -80,7 +80,7 @@ public class AssertFileTests {
 			executeAssertEquals("blank.txt", "input1.txt");
 			fail();
 		}
-		catch (AssertionFailedError e) {
+		catch (AssertionError e) {
 			assertTrue(e.getMessage().startsWith("More lines than expected.  There should not be a line number 1."));
 		}
 	}
@@ -91,7 +91,7 @@ public class AssertFileTests {
 			executeAssertEquals("input1.txt", "blank.txt");
 			fail();
 		}
-		catch (AssertionFailedError e) {
+		catch (AssertionError e) {
 			assertTrue(e.getMessage().startsWith("Line number 1 does not match."));
 		}
 	}


### PR DESCRIPTION
junit.framework.Assert has been deprecated in favor of
org.junit.Assert.

 - replace junit.framework.Assert with org.junit.Assert

Issue: BATCH-2410