### PR TITLE
BATCH-2672: add method to set the encoding in the FlatFileItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Michael Minella
  * @author Glenn Renfro
+ * @author Mahmoud Ben Hassine
  * @since 4.0
  * @see FlatFileItemReader
  */
@@ -61,6 +62,8 @@ public class FlatFileItemReaderBuilder<T> {
 	protected Log logger = LogFactory.getLog(getClass());
 
 	private boolean strict = true;
+
+	private String encoding = FlatFileItemReader.DEFAULT_CHARSET;
 
 	private RecordSeparatorPolicy recordSeparatorPolicy =
 			new SimpleRecordSeparatorPolicy();
@@ -219,6 +222,19 @@ public class FlatFileItemReaderBuilder<T> {
 	 */
 	public FlatFileItemReaderBuilder<T> strict(boolean strict) {
 		this.strict = strict;
+		return this;
+	}
+
+	/**
+	 * Configure the encoding used by the reader to read the input source.
+	 * Default value is {@link FlatFileItemReader#DEFAULT_CHARSET}.
+	 *
+	 * @param encoding to use to read the input source.
+	 * @return The current instance of the builder.
+	 * @see FlatFileItemReader#setEncoding(String)
+	 */
+	public FlatFileItemReaderBuilder<T> encoding(String encoding) {
+		this.encoding = encoding;
 		return this;
 	}
 
@@ -418,6 +434,10 @@ public class FlatFileItemReaderBuilder<T> {
 
 		if(StringUtils.hasText(this.name)) {
 			reader.setName(this.name);
+		}
+
+		if(StringUtils.hasText(this.encoding)) {
+			reader.setEncoding(this.encoding);
 		}
 
 		reader.setResource(this.resource);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -43,6 +44,7 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 public class FlatFileItemReaderBuilderTests {
 
@@ -401,6 +403,36 @@ public class FlatFileItemReaderBuilderTests {
 				.name("foobar")
 				.build());
 
+	}
+
+	@Test
+	public void testDefaultEncoding() {
+		String encoding = FlatFileItemReader.DEFAULT_CHARSET;
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>()
+				.name("fooReader")
+				.resource(getResource("1,2,3"))
+				.delimited()
+				.names(new String[] {"first", "second", "third"})
+				.targetType(Foo.class)
+				.build();
+
+		assertEquals(encoding, ReflectionTestUtils.getField(reader, "encoding"));
+	}
+
+	@Test
+	public void testCustomEncoding() {
+		String encoding = "UTF-8";
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>()
+				.name("fooReader")
+				.resource(getResource("1  2  3"))
+				.encoding(encoding)
+				.fixedLength()
+				.columns(new Range[] {new Range(1, 3), new Range(4, 6), new Range(7)})
+				.names(new String[] {"first", "second", "third"})
+				.targetType(Foo.class)
+				.build();
+
+		assertEquals(encoding, ReflectionTestUtils.getField(reader, "encoding"));
 	}
 
 	private Resource getResource(String contents) {


### PR DESCRIPTION
This PR resolves [BATCH-2672](https://jira.spring.io/browse/BATCH-2672) by adding a method to set the resource encoding in the `FlatFileItemReaderBuilder`