### PR TITLE
Add support to build/run on Java 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,10 @@ configure(subprojects - project(":spring-build-src")) { subproject ->
 //		testLogging {
 //			showStandardStreams = true
 //		}
+
+		if (JavaVersion.current().isJava9Compatible()) {
+			jvmArgs '--add-modules', 'java.xml.bind'
+		}
 	}
 
 	task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ allprojects {
 		gsonVersion = '2.8.5'
 		javaMailVersion = '1.6.0'
 		javaxBatchApiVersion = '1.0'
+		javaxAnnotationApiVersion = '1.3.2'
 		javaxInjectVersion = '1'
 		javaxTransactionVersion = '1.2'
 		jbatchTckSpi = '1.0'
@@ -288,6 +289,7 @@ project('spring-batch-core') {
 		optional "org.springframework:spring-jdbc:$springVersion"
 		optional "org.apache.logging.log4j:log4j-api:$log4jVersion"
 		optional "org.apache.logging.log4j:log4j-core:$log4jVersion"
+		optional "javax.annotation:javax.annotation-api:$javaxAnnotationApiVersion"
 		// JSR-305 only used for non-required meta-annotations
 		compileOnly("com.google.code.findbugs:jsr305:3.0.2")
 		testCompileOnly("com.google.code.findbugs:jsr305:3.0.2")

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ configure(subprojects - project(":spring-build-src")) { subproject ->
 	apply plugin: 'merge'
 
 	jacoco {
-		toolVersion = "0.7.6.201602180812"
+		toolVersion = "0.8.2"
 	}
 
     compileJava {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactory.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactory.java
@@ -137,7 +137,13 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 		 * @param parent
 		 */
 		public ResourceXmlApplicationContext(ConfigurableApplicationContext parent, Object... resources) {
-			helper = new ApplicationContextHelper(parent, this, resources) {
+
+			class ResourceXmlApplicationContextHelper extends ApplicationContextHelper {
+
+				ResourceXmlApplicationContextHelper(ConfigurableApplicationContext parent, GenericApplicationContext context, Object... config) {
+					super(parent, context, config);
+				}
+
 				@Override
 				protected String generateId(Object... configs) {
 					Resource[] resources = Arrays.copyOfRange(configs, 0, configs.length, Resource[].class);
@@ -155,9 +161,10 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 				@Override
 				protected void loadConfiguration(Object... configs) {
 					Resource[] resources = Arrays.copyOfRange(configs, 0, configs.length, Resource[].class);
- 					load(resources);
+					load(resources);
 				}
-			};
+			}
+			helper = new ResourceXmlApplicationContextHelper(parent, this, resources);
 			refresh();
 		}
 
@@ -179,7 +186,13 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 		private final ApplicationContextHelper helper;
 
 		public ResourceAnnotationApplicationContext(ConfigurableApplicationContext parent, Object... resources) {
-			helper = new ApplicationContextHelper(parent, this, resources) {
+
+			class ResourceAnnotationApplicationContextHelper extends ApplicationContextHelper {
+
+				public ResourceAnnotationApplicationContextHelper(ConfigurableApplicationContext parent, GenericApplicationContext context, Object... config) {
+					super(parent, context, config);
+				}
+
 				@Override
 				protected String generateId(Object... configs) {
 					if (allObjectsOfType(configs, Class.class)) {
@@ -205,7 +218,8 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 						scan(pkgs);
 					}
 				}
-			};
+			}
+			helper = new ResourceAnnotationApplicationContextHelper(parent, this, resources);
 			refresh();
 		}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrBeanDefinitionDocumentReaderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrBeanDefinitionDocumentReaderTests.java
@@ -251,7 +251,7 @@ public class JsrBeanDefinitionDocumentReaderTests extends AbstractJsrTestCase {
 	}
 
 	private Document getDocument(String location) {
-		InputStream inputStream = ClassLoader.class.getResourceAsStream(location);
+		InputStream inputStream = this.getClass().getResourceAsStream(location);
 
 		try {
 			return documentLoader.loadDocument(new InputSource(inputStream),

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/job/DefaultJobParametersExtractorJobParametersTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/job/DefaultJobParametersExtractorJobParametersTests.java
@@ -49,7 +49,8 @@ public class DefaultJobParametersExtractorJobParametersTests {
 		StepExecution stepExecution = getStepExecution("foo=bar,spam=bucket");
 		extractor.setKeys(new String[] {"foo", "bar"});
 		JobParameters jobParameters = extractor.getJobParameters(null, stepExecution);
-		assertEquals("{spam=bucket, foo=bar}", jobParameters.toString());
+		assertEquals("bar", jobParameters.getString("foo"));
+		assertEquals("bucket", jobParameters.getString("spam"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR resolves [BATCH-2751](https://jira.spring.io/browse/BATCH-2751).

It fixes:

* `Javadoc` generation issues when using Java 9
* tests failing on Java 9