### PR TITLE
Fix typo with ExecutionContext class name

### DIFF
--- a/src/site/docbook/reference/common-patterns.xml
+++ b/src/site/docbook/reference/common-patterns.xml
@@ -584,7 +584,7 @@ public Trade read() throws Exception {
 &lt;/beans:bean&gt;</emphasis></programlisting>
 
     <para>Finally, the saved values must be retrieved from the
-    <classname>Job</classname> <classname>ExeuctionContext</classname>:</para>
+    <classname>Job</classname> <classname>ExecutionContext</classname>:</para>
 
     <programlisting language="java">public class RetrievingItemWriter implements ItemWriter&lt;Object&gt; {
     private Object someObject;


### PR DESCRIPTION
Fixes a typo in the Common Batch Patterns section of the reference.