### PR TITLE
Fix for BATCH-2500

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +151,7 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 		if (executionContext.containsKey(getExecutionContextKey(CURRENT_RESOURCE_ITEM_COUNT))) {
 			// It's a restart
 			delegate.open(executionContext);
+			opened = true;
 		}
 		else {
 			opened = false;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/AbstractMultiResourceItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/AbstractMultiResourceItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2009 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.core.io.FileSystemResource;
  */
 public class AbstractMultiResourceItemWriterTests {
 
-	protected MultiResourceItemWriter<String> tested = new MultiResourceItemWriter<String>();
+	protected MultiResourceItemWriter<String> tested;
 
 	protected File file;
 
@@ -39,13 +39,16 @@ public class AbstractMultiResourceItemWriterTests {
 	protected ExecutionContext executionContext = new ExecutionContext();
 
 	protected void setUp(ResourceAwareItemWriterItemStream<String> delegate) throws Exception {
-		file = File.createTempFile(MultiResourceItemWriterFlatFileTests.class.getSimpleName(), null);
+		tested = new MultiResourceItemWriter<String>();
 		tested.setResource(new FileSystemResource(file));
 		tested.setDelegate(delegate);
 		tested.setResourceSuffixCreator(suffixCreator);
 		tested.setItemCountLimitPerResource(2);
 		tested.setSaveState(true);
-		tested.open(executionContext);
+	}
+
+	public void createFile() throws Exception {
+		file = File.createTempFile(MultiResourceItemWriterFlatFileTests.class.getSimpleName(), null);
 	}
 
 	protected String readFile(File f) throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterFlatFileTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterFlatFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 
 	@Before
 	public void setUp() throws Exception {
+		super.createFile();
 		delegate = new FlatFileItemWriter<String>();
 		delegate.setLineAggregator(new PassThroughLineAggregator<String>());
 	}
@@ -74,6 +75,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 	public void testBasicMultiResourceWriteScenario() throws Exception {
 
 		super.setUp(delegate);
+		tested.open(executionContext);
 
 		tested.write(Arrays.asList("1", "2", "3"));
 
@@ -99,6 +101,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 	public void testUpdateAfterDelegateClose() throws Exception {
 
 		super.setUp(delegate);
+		tested.open(executionContext);
 
 		tested.update(executionContext);
 		assertEquals(0, executionContext.getInt(tested.getExecutionContextKey("resource.item.count")));
@@ -120,6 +123,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 			}
 		});
 		super.setUp(delegate);
+		tested.open(executionContext);
 
 		tested.write(Arrays.asList("1", "2", "3"));
 
@@ -129,7 +133,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 		tested.write(Arrays.asList("4"));
 		File part2 = new File(file.getAbsolutePath() + suffixCreator.getSuffix(2));
 		assertTrue(part2.exists());
-		
+
 		tested.close();
 
 		assertEquals("123f", readFile(part1));
@@ -147,9 +151,10 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 			}
 		});
 		super.setUp(delegate);
-		
+		tested.open(executionContext);
+
 		ResourcelessTransactionManager transactionManager = new ResourcelessTransactionManager();
-		
+
 		new TransactionTemplate(transactionManager).execute(new WriterCallback(Arrays.asList("1", "2", "3")));
 
 		File part1 = new File(file.getAbsolutePath() + suffixCreator.getSuffix(1));
@@ -158,7 +163,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 		new TransactionTemplate(transactionManager).execute(new WriterCallback(Arrays.asList("4")));
 		File part2 = new File(file.getAbsolutePath() + suffixCreator.getSuffix(2));
 		assertTrue(part2.exists());
-		
+
 		tested.close();
 
 		assertEquals("123f", readFile(part1));
@@ -170,6 +175,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 	public void testRestart() throws Exception {
 
 		super.setUp(delegate);
+		tested.open(executionContext);
 
 		tested.write(Arrays.asList("1", "2", "3"));
 
@@ -184,6 +190,8 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 
 		tested.update(executionContext);
 		tested.close();
+
+		super.setUp(delegate);
 		tested.open(executionContext);
 
 		tested.write(Arrays.asList("5"));
@@ -204,7 +212,9 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 				writer.write("f");
 			}
 		});
+
 		super.setUp(delegate);
+		tested.open(executionContext);
 
 		tested.write(Arrays.asList("1", "2", "3"));
 
@@ -219,6 +229,8 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 
 		tested.update(executionContext);
 		tested.close();
+
+		super.setUp(delegate);
 		tested.open(executionContext);
 
 		tested.write(Arrays.asList("5"));
@@ -240,9 +252,10 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 			}
 		});
 		super.setUp(delegate);
+		tested.open(executionContext);
 
 		ResourcelessTransactionManager transactionManager = new ResourcelessTransactionManager();
-		
+
 		new TransactionTemplate(transactionManager).execute(new WriterCallback(Arrays.asList("1", "2", "3")));
 
 		File part1 = new File(file.getAbsolutePath() + suffixCreator.getSuffix(1));
@@ -256,6 +269,8 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 
 		tested.update(executionContext);
 		tested.close();
+
+		super.setUp(delegate);
 		tested.open(executionContext);
 
 		new TransactionTemplate(transactionManager).execute(new WriterCallback(Arrays.asList("5")));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterXmlTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterXmlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2014 the original author or authors.
+ * Copyright 2009-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public class MultiResourceItemWriterXmlTests extends AbstractMultiResourceItemWr
 
 	@Before
 	public void setUp() throws Exception {
+		super.createFile();
 		delegate = new StaxEventItemWriter<String>();
 		delegate.setMarshaller(new SimpleMarshaller());
 	}
@@ -88,8 +89,9 @@ public class MultiResourceItemWriterXmlTests extends AbstractMultiResourceItemWr
 
 	@Test
 	public void multiResourceWritingWithRestart() throws Exception {
-		
-		setUp(delegate);
+
+		super.setUp(delegate);
+		tested.open(executionContext);
 
 		tested.write(Arrays.asList("1", "2", "3"));
 
@@ -103,10 +105,12 @@ public class MultiResourceItemWriterXmlTests extends AbstractMultiResourceItemWr
 		tested.update(executionContext);
 		tested.close();
 
+
 		assertEquals(xmlDocStart + "<prefix:4/>" + xmlDocEnd, readFile(part2));
 		assertEquals(xmlDocStart + "<prefix:1/><prefix:2/><prefix:3/>" + xmlDocEnd,
 				readFile(part1));
 
+		super.setUp(delegate);
 		tested.open(executionContext);
 
 		tested.write(Arrays.asList("5"));


### PR DESCRIPTION
Fix for BATCH 2500 : MultiResourceItemWriter with StaxEventItemWriter restarts at position 0

MultiResourceItemWriter delegating to a StaxEventItemWriter doesn't restart properly.
- Changed the open() method in MultiResourceItemWriter by setting the flag 'opened' to true
  so that the executionContext isn't lost when restarting to write.

(also changed line endings of MultiResourceItemWriterFlatFileTests to LF)
