### PR TITLE
Align XML and Java based configuration

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -178,7 +178,7 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 	@Override
 	protected Tasklet createTasklet() {
 		Assert.state(getReader() != null, "ItemReader must be provided");
-		Assert.state(getProcessor() != null || getWriter() != null, "ItemWriter or ItemProcessor must be provided");
+		Assert.state(getWriter() != null, "ItemWriter must be provided");
 		addSpecialExceptions();
 		registerSkipListeners();
 		ChunkProvider<I> chunkProvider = createChunkProvider();
@@ -772,6 +772,6 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 			}
 			return chunkListener.equals(obj);
 		}
-		
+
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/SimpleStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/SimpleStepBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,7 +156,7 @@ public class SimpleStepBuilder<I, O> extends AbstractTaskletStepBuilder<SimpleSt
 	@Override
 	protected Tasklet createTasklet() {
 		Assert.state(reader != null, "ItemReader must be provided");
-		Assert.state(processor != null || writer != null, "ItemWriter or ItemProcessor must be provided");
+		Assert.state(writer != null, "ItemWriter must be provided");
 		RepeatOperations repeatOperations = createChunkOperations();
 		SimpleChunkProvider<I> chunkProvider = new SimpleChunkProvider<>(getReader(), repeatOperations);
 		SimpleChunkProcessor<I, O> chunkProcessor = new SimpleChunkProcessor<>(getProcessor(), getWriter());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -366,30 +366,6 @@ public class FaultTolerantStepFactoryBeanTests {
 
 		List<String> expectedOutput = Arrays.asList(StringUtils.commaDelimitedListToStringArray("1,2,3,5"));
 		assertEquals(expectedOutput, writer.getWritten());
-
-		assertEquals(BatchStatus.COMPLETED, stepExecution.getStatus());
-		assertStepExecutionsAreEqual(stepExecution, repository.getLastStepExecution(jobExecution.getJobInstance(), step
-				.getName()));
-	}
-
-	@Test
-	public void testNullWriter() throws Exception {
-
-		factory.setItemWriter(null);
-		Step step = factory.getObject();
-
-		step.execute(stepExecution);
-
-		assertEquals(0, stepExecution.getSkipCount());
-		assertEquals(0, stepExecution.getReadSkipCount());
-		assertEquals(5, stepExecution.getReadCount());
-		// Write count is incremented even if nothing happens
-		assertEquals(5, stepExecution.getWriteCount());
-		assertEquals(0, stepExecution.getFilterCount());
-		assertEquals(0, stepExecution.getRollbackCount());
-
-		// writer skips "4"
-		assertTrue(reader.getRead().contains("4"));
 
 		assertEquals(BatchStatus.COMPLETED, stepExecution.getStatus());
 		assertStepExecutionsAreEqual(stepExecution, repository.getLastStepExecution(jobExecution.getJobInstance(), step

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ChunkListener;
@@ -472,32 +473,6 @@ public class SimpleStepFactoryBeanTests {
 
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 		assertEquals("[write, write, write]", listenerCalls.toString());
-
-	}
-
-	@Test
-	public void testNullWriter() throws Exception {
-
-		SimpleStepFactoryBean<String, String> factory = getStepFactory(new String[] { "foo", "bar", "spam" });
-		factory.setItemWriter(null);
-		factory.setItemProcessor(new ItemProcessor<String, String>() {
-			@Override
-			public String process(String item) throws Exception {
-				written.add(item);
-				return null;
-			}
-		});
-
-		Step step = factory.getObject();
-
-		job.setSteps(Collections.singletonList(step));
-
-		JobExecution jobExecution = repository.createJobExecution(job.getName(), new JobParameters());
-
-		job.execute(jobExecution);
-
-		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
-		assertEquals("[foo, bar, spam]", written.toString());
 
 	}
 


### PR DESCRIPTION
This commit aligns the XML and Java based validations.

When using XML to configure a chunk oriented step both an ItemReader and
ItemWriter are requied. However when using Java based configuration the
ItemWriter is optional if an ItemProcessor is present.

Having no ItemWriter and only an ItemProcessor lead to strange results
in one of our batch jobs, which was accidentily configured without an
ItemProcessor.

Related: BATCH-1520
Fixes: BATCH-2624