### PR TITLE
BATCH-2630 - Infinite loop on job restart when step was repeated

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -229,7 +229,9 @@ public class SimpleJobRepository implements JobRepository {
 			if (latest == null) {
 				latest = stepExecution;
 			}
-			if (latest.getStartTime().getTime() < stepExecution.getStartTime().getTime()) {
+			// Ordered by step execution ID so less than or equal makes last step execution ID 
+			// the tie breaker if start time is identical
+			if (latest.getStartTime().getTime() <= stepExecution.getStartTime().getTime()) {
 				latest = stepExecution;
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -229,9 +229,12 @@ public class SimpleJobRepository implements JobRepository {
 			if (latest == null) {
 				latest = stepExecution;
 			}
-			// Ordered by step execution ID so less than or equal makes last step execution ID 
-			// the tie breaker if start time is identical
-			if (latest.getStartTime().getTime() <= stepExecution.getStartTime().getTime()) {
+			if (latest.getStartTime().getTime() < stepExecution.getStartTime().getTime()) { 
+				latest = stepExecution;
+			}
+			// Use step execution ID as the tie breaker if start time is identical
+			if (latest.getStartTime().getTime() == stepExecution.getStartTime().getTime() && 
+			        latest.getId() < stepExecution.getId()) {
 				latest = stepExecution;
 			}
 		}


### PR DESCRIPTION
Bug fix:  use step execution ID as tie breaker when start time is identical