### PR TITLE
BATCH-2679: Add "Back to index" link in the sidebar of the documentation

### DIFF
--- a/spring-batch-docs/asciidoc/docinfo-footer.html
+++ b/spring-batch-docs/asciidoc/docinfo-footer.html
@@ -36,4 +36,14 @@
     window.addEventListener('resize', handleTocOnResize);
     window.addEventListener('tocRefresh', handleTocRefresh);
     handleTocOnResize();
+
+    var link = document.createElement("a");
+    link.setAttribute("href", "index.html");
+    link.innerHTML = "<i class=\"fa fa-chevron-left\"></i>&nbsp;&nbsp;Back to index";
+    var p = document.createElement("p");
+    p.setAttribute("id", "backToIndex");
+    p.appendChild(link);
+    var toc = document.getElementById('toc');
+    toc.insertBefore(p, toctitle);
+
 </script>


### PR DESCRIPTION
This PR resolves [BATCH-2679](https://jira.spring.io/browse/BATCH-2679).

It adds a "Back to index" link to the sidebar of the reference documentation.
The snippet was [friendly copied](https://github.com/spring-projects/spring-framework/blob/master/src/docs/asciidoc/docinfo-footer.html#L37-L44) from Spring Framework's docs 😄 

@Buzzardo Hi Jay, I wanted to add you as a reviewer for this PR but was not able find you in the list. What do you think of this change?