### PR TITLE
Fixed typos in unit testing docs.

### DIFF
--- a/spring-batch-docs/asciidoc/testing.adoc
+++ b/spring-batch-docs/asciidoc/testing.adoc
@@ -90,10 +90,10 @@ public class SkipSampleFunctionalTests {
                                       i, "customer" + i);
         }
 
-        JobExecution jobExecution = jobLauncherTestUtils.launchJob().getStatus();
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
 
-        Assert.assertEquals("COMPLETED", jobExecution.getExitStatus());
+        Assert.assertEquals("COMPLETED", jobExecution.getExitStatus().getExitCode());
     }
 }
 ----


### PR DESCRIPTION
# Obvious Fix

Source code in [10.2](https://docs.spring.io/spring-batch/trunk/reference/html/testing.html#endToEndTesting) does not work for two reasons:

- jobLauncherTestUtils.launchJob().getStatus() does not return JobExecution.
- jobExecution.getExitStatus() does not return String.

Fixed the codes to compile and pass the test.