### PR TITLE
Add support to build/run on Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ allprojects {
 		xstreamVersion = '1.4.10'
 		jrubyVersion = '1.7.26'
 		beanshellVersion = '2.0b5'
+		jaxbVersion = '2.3.0'
 	}
 
 	apply plugin: 'idea'
@@ -170,10 +171,6 @@ configure(subprojects - project(":spring-build-src")) { subproject ->
 //		testLogging {
 //			showStandardStreams = true
 //		}
-
-		if (JavaVersion.current().isJava9Compatible()) {
-			jvmArgs '--add-modules', 'java.xml.bind'
-		}
 	}
 
 	task sourcesJar(type: Jar) {
@@ -328,6 +325,7 @@ project('spring-batch-infrastructure') {
 		testCompile "org.aspectj:aspectjweaver:$aspectjVersion"
 		testCompile "org.mockito:mockito-core:$mockitoVersion"
 		testCompile "org.xerial:sqlite-jdbc:$sqliteVersion"
+		testCompile "javax.xml.bind:jaxb-api:$jaxbVersion"
 
 		testRuntime "com.sun.mail:javax.mail:$javaMailVersion"
 		testRuntime "org.codehaus.groovy:groovy-jsr223:$groovyVersion"
@@ -335,6 +333,8 @@ project('spring-batch-infrastructure') {
 		testRuntime "org.hibernate.validator:hibernate-validator:$hibernateValidatorVersion"
 		testRuntime "org.glassfish:javax.el:$javaxElVersion"
 		testRuntime "org.beanshell:bsh:$beanshellVersion"
+		testRuntime "com.sun.xml.bind:jaxb-core:$jaxbVersion"
+		testRuntime "com.sun.xml.bind:jaxb-impl:$jaxbVersion"
 
 		optional "javax.jms:javax.jms-api:$jmsVersion"
 		optional "com.fasterxml.jackson.core:jackson-databind:${jackson2Version}"
@@ -476,6 +476,7 @@ project('spring-batch-infrastructure-tests') {
 		testCompile "org.springframework:spring-jdbc:$springVersion"
 		testCompile "org.springframework:spring-test:$springVersion"
 		testCompile "org.mockito:mockito-core:$mockitoVersion"
+		testCompile "javax.xml.bind:jaxb-api:$jaxbVersion"
 
 		compile("org.hibernate:hibernate-core:$hibernateVersion") { dep ->
 			optional dep
@@ -622,6 +623,9 @@ project('spring-batch-samples') {
 		testRuntime "com.sun.mail:javax.mail:$javaMailVersion"
 		testRuntime "org.hibernate.validator:hibernate-validator:$hibernateValidatorVersion"
 		testRuntime "org.glassfish:javax.el:$javaxElVersion"
+		testRuntime "javax.xml.bind:jaxb-api:$jaxbVersion"
+		testRuntime "com.sun.xml.bind:jaxb-core:$jaxbVersion"
+		testRuntime "com.sun.xml.bind:jaxb-impl:$jaxbVersion"
 
 		provided "mysql:mysql-connector-java:$mysqlVersion"
 		provided "com.h2database:h2:$h2databaseVersion"


### PR DESCRIPTION
This PR resolves [BATC-2757](https://jira.spring.io/browse/BATCH-2757).

It fixes compilation/test issues on Java 11 due to the removal of JAXB from the JDK (See [JEP-320](http://openjdk.java.net/jeps/320)). More details in the commit message.

The `asciidoc` task fails on Java 11 due to a transitive dependency of jruby (jruby-openssl) which is not compatible yet with Java 11 (See https://github.com/jruby/jruby-openssl#compatibility).

So this PR can be tested using the following command: `./gradlew clean build -x asciidoc`. The build should succeed with Open JDK 11 ea 28 (from SDKMAN `11.ea.28-open`).

Note: This PR should be merged after https://github.com/spring-projects/spring-batch/pull/639.