### PR TITLE
BATCH-1767: fix optimistic locking exception in multi-threaded step

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/MultiThreadedTaskletStepIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/MultiThreadedTaskletStepIntegrationTests.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.listener.JobExecutionListenerSupport;
+import org.springframework.batch.core.step.tasklet.TaskletStep;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+
+import javax.sql.DataSource;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the behavior of a multi-threaded TaskletStep.
+ *
+ * @author Mahmoud Ben Hassine
+ */
+public class MultiThreadedTaskletStepIntegrationTests {
+
+	@Test
+	public void testMultiThreadedTaskletExecutionWhenNoErrors() throws Exception {
+		// given
+		Class[] configurationClasses = {JobConfiguration.class, TransactionManagerConfiguration.class};
+		ApplicationContext context = new AnnotationConfigApplicationContext(configurationClasses);
+		JobLauncher jobLauncher = context.getBean(JobLauncher.class);
+		Job job = context.getBean(Job.class);
+
+		// when
+		JobExecution jobExecution = jobLauncher.run(job, new JobParameters());
+
+		// then
+		assertNotNull(jobExecution);
+		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+		StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+		assertEquals(BatchStatus.COMPLETED, stepExecution.getStatus());
+		assertEquals(0, stepExecution.getFailureExceptions().size());
+	}
+
+	@Test
+	public void testMultiThreadedTaskletExecutionWhenCommitFails() throws Exception {
+		// given
+		Class[] configurationClasses = {JobConfiguration.class, CommitFailingTransactionManagerConfiguration.class};
+		ApplicationContext context = new AnnotationConfigApplicationContext(configurationClasses);
+		JobLauncher jobLauncher = context.getBean(JobLauncher.class);
+		Job job = context.getBean(Job.class);
+
+		// when
+		JobExecution jobExecution = jobLauncher.run(job, new JobParameters());
+
+		// then
+		assertNotNull(jobExecution);
+		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+		StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+		assertEquals(BatchStatus.FAILED, stepExecution.getStatus());
+		Throwable e = stepExecution.getFailureExceptions().get(0);
+		assertEquals("Planned commit exception!", e.getMessage());
+		// No assertions on execution context because it is undefined in this case
+	}
+
+	@Test
+	public void testMultiThreadedTaskletExecutionWhenRollbackFails() throws Exception {
+		// given
+		Class[] configurationClasses = {JobConfiguration.class, RollbackFailingTransactionManagerConfiguration.class};
+		ApplicationContext context = new AnnotationConfigApplicationContext(configurationClasses);
+		JobLauncher jobLauncher = context.getBean(JobLauncher.class);
+		Job job = context.getBean(Job.class);
+
+		// when
+		JobExecution jobExecution = jobLauncher.run(job, new JobParameters());
+
+		// then
+		assertNotNull(jobExecution);
+		assertEquals(BatchStatus.UNKNOWN, jobExecution.getStatus());
+		StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+		assertEquals(BatchStatus.UNKNOWN, stepExecution.getStatus());
+		Throwable e = stepExecution.getFailureExceptions().get(0);
+		assertEquals("Planned rollback exception!", e.getMessage());
+		// No assertions on execution context because it is undefined in this case
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	public static class JobConfiguration {
+
+		@Autowired
+		private JobBuilderFactory jobBuilderFactory;
+		@Autowired
+		private StepBuilderFactory stepBuilderFactory;
+
+		@Bean
+		public TaskletStep step() {
+			return stepBuilderFactory.get("step")
+					.<Integer, Integer>chunk(3)
+					.reader(itemReader())
+					.writer(itemWriter())
+					.taskExecutor(taskExecutor())
+					.build();
+		}
+
+		@Bean
+		public Job job(ThreadPoolTaskExecutor taskExecutor) {
+			return jobBuilderFactory.get("job")
+					.start(step())
+					.listener(new JobExecutionListenerSupport() {
+						@Override
+						public void afterJob(JobExecution jobExecution) {
+							taskExecutor.shutdown();
+						}
+					})
+					.build();
+		}
+
+		@Bean
+		public ThreadPoolTaskExecutor taskExecutor() {
+			ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+			taskExecutor.setCorePoolSize(3);
+			taskExecutor.setMaxPoolSize(3);
+			taskExecutor.setThreadNamePrefix("spring-batch-worker-thread-");
+			return taskExecutor;
+		}
+
+		@Bean
+		public ItemReader<Integer> itemReader() {
+			return new ItemReader<Integer>() {
+				private AtomicInteger atomicInteger = new AtomicInteger();
+
+				@Override
+				public synchronized Integer read() {
+					int value = atomicInteger.incrementAndGet();
+					return value <= 9 ? value : null;
+				}
+			};
+		}
+
+		@Bean
+		public ItemWriter<Integer> itemWriter() {
+			return items -> {
+			};
+		}
+	}
+
+	@Configuration
+	public static class DataSourceConfiguration {
+
+		@Bean
+		public DataSource dataSource() {
+			return new EmbeddedDatabaseBuilder()
+					.setType(EmbeddedDatabaseType.HSQL)
+					.addScript("org/springframework/batch/core/schema-drop-hsqldb.sql")
+					.addScript("org/springframework/batch/core/schema-hsqldb.sql")
+					.build();
+		}
+
+	}
+
+	@Configuration
+	@Import(DataSourceConfiguration.class)
+	public static class TransactionManagerConfiguration {
+
+		@Bean
+		public PlatformTransactionManager transactionManager(DataSource dataSource) {
+			return new DataSourceTransactionManager(dataSource);
+		}
+
+	}
+
+	@Configuration
+	@Import(DataSourceConfiguration.class)
+	public static class CommitFailingTransactionManagerConfiguration {
+
+		@Bean
+		public PlatformTransactionManager transactionManager(DataSource dataSource) {
+			return new DataSourceTransactionManager(dataSource) {
+				@Override
+				protected void doCommit(DefaultTransactionStatus status) {
+					super.doCommit(status);
+					if (Thread.currentThread().getName().equals("spring-batch-worker-thread-2")) {
+						throw new RuntimeException("Planned commit exception!");
+					}
+				}
+			};
+		}
+
+	}
+
+	@Configuration
+	@Import(DataSourceConfiguration.class)
+	public static class RollbackFailingTransactionManagerConfiguration {
+
+		@Bean
+		public PlatformTransactionManager transactionManager(DataSource dataSource) {
+			return new DataSourceTransactionManager(dataSource) {
+				@Override
+				protected void doCommit(DefaultTransactionStatus status) {
+					super.doCommit(status);
+					if (Thread.currentThread().getName().equals("spring-batch-worker-thread-2")) {
+						throw new RuntimeException("Planned commit exception!");
+					}
+				}
+
+				@Override
+				protected void doRollback(DefaultTransactionStatus status) {
+					super.doRollback(status);
+					if (Thread.currentThread().getName().equals("spring-batch-worker-thread-2")) {
+						throw new RuntimeException("Planned rollback exception!");
+					}
+				}
+			};
+		}
+
+	}
+
+}

--- a/spring-batch-docs/src/main/asciidoc/scalability.adoc
+++ b/spring-batch-docs/src/main/asciidoc/scalability.adoc
@@ -123,7 +123,9 @@ your step, such as a `DataSource`.  Be sure to make the pool in those resources 
 as large as the desired number of concurrent threads in the step.
 
 There are some practical limitations of using multi-threaded `Step` implementations for
-some common batch use cases. Many participants in a `Step` (such as readers and writers)
+some common batch use cases:
+
+* Many participants in a `Step` (such as readers and writers)
 are stateful. If the state is not segregated by thread, then those components are not
 usable in a multi-threaded `Step`. In particular, most of the off-the-shelf readers and
 writers from Spring Batch are not designed for multi-threaded use. It is, however,
@@ -132,9 +134,8 @@ possible to work with stateless or thread safe readers and writers, and there is
 https://github.com/spring-projects/spring-batch/tree/master/spring-batch-samples[Spring
 Batch Samples] that shows the use of a process indicator (see
 <<readersAndWriters.adoc#process-indicator,Preventing State Persistence>>) to keep track
-of items that have been processed in a database input table.
-
-Spring Batch provides some implementations of `ItemWriter` and `ItemReader`.  Usually,
+of items that have been processed in a database input table. Spring Batch provides some
+ implementations of `ItemWriter` and `ItemReader`. Usually,
 they say in the Javadoc if they are thread safe or not or what you have to do to avoid
 problems in a concurrent environment.  If there is no information in the Javadoc, you can
 check the implementation to see if there is any state.  If a reader is not thread safe,
@@ -142,6 +143,11 @@ you can decorate it with the provided `SynchronizedItemStreamReader` or use it i
 synchronizing delegator. You can synchronize the call to `read()` and as long as the
 processing and writing is the most expensive part of the chunk, your step may still
 complete much faster than it would in a single threaded configuration.
+
+* In a multi-threaded `Step`, each thread runs in its own transaction and the `ChunkContext`
+is shared between threads. This shared state might end up in an inconsistent state
+if one of the transactions is rolled back. Hence, we recommend avoiding `ExecutionContext`
+manipulation in a multi-threaded `Step`.
 
 [[scalabilityParallelSteps]]
 


### PR DESCRIPTION
This PR is an attempt to resolve [BATCH-1767](https://jira.spring.io/browse/BATCH-1767). I will first explain the problem and then suggest a possible solution.

## The problem:

Currently, when the commit of the chunk fails in a multi-threaded step, the step execution is rolled back to a previous, eventually obsolete version. This previous version might be obsolete because it could have been modified by another thread. In this case, a `OptimisticLockingFailureException` is thrown when trying to persist the step execution leaving the step in an `UNKNOWN` state while it should be in a `FAILED` state. Here is a simple diagram that illustrates the issue:

<img width="1509" alt="batch-1767" src="https://user-images.githubusercontent.com/1210553/37710683-b002e164-2d0e-11e8-94f6-a12baa323973.png">

SE: StepExecution | SC: StepContribution | OV: old version variable (of type StepExecution)

In this diagram, 3 threads are running in parallel to execute the `TaskletStep`. All of them start with a `StepExecution` instance at version 1. This instance is shared between threads. In pseudo code, each thread will do the following:

```
1. copy the StepExecution in oldVersion variable (which is also shared)
2. create a StepContribution instance (not shared), do the work and assign metrics to it
3. take the lock {
      3.1 apply contribution to the StepExecution
      3.2 try {
               3.2.1 update the StepExecution in the database 
               3.2.2 commit
          catch(Exception e) {
               3.2.3 rollback the in-memory StepExecution instance to oldVersion
          }
}
```

There are two issues with this:

1. The `StepContribution` might be applied on an obsolete version of the `StepExecution` (which might have changed between step 1 and and step 3). This results in `OptimisticLockingFailureException` when one of the threads tries to persist the step execution after applying its contribution

2. In case of a commit failure, the `StepExecution` is rolled back to a possibly obsolete version (oldVersion which is always at version 1). This also results in a `OptimisticLockingFailureException` when the control returns back to `AbstractStep` which tries to persist the in-memory `StepExecution` at version 1 while the `StepExecution` in the database is at version 3 (This is the reported issue in BATCH-1767).

## A possible solution

This PR fixes:

*  Issue 1) by refreshing the step execution to the latest correctly persisted version just before applying the step contribution so that each thread applies its contribution on a fresh and correct state.

* Issue 2) by reverting all metrics but the version when reverting the in-memory `StepExecution` in case of rollback. The goal of the rollback is to undo the (failed) contribution metrics and not the technical field `version`. "Reverting" a version is not compatible with an optimistic locking strategy, we use the version to check if there is a version conflict but we don't need to revert it (in the in-memory instance of `StepExecution`, note that the `StepExecution` is correctly reverted in the database since the update is executed within the transaction (`doInTransaction` method) being rolled back).

The most important detail in the story is that each thread creates its own contribution to the step, but the `ChunkContext` (and the `StepExecution`) is shared between threads. This shared state might end up in an inconsistent state if one of the transactions is rolled back. Tests in this PR do not assert any result on the (undefined) execution context.

It is technically possible to make the execution context consistent by using `ThreadLocal`s for instance, but I would not go down this path for two reasons:

* It will increase memory footprint by making each thread have its own copy of the execution context (and probably introduce a performance degradation).
* It will also introduce another level of complexity to the code (and hence impacts maintainability) just to solve a very specific problem. It's always a trade-off..

The "practical limitations of multi-threaded Step" section of the documentation already mentions to turn-off the state in this case. This PR updates the section by mentioning that it is not advised to manipulate the execution context in a multi-threaded step.