### PR TITLE
Fix typos in JdbcPagingItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilder.java
@@ -331,7 +331,7 @@ public class JdbcPagingItemReaderBuilder<T> {
 	private PagingQueryProvider determineQueryProvider(DataSource dataSource) {
 
 		try {
-			DatabaseType databaseType = DatabaseType.fromMetaData(this.dataSource);
+			DatabaseType databaseType = DatabaseType.fromMetaData(dataSource);
 
 			AbstractSqlPagingQueryProvider provider;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilder.java
@@ -204,7 +204,7 @@ public class JdbcPagingItemReaderBuilder<T> {
 
 	/**
 	 * The SQL <code>GROUP BY</code> clause for a db specific @{@link PagingQueryProvider}.
-	 * This is only used if a PaginingQueryProvider is not provided.
+	 * This is only used if a PagingQueryProvider is not provided.
 	 *
 	 * @param groupClause the SQL clause
 	 * @return this instance for method chaining
@@ -218,7 +218,7 @@ public class JdbcPagingItemReaderBuilder<T> {
 
 	/**
 	 * The SQL <code>SELECT</code> clause for a db specific {@link PagingQueryProvider}.
-	 * This is only used if a PagingQueyrProvider is not provided.
+	 * This is only used if a PagingQueryProvider is not provided.
 	 *
 	 * @param selectClause the SQL clause
 	 * @return this instance for method chaining
@@ -351,7 +351,8 @@ public class JdbcPagingItemReaderBuilder<T> {
 				case SYBASE: provider = new SybasePagingQueryProvider(); break;
 				case SQLITE: provider = new SqlitePagingQueryProvider(); break;
 				default:
-					throw new IllegalArgumentException("Unalbe to determine PaaginQueryProvider type");
+					throw new IllegalArgumentException("Unable to determine PagingQueryProvider type " +
+							"from database type: " + databaseType);
 			}
 
 			provider.setSelectClause(this.selectClause);


### PR DESCRIPTION
Fix some spelling typos in javadoc, typo in an `IllegalArgumentException` message, and typo with an accidental field usage.