### PR TITLE
BATCH-2673: fix the PDF version of the reference documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -739,7 +739,7 @@ task docsZip(type: Zip) {
 			exclude 'pdf/common-patterns.pdf'
 			exclude 'pdf/domain.pdf'
 			exclude 'pdf/index.pdf'
-			exclude 'pdf/index-single.pdf'
+			exclude 'pdf/toggle.pdf'
 			exclude 'pdf/job.pdf'
 			exclude 'pdf/jsr-352.pdf'
 			exclude 'pdf/readersAndWriters.pdf'
@@ -754,6 +754,8 @@ task docsZip(type: Zip) {
 			exclude 'pdf/transaction-appendix.pdf'
 			exclude 'pdf/whatsnew.pdf'
 			exclude 'pdf/glossary.pdf'
+
+			rename  'index-single.pdf', 'spring-batch-reference.pdf'
 
 			into 'reference'
 		}


### PR DESCRIPTION
Currently, the PDF version of the reference documentation is correctly generated (in `build/asciidoc/pdf/index-single.pdf`) but not included in the distribution (instead, it is the empty `toggle.pdf` file that is included).

This PR fixes this issue and renames the `index-single.pdf` to `spring-batch-reference.pdf` (like the [current](https://docs.spring.io/spring-batch/trunk/reference/pdf/spring-batch-reference.pdf) file name)