### PR TITLE
[BATCH-2762] Introducing SynchronizedItemStreamWriter

### DIFF
--- a/spring-batch-docs/asciidoc/readersAndWriters.adoc
+++ b/spring-batch-docs/asciidoc/readersAndWriters.adoc
@@ -3000,6 +3000,7 @@ Spring Batch includes the following decorators:
 
 * <<synchronizedItemStreamReader>>
 * <<singleItemPeekableItemReader>>
+* <<synchronizedItemStreamWriter>>
 * <<multiResourceItemWriter>>
 * <<classifierCompositeItemWriter>>
 * <<classifierCompositeItemProcessor>>
@@ -3022,6 +3023,13 @@ item, and this is the next item returned from the `read` method. Spring Batch pr
 NOTE: SingleItemPeekableItemReader's peek method is not thread-safe, because it would not
 be possible to honor the peek in multiple threads. Only one of the threads that peeked
 would get that item in the next call to read.
+
+[[synchronizedItemStreamWriter]]
+===== `SynchronizedItemStreamWriter`
+When using an `ItemWriter` that is not thread safe, Spring Batch offers the
+`SynchronizedItemStreamWriter` decorator, which can be used to make the `ItemWriter`
+thread safe. Spring Batch provides a `SynchronizedItemStreamWriterBuilder` to construct
+an instance of the `SynchronizedItemStreamWriter`.
 
 [[multiResourceItemWriter]]
 ===== `MultiResourceItemWriter`

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
@@ -28,6 +28,8 @@ import java.util.List;
  * {@link SynchronizedItemStreamWriter#write write()} method
  *
  * @author Dimitrios Liapis
+ *
+ * @param <T> type of object being written
  */
 public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, InitializingBean {
 
@@ -62,6 +64,6 @@ public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, Ini
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.delegate, "A delegate item reader is required");
+		Assert.notNull(this.delegate, "A delegate item writer is required");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.item.support;
 
 import org.springframework.batch.item.ExecutionContext;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
@@ -1,0 +1,52 @@
+package org.springframework.batch.item.support;
+
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamWriter;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+/**
+ * An {@link ItemStreamWriter} decorator with a synchronized
+ * {@link SynchronizedItemStreamWriter#write write()} method
+ *
+ * @author Dimitrios Liapis
+ */
+public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, InitializingBean {
+
+	private ItemStreamWriter<T> delegate;
+
+	public void setDelegate(ItemStreamWriter<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * This delegates to the write method of the <code>delegate</code>
+	 */
+	@Override
+	public synchronized void write(List<? extends T> items) throws Exception {
+		this.delegate.write(items);
+	}
+
+	@Override
+	public void open(ExecutionContext executionContext) throws ItemStreamException {
+		this.delegate.open(executionContext);
+	}
+
+	@Override
+	public void update(ExecutionContext executionContext) throws ItemStreamException {
+		this.delegate.update(executionContext);
+	}
+
+	@Override
+	public void close() throws ItemStreamException {
+		this.delegate.close();
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(this.delegate, "A delegate item reader is required");
+	}
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.item.support.builder;
 
 import org.springframework.batch.item.ItemStreamWriter;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilder.java
@@ -1,0 +1,29 @@
+package org.springframework.batch.item.support.builder;
+
+import org.springframework.batch.item.ItemStreamWriter;
+import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
+import org.springframework.util.Assert;
+
+/**
+ * Creates a fully qualified {@link SynchronizedItemStreamWriter}.
+ *
+ * @author Dimitrios Liapis
+ */
+public class SynchronizedItemStreamWriterBuilder<T> {
+
+	private ItemStreamWriter<T> delegate;
+
+	public SynchronizedItemStreamWriterBuilder<T> delegate(ItemStreamWriter<T> delegate) {
+		this.delegate = delegate;
+
+		return this;
+	}
+
+	public SynchronizedItemStreamWriter<T> build() {
+		Assert.notNull(this.delegate, "A delegate is required");
+
+		SynchronizedItemStreamWriter<T> writer = new SynchronizedItemStreamWriter<>();
+		writer.setDelegate(this.delegate);
+		return writer;
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
@@ -16,22 +16,19 @@
 package org.springframework.batch.item.support;
 
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamWriter;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Common parent class for {@link SynchronizedItemStreamWriterTests} and
@@ -42,111 +39,46 @@ import static org.junit.Assert.assertThat;
  */
 public abstract class AbstractSynchronizedItemStreamWriterTests {
 
-	private static final int THREAD_SIZE = 20;
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
-	private AtomicInteger numberOfThreadsInsideWriteMethod = new AtomicInteger(0);
-	private CountDownLatch threadsStartingLine = new CountDownLatch(1);
-	private List<String> errors = Collections.synchronizedList(new ArrayList<>());
-	private boolean isClosed = false;
+	@Mock
+	protected ItemStreamWriter<Object> delegate;
 
+	private SynchronizedItemStreamWriter<Object> synchronizedItemStreamWriter;
+	private final List<Object> testList = Collections.unmodifiableList(new ArrayList<>());
+	private final ExecutionContext testExecutionContext = new ExecutionContext();
+
+	abstract protected SynchronizedItemStreamWriter<Object> createNewSynchronizedItemStreamWriter();
 
 	@Before
 	public void init() {
-		numberOfThreadsInsideWriteMethod = new AtomicInteger(0);
-		threadsStartingLine = new CountDownLatch(1);
-		errors = Collections.synchronizedList(new ArrayList<>());
-		isClosed = false;
+		initMocks(this);
+		synchronizedItemStreamWriter = createNewSynchronizedItemStreamWriter();
 	}
 
-	protected void multiThreadedInvocation(ItemStreamWriter itemStreamWriter) throws Exception {
-
-		ExecutionContext executionContext = new ExecutionContext();
-
-		itemStreamWriter.open(executionContext);
-		assertEquals(true, executionContext.get(TestItemWriter.HAS_BEEN_OPENED));
-		assertThat(isClosed, is(false));
-
-		IntStream.rangeClosed(1, THREAD_SIZE)
-				.mapToObj(i -> new ItemStreamWriterTestThread(itemStreamWriter, executionContext))
-				.forEach(Thread::start);
-
-		//release all the threads
-		threadsStartingLine.countDown();
-
-		Thread.sleep(5000);
-		itemStreamWriter.close();
-
-		assertThat(errors,is(empty()));
-		assertThat(isClosed, is(true));
-		assertEquals(THREAD_SIZE, executionContext.getInt(TestItemWriter.UPDATE_COUNT_KEY));
-
+	@Test
+	public void testDelegateWriteIsCalled() throws Exception {
+		synchronizedItemStreamWriter.write(testList);
+		verify(delegate).write(testList);
 	}
 
-	/**
-	 * Inspired by the SynchronizedItemStreamReaderTests#TestItemReader
-	 */
-	public class TestItemWriter extends AbstractItemStreamItemWriter<Integer> implements ItemStreamWriter<Integer> {
-
-		static final String HAS_BEEN_OPENED = "hasBeenOpened";
-		static final String UPDATE_COUNT_KEY = "updateCount";
-
-		@Override
-		public void write(List<? extends Integer> items) {
-			//If synchronized there can only be one thread at a time
-			//therefore the atomic integer can never grow above one
-			assertThat(numberOfThreadsInsideWriteMethod.incrementAndGet(), is(not(greaterThan(1))));
-			numberOfThreadsInsideWriteMethod.decrementAndGet();
-		}
-
-		@Override
-		public void close() {
-			isClosed = true;
-		}
-
-		@Override
-		public void open(ExecutionContext executionContext) {
-			isClosed = false;
-			executionContext.put(HAS_BEEN_OPENED, true);
-			executionContext.remove(UPDATE_COUNT_KEY);
-		}
-
-		@Override
-		public void update(ExecutionContext executionContext) {
-
-			if (!executionContext.containsKey(UPDATE_COUNT_KEY)) {
-				executionContext.putInt(UPDATE_COUNT_KEY, 0);
-			}
-
-			executionContext.putInt(UPDATE_COUNT_KEY
-					, executionContext.getInt(UPDATE_COUNT_KEY) + 1
-			);
-		}
+	@Test
+	public void testDelegateOpenIsCalled() {
+		synchronizedItemStreamWriter.open(testExecutionContext);
+		verify(delegate).open(testExecutionContext);
 	}
 
-	private class ItemStreamWriterTestThread extends Thread {
-
-		private ItemStreamWriter itemStreamWriter;
-		private ExecutionContext executionContext;
-
-		ItemStreamWriterTestThread(ItemStreamWriter itemStreamWriter, ExecutionContext executionContext) {
-			this.itemStreamWriter = itemStreamWriter;
-			this.executionContext = executionContext;
-		}
-
-		public void run() {
-
-			try {
-				//ensure all threads await invocation of the write() method
-				threadsStartingLine.await();
-				itemStreamWriter.write(new ArrayList());
-				itemStreamWriter.update(executionContext);
-
-			} catch (AssertionError assertionError) {
-				//should be the case on non-thread safe invocations
-				errors.add(assertionError.getMessage());
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}
+	@Test
+	public void testDelegateUpdateIsCalled() {
+		synchronizedItemStreamWriter.update(testExecutionContext);
+		verify(delegate).update(testExecutionContext);
 	}
+
+	@Test
+	public void testDelegateCloseIsClosed() {
+		synchronizedItemStreamWriter.close();
+		verify(delegate).close();
+	}
+
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.item.support;
 
 import org.junit.Before;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
@@ -1,0 +1,137 @@
+package org.springframework.batch.item.support;
+
+import org.junit.Before;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamWriter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Common parent class for {@link SynchronizedItemStreamWriterTests} and
+ * {@link org.springframework.batch.item.support.builder.SynchronizedItemStreamWriterBuilderTests}
+ *
+ * @author Dimitrios Liapis
+ *
+ */
+public abstract class AbstractSynchronizedItemStreamWriterTests {
+
+	private static final int THREAD_SIZE = 20;
+
+	private AtomicInteger numberOfThreadsInsideWriteMethod = new AtomicInteger(0);
+	private CountDownLatch threadsStartingLine = new CountDownLatch(1);
+	private List<String> errors = Collections.synchronizedList(new ArrayList<>());
+	private boolean isClosed = false;
+
+
+	@Before
+	public void init() {
+		numberOfThreadsInsideWriteMethod = new AtomicInteger(0);
+		threadsStartingLine = new CountDownLatch(1);
+		errors = Collections.synchronizedList(new ArrayList<>());
+		isClosed = false;
+	}
+
+	protected void multiThreadedInvocation(ItemStreamWriter itemStreamWriter) throws Exception {
+
+		ExecutionContext executionContext = new ExecutionContext();
+
+		itemStreamWriter.open(executionContext);
+		assertEquals(true, executionContext.get(TestItemWriter.HAS_BEEN_OPENED));
+		assertThat(isClosed, is(false));
+
+		IntStream.rangeClosed(1, THREAD_SIZE)
+				.mapToObj(i -> new ItemStreamWriterTestThread(itemStreamWriter, executionContext))
+				.forEach(Thread::start);
+
+		//release all the threads
+		threadsStartingLine.countDown();
+
+		Thread.sleep(5000);
+		itemStreamWriter.close();
+
+		assertThat(errors,is(empty()));
+		assertThat(isClosed, is(true));
+		assertEquals(THREAD_SIZE, executionContext.getInt(TestItemWriter.UPDATE_COUNT_KEY));
+
+	}
+
+	/**
+	 * Inspired by the SynchronizedItemStreamReaderTests#TestItemReader
+	 */
+	public class TestItemWriter extends AbstractItemStreamItemWriter<Integer> implements ItemStreamWriter<Integer> {
+
+		static final String HAS_BEEN_OPENED = "hasBeenOpened";
+		static final String UPDATE_COUNT_KEY = "updateCount";
+
+		@Override
+		public void write(List<? extends Integer> items) {
+			//If synchronized there can only be one thread at a time
+			//therefore the atomic integer can never grow above one
+			assertThat(numberOfThreadsInsideWriteMethod.incrementAndGet(), is(not(greaterThan(1))));
+			numberOfThreadsInsideWriteMethod.decrementAndGet();
+		}
+
+		@Override
+		public void close() {
+			isClosed = true;
+		}
+
+		@Override
+		public void open(ExecutionContext executionContext) {
+			isClosed = false;
+			executionContext.put(HAS_BEEN_OPENED, true);
+			executionContext.remove(UPDATE_COUNT_KEY);
+		}
+
+		@Override
+		public void update(ExecutionContext executionContext) {
+
+			if (!executionContext.containsKey(UPDATE_COUNT_KEY)) {
+				executionContext.putInt(UPDATE_COUNT_KEY, 0);
+			}
+
+			executionContext.putInt(UPDATE_COUNT_KEY
+					, executionContext.getInt(UPDATE_COUNT_KEY) + 1
+			);
+		}
+	}
+
+	private class ItemStreamWriterTestThread extends Thread {
+
+		private ItemStreamWriter itemStreamWriter;
+		private ExecutionContext executionContext;
+
+		ItemStreamWriterTestThread(ItemStreamWriter itemStreamWriter, ExecutionContext executionContext) {
+			this.itemStreamWriter = itemStreamWriter;
+			this.executionContext = executionContext;
+		}
+
+		public void run() {
+
+			try {
+				//ensure all threads await invocation of the write() method
+				threadsStartingLine.await();
+				itemStreamWriter.write(new ArrayList());
+				itemStreamWriter.update(executionContext);
+
+			} catch (AssertionError assertionError) {
+				//should be the case on non-thread safe invocations
+				errors.add(assertionError.getMessage());
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
@@ -16,6 +16,7 @@
 package org.springframework.batch.item.support;
 
 import org.junit.Test;
+import org.springframework.beans.factory.InitializingBean;
 
 /**
  *
@@ -24,18 +25,18 @@ import org.junit.Test;
  */
 public class SynchronizedItemStreamWriterTests extends AbstractSynchronizedItemStreamWriterTests {
 
-	@Test(expected = AssertionError.class)
-	public void givenMultipleThreads_whenAllCallItemStreamWriter_thenNotThreadSafe() throws Exception {
-		TestItemWriter testItemWriter = new TestItemWriter();
-		multiThreadedInvocation(testItemWriter);
+
+	@Override
+	protected SynchronizedItemStreamWriter<Object> createNewSynchronizedItemStreamWriter() {
+		SynchronizedItemStreamWriter<Object> synchronizedItemStreamWriter = new SynchronizedItemStreamWriter<>();
+		synchronizedItemStreamWriter.setDelegate(delegate);
+		return synchronizedItemStreamWriter;
 	}
 
 	@Test
-	public void givenMultipleThreads_whenAllCallSynchronizedItemStreamWriter_thenThreadSafe() throws Exception {
-		TestItemWriter testItemWriter = new TestItemWriter();
-		SynchronizedItemStreamWriter<Integer> synchronizedItemStreamWriter = new SynchronizedItemStreamWriter<>();
-		synchronizedItemStreamWriter.setDelegate(testItemWriter);
-		multiThreadedInvocation(synchronizedItemStreamWriter);
+	public void testDelegateIsNotNullWhenPropertiesSet() throws Exception {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("A delegate item writer is required");
+		((InitializingBean) new SynchronizedItemStreamWriter<>()).afterPropertiesSet();
 	}
-
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
@@ -1,0 +1,26 @@
+package org.springframework.batch.item.support;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Dimitrios Liapis
+ *
+ */
+public class SynchronizedItemStreamWriterTests extends AbstractSynchronizedItemStreamWriterTests {
+
+	@Test(expected = AssertionError.class)
+	public void givenMultipleThreads_whenAllCallItemStreamWriter_thenNotThreadSafe() throws Exception {
+		TestItemWriter testItemWriter = new TestItemWriter();
+		multiThreadedInvocation(testItemWriter);
+	}
+
+	@Test
+	public void givenMultipleThreads_whenAllCallSynchronizedItemStreamWriter_thenThreadSafe() throws Exception {
+		TestItemWriter testItemWriter = new TestItemWriter();
+		SynchronizedItemStreamWriter<Integer> synchronizedItemStreamWriter = new SynchronizedItemStreamWriter<>();
+		synchronizedItemStreamWriter.setDelegate(testItemWriter);
+		multiThreadedInvocation(synchronizedItemStreamWriter);
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.item.support;
 
 import org.junit.Test;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.item.support.builder;
 
 import org.junit.Test;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
@@ -1,0 +1,25 @@
+package org.springframework.batch.item.support.builder;
+
+import org.junit.Test;
+
+import org.springframework.batch.item.support.AbstractSynchronizedItemStreamWriterTests;
+import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
+
+/**
+ *
+ * @author Dimitrios Liapis
+ *
+ */
+public class SynchronizedItemStreamWriterBuilderTests extends AbstractSynchronizedItemStreamWriterTests {
+
+	@Test
+	public void givenMultipleThreads_whenAllCallSynchronizedItemStreamWriter_thenThreadSafe() throws Exception {
+		TestItemWriter testItemWriter = new TestItemWriter();
+		SynchronizedItemStreamWriter<Integer> synchronizedItemStreamWriter =
+				new SynchronizedItemStreamWriterBuilder<Integer>()
+						.delegate(testItemWriter)
+						.build();
+		multiThreadedInvocation(synchronizedItemStreamWriter);
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
@@ -16,7 +16,6 @@
 package org.springframework.batch.item.support.builder;
 
 import org.junit.Test;
-
 import org.springframework.batch.item.support.AbstractSynchronizedItemStreamWriterTests;
 import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
 
@@ -27,14 +26,18 @@ import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
  */
 public class SynchronizedItemStreamWriterBuilderTests extends AbstractSynchronizedItemStreamWriterTests {
 
-	@Test
-	public void givenMultipleThreads_whenAllCallSynchronizedItemStreamWriter_thenThreadSafe() throws Exception {
-		TestItemWriter testItemWriter = new TestItemWriter();
-		SynchronizedItemStreamWriter<Integer> synchronizedItemStreamWriter =
-				new SynchronizedItemStreamWriterBuilder<Integer>()
-						.delegate(testItemWriter)
-						.build();
-		multiThreadedInvocation(synchronizedItemStreamWriter);
+
+	@Override
+	protected SynchronizedItemStreamWriter<Object> createNewSynchronizedItemStreamWriter() {
+		return new SynchronizedItemStreamWriterBuilder<>()
+				.delegate(delegate)
+				.build();
 	}
 
+	@Test
+	public void testBuilderDelegateIsNotNull() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("A delegate is required");
+		new SynchronizedItemStreamWriterBuilder<>().build();
+	}
 }


### PR DESCRIPTION
Also introducing SynchronizedItemStreamWriterBuilder. Multi-threaded
Tests have been that additionally prove that currently ItemStreamWriter
is not thread-safe.