### PR TITLE
Update TaskletStep.java

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -394,11 +394,7 @@ public class TaskletStep extends AbstractStep {
 
 			chunkListener.beforeChunk(chunkContext);
 
-			// In case we need to push it back to its old value
-			// after a commit fails...
-			oldVersion = new StepExecution(stepExecution.getStepName(), stepExecution.getJobExecution());
-			copy(stepExecution, oldVersion);
-
+		
 			try {
 
 				try {
@@ -431,6 +427,10 @@ public class TaskletStep extends AbstractStep {
 						stepExecution.setTerminateOnly();
 						Thread.currentThread().interrupt();
 					}
+			// In case we need to push it back to its old value
+			// after a commit fails...
+			oldVersion = new StepExecution(stepExecution.getStepName(), stepExecution.getJobExecution());
+			copy(stepExecution, oldVersion);
 
 					// Apply the contribution to the step
 					// even if unsuccessful


### PR DESCRIPTION
	The save of the old stepExecution should be done after the thread get the lock, otherwise, it may overwrite committed changes made from another thread during roll back.