### PR TITLE
Return null instead of 0 when a Long/Double job parameter is absent

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParameters.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Value object representing runtime parameters to a batch job. Because the
  * parameters have no individual meaning outside of the JobParameters they are
@@ -35,6 +37,7 @@ import java.util.Properties;
  * 
  * @author Lucas Ward
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  * @since 1.0
  */
 @SuppressWarnings("serial")
@@ -54,14 +57,15 @@ public class JobParameters implements Serializable {
 	 * Typesafe Getter for the Long represented by the provided key.
 	 * 
 	 * @param key The key to get a value for
-	 * @return The <code>Long</code> value
+	 * @return The <code>Long</code> value or {@code null} if the key is absent
 	 */
+	@Nullable
 	public Long getLong(String key){
 		if (!parameters.containsKey(key)) {
-			return 0L;
+			return null;
 		}
 		Object value = parameters.get(key).getValue();
-		return value==null ? 0L : ((Long)value).longValue();
+		return value==null ? null : ((Long)value).longValue();
 	}
 
 	/**
@@ -72,8 +76,30 @@ public class JobParameters implements Serializable {
 	 * @param defaultValue to return if the value doesn't exist
 	 * @return the parameter represented by the provided key, defaultValue
 	 * otherwise.
+	 * @deprecated Use {@link JobParameters#getLong(java.lang.String, java.lang.Long)}
+	 * instead. This method will be removed in a future release.
 	 */
+	@Deprecated
 	public Long getLong(String key, long defaultValue){
+		if(parameters.containsKey(key)){
+			return getLong(key);
+		}
+		else{
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Typesafe Getter for the Long represented by the provided key.  If the
+	 * key does not exist, the default value will be returned.
+	 *
+	 * @param key to return the value for
+	 * @param defaultValue to return if the value doesn't exist
+	 * @return the parameter represented by the provided key, defaultValue
+	 * otherwise.
+	 */
+	@Nullable
+	public Long getLong(String key, @Nullable Long defaultValue){
 		if(parameters.containsKey(key)){
 			return getLong(key);
 		}
@@ -86,8 +112,9 @@ public class JobParameters implements Serializable {
 	 * Typesafe Getter for the String represented by the provided key.
 	 * 
 	 * @param key The key to get a value for
-	 * @return The <code>String</code> value
+	 * @return The <code>String</code> value or {@code null} if the key is absent
 	 */
+	@Nullable
 	public String getString(String key){
 		JobParameter value = parameters.get(key);
 		return value==null ? null : value.toString();
@@ -102,7 +129,8 @@ public class JobParameters implements Serializable {
 	 * @return the parameter represented by the provided key, defaultValue
 	 * otherwise.
 	 */
-	public String getString(String key, String defaultValue){
+	@Nullable
+	public String getString(String key, @Nullable String defaultValue){
 		if(parameters.containsKey(key)){
 			return getString(key);
 		}
@@ -115,14 +143,15 @@ public class JobParameters implements Serializable {
 	 * Typesafe Getter for the Long represented by the provided key.
 	 * 
 	 * @param key The key to get a value for
-	 * @return The <code>Double</code> value
+	 * @return The <code>Double</code> value or {@code null} if the key is absent
 	 */
+	@Nullable
 	public Double getDouble(String key){
 		if (!parameters.containsKey(key)) {
-			return 0.0;
+			return null;
 		}
 		Double value = (Double)parameters.get(key).getValue();
-		return value==null ? 0.0 : value.doubleValue();
+		return value==null ? null : value.doubleValue();
 	}
 
 	/**
@@ -133,8 +162,30 @@ public class JobParameters implements Serializable {
 	 * @param defaultValue to return if the value doesn't exist
 	 * @return the parameter represented by the provided key, defaultValue
 	 * otherwise.
+	 * @deprecated Use {@link JobParameters#getDouble(java.lang.String, java.lang.Double)}
+	 * instead. This method will be removed in a future release.
 	 */
+	@Deprecated
 	public Double getDouble(String key, double defaultValue){
+		if(parameters.containsKey(key)){
+			return getDouble(key);
+		}
+		else{
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Typesafe Getter for the Double represented by the provided key.  If the
+	 * key does not exist, the default value will be returned.
+	 *
+	 * @param key to return the value for
+	 * @param defaultValue to return if the value doesn't exist
+	 * @return the parameter represented by the provided key, defaultValue
+	 * otherwise.
+	 */
+	@Nullable
+	public Double getDouble(String key, @Nullable Double defaultValue){
 		if(parameters.containsKey(key)){
 			return getDouble(key);
 		}
@@ -147,8 +198,10 @@ public class JobParameters implements Serializable {
 	 * Typesafe Getter for the Date represented by the provided key.
 	 * 
 	 * @param key The key to get a value for
-	 * @return The <code>java.util.Date</code> value
+	 * @return The <code>java.util.Date</code> value or {@code null} if the key
+	 * is absent
 	 */
+	@Nullable
 	public Date getDate(String key){
 		return this.getDate(key,null);
 	}
@@ -162,7 +215,8 @@ public class JobParameters implements Serializable {
 	 * @return the parameter represented by the provided key, defaultValue
 	 * otherwise.
 	 */
-	public Date getDate(String key, Date defaultValue){
+	@Nullable
+	public Date getDate(String key, @Nullable Date defaultValue){
 		if(parameters.containsKey(key)){
 			return (Date)parameters.get(key).getValue();
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -31,6 +31,7 @@ import org.springframework.batch.core.launch.support.RunIdIncrementer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -126,10 +127,10 @@ public class JobParametersBuilderTests {
 		this.parametersBuilder.addDouble("DOUBLE", null);
 
 		JobParameters parameters = this.parametersBuilder.toJobParameters();
-		assertEquals(null, parameters.getDate("SCHEDULE_DATE"));
-		assertEquals(0L, parameters.getLong("LONG").longValue());
-		assertEquals(null, parameters.getString("STRING"));
-		assertEquals(0, parameters.getLong("DOUBLE").doubleValue(), 1e-15);
+		assertNull(parameters.getDate("SCHEDULE_DATE"));
+		assertNull(parameters.getLong("LONG"));
+		assertNull(parameters.getString("STRING"));
+		assertNull(parameters.getLong("DOUBLE"));
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.SerializationUtils;
  * @author Lucas Ward
  * @author Dave Syer
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  *
  */
 public class JobParametersTests {
@@ -74,7 +75,7 @@ public class JobParametersTests {
 	@Test
 	public void testGetNullString() {
 		parameters = new JobParameters(Collections.singletonMap("string.key1", new JobParameter((String) null, true)));
-		assertEquals(null, parameters.getDate("string.key1"));
+		assertNull(parameters.getDate("string.key1"));
 	}
 
 	@Test
@@ -98,23 +99,23 @@ public class JobParametersTests {
 	@Test
 	public void testGetNullDate() {
 		parameters = new JobParameters(Collections.singletonMap("date.key1", new JobParameter((Date)null, true)));
-		assertEquals(null, parameters.getDate("date.key1"));
+		assertNull(parameters.getDate("date.key1"));
 	}
 
 	@Test
 	public void testGetEmptyLong() {
 		parameters = new JobParameters(Collections.singletonMap("long1", new JobParameter((Long)null, true)));
-		assertEquals(0L, parameters.getLong("long1").longValue());
+		assertNull(parameters.getLong("long1"));
 	}
 
 	@Test
 	public void testGetMissingLong() {
-		assertEquals(0L, parameters.getLong("missing.long1").longValue());
+		assertNull(parameters.getLong("missing.long1"));
 	}
 
 	@Test
 	public void testGetMissingDouble() {
-		assertEquals(0.0, parameters.getDouble("missing.double1"), 0.0001);
+		assertNull(parameters.getDouble("missing.double1"));
 	}
 
 	@Test
@@ -209,8 +210,8 @@ public class JobParametersTests {
 	}
 
 	@Test
-	public void testLongReturns0WhenKeyDoesntExit(){
-		assertEquals(0L,new JobParameters().getLong("keythatdoesntexist").longValue());
+	public void testLongReturnsNullWhenKeyDoesntExit(){
+		assertNull(new JobParameters().getLong("keythatdoesntexist"));
 	}
 
 	@Test
@@ -219,8 +220,8 @@ public class JobParametersTests {
 	}
 
 	@Test
-	public void testDoubleReturns0WhenKeyDoesntExit(){
-		assertEquals(0.0,new JobParameters().getLong("keythatdoesntexist"), 0.0001);
+	public void testDoubleReturnsNullWhenKeyDoesntExit(){
+		assertNull(new JobParameters().getDouble("keythatdoesntexist"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR resolves [BATCH-2385](https://jira.spring.io/browse/BATCH-2385):

* It makes the `JobParameters#getLong` and `JobParameters#getDouble` methods return `null` instead of 0 when the provided key is absent (same behaviour as `JobParameters#getString` which returns `null` when the key is absent and not an empty String). Indeed, with the current implementation, asking for a parameter and getting 0 back makes it impossible to know if the parameter was actually set to the value 0 or if the parameter is absent.
* It deprecates `JobParameters#getLong(String key, long defaultValue)` in favor of a new equivalent method with a wrapper type for the default value `JobParameters#getLong(String key, Long defaultValue)` in order to make it possible to specify `null` as a default value.
* It adds `@Nullable` where appropriate