### PR TITLE
Make JobParametersBuilder#getNextJobParameters consistent with CommandLineJobRunner and JobOperator

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersIncrementer;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
@@ -45,7 +45,6 @@ import org.springframework.batch.core.launch.JobExecutionNotRunningException;
 import org.springframework.batch.core.launch.JobInstanceAlreadyExistsException;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.JobOperator;
-import org.springframework.batch.core.launch.JobParametersNotFoundException;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 import org.springframework.batch.core.launch.NoSuchJobInstanceException;
@@ -79,6 +78,7 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @author Lucas Ward
  * @author Will Schipp
+ * @author Mahmoud Ben Hassine
  * @since 2.0
  */
 public class SimpleJobOperator implements JobOperator, InitializingBean {
@@ -334,30 +334,15 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 	 * @see JobOperator#startNextInstance(String )
 	 */
 	@Override
-	public Long startNextInstance(String jobName) throws NoSuchJobException, JobParametersNotFoundException,
+	public Long startNextInstance(String jobName) throws NoSuchJobException,
 	UnexpectedJobExecutionException, JobParametersInvalidException {
 
 		logger.info("Locating parameters for next instance of job with name=" + jobName);
 
 		Job job = jobRegistry.getJob(jobName);
-		List<JobInstance> lastInstances = jobExplorer.getJobInstances(jobName, 0, 1);
-
-		JobParametersIncrementer incrementer = job.getJobParametersIncrementer();
-		if (incrementer == null) {
-			throw new JobParametersNotFoundException("No job parameters incrementer found for job=" + jobName);
-		}
-
-		JobParameters parameters;
-		if (lastInstances.isEmpty()) {
-			parameters = incrementer.getNext(new JobParameters());
-			if (parameters == null) {
-				throw new JobParametersNotFoundException("No bootstrap parameters found for job=" + jobName);
-			}
-		}
-		else {
-			List<JobExecution> lastExecutions = jobExplorer.getJobExecutions(lastInstances.get(0));
-			parameters = incrementer.getNext(lastExecutions.get(0).getJobParameters());
-		}
+		JobParameters parameters = new JobParametersBuilder(jobExplorer)
+				.getNextJobParameters(job)
+				.toJobParameters();
 
 		logger.info(String.format("Attempting to launch job with name=%s and parameters=%s", jobName, parameters));
 		try {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.SimpleJob;
@@ -55,6 +57,9 @@ public class JobParametersBuilderTests {
 	private List<JobExecution> jobExecutionList;
 
 	private Date date = new Date(System.currentTimeMillis());
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	@Before
 	public void initialize() {
@@ -198,9 +203,10 @@ public class JobParametersBuilderTests {
 
 	@Test
 	public void testGetNextJobParametersNoIncrementer(){
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("No job parameters incrementer found for job=simpleJob");
 		initializeForNextJobParameters();
 		this.parametersBuilder.getNextJobParameters(this.job);
-		baseJobParametersVerify(this.parametersBuilder.toJobParameters(), 3);
 	}
 
 	@Test
@@ -226,14 +232,13 @@ public class JobParametersBuilderTests {
 		initializeForNextJobParameters();
 		this.parametersBuilder.addLong("NON_IDENTIFYING_LONG", new Long(1), false);
 		this.parametersBuilder.getNextJobParameters(this.job);
-		baseJobParametersVerify(this.parametersBuilder.toJobParameters(), 3);
+		baseJobParametersVerify(this.parametersBuilder.toJobParameters(), 5);
 	}
 
 	@Test
 	public void testGetNextJobParametersNoPreviousExecution(){
 		this.job.setJobParametersIncrementer(new RunIdIncrementer());
 		this.jobInstanceList.add(new JobInstance(1L, "simpleJobInstance"));
-		this.jobExecutionList.add(null);
 		when(this.jobExplorer.getJobInstances("simpleJob",0,1)).thenReturn(this.jobInstanceList);
 		when(this.jobExplorer.getJobExecutions(any())).thenReturn(this.jobExecutionList);
 		initializeForNextJobParameters();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Dave Syer
  * @author Will Schipp
+ * @author Mahmoud Ben Hassine
  *
  */
 public class SimpleJobOperatorTests {
@@ -153,6 +154,7 @@ public class SimpleJobOperatorTests {
 	 */
 	@Test
 	public void testStartNextInstanceSunnyDay() throws Exception {
+		jobParameters = new JobParameters();
 		JobInstance jobInstance = new JobInstance(321L, "foo");
 		when(jobExplorer.getJobInstances("foo", 0, 1)).thenReturn(Collections.singletonList(jobInstance));
 		when(jobExplorer.getJobExecutions(jobInstance)).thenReturn(Collections.singletonList(new JobExecution(jobInstance, new JobParameters())));


### PR DESCRIPTION
This PR resolves [BATCH-2711](https://jira.spring.io/browse/BATCH-2711).

Before this commit, `JobParametersBuilder#getNextJobParameters` was checking for restartability conditions. This is not only already done by the `JobLauncher`, but also makes it inconsistent with the behaviour of `CommandLineJobRunner` when used with "-next" option and `JobOperator#startNextInstance`, which is starting the next instance in sequence based on the incrementer **without** dealing with restartability.

This commit fixes the `JobParametersBuilder#getNextJobParameters` to behave like the `CommandLineJobRunner` and `JobOperator` in regards to starting the next instance.

This PR is coupled with another [PR](https://github.com/spring-projects/spring-boot/pull/14933) against boot. Both PRs should be merged together to correctly fix the issue.