### PR TITLE
BATCH-2481: Fixed DB2 on the AS/400 (iSeries) and DB2 Server for VM and VSE

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
@@ -37,7 +37,9 @@ public enum DatabaseType {
 
 	DERBY("Apache Derby"),
 	DB2("DB2"),
+	DB2VSE("DB2VSE"),
 	DB2ZOS("DB2ZOS"),
+	DB2AS400("DB2AS400"),
 	HSQL("HSQL Database Engine"),
 	SQLSERVER("Microsoft SQL Server"),
 	MYSQL("MySQL"),
@@ -94,11 +96,18 @@ public enum DatabaseType {
 	public static DatabaseType fromMetaData(DataSource dataSource) throws MetaDataAccessException {
 		String databaseProductName =
 				JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductName").toString();
-		if (StringUtils.hasText(databaseProductName) && !databaseProductName.equals("DB2/Linux") && databaseProductName.startsWith("DB2")) {
+		if (StringUtils.hasText(databaseProductName) && databaseProductName.startsWith("DB2")) {
 			String databaseProductVersion =
 					JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductVersion").toString();
-			if (!databaseProductVersion.startsWith("SQL")) {
+			if (databaseProductVersion.startsWith("ARI")) {
+				databaseProductName = "DB2VSE";
+			}
+			else if (databaseProductVersion.startsWith("DSN")) {
 				databaseProductName = "DB2ZOS";
+			}
+			else if (databaseProductName.indexOf("AS") != -1 && (databaseProductVersion.startsWith("QSQ") ||
+					databaseProductVersion.substring(databaseProductVersion.indexOf('V')).matches("V\\dR\\d[mM]\\d"))) {
+				databaseProductName = "DB2AS400";
 			}
 			else {
 				databaseProductName = JdbcUtils.commonDatabaseName(databaseProductName);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTests.java
@@ -22,7 +22,9 @@ import javax.sql.DataSource;
 
 import static org.junit.Assert.assertEquals;
 import static org.springframework.batch.support.DatabaseType.DB2;
+import static org.springframework.batch.support.DatabaseType.DB2VSE;
 import static org.springframework.batch.support.DatabaseType.DB2ZOS;
+import static org.springframework.batch.support.DatabaseType.DB2AS400;
 import static org.springframework.batch.support.DatabaseType.DERBY;
 import static org.springframework.batch.support.DatabaseType.HSQL;
 import static org.springframework.batch.support.DatabaseType.MYSQL;
@@ -45,7 +47,9 @@ public class DatabaseTypeTests {
 	public void testFromProductName() {
 		assertEquals(DERBY, fromProductName("Apache Derby"));
 		assertEquals(DB2, fromProductName("DB2"));
+		assertEquals(DB2VSE, fromProductName("DB2VSE"));
 		assertEquals(DB2ZOS, fromProductName("DB2ZOS"));
+		assertEquals(DB2AS400, fromProductName("DB2AS400"));
 		assertEquals(HSQL, fromProductName("HSQL Database Engine"));
 		assertEquals(SQLSERVER, fromProductName("Microsoft SQL Server"));
 		assertEquals(MYSQL, fromProductName("MySQL"));
@@ -69,8 +73,17 @@ public class DatabaseTypeTests {
 
 	@Test
 	public void testFromMetaDataForDB2() throws Exception {
-		DataSource ds = DatabaseTypeTestUtils.getMockDataSource("DB2/Linux");
-		assertEquals(DB2, DatabaseType.fromMetaData(ds));
+		DataSource oldDs = DatabaseTypeTestUtils.getMockDataSource("DB2/Linux", "SQL0901");
+		assertEquals(DB2, DatabaseType.fromMetaData(oldDs));
+
+		DataSource newDs = DatabaseTypeTestUtils.getMockDataSource("DB2/NT", "SQL0901");
+		assertEquals(DB2, DatabaseType.fromMetaData(newDs));
+	}
+
+	@Test
+	public void testFromMetaDataForDB2VSE() throws Exception {
+		DataSource ds = DatabaseTypeTestUtils.getMockDataSource("DB2 for DB2 for z/OS VUE", "ARI08015");
+		assertEquals(DB2VSE, DatabaseType.fromMetaData(ds));
 	}
 
 	@Test
@@ -80,6 +93,18 @@ public class DatabaseTypeTests {
 
 		DataSource newDs = DatabaseTypeTestUtils.getMockDataSource("DB2 for DB2 UDB for z/OS", "DSN08015");
 		assertEquals(DB2ZOS, DatabaseType.fromMetaData(newDs));
+	}
+
+	@Test
+	public void testFromMetaDataForDB2AS400() throws Exception {
+		DataSource toolboxDs = DatabaseTypeTestUtils.getMockDataSource("DB2 UDB for AS/400", "07.01.0000 V7R1m0");
+		assertEquals(DB2AS400, DatabaseType.fromMetaData(toolboxDs));
+
+		DataSource nativeDs = DatabaseTypeTestUtils.getMockDataSource("DB2 UDB for AS/400", "V7R1M0");
+		assertEquals(DB2AS400, DatabaseType.fromMetaData(nativeDs));
+
+		DataSource prdidDs = DatabaseTypeTestUtils.getMockDataSource("DB2 UDB for AS/400", "QSQ07010");
+		assertEquals(DB2AS400, DatabaseType.fromMetaData(prdidDs));
 	}
 
 	@Test


### PR DESCRIPTION
DB2 connections to the AS/400 report incorrectly back as DB2 z/OS. The
current AS/400 reports Database Product Name as "DB2 UDB for AS/400".
Database Product Version has three possible return values based on
product used:
JTOpen reports "07.01.0000 V7R1m0".
Native Driver reports "V7R1M0".
PRDID reports "QSQ07010"

http://www-01.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.java/src/tpc/imjcc_c0053013.dita

Also added code to handle DB2 Server for VM and VSE.  This code should
handle the different DB2 Versions.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.