### PR TITLE
BATCH-2698 - Remove commons io from test module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -492,7 +492,6 @@ project('spring-batch-test') {
 		compile "org.hamcrest:hamcrest-library:$hamcrestVersion"
 		compile "org.springframework:spring-test:$springVersion"
 		compile "org.springframework:spring-jdbc:$springVersion"
-		compile "commons-io:commons-io:$commonsIoVersion"
 		compile "commons-collections:commons-collections:$commonsCollectionsVersion"
 
         testCompile "org.apache.commons:commons-dbcp2:$commonsDdbcpVersion"


### PR DESCRIPTION
The only occurrence of it used was `IOUtils.readLines` in `DataSourceInitializer`. And since Spring Batch 4 requires Java 8, we can make use of `Files.lines` instead of common io's `IOUtils.readLines`.

Also noticed in the `spring-batch-test` module that `commons-collections:commons-collections` is not used? And `hamcrest-library` should be a `testCompile`?