### PR TITLE
BATCH-2465: add note about the importance to have a unique key constraint on the sortKey

### DIFF
--- a/spring-batch-docs/asciidoc/readersAndWriters.adoc
+++ b/spring-batch-docs/asciidoc/readersAndWriters.adoc
@@ -2247,6 +2247,9 @@ The `SqlPagingQueryProviderFactoryBean` requires that you specify a `select` cla
 `from` clause. You can also provide an optional `where` clause. These clauses and the
 required `sortKey` are used to build an SQL statement.
 
+NOTE: It is important to have a unique key constraint on the `sortKey` to guarantee that
+ no data is lost between executions.
+
 After the reader has been opened, it passes back one item per call to `read` in the same
 basic fashion as any other `ItemReader`. The paging happens behind the scenes when
 additional rows are needed.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ import org.springframework.util.ClassUtils;
  * needed as {@link #read()} method is called, returning an object corresponding
  * to current position. On restart it uses the last sort key value to locate the
  * first page to read (so it doesn't matter if the successfully processed items
- * have been removed or modified).
+ * have been removed or modified). It is important to have a unique key constraint
+ * on the sort key to guarantee that no data is lost between executions.
  * </p>
  * 
  * <p>
@@ -71,6 +72,7 @@ import org.springframework.util.ClassUtils;
  * @author Thomas Risberg
  * @author Dave Syer
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  * @since 2.0
  */
 public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> implements InitializingBean {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,14 @@ import org.springframework.util.StringUtils;
  * Provides properties and preparation for the mandatory "selectClause" and
  * "fromClause" as well as for the optional "whereClause". Also provides
  * property for the mandatory "sortKeys".  <b>Note:</b> The columns that make up 
- * the sort key must be a true key and not just a column to order by.
+ * the sort key must be a true key and not just a column to order by. It is important
+ * to have a unique key constraint on the sort key to guarantee that no data is lost
+ * between executions.
  * 
  * @author Thomas Risberg
  * @author Dave Syer
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  * @since 2.0
  */
 public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvider {


### PR DESCRIPTION
This PR is for [BATCH-2465](https://jira.spring.io/browse/BATCH-2465).

It updates the reference documentation and the Javadoc to mention explicitly the importance to have a unique key constraint on the `sortKey` when using paging item readers.

I deliberately used "It is important" and not "It is required" (or mandatory) because in the end this is not required but in that case there is no guarantee to not lose data between executions.

Please let me know if the wording should be updated.