### PR TITLE
JdbcCursorItemReader's fields should be private

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,13 +52,13 @@ import org.springframework.util.ClassUtils;
  */
 public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
-	PreparedStatement preparedStatement;
+	private PreparedStatement preparedStatement;
 
-	PreparedStatementSetter preparedStatementSetter;
+	private PreparedStatementSetter preparedStatementSetter;
 
-	String sql;
+	private String sql;
 
-	RowMapper<T> rowMapper;
+	private RowMapper<T> rowMapper;
 
 	public JdbcCursorItemReader() {
 		super();


### PR DESCRIPTION
Since this is a trivial change imo, I omitted out an `@author` update. I did however update the copyright year.