### PR TITLE
BATCH-2783: Update method to truly return a unique job parameter through a UUID

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.batch.test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -155,12 +156,12 @@ public class JobLauncherTestUtils {
 	}
 
 	/**
-	 * @return a new JobParameters object containing only a parameter for the
-	 * current timestamp, to ensure that the job instance will be unique.
+	 * @return a new JobParameters object containing only a UUID parameter,
+	 * to ensure that the job instance will be unique.
 	 */
 	public JobParameters getUniqueJobParameters() {
 		Map<String, JobParameter> parameters = new HashMap<>();
-		parameters.put("random", new JobParameter((long) (Math.random() * JOB_PARAMETER_MAXIMUM)));
+		parameters.put("random", new JobParameter(UUID.randomUUID().toString()));
 		return new JobParameters(parameters);
 	}
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
@@ -17,11 +17,7 @@ package org.springframework.batch.test;
 
 import org.junit.Test;
 
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
@@ -34,7 +30,11 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author mminella
@@ -50,6 +50,18 @@ public class JobLauncherTestUtilsTests {
 		JobExecution execution = testUtils.launchStep("step1");
 
 		assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+	}
+
+	@Test
+	public void getUniqueJobParameters_doesNotRepeatJobParameters() {
+		ApplicationContext context = new AnnotationConfigApplicationContext(TestJobConfiguration.class);
+		JobLauncherTestUtils testUtils = context.getBean(JobLauncherTestUtils.class);
+		Set<JobParameters> jobParametersSeen = new HashSet<>();
+		for (int i = 0; i < 10_000; i++) {
+			JobParameters jobParameters = testUtils.getUniqueJobParameters();
+			assertFalse(jobParametersSeen.contains(jobParameters));
+			jobParametersSeen.add(jobParameters);
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
We noticed that integration tests for a batch job (with many tests) were failing intermittently.  After debugging, I found that JobLauncherTestUtils.launchJob was occasionally relaunching the same job instance. After looking at the code, I saw that a random number generator was being used which does not guarantee that the number generate would be unique. I believe a UUID would be more appropriate as strongly guarantees that an ID does not repeat (except in highly exceptional cases). This change strongly assures that the JobParameter is unique every time getUniqueJobParameters() is called.