### PR TITLE
BATCH-2682: add link to the single page documentation in the index

### DIFF
--- a/spring-batch-docs/asciidoc/footer/index-footer.adoc
+++ b/spring-batch-docs/asciidoc/footer/index-footer.adoc
@@ -1,0 +1,11 @@
+'''
+Lucas Ward, Dave Syer, Thomas Risberg, Robert Kasanicky, Dan Garrette, Wayne Lund,
+Michael Minella, Chris Schaefer, Gunnar Hillert, Glenn Renfro, Jay Bryant, Mahmoud Ben Hassine
+
+Copyright © 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018 Pivotal, Inc. All Rights
+Reserved.
+
+Copies of this document may be made for your own use and for
+distribution to others, provided that you do not charge any fee for such
+copies and further provided that each copy contains this Copyright
+Notice, whether distributed in print or electronically.

--- a/spring-batch-docs/asciidoc/header/index-header.adoc
+++ b/spring-batch-docs/asciidoc/header/index-header.adoc
@@ -1,14 +1,3 @@
 = Spring Batch - Reference Documentation
 
-Lucas Ward, Dave Syer, Thomas Risberg, Robert Kasanicky, Dan Garrette, Wayne Lund,
-Michael Minella, Chris Schaefer, Gunnar Hillert, Glenn Renfro, Jay Bryant
-
 :batch-asciidoc: http://docs.spring.io/spring-batch/reference/html/
-
-Copyright © 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Pivotal, Inc. All Rights
-Reserved.
-
-Copies of this document may be made for your own use and for
-distribution to others, provided that you do not charge any fee for such
-copies and further provided that each copy contains this Copyright
-Notice, whether distributed in print or electronically.

--- a/spring-batch-docs/asciidoc/index.adoc
+++ b/spring-batch-docs/asciidoc/index.adoc
@@ -2,38 +2,45 @@ include::header/index-header.adoc[]
 
 // ======================================================================================
 
-* <<spring-batch-intro.adoc#spring-batch-intro,Spring Batch Introduction>>
+Welcome to the Spring Batch reference documentation! This documentation is also available
+as single link:index-single.html[html] and link:../pdf/index-single.pdf[pdf] documents.
 
-* <<whatsnew.adoc#whatsNew,What's New in Spring Batch 4.0>>
+The reference documentation is divided into several sections:
 
-* <<domain.adoc#domainLanguageOfBatch,The Domain Language of Batch>>
+[horizontal]
+<<spring-batch-intro.adoc#spring-batch-intro,Spring Batch Introduction>> :: Background, usage
+ scenarios and general guidelines.
+<<whatsnew.adoc#whatsNew,What's new in Spring Batch 4.0>> :: New features introduced in version 4.0.
+<<domain.adoc#domainLanguageOfBatch,The Domain Language of Batch>> :: Core concepts and abstractions
+of the Batch domain language.
+<<job.adoc#configureJob,Configuring and Running a Job>> :: Job configuration, execution and
+administration.
+<<step.adoc#configureStep,Configuring a Step>> :: Step configuration, different types of steps,
+controlling step flow.
+<<readersAndWriters.adoc#readersAndWriters,ItemReaders and ItemWriters>> :: Item readers
+and writers interfaces and how to use them.
+<<scalability.adoc#scalability,Scaling and Parallel Processing>> :: Multi-threaded steps,
+parallel steps, remote chunking and partitioning.
+<<repeat.adoc#repeat,Repeat>> :: Completion policies and exception handling of repetitive actions.
+<<retry.adoc#retry,Retry>> :: Retry and backoff policies of retryable operations.
+<<testing.adoc#testing,Unit Testing>> :: Job and Step testing facilities and APIs.
+<<common-patterns.adoc#commonPatterns, Common Patterns>> :: Common batch processing patterns
+and guidelines.
+<<jsr-352.adoc#jsr-352,JSR-352 Support>> :: JSR-352 support, similarities and differences
+with Spring Batch.
+<<spring-batch-integration.adoc#springBatchIntegration,Spring Batch Integration>> :: Integration
+between Spring Batch and Spring Integration projects.
 
-* <<job.adoc#configureJob,Configuring and Running a Job>>
+The following appendices are available:
 
-* <<step.adoc#configureStep,Configuring a Step>>
+[horizontal]
+<<appendix.adoc#listOfReadersAndWriters,List of ItemReaders and ItemWriters>> :: List of
+all item readers and writers provided out-of-the box.
+<<schema-appendix.adoc#metaDataSchema,Meta-Data Schema>> :: Core tables used by the Batch
+domain model.
+<<transaction-appendix.adoc#transactions,Batch Processing and Transactions>> :: Transaction
+boundaries, propagation and isolation levels used in Spring Batch.
+<<glossary.adoc#glossary,Glossary>> :: Glossary of common terms, concepts and vocabulary of
+the Batch domain.
 
-* <<readersAndWriters.adoc#readersAndWriters,ItemReaders and ItemWriters>>
-
-* <<scalability.adoc#scalability,Scaling and Parallel Processings>>
-
-* <<repeat.adoc#repeat,Repeat>>
-
-* <<retry.adoc#retry,Retry>>
-
-* <<testing.adoc#testing,Unit Testing>>
-
-* <<common-patterns.adoc#commonPatterns, Common Patterns>>
-
-* <<jsr-352.adoc#jsr-352,JSR-352 Support>>
-
-* <<spring-batch-integration.adoc#springBatchIntegration,Spring Batch Integration>>
-
-[big maroon]#Appendix#
-
-* <<appendix.adoc#listOfReadersAndWriters,List of ItemReaders and ItemWriters>>
-
-* <<schema-appendix.adoc#metaDataSchema,Meta-Data Schema>>
-
-* <<transaction-appendix.adoc#transactions,Batch Processing and Transactions>>
-
-* <<glossary.adoc#glossary,Glossary>>
+include::footer/index-footer.adoc[]


### PR DESCRIPTION
This PR resolves [BATCH-2682](https://jira.spring.io/browse/BATCH-2682).

It adds a link to the single html/pdf page documentation in the index.

It also:

* moves the copyright text to the bottom of the file
* removes the bullet points from the index page and replace them with a table (to be consistent with Spring Framework's documentation).

@mminella @Buzzardo Please let me know if the wording of the new section descriptions should be updated.

⚠️  Important note: if this PR is merged after #573 , the link to the pdf file should be updated with the new file name `spring-batch-reference.pdf`