### PR TITLE
Adding a getJobId convenience method

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
@@ -102,6 +102,19 @@ public class StepContext extends SynchronizedAttributeAccessor {
 	}
 
 	/**
+	 * Convenient accessor for current job id identifier.
+	 *
+	 * @return the job id identifier of the enclosing {@link JobInstance}
+	 * associated with the current {@link StepExecution}
+	 */
+	public Long getJobId() {
+		Assert.state(stepExecution.getJobExecution() != null, "StepExecution does not have a JobExecution");
+		Assert.state(stepExecution.getJobExecution().getJobInstance() != null,
+				"StepExecution does not have a JobInstance");
+		return stepExecution.getJobExecution().getJobInstance().getId();
+	}
+
+	/**
 	 * Convenient accessor for System properties to make it easy to access them
 	 * from placeholder expressions.
 	 *

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Nicolas Widart
  *
  */
 public class StepContext extends SynchronizedAttributeAccessor {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/scope/context/StepContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/scope/context/StepContextTests.java
@@ -165,6 +165,11 @@ public class StepContextTests {
 	}
 
 	@Test
+	public void testJobId() throws Exception {
+		assertEquals(2L, (long)context.getJobId());
+	}
+
+	@Test
 	public void testStepExecutionContext() throws Exception {
 		ExecutionContext executionContext = stepExecution.getExecutionContext();
 		executionContext.put("foo", "bar");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/scope/context/StepContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/scope/context/StepContextTests.java
@@ -37,6 +37,7 @@ import org.springframework.batch.item.ExecutionContext;
 
 /**
  * @author Dave Syer
+ * @author Nicolas Widart
  *
  */
 public class StepContextTests {


### PR DESCRIPTION
This adds the ability to get the current job id.

***

This solves the issue of instantiating the `JobInstance` in order to use the `JobRepository.getLastStepExecution()` method.