### PR TITLE
Fix off-by-one error in DelimitedLineTokenizer on blank strings

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
@@ -211,7 +211,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer
         int start = offset;
         int len = count;
 
-        while ((start < (start + len)) && (chars[start] <= ' ')) {
+        while ((start < (start + len - 1)) && (chars[start] <= ' ')) {
             start++;
             len--;
         }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
@@ -47,7 +47,7 @@ public class DelimitedLineTokenizerTests {
 	}
 
     @Test
-    public void testEmptyString() {
+    public void testBlankString() {
         FieldSet tokens = tokenizer.tokenize("   ");
         assertTrue(TOKEN_MATCHES, tokens.readString(0).equals(""));
     }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
@@ -47,6 +47,11 @@ public class DelimitedLineTokenizerTests {
 	}
 
 	@Test
+	public void testEmptyString() {
+		tokenizer.tokenize("   ");
+	}
+
+	@Test
 	public void testInvalidConstructorArgument() {
 		try {
 			new DelimitedLineTokenizer(String.valueOf(DelimitedLineTokenizer.DEFAULT_QUOTE_CHARACTER));
@@ -130,20 +135,20 @@ public class DelimitedLineTokenizerTests {
 		FieldSet line = tokenizer.tokenize("a b c");
 		assertEquals(3, line.getFieldCount());
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testDelimitedLineTokenizerNullDelimiter() {
 		AbstractLineTokenizer tokenizer = new DelimitedLineTokenizer(null);
 		tokenizer.tokenize("a b c");
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testDelimitedLineTokenizerEmptyString() throws Exception {
 		DelimitedLineTokenizer tokenizer = new DelimitedLineTokenizer("");
 		tokenizer.afterPropertiesSet();
 		tokenizer.tokenize("a b c");
 	}
-	
+
 	@Test
 	public void testDelimitedLineTokenizerString() {
 		AbstractLineTokenizer tokenizer = new DelimitedLineTokenizer(" b ");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
@@ -46,10 +46,11 @@ public class DelimitedLineTokenizerTests {
 		assertTrue(TOKEN_MATCHES, tokens.readString(1).equals(""));
 	}
 
-	@Test
-	public void testEmptyString() {
-		tokenizer.tokenize("   ");
-	}
+    @Test
+    public void testEmptyString() {
+        FieldSet tokens = tokenizer.tokenize("   ");
+        assertTrue(TOKEN_MATCHES, tokens.readString(0).equals(""));
+    }
 
 	@Test
 	public void testInvalidConstructorArgument() {


### PR DESCRIPTION
There is currently a bug causing an ArrayIndexOutOfBoundsException
when trying to tokenize a blank string with more than two characters.