### PR TITLE
Update SmokeTests to be compatible with Spring Integration 4.2

### DIFF
--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/SmokeTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/SmokeTests.java
@@ -17,7 +17,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-@MessageEndpoint
 public class SmokeTests {
 
 	@Autowired
@@ -26,17 +25,6 @@ public class SmokeTests {
 	@Autowired
 	private PollableChannel smokeout;
 
-	// This has to be static because Spring Integration registers the handler
-	// more than once (every time a test instance is created), but only one of
-	// them will get the message.
-	private volatile static int count = 0;
-
-	@ServiceActivator(inputChannel = "smokein", outputChannel = "smokeout")
-	public String process(String message) {
-		count++;
-		String result = message + ": " + count;
-		return result;
-	}
 
 	@Test
 	public void testDummyWithSimpleAssert() throws Exception {
@@ -50,7 +38,24 @@ public class SmokeTests {
 		Message<String> message = (Message<String>) smokeout.receive(100);
 		String result = message == null ? null : message.getPayload();
 		assertEquals("foo: 1", result);
-		assertEquals(1, count);
+		assertEquals(1, AnnotatedEndpoint.count);
+	}
+
+	@MessageEndpoint
+	static class AnnotatedEndpoint {
+		
+		// This has to be static because Spring Integration registers the handler
+		// more than once (every time a test instance is created), but only one of
+		// them will get the message.
+		private volatile static int count = 0;
+		
+		@ServiceActivator(inputChannel = "smokein", outputChannel = "smokeout")
+		public String process(String message) {
+			count++;
+			String result = message + ": " + count;
+			return result;
+		}
+
 	}
 
 }

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/SmokeTests-context.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/SmokeTests-context.xml
@@ -12,6 +12,7 @@
                                  http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
                         
 	<annotation-config/>
+	<beans:bean class="org.springframework.batch.integration.SmokeTests.AnnotatedEndpoint"/>
 	<channel id="smokein"/>
 	<channel id="smokeout">
 		<queue/>


### PR DESCRIPTION
Spring Integration 4.2 has fixed a bug where integration components
were being started too early. SmokeTests was relying on this bug to
start the test class which is also a @MessageEndpoint.

This commit updates the test to use a nested inner-class for the
endpoint and a bean declaration in the XML configuration. This allows
the test to pass against both Spring Integration 4.0 and 4.2.