### PR TITLE
partitionJob.xml should demonstrate asynch process

### DIFF
--- a/spring-batch-samples/src/main/resources/jobs/partitionFileJob.xml
+++ b/spring-batch-samples/src/main/resources/jobs/partitionFileJob.xml
@@ -16,7 +16,7 @@
 		<property name="resources" value="classpath:data/iosample/input/delimited*.csv" />
 	</bean>
 
-	<bean id="taskExecutor" class="org.springframework.core.task.SyncTaskExecutor" />
+	<bean id="taskExecutor" class="org.springframework.core.task.SimpleAsyncTaskExecutor" />
 
 	<step id="step1" xmlns="http://www.springframework.org/schema/batch">
 		<tasklet transaction-manager="transactionManager">


### PR DESCRIPTION
The README file on samples describes the partitionJob as an example of the asynch process feature, so I changed the class of the taskExecutor to SimpleAsyncTaskExecutor