### PR TITLE
Override the version of Mockito used for Spring IO tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,6 +241,9 @@ configure(mainProjects) {
 				imports {
 					mavenBom "io.spring.platform:platform-bom:${platformVersion}"
 				}
+				dependencies {
+					dependency "org.mockito:mockito-core:$mockitoVersion"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Spring Boot 2.0 (and therefore Spring IO Platform Cairo) have upgraded
to Mockito 2.x which is not backwards compatible with 1.x. This breaks
a number of Spring Batch's tests when they're run with Mockito 2.x.

As Mockito is a test-only dependency, its version can be safely
overridden when running Spring IO compatibility tests without having
an adverse affect on compatibility for users. This commit overrides
the Platform's dependency management so that the Spring IO tests are
run using Mockito 1.x.