### PR TITLE
BATCH-2782: Fix typo in log message

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -358,7 +358,7 @@ InitializingBean {
 				try {
 					listener.afterJob(execution);
 				} catch (Exception e) {
-					logger.error("Exception encountered in afterStep callback", e);
+					logger.error("Exception encountered in afterJob callback", e);
 				}
 
 				jobRepository.update(execution);


### PR DESCRIPTION
Previously, a runtime exceptions raised in `org.springframework.batch.core.JobExecutionListener#afterJob` would log:

`Exception encountered in afterStep callback`

With this change it logs:

`Exception encountered in afterJob callback`

which is a more appropriate log message since the error happens in the afterJob callback.