### PR TITLE
Handle DB2 on the AS/400 (iSeries)

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
@@ -94,7 +94,8 @@ public enum DatabaseType {
 	public static DatabaseType fromMetaData(DataSource dataSource) throws MetaDataAccessException {
 		String databaseProductName =
 				JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductName").toString();
-		if (StringUtils.hasText(databaseProductName) && !databaseProductName.equals("DB2/Linux") && databaseProductName.startsWith("DB2")) {
+        	if (!databaseProductName.isEmpty() && !databaseProductName.equals("DB2/Linux")
+                	&& !databaseProductName.equals("DB2 UDB for AS/400") && databaseProductName.startsWith("DB2")) {
 			String databaseProductVersion =
 					JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductVersion").toString();
 			if (!databaseProductVersion.startsWith("SQL")) {


### PR DESCRIPTION
DB2 connections to the AS/400 report back DB2 z/OS incorrectly. The current AS/400 reports Database Product Name as "DB2 UDB for AS/400" and Database Product Version as "07.01.0000 V7R1m0". This code should handle the misreporting.