### PR TITLE
Fix for BATCH-2636

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -15,12 +15,8 @@
  */
 package org.springframework.batch.core.configuration.annotation;
 
-import javax.annotation.PostConstruct;
-import javax.sql.DataSource;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.batch.core.configuration.BatchConfigurationException;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
@@ -31,13 +27,13 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
 
 @Component
 public class DefaultBatchConfigurer implements BatchConfigurer {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -48,6 +48,9 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 
 	@Autowired(required = false)
 	public void setDataSource(DataSource dataSource) {
+		if(this.dataSource != null) {
+			return;
+		}
 		this.dataSource = dataSource;
 		this.transactionManager = new DataSourceTransactionManager(dataSource);
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -46,20 +46,16 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 	private JobExplorer jobExplorer;
 
 	public void setDataSource(DataSource dataSource) {
-		setDataSource(dataSource, false);
+		this.dataSource = dataSource;
+		this.transactionManager = new DataSourceTransactionManager(dataSource);
 	}
 
 	@Autowired(required = false)
 	private void setDataSourceByAutowire(DataSource dataSource) {
-		setDataSource(dataSource, true);
-	}
-
-	private void setDataSource(DataSource dataSource, boolean isAutowireDataSource) {
-		if(isAutowireDataSource && this.dataSource != null) {
+		if(this.dataSource != null) {
 			return;
 		}
-		this.dataSource = dataSource;
-		this.transactionManager = new DataSourceTransactionManager(dataSource);
+		setDataSource(dataSource);
 	}
 
 	protected DefaultBatchConfigurer() {}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -31,6 +31,9 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Component;
@@ -46,9 +49,17 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 	private JobLauncher jobLauncher;
 	private JobExplorer jobExplorer;
 
-	@Autowired(required = false)
 	public void setDataSource(DataSource dataSource) {
-		if(this.dataSource != null) {
+		setDataSource(dataSource, false);
+	}
+
+	@Autowired(required = false)
+	private void setDataSourceByAutowire(DataSource dataSource) {
+		setDataSource(dataSource, true);
+	}
+
+	private void setDataSource(DataSource dataSource, boolean isAutowireDataSource) {
+		if(isAutowireDataSource && this.dataSource != null) {
 			return;
 		}
 		this.dataSource = dataSource;


### PR DESCRIPTION
Fix for BATCH-2636 : In the DefaultBatchConfigurer, autowiring the setDataSource Method makes the dataSource injection of the public construct meaningless.

The null check avoids injected DataSource due to AutowiredAnnotationBeanPostProcessor.