### PR TITLE
Allow override factory properties in user-defined configurer subclass

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -125,18 +125,28 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 		return jobLauncher;
 	}
 
-	protected JobRepository createJobRepository() throws Exception {
+	protected JobRepositoryFactoryBean createJobRepositoryFactory() {
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(dataSource);
 		factory.setTransactionManager(transactionManager);
+		return factory;
+	}
+
+	protected JobExplorerFactoryBean createJobExplorerFactory() {
+		JobExplorerFactoryBean factory = new JobExplorerFactoryBean();
+		factory.setDataSource(dataSource);
+		return factory;
+	}
+
+	private JobRepository createJobRepository() throws Exception {
+		JobRepositoryFactoryBean factory = createJobRepositoryFactory();
 		factory.afterPropertiesSet();
 		return factory.getObject();
 	}
 
-	protected JobExplorer createJobExplorer() throws Exception {
-		JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
-		jobExplorerFactoryBean.setDataSource(this.dataSource);
-		jobExplorerFactoryBean.afterPropertiesSet();
-		return jobExplorerFactoryBean.getObject();
+	private JobExplorer createJobExplorer() throws Exception {
+		JobExplorerFactoryBean factory = createJobExplorerFactory();
+		factory.afterPropertiesSet();
+		return factory.getObject();
 	}
 }


### PR DESCRIPTION
E.g. to set custom serializer. It was a pain to workaround https://jira.spring.io/browse/BATCH-2575 in spring-batch 3.x because neither factories nor dataSource/transactionManager are not exposed to subclass of default configurer - so the only solution is to create new implementation of BatchConfigurer and copy-paste most of the DefaultBatchConfigurer code there just to call one setter on factory.