### PR TITLE
BATCH-2662: Fix syntax highlighting of Java example

### DIFF
--- a/spring-batch-docs/asciidoc/job.adoc
+++ b/spring-batch-docs/asciidoc/job.adoc
@@ -172,7 +172,7 @@ restartable property may be set to 'false':
 ----
 
 .Java Configuration
-[source, xml, role="javaContent"]
+[source, java, role="javaContent"]
 ----
 @Bean
 public Job footballJob() {


### PR DESCRIPTION
This PR fixes the syntax highlighting of the Java example (which currently uses XML code colors) in section 1.1.1 of the documentation as reported in [BATCH-2662](https://jira.spring.io/browse/BATCH-2662)  