### PR TITLE
BATCH-2668: Fixed failing test on CET timezone

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java
@@ -27,7 +27,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
@@ -54,6 +57,20 @@ import static org.junit.Assert.fail;
 
 public class BeanWrapperFieldSetMapperTests {
 	
+	private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+	
+	private TimeZone defaultTimeZone = TimeZone.getDefault();
+
+	@Before
+	public void setUp() {
+		TimeZone.setDefault(UTC_TIME_ZONE);
+	}
+
+	@After
+	public void tearDown() {
+		TimeZone.setDefault(defaultTimeZone);
+	}
+
 	@Test
 	public void testNameAndTypeSpecified() throws Exception {
 		boolean errorCaught = false;


### PR DESCRIPTION
This PR is a possible fix for [BATCH-2668](https://jira.spring.io/browse/BATCH-2668). **It is not ready to merge**, there are different ways to fix the issue and I want to discuss the best way to do it.

In order to convert a String value to a Date, The `DefaultConversionService`
uses the constructor `java.util.Date(java.lang.String)` behind the scene
(from `org.springframework.core.convert.support.ObjectToObjectConverter.convert`).

This constructor throws a `java.lang.IllegalArgumentException` for values in
CET timezone, for example: "Thu Jan 04 09:05:50 CET 2018".

This PR updates the failing test `BeanWrapperFieldSetMapperTests#testDefaultConversion` to use a fixed timezone (UTC). Note that fixing the timezone is narrowed to the scope of the failing test only. It is probably better to do it in a setup/teardown methods, but since `TimeZone.setDefault` is static, this would impact other tests that might run in parallel during the build. I'm not sure this would be a real problem since in the end we would want to run all tests in the same fixed timezone to avoid this issue.

Some other alternatives:

1. Use the *same* date format in the [expected](https://github.com/spring-projects/spring-batch/blob/master/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java#L466) and [actual](https://github.com/spring-projects/spring-batch/blob/master/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java#L485) values (using `Date.toGMTString()` or `Date.toLocaleString()`). This works fine and the test passes, but both methods are deprecated..
2. Use an explicit date format *without* timezone details to format the actual and expected values (like `DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy");`) and an example of expected date in that format (`String dateString = "Thu Jan 04 09:05:50 2018";`). This is similar to the previous solution and does not use deprecated methods.
3. Set the system property `user.timezone` to `UTC` in a setup method and revert it to the default one in a teardown method. This also works fine and is probably the least intrusive solution.

Please let me know what do you think about these solutions or if there is a better way to tackle the issue, and I will update the PR accordingly.
  
  
  