### PR TITLE
Add shutdown to ThreadPoolTaskExecutor

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/partition/JsrPartitionHandler.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/partition/JsrPartitionHandler.java
@@ -202,7 +202,7 @@ public class JsrPartitionHandler implements PartitionHandler, InitializingBean {
 		}
 
 		processPartitionResults(tasks, result);
-
+		taskExecutor.shutdown();
 		return result;
 	}
 


### PR DESCRIPTION
I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

Associated with ticket https://jira.spring.io/browse/BATCH-2439

This fixes an issue where the thread pool is not properly cleaned up which leaves any threads it has created blocked in memory.  