### PR TITLE
[BATCH-2741] Fix issue - job parameter overwrites

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
@@ -19,7 +19,13 @@ package org.springframework.batch.core;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.util.Assert;
 
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 
 /**
  * Helper class for creating {@link JobParameters}. Useful because all

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
@@ -219,6 +219,7 @@ public class JobParametersBuilder {
 
 	/**
 	 * Copy job parameters into the current state.
+	 * Current state is Supplied Job Parameter
 	 * @param jobParameters parameters to copy in
 	 * @return a reference to this object.
 	 */
@@ -230,6 +231,12 @@ public class JobParametersBuilder {
 		return this;
 	}
 
+	/**
+	 * Newly received job parameters have the same key but different values.
+	 * The previously failed job parameter is entered first, and the newly received job parameter overwrites it.
+	 * @param jobParameters
+	 * @return
+	 */
 	private Map<String, JobParameter> merge(JobParameters jobParameters) {
 		Map<String, JobParameter> merged = new LinkedHashMap<>();
 		merged.putAll(jobParameters.getParameters());

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
@@ -16,15 +16,10 @@
 
 package org.springframework.batch.core;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.util.Assert;
+
+import java.util.*;
 
 /**
  * Helper class for creating {@link JobParameters}. Useful because all
@@ -230,9 +225,16 @@ public class JobParametersBuilder {
 	public JobParametersBuilder addJobParameters(JobParameters jobParameters) {
 		Assert.notNull(jobParameters, "jobParameters must not be null");
 
-		this.parameterMap.putAll(jobParameters.getParameters());
+		this.parameterMap.putAll(merge(jobParameters));
 
 		return this;
+	}
+
+	private Map<String, JobParameter> merge(JobParameters jobParameters) {
+		Map<String, JobParameter> merged = new LinkedHashMap<>();
+		merged.putAll(jobParameters.getParameters());
+		merged.putAll(this.parameterMap);
+		return merged;
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -21,7 +21,12 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.SimpleJob;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -15,19 +15,13 @@
  */
 package org.springframework.batch.core;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.SimpleJob;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
+
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -64,6 +58,10 @@ public class JobParametersBuilderTests {
 		this.parametersBuilder = new JobParametersBuilder(this.jobExplorer);
 	}
 
+	/**
+	 * Newly received job parameters have the same key but different values.
+	 * The previously failed job parameter is entered first, and the newly received job parameter overwrites it.
+	 */
 	@Test
 	public void testAddingExistingJobParameters() {
 		JobParameters params1 = new JobParametersBuilder()
@@ -81,7 +79,7 @@ public class JobParametersBuilderTests {
 				.addJobParameters(params2)
 				.toJobParameters();
 
-		assertEquals(finalParams.getString("foo"), "baz");
+		assertEquals(finalParams.getString("foo"), "bar");
 		assertEquals(finalParams.getString("bar"), "baz");
 		assertEquals(finalParams.getString("baz"), "quix");
 	}


### PR DESCRIPTION
Hello?
I recently updated SpringBoot 2.0 with Spring Batch 4.0.
But I think there is a bug.
If the job fails, I keep getting the value of the failed Job Parameter even if I change the value of the Job Parameter with the same key next time.
In 1.5.x, I confirmed that it did not happen, and when I checked the code, it showed a bug in the code and sent a PR