### PR TITLE
BATCH-2647 JobStep does not update the ExitStatus of the StepExecution

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/job/JobStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/job/JobStep.java
@@ -124,6 +124,9 @@ public class JobStep extends AbstractStep {
 			// AbstractStep will take care of the step execution status
 			throw new UnexpectedJobExecutionException("Step failure: the delegate Job failed in JobStep.");
 		}
+		else if(jobExecution.getStatus().equals(BatchStatus.STOPPED)) {
+			stepExecution.setStatus(BatchStatus.STOPPED);
+		}
 	}
 	
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/job/JobStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/job/JobStepTests.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
@@ -202,5 +203,20 @@ public class JobStepTests {
 		jobRepository.update(jobExecution);
 
 		assertEquals(BatchStatus.STOPPED, stepExecution.getStatus());
+	}
+	
+	@Test
+	public void testStepExecutionExitStatus() throws Exception {
+		step.setJob(new JobSupport("child") {
+			@Override
+			public void execute(JobExecution execution) throws UnexpectedJobExecutionException {
+				execution.setStatus(BatchStatus.COMPLETED);
+				execution.setExitStatus(new ExitStatus("CUSTOM"));
+				execution.setEndTime(new Date());
+			}
+		});
+		step.afterPropertiesSet();
+		step.execute(stepExecution);
+		assertEquals("CUSTOM", stepExecution.getExitStatus().getExitCode());
 	}
 }


### PR DESCRIPTION
As said in the AbstractStep: "Subclasses should set the {@link ExitStatus} on the {@link StepExecution} before returning."
Relevant for a JobExecution custom exit status.