### PR TITLE
fix typo

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
@@ -105,7 +105,7 @@ public abstract class AbstractBatchConfiguration implements ImportAware {
 				this.configurer = configurer;
 				return configurer;
 			} else {
-				throw new IllegalStateException("To use the default BatchConfigurer the context must contain no more than" +
+				throw new IllegalStateException("To use the default BatchConfigurer the context must contain no more than " +
 														"one DataSource, found " + dataSources.size());
 			}
 		}


### PR DESCRIPTION
fix error message.


Caused by: java.lang.IllegalStateException: To use the default BatchConfigurer the context must contain no more `thanone` DataSource, found 2


Caused by: java.lang.IllegalStateException: To use the default BatchConfigurer the context must contain no more `than one` DataSource, found 2