### PR TITLE
BATCH-2161 ScopeConfiguration methods should be static

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
@@ -129,19 +129,18 @@ public abstract class AbstractBatchConfiguration implements ImportAware {
 @Configuration
 class ScopeConfiguration {
 
-	private StepScope stepScope = new StepScope();
-
-	private JobScope jobScope = new JobScope();
-
 	@Bean
-	public StepScope stepScope() {
+	public static StepScope stepScope() {
+		StepScope stepScope = new StepScope();
 		stepScope.setAutoProxy(false);
 		return stepScope;
 	}
 
 	@Bean
-	public JobScope jobScope() {
+	public static JobScope jobScope() {
+		JobScope jobScope = new JobScope();
 		jobScope.setAutoProxy(false);
 		return jobScope;
 	}
+
 }


### PR DESCRIPTION
The scope bean factory methods in ScopeConfiguration are
BeanFactoryPostProcessors and should therefore be static.
- Declare the scope beans in ScopeConfiguration as static

Issue: BATCH-2161
