### PR TITLE
BATCH-2699: Move derby's generated files under "build" directory

### DIFF
--- a/spring-batch-core-tests/src/test/java/test/jdbc/datasource/DerbyDataSourceFactoryBean.java
+++ b/spring-batch-core-tests/src/test/java/test/jdbc/datasource/DerbyDataSourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2014 the original author or authors.
+ * Copyright 2009-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 
 public class DerbyDataSourceFactoryBean extends AbstractFactoryBean<DataSource> {
 
-	private String dataDirectory = "derby-home";
+	private String dataDirectory = "build/derby-home";
 
 	public void setDataDirectory(String dataDirectory) {
 		this.dataDirectory = dataDirectory;
@@ -38,7 +38,7 @@ public class DerbyDataSourceFactoryBean extends AbstractFactoryBean<DataSource> 
 		System.setProperty("derby.storage.pageCacheSize", "100");
 
 		final EmbeddedDataSource ds = new EmbeddedDataSource();
-		ds.setDatabaseName("derbydb");
+		ds.setDatabaseName("build/derbydb");
 		ds.setCreateDatabase("create");
 
 		return ds;

--- a/spring-batch-core-tests/src/test/resources/batch-derby.properties
+++ b/spring-batch-core-tests/src/test/resources/batch-derby.properties
@@ -1,7 +1,7 @@
 # Placeholders batch.*
 #    for Derby:
 batch.jdbc.driver=org.apache.derby.jdbc.EmbeddedDriver
-batch.jdbc.url=jdbc:derby:derby-home/test;create=true
+batch.jdbc.url=jdbc:derby:build/derby-home/test;create=true
 batch.jdbc.user=sa
 batch.jdbc.password=
 batch.jdbc.testWhileIdle=false

--- a/spring-batch-infrastructure-tests/src/test/resources/batch-derby.properties
+++ b/spring-batch-infrastructure-tests/src/test/resources/batch-derby.properties
@@ -1,7 +1,7 @@
 # Placeholders batch.*
 #    for Derby:
 batch.jdbc.driver=org.apache.derby.jdbc.EmbeddedDriver
-batch.jdbc.url=jdbc:derby:derby-home/test;create=true
+batch.jdbc.url=jdbc:derby:build/derby-home/test;create=true
 batch.jdbc.user=app
 batch.jdbc.password=
 batch.jdbc.testWhileIdle=false

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2009 the original author or authors.
+ * Copyright 2006-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class DatabaseTypeIntegrationTests {
 	@Test
 	public void testDerby() throws Exception {
 		DataSource dataSource = DatabaseTypeTestUtils.getDataSource(org.apache.derby.jdbc.EmbeddedDriver.class,
-				"jdbc:derby:derby-home/test;create=true", "sa", "");
+				"jdbc:derby:./build/derby-home/test;create=true", "sa", "");
 		assertEquals(DatabaseType.DERBY, DatabaseType.fromMetaData(dataSource));
 		dataSource.getConnection();
 	}

--- a/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DerbyDataSourceFactoryBean.java
+++ b/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DerbyDataSourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class DerbyDataSourceFactoryBean extends AbstractFactoryBean<DataSource> 
 
 	private static Log logger = LogFactory.getLog(DerbyDataSourceFactoryBean.class);
 
-	private String dataDirectory = "derby-home";
+	private String dataDirectory = "build/derby-home";
 
 	public void setDataDirectory(String dataDirectory) {
 		this.dataDirectory = dataDirectory;
@@ -42,7 +42,7 @@ public class DerbyDataSourceFactoryBean extends AbstractFactoryBean<DataSource> 
 		System.setProperty("derby.storage.pageCacheSize", "100");
 
 		final EmbeddedDataSource ds = new EmbeddedDataSource();
-		ds.setDatabaseName("derbydb");
+		ds.setDatabaseName("build/derbydb");
 		ds.setCreateDatabase("create");
 
 		logger.info("Created instance of " + ds.toString());


### PR DESCRIPTION
This PR resolves [BATCH-2699](https://jira.spring.io/browse/BATCH-2699).

To test the fix:

1. `git checkout master`
2. `./gradlew clean build`
3. `git checkout 3.0.x`
4. `./gradlew clean build` --> fails

Apply the patch in this PR then repeat steps 1 to 4. Now the build should work fine.