### PR TITLE
 [BATCH-2760] Failed JobExecution due to unavailable TaskExecutor leaves End Time unpopulated

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobLauncher.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobLauncher.java
@@ -165,6 +165,7 @@ public class SimpleJobLauncher implements JobLauncher, InitializingBean {
 		}
 		catch (TaskRejectedException e) {
 			jobExecution.upgradeStatus(BatchStatus.FAILED);
+			jobExecution.setStartTime(new Date(System.currentTimeMillis()));
 			jobExecution.setEndTime(new Date(System.currentTimeMillis()));
 			if (jobExecution.getExitStatus().equals(ExitStatus.UNKNOWN)) {
 				jobExecution.setExitStatus(ExitStatus.FAILED.addExitDescription(e));


### PR DESCRIPTION
On instances when the `taskExecutor` is not picking up the submitted **Job Execution**, with this fix we are explicitly setting the **End Time** of the JobExecution in order not to give false positives via the `JobExplorer#findRunningJobExecutions()`. This last method is judging on running **Job Executions** based on **End Time** being null.