### PR TITLE
Make the outputChannel and messagingTemplate mutually exclusive

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilder.java
@@ -19,9 +19,9 @@ import org.springframework.batch.core.step.item.SimpleChunkProcessor;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.PassThroughItemProcessor;
-import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**
@@ -49,8 +49,8 @@ public class RemoteChunkingWorkerBuilder<I, O> {
 
 	private ItemProcessor<I, O> itemProcessor;
 	private ItemWriter<O> itemWriter;
-	private DirectChannel inputChannel;
-	private DirectChannel outputChannel;
+	private MessageChannel inputChannel;
+	private MessageChannel outputChannel;
 
 	/**
 	 * Set the {@link ItemProcessor} to use to process items sent by the master
@@ -83,7 +83,7 @@ public class RemoteChunkingWorkerBuilder<I, O> {
 	 * @param inputChannel the input channel
 	 * @return this builder instance for fluent chaining
 	 */
-	public RemoteChunkingWorkerBuilder<I, O> inputChannel(DirectChannel inputChannel) {
+	public RemoteChunkingWorkerBuilder<I, O> inputChannel(MessageChannel inputChannel) {
 		Assert.notNull(inputChannel, "inputChannel must not be null");
 		this.inputChannel = inputChannel;
 		return this;
@@ -95,7 +95,7 @@ public class RemoteChunkingWorkerBuilder<I, O> {
 	 * @param outputChannel the output channel
 	 * @return this builder instance for fluent chaining
 	 */
-	public RemoteChunkingWorkerBuilder<I, O> outputChannel(DirectChannel outputChannel) {
+	public RemoteChunkingWorkerBuilder<I, O> outputChannel(MessageChannel outputChannel) {
 		Assert.notNull(outputChannel, "outputChannel must not be null");
 		this.outputChannel = outputChannel;
 		return this;

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingMasterStepBuilderTest.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingMasterStepBuilderTest.java
@@ -176,13 +176,15 @@ public class RemoteChunkingMasterStepBuilderTest {
 	}
 
 	@Test
-	public void testMandatoryOutputChannel() {
+	public void eitherOutputChannelOrMessagingTemplateMustBeProvided() {
 		// given
 		RemoteChunkingMasterStepBuilder<String, String> builder = new RemoteChunkingMasterStepBuilder<String, String>("step")
-				.inputChannel(this.inputChannel);
+				.inputChannel(this.inputChannel)
+				.outputChannel(new DirectChannel())
+				.messagingTemplate(new MessagingTemplate());
 
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An OutputChannel must be provided");
+		this.expectedException.expect(IllegalStateException.class);
+		this.expectedException.expectMessage("You must specify either an outputChannel or a messagingTemplate but not both.");
 
 		// when
 		TaskletStep step = builder.build();

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningMasterStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningMasterStepBuilderTests.java
@@ -118,12 +118,14 @@ public class RemotePartitioningMasterStepBuilderTests {
 	}
 
 	@Test
-	public void testMandatoryOutputChannel() {
+	public void eitherOutputChannelOrMessagingTemplateMustBeProvided() {
 		// given
-		RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
+		RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step")
+				.outputChannel(new DirectChannel())
+				.messagingTemplate(new MessagingTemplate());
 
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An outputChannel must be provided");
+		this.expectedException.expect(IllegalStateException.class);
+		this.expectedException.expectMessage("You must specify either an outputChannel or a messagingTemplate but not both.");
 
 		// when
 		Step step = builder.build();


### PR DESCRIPTION
This PR changes the remote chunking and partitioning master step builders to accept either an output channel or a messaging template but not both.

I also took the opportunity to change the parameter type of `org.springframework.batch.integration.chunk.RemoteChunkingMasterStepBuilder#outputChannel` from `DirectChannel` (implementation) to `MessageChannel` (interface).