### PR TITLE
BATCH-2566: Use a DataFieldMaxValueIncrementer that works with MySQL …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ allprojects {
 		jbatchTckSpi = '1.0'
 		jettisonVersion = '1.2'
 		jtdsVersion = '1.2.4'
-		junitVersion = '4.11'
+		junitVersion = '4.12'
 		log4jVersion = '1.2.17'
 		mysqlVersion = '5.1.29'
 		mockitoVersion = '1.9.5'

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ public class CommandLineJobRunnerTests {
 		assertEquals(1, StubSystemExiter.status);
 		String errorMessage = CommandLineJobRunner.getErrorMessage();
 		assertTrue("Wrong error message: " + errorMessage, errorMessage
-				.contains("No bean named 'no-such-job' is defined"));
+				.contains("No bean named 'no-such-job'"));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DefaultDataFieldMaxValueIncrementerFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DefaultDataFieldMaxValueIncrementerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,11 @@ import junit.framework.TestCase;
 
 import static org.mockito.Mockito.mock;
 
+import java.lang.reflect.Field;
+
+import org.springframework.core.SpringVersion;
 import org.springframework.jdbc.support.incrementer.DB2SequenceMaxValueIncrementer;
+import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.DerbyMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.HsqlMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.MySQLMaxValueIncrementer;
@@ -30,10 +34,12 @@ import org.springframework.jdbc.support.incrementer.PostgreSQLSequenceMaxValueIn
 import org.springframework.jdbc.support.incrementer.SqlServerMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.SybaseMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.DB2MainframeSequenceMaxValueIncrementer;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Lucas Ward
  * @author Will Schipp
+ * @author Thomas Risberg
  *
  */
 public class DefaultDataFieldMaxValueIncrementerFactoryTests extends TestCase {
@@ -98,6 +104,17 @@ public class DefaultDataFieldMaxValueIncrementerFactoryTests extends TestCase {
 
 	public void testMysql(){
 		assertTrue(factory.getIncrementer("mysql", "NAME") instanceof MySQLMaxValueIncrementer);
+		if (SpringVersion.getVersion().compareTo("4.3.6.RELEASE") >= 0) {
+			DataFieldMaxValueIncrementer incr = factory.getIncrementer("mysql", "NAME");
+			Field field = ReflectionUtils.findField(incr.getClass(), "useNewConnection", boolean.class);
+			Object value = null;
+			if (field != null) {
+				field.setAccessible(true);
+				value = ReflectionUtils.getField(field, incr);
+			}
+			assertNotNull(value);
+			assertEquals(true, value);
+		}
 	}
 
 	public void testOracle(){

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/config/xml/JobLaunchingGatewayParserTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/config/xml/JobLaunchingGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -77,7 +77,7 @@ public class JobLaunchingGatewayParserTests {
 			setUp("JobLaunchingGatewayParserTestsNoJobLauncher-context.xml", getClass());
 		}
 		catch(BeanCreationException e) {
-			assertEquals("No bean named 'jobLauncher' is defined", e.getCause().getMessage());
+			assertTrue(e.getCause().getMessage().contains("No bean named 'jobLauncher'"));
 			return;
 		}
 		fail("Expected a NoSuchBeanDefinitionException to be thrown.");


### PR DESCRIPTION
…InnoDB table

- use refection to set MySQLMaxValueIncrementer#setUseNewConnection to true for Spring 4.3.6 and later

- update test for DefaultDataFieldMaxValueIncrementerFactory to check "useNewConnection" is set for MySQL with later Spring versions

- update junit to 4.12, required by Spring 4.3.x and later

- change tests for undefined beans, error message no longer ends with "is defined" in more recent Spring versions