### PR TITLE
fix assert message in PatternMatchingCompositeLineMapper.java

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
@@ -71,7 +71,7 @@ public class PatternMatchingCompositeLineMapper<T> implements LineMapper<T>, Ini
     @Override
 	public void afterPropertiesSet() throws Exception {
 		this.tokenizer.afterPropertiesSet();
-		Assert.isTrue(this.patternMatcher != null, "The 'fieldSetMappers' property must be non-empty");
+		Assert.isTrue(this.patternMatcher != null, "The 'patternMatcher' property must be non-null");
 	}
 
 	public void setTokenizers(Map<String, LineTokenizer> tokenizers) {


### PR DESCRIPTION
per BATCH-2427, changed assertion message to say "The 'patternMatcher' property must be non-null"