### PR TITLE
BATCH-2435 FlatFileItemWriter buffers entire chunk

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
@@ -261,14 +261,14 @@ InitializingBean {
 
 		OutputState state = getOutputState();
 
-		StringBuilder lines = new StringBuilder();
 		int lineCount = 0;
-		for (T item : items) {
-			lines.append(lineAggregator.aggregate(item) + lineSeparator);
-			lineCount++;
-		}
 		try {
-			state.write(lines.toString());
+			for (T item : items) {
+				state.write(lineAggregator.aggregate(item));
+				state.write(lineSeparator);
+				lineCount++;
+			}
+			state.flush();
 		}
 		catch (IOException e) {
 			throw new WriteFailedException("Could not write data.  The file may be corrupt.", e);
@@ -340,6 +340,7 @@ InitializingBean {
 				try {
 					headerCallback.writeHeader(outputState.outputBufferedWriter);
 					outputState.write(lineSeparator);
+					outputState.flush();
 				}
 				catch (IOException e) {
 					throw new ItemStreamException("Could not write headers.  The file may be corrupt.", e);
@@ -535,6 +536,17 @@ InitializingBean {
 			}
 
 			outputBufferedWriter.write(line);
+		}
+
+		/**
+		 * @param line
+		 * @throws IOException
+		 */
+		public void flush() throws IOException {
+			if (!initialized) {
+				initializeBufferedWriter();
+			}
+
 			outputBufferedWriter.flush();
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
@@ -48,7 +48,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -826,8 +825,9 @@ public class FlatFileItemWriterTests {
 			assertEquals("aggregation failed on 2", expected.getMessage());
 		}
 
-		// nothing was written to output
-		assertNull(readLine());
+		// "1" was written to output, on "2" there was an exception
+		// transactions are handled by TransactionAwareBufferedWriter, not FlatFileItemWriter
+		assertEquals("1", readLine());
 	}
 
 	@Test


### PR DESCRIPTION
FlatFileItemWriter currently buffers the entire string conversion of a
chunk in memory. There is no need to do that, it can just as easily be
streamed out.

 * stream out individual lines of a chunk

This change should help to reduce both live set size and allocation
rate.

Issue: BATCH-2435
https://jira.spring.io/browse/BATCH-2435