### PR TITLE
Domain documentation: "loadDate" -> "loadData"

### DIFF
--- a/src/site/docbook/reference/domain.xml
+++ b/src/site/docbook/reference/domain.xml
@@ -852,7 +852,7 @@
 
               <entry>1</entry>
 
-              <entry>loadDate</entry>
+              <entry>loadData</entry>
 
               <entry>2008-01-01 21:00</entry>
 


### PR DESCRIPTION
The step name in the example is "loadData" while the table entry references "loadDate".
