### PR TITLE
Make FlatFileItemReaderTests Spring Framework 4.2 compatible

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemReaderTests.java
@@ -37,6 +37,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.endsWith;
 
 /**
  * Tests for {@link FlatFileItemReader}.
@@ -445,7 +448,8 @@ public class FlatFileItemReaderTests {
 			assertEquals(2, expected.getLineNumber());
 			assertEquals("testLine2", expected.getInput());
 			assertEquals("Couldn't map line 2", expected.getCause().getMessage());
-			assertEquals("Parsing error at line: 2 in resource=[resource loaded from byte array], input=[testLine2]", expected.getMessage());
+			assertThat(expected.getMessage(), startsWith("Parsing error at line: 2 in resource=["));
+			assertThat(expected.getMessage(), endsWith("], input=[testLine2]"));
 		}
 	}
 


### PR DESCRIPTION
Previously, FlatFileItemReaderTests made a precise assertion that
involved the toString output from ByteArrayResource. This output
has changed between Spring Framework 4.0.x and Spring Framework 4.2.x.
As a result, the test fails when run as part of the Spring IO Platform
build which forces the version of Spring Framework to 4.2.x.

This commit updates the failing test so that it passes against both
Spring Framework 4.0.x and Spring Framework 4.2.x by relaxing the
assertion a little so that it is not dependent on the precise output
of ByteArrayResource's toString method.