### PR TITLE
BATCH-2715: Change the method name "getStartable" to "isStartable".

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/partition/JsrStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/partition/JsrStepExecutionSplitter.java
@@ -84,7 +84,7 @@ public class JsrStepExecutionSplitter extends SimpleStepExecutionSplitter {
 			JobExecution curJobExecution = new JobExecution(jobExecution);
 			StepExecution curStepExecution = new StepExecution(stepName, curJobExecution);
 
-			if(!restoreState || getStartable(curStepExecution, new ExecutionContext())) {
+			if(!restoreState || isStartable(curStepExecution, new ExecutionContext())) {
 				executions.add(curStepExecution);
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
@@ -184,7 +184,7 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter, Initi
 
 			StepExecution currentStepExecution = jobExecution.createStepExecution(stepName);
 
-			boolean startable = getStartable(currentStepExecution, context.getValue());
+			boolean startable = isStartable(currentStepExecution, context.getValue());
 
 			if (startable) {
 				set.add(currentStepExecution);
@@ -238,6 +238,11 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter, Initi
 		return result;
 	}
 
+	protected boolean isStartable(StepExecution stepExecution, ExecutionContext context) throws JobExecutionException {
+		return getStartable(stepExecution, context);
+	}
+	
+	@Deprecated
 	protected boolean getStartable(StepExecution stepExecution, ExecutionContext context) throws JobExecutionException {
 
 		JobInstance jobInstance = stepExecution.getJobExecution().getJobInstance();


### PR DESCRIPTION
The method is named as "getStartable". "getStartable" is prone to obtain something. "isStartable" is a query asking whether the stepExecution is startable, which describes what the method is doning. So, "isStartable" should be more intuitive.