### PR TITLE
BATCH-2710 - Add beanRowMapper to JdbcCursorItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
@@ -24,6 +24,7 @@ import org.springframework.batch.item.database.support.ListPreparedStatementSett
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
 import org.springframework.jdbc.core.ArgumentTypePreparedStatementSetter;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.util.Assert;
@@ -306,6 +307,20 @@ public class JdbcCursorItemReaderBuilder<T> {
 	 */
 	public JdbcCursorItemReaderBuilder<T> rowMapper(RowMapper<T> rowMapper) {
 		this.rowMapper = rowMapper;
+
+		return this;
+	}
+
+	/**
+	 * Creates a {@link BeanPropertyRowMapper} to be used as your
+	 * {@link RowMapper}.
+	 *
+	 * @param mappedClass the class for the row mapper
+	 * @return this instance for method chaining
+	 * @see BeanPropertyRowMapper
+	 */
+	public JdbcCursorItemReaderBuilder<T> beanRowMapper(Class<T> mappedClass) {
+		this.rowMapper = new BeanPropertyRowMapper<>(mappedClass);
 
 		return this;
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilderTests.java
@@ -301,15 +301,7 @@ public class JdbcCursorItemReaderBuilderTests {
 				.ignoreWarnings(true)
 				.driverSupportsAbsolute(true)
 				.useSharedExtendedConnection(true)
-				.rowMapper((rs, rowNum) -> {
-					Foo foo = new Foo();
-
-					foo.setFirst(rs.getInt("FIRST"));
-					foo.setSecond(rs.getString("SECOND"));
-					foo.setThird(rs.getString("THIRD"));
-
-					return foo;
-				})
+				.beanRowMapper(Foo.class)
 				.build();
 
 		assertEquals(1, ReflectionTestUtils.getField(reader, "fetchSize"));


### PR DESCRIPTION
Adds a builder method, `beanRowMapper`, that sets the `rowMapper` of the `JdbcCursorItemReader` as a `BeanPropertyRowMapper`