### PR TITLE
BATCH-2667: update warning message to be more explicit

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -425,7 +425,7 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 			}
 		}
 		catch (NoSuchJobException e) {
-			logger.warn("Cannot find Job object",e);
+			logger.warn("Cannot find Job object in the job registry. StoppableTasklet#stop() will not be called",e);
 		}
 
 		return true;


### PR DESCRIPTION
Before this commit, when a job execution is stopped from a different
JVM than the one running the job, a warning says that the job cannot
be found. This was confusing to some users since the job can be found
in the database (but is actually not defined in the job registry of
the application context of the second JVM).

After this commit is applied, the warning will be more explicit to
inform the user that the job cannot be found in the job registry
(to not be confused with the database)

Resolves [BATCH-2667](https://jira.spring.io/browse/BATCH-2667)