### PR TITLE
Update the tests to use the latest version of JRuby 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ allprojects {
 		xercesVersion = '2.8.1'
 		xmlunitVersion = '1.5'
 		xstreamVersion = '1.4.7'
-		jrubyVersion = '1.1.7'
+		jrubyVersion = '1.7.22'
 		beanshellVersion = '2.0b5'
 	}
 }
@@ -297,7 +297,8 @@ project('spring-batch-infrastructure') {
 
 		testRuntime "com.sun.mail:javax.mail:$javaMailVersion"
 		testRuntime "org.codehaus.groovy:groovy-jsr223:$groovyVersion"
-		testRuntime "com.sun.script.jruby:jruby-engine:$jrubyVersion"
+		testRuntime "org.jruby:jruby:$jrubyVersion"
+
 		testRuntime "org.beanshell:bsh:$beanshellVersion"
 
 		optional "javax.jms:jms-api:1.1-rev-1"


### PR DESCRIPTION
Previously, the JRuby engine that was being used pulled in an old
version of JRuby. The engine is incompatible with more recent JRuby 1.x
releases which causes problems for the Spring IO Platform which uses
JRuby 1.7.x.

This commit updates the tests to use the latest version of JRuby 1.x
(1.7.22) which contains its own JSR 223 integration, i.e. there’s no
need for a separate script engine dependency.