### PR TITLE
BATCH-2537: add support for @Primary annotated data sources

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import java.util.Collection;
  * 
  * @author Dave Syer
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  * @since 2.2
  * @see EnableBatchProcessing
  */
@@ -49,7 +50,7 @@ import java.util.Collection;
 public abstract class AbstractBatchConfiguration implements ImportAware {
 
 	@Autowired(required = false)
-	private Collection<DataSource> dataSources;
+	private DataSource dataSource;
 
 	private BatchConfigurer configurer;
 
@@ -93,20 +94,16 @@ public abstract class AbstractBatchConfiguration implements ImportAware {
 			return this.configurer;
 		}
 		if (configurers == null || configurers.isEmpty()) {
-			if (dataSources == null || dataSources.isEmpty()) {
+			if (dataSource == null) {
 				DefaultBatchConfigurer configurer = new DefaultBatchConfigurer();
 				configurer.initialize();
 				this.configurer = configurer;
 				return configurer;
-			} else if(dataSources != null && dataSources.size() == 1) {
-				DataSource dataSource = dataSources.iterator().next();
+			} else {
 				DefaultBatchConfigurer configurer = new DefaultBatchConfigurer(dataSource);
 				configurer.initialize();
 				this.configurer = configurer;
 				return configurer;
-			} else {
-				throw new IllegalStateException("To use the default BatchConfigurer the context must contain no more than " +
-														"one DataSource, found " + dataSources.size());
 			}
 		}
 		if (configurers.size() > 1) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.batch.core.configuration.support.ApplicationContextFa
 import org.springframework.batch.core.configuration.support.AutomaticJobRegistrar;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -85,7 +86,12 @@ import org.springframework.transaction.PlatformTransactionManager;
  * </pre>
  *
  * If a user does not provide a {@link javax.sql.DataSource} within the context, a Map based
- * {@link org.springframework.batch.core.repository.JobRepository} will be used.
+ * {@link org.springframework.batch.core.repository.JobRepository} will be used. If multiple
+ * {@link javax.sql.DataSource}s are defined in the context, the one annotated with
+ * {@link org.springframework.context.annotation.Primary} will be used (Note that if none
+ * of them is annotated with {@link org.springframework.context.annotation.Primary}, the one
+ * named <code>dataSource</code> will be used if any, otherwise a {@link UnsatisfiedDependencyException}
+ * will be thrown).
  *
  * Note that only one of your configuration classes needs to have the <code>&#064;EnableBatchProcessing</code>
  * annotation. Once you have an <code>&#064;EnableBatchProcessing</code> class in your configuration you will have an
@@ -156,6 +162,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * </pre>
  *
  * @author Dave Syer
+ * @author Mahmoud Ben Hassine
  *
  */
 @Target(ElementType.TYPE)


### PR DESCRIPTION
This PR resolves [BATCH-2537](https://jira.spring.io/browse/BATCH-2537).

Currently, the data source configuration in `AbstractBatchConfiguration` is defined as follows:

1. If there is no data source defined in the context, a map based job repository is used
2. If there is exactly one data source defined, it is used
3. If there are 2+ data sources,  an `IllegalStateException` is thrown **even if one of the data sources is annotated with `@Primary` (which should be the one to use)**.

This PR makes it possible to use the data source annotated with `@Primary` when multiple data sources are defined in the context. The new configuration is defined as follows:

1. If there is no data source defined in the context, a map based job repository is used
2. If there is exactly one data source defined, it is used
```diff
--3. If there are 2+ data sources,  an `IllegalStateException` is thrown **even if one of the data sources is annotated with `@Primary` (which should be the one to use)**.
++3.1 If there are 2+ data sources and one of them is annotated with `@Primary`,  this one is used.
++3.2 If there are 2+ data sources and none of them is annotated with `@Primary`,  a `UnsatisfiedDependencyException` is thrown (except when one them is named "dataSource", in which case it will be used (due to auto wiring by name)).
```

When a `UnsatisfiedDependencyException` is thrown, it is clearly said that Spring is not able to autowire a data source due to the presence of multiple candidates. In this case, the user may add `@Primary` on one of the data sources or name one of them "dataSource". This PR clearly documents this detail in the javadoc of `@EnableBatchProcessing`.