### PR TITLE
Add a default constructor to StepExecutionRequest

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/StepExecutionRequest.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/StepExecutionRequest.java
@@ -1,17 +1,49 @@
+/*
+ * Copyright 2009-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.partition;
 
 import java.io.Serializable;
 
+/**
+ * Class encapsulating information required to request a step execution in
+ * a remote partitioning setup.
+ *
+ * @author Dave Syer
+ * @author Mahmoud Ben Hassine
+ */
 public class StepExecutionRequest implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Long stepExecutionId;
+	private Long stepExecutionId;
 
-	private final String stepName;
+	private String stepName;
 
-	private final Long jobExecutionId;
+	private Long jobExecutionId;
 
+	private StepExecutionRequest() {
+		//For Jackson deserialization
+	}
+
+	/**
+	 * Create a new {@link StepExecutionRequest} instance.
+	 * @param stepName the name of the step to execute
+	 * @param jobExecutionId the id of the job execution
+	 * @param stepExecutionId the id of the step execution
+	 */
 	public StepExecutionRequest(String stepName, Long jobExecutionId, Long stepExecutionId) {
 		this.stepName = stepName;
 		this.jobExecutionId = jobExecutionId;

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/StepExecutionRequestTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/StepExecutionRequestTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.integration.partition;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Mahmoud Ben Hassine
+ */
+public class StepExecutionRequestTests {
+
+	private static final String SERIALIZED_REQUEST = "{\"stepExecutionId\":1,\"stepName\":\"step\",\"jobExecutionId\":1}";
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	public void stepExecutionRequestShouldBeSerializableWithJackson() throws IOException {
+		// given
+		StepExecutionRequest request = new StepExecutionRequest("step", 1L, 1L);
+
+		// when
+		String serializedRequest = this.objectMapper.writeValueAsString(request);
+
+		// then
+		Assert.assertEquals(SERIALIZED_REQUEST, serializedRequest);
+	}
+
+	@Test
+	public void stepExecutionRequestShouldBeDeserializableWithJackson() throws IOException {
+		// when
+		StepExecutionRequest deserializedRequest = this.objectMapper.readValue(SERIALIZED_REQUEST, StepExecutionRequest.class);
+
+		// then
+		Assert.assertNotNull(deserializedRequest);
+		Assert.assertEquals("step", deserializedRequest.getStepName());
+		Assert.assertEquals(1L, deserializedRequest.getJobExecutionId().longValue());
+		Assert.assertEquals(1L, deserializedRequest.getStepExecutionId().longValue());
+	}
+}


### PR DESCRIPTION
Without a default constructor, a `StepExecutionRequest` instance cannot
be deserialized using Jackson. This commit adds a (private) default
constructor to fix the issue.

Resolves [BATCH-2732](https://jira.spring.io/browse/BATCH-2732).