### PR TITLE
BATCH-2411 Remove @SuppressWarnings("unchecked")

### DIFF
--- a/spring-batch-infrastructure-tests/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-infrastructure-tests/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -105,7 +105,6 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 		final JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		String[] scripts;
 		try {
-			@SuppressWarnings("unchecked")
 			String[] list = StringUtils.delimitedListToStringArray(stripComments(IOUtils.readLines(scriptResource
 					.getInputStream())), ";");
 			scripts = list;

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/quartz/JobLauncherDetails.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/quartz/JobLauncherDetails.java
@@ -63,7 +63,6 @@ public class JobLauncherDetails extends QuartzJobBean {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected void executeInternal(JobExecutionContext context) {
 		Map<String, Object> jobDataMap = context.getMergedJobDataMap();
 		String jobName = (String) jobDataMap.get(JOB_NAME);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/CompositeItemWriterSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/CompositeItemWriterSampleFunctionalTests.java
@@ -104,7 +104,7 @@ public class CompositeItemWriterSampleFunctionalTests {
 	}
 
 	private void checkOutputFile(String fileName) throws IOException {
-		@SuppressWarnings({ "unchecked", "resource" })
+		@SuppressWarnings("resource")
 		List<String> outputLines = IOUtils.readLines(new FileInputStream(fileName));
 
 		String output = "";

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
@@ -122,7 +122,6 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 
             @Override
-			@SuppressWarnings("unchecked")
 			public Void doInTransaction(TransactionStatus status) {
 				JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 				String[] scripts;


### PR DESCRIPTION
The source code contains various @SuppressWarnings("unchecked") that
are no longer unnecessary since the relevant APIs have been upgraded to
support Java 5 generics.

 - remove @SuppressWarnings("unchecked") where no longer unnecessary

Issue: BATCH-2411