### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <a href="https://gitter.im/spring-batch/Lobby?source=badge"><img src="https://badges.gitter.im/spring-projects/spring-batch.svg"/></a>
+<a href="https://lgtm.com/projects/g/spring-projects/spring-batch/context:java"><img src="https://img.shields.io/lgtm/grade/java/g/spring-projects/spring-batch.svg?logo=lgtm&logoWidth=18" alt="Code Quality: Java" height="18"></a>
+<a href="https://lgtm.com/projects/g/spring-projects/spring-batch/alerts"><img src="https://img.shields.io/lgtm/alerts/g/spring-projects/spring-batch.svg?logo=lgtm&logoWidth=18" alt="Total Alerts" height="18"></a>
 
 # Spring Batch [![build status](https://build.spring.io/plugins/servlet/wittified/build-status/BATCH-GRAD)](https://build.spring.io/browse/BATCH-GRAD)
 


### PR DESCRIPTION
Obvious fix
Hi there!

I thought you might be interested in adding these [code quality badges](https://lgtm.com/projects/g/spring-projects/spring-batch/ci/#badges) to your project. They will indicate a very high code quality to potential users and contributors.
You can also check the alerts discovered by [LGTM](https://lgtm.com/projects/g/spring-projects/spring-batch).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
