### PR TITLE
Fix typo in documentation

### DIFF
--- a/spring-batch-docs/asciidoc/whatsnew.adoc
+++ b/spring-batch-docs/asciidoc/whatsnew.adoc
@@ -61,7 +61,7 @@ Spring Batch 4 is providing a collection of builders for all of the `ItemReader`
 		* `HibernatePagingItemReader` - `HibernatePagingItemReaderBuilder`
 		* `JdbcBatchItemWriter` - `JdbcBatchItemWriterBuilder`
 		* `JdbcCursorItemReader` - `JdbcCursorItemReaderBuilder`
-		* `JdbcPagingItemReader` - `JdbcCursorItemReaderBuilder`
+		* `JdbcPagingItemReader` - `JdbcPagingItemReaderBuilder`
 		* `JmsItemReader` - `JmsItemReaderBuilder`
 		* `JmsItemWriter` - `JmsItemWriterBuilder`
 		* `JpaPagingItemReader` - `JpaPagingItemReaderBuilder`


### PR DESCRIPTION
Hi,

I think the builder for `JdbcPagingItemReader` should be `JdbcPagingItemReaderBuilder` and not `JdbcCursorItemReaderBuilder`. Is this correct ?

Kind regards,
Mahmoud