### PR TITLE
BATCH-2455 unifie listener ordering

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/CompositeChunkListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/CompositeChunkListener.java
@@ -49,35 +49,40 @@ public class CompositeChunkListener implements ChunkListener {
 	}
 
 	/**
-	 * Call the registered listeners in order, respecting and prioritizing those
-	 * that implement {@link Ordered}.
+	 * Call the registered listeners in reverse order.
 	 *
 	 * @see org.springframework.batch.core.ChunkListener#afterChunk(ChunkContext context)
 	 */
 	@Override
 	public void afterChunk(ChunkContext context) {
-		for (Iterator<ChunkListener> iterator = listeners.iterator(); iterator.hasNext();) {
+		for (Iterator<ChunkListener> iterator = listeners.reverse(); iterator.hasNext();) {
 			ChunkListener listener = iterator.next();
 			listener.afterChunk(context);
 		}
 	}
 
 	/**
-	 * Call the registered listeners in reverse order.
+	 * Call the registered listeners in order, respecting and prioritizing those
+	 * that implement {@link Ordered}.
 	 *
 	 * @see org.springframework.batch.core.ChunkListener#beforeChunk(ChunkContext context)
 	 */
 	@Override
 	public void beforeChunk(ChunkContext context) {
-		for (Iterator<ChunkListener> iterator = listeners.reverse(); iterator.hasNext();) {
+		for (Iterator<ChunkListener> iterator = listeners.iterator(); iterator.hasNext();) {
 			ChunkListener listener = iterator.next();
 			listener.beforeChunk(context);
 		}
 	}
 
+	/**
+	 * Call the registered listeners in reverse order.
+	 *
+	 * @see org.springframework.batch.core.ChunkListener#afterChunkError(ChunkContext context)
+	 */
 	@Override
 	public void afterChunkError(ChunkContext context) {
-		for (Iterator<ChunkListener> iterator = listeners.iterator(); iterator.hasNext();) {
+		for (Iterator<ChunkListener> iterator = listeners.reverse(); iterator.hasNext();) {
 			ChunkListener listener = iterator.next();
 			listener.afterChunkError(context);
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/CompositeItemReadListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/CompositeItemReadListener.java
@@ -81,7 +81,7 @@ public class CompositeItemReadListener<T> implements ItemReadListener<T> {
 	 */
 	@Override
 	public void onReadError(Exception ex) {
-		for (Iterator<ItemReadListener<? super T>> iterator = listeners.iterator(); iterator.hasNext();) {
+		for (Iterator<ItemReadListener<? super T>> iterator = listeners.reverse(); iterator.hasNext();) {
 			ItemReadListener<? super T> listener = iterator.next();
 			listener.onReadError(ex);
 		}


### PR DESCRIPTION
Why:
Listeners should be called in normal order before some event
(i.e. read, write) and after that event in reverse order.

Side effects:
The ordering of Chunk and ItemReader Listeners is changed and will
change some behaviors of users. This change is still neccesary because
it is not only the correct and obviouse way, but also prevents new
users to hack around this problem.