### PR TITLE
Constructors with var args/Lists

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/CompositeChunkListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/CompositeChunkListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.listener;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -29,6 +30,28 @@ import org.springframework.core.Ordered;
 public class CompositeChunkListener implements ChunkListener {
 
 	private OrderedComposite<ChunkListener> listeners = new OrderedComposite<>();
+
+	public CompositeChunkListener() {
+
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link ChunkListener}s.
+	 *
+	 * @param listeners list of {@link ChunkListener}.
+	 */
+	public CompositeChunkListener(List<? extends ChunkListener> listeners) {
+		setListeners(listeners);
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link ChunkListener}s.
+	 *
+	 * @param listeners array of {@link ChunkListener}.
+	 */
+	public CompositeChunkListener(ChunkListener... listeners) {
+		this(Arrays.asList(listeners));
+	}
 
 	/**
 	 * Public setter for the listeners.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemProcessor.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -37,6 +38,30 @@ import java.util.List;
 public class CompositeItemProcessor<I, O> implements ItemProcessor<I, O>, InitializingBean {
 
 	private List<? extends ItemProcessor<?, ?>> delegates;
+
+	public CompositeItemProcessor() {
+
+	}
+
+	/**
+	 * Convenience constructor for setting the delegates.
+	 *
+	 * @param delegates array of {@link ItemProcessor} delegates that will work on the
+	 * item.
+	 */
+	public CompositeItemProcessor(ItemProcessor<?, ?>... delegates) {
+		this(Arrays.asList(delegates));
+	}
+
+	/**
+	 * Convenience constructor for setting the delegates.
+	 *
+	 * @param delegates list of {@link ItemProcessor} delegates that will work on the
+	 * item.
+	 */
+	public CompositeItemProcessor(List<? extends ItemProcessor<?, ?>> delegates) {
+		setDelegates(delegates);
+	}
 
 	@Nullable
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemStream.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,15 @@ public class CompositeItemStream implements ItemStream {
 
 	/**
 	 * Public setter for the {@link ItemStream}s.
+	 *
+	 * @param streams {@link List} of {@link ItemStream}.
+	 */
+	public void setStreams(List<ItemStream> streams) {
+		this.streams = streams;
+	}
+
+	/**
+	 * Public setter for the {@link ItemStream}s.
 	 * 
 	 * @param streams array of {@link ItemStream}.
 	 */
@@ -61,6 +70,24 @@ public class CompositeItemStream implements ItemStream {
 	 */
 	public CompositeItemStream() {
 		super();
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link ItemStream}s.
+	 *
+	 * @param streams {@link List} of {@link ItemStream}.
+	 */
+	public CompositeItemStream(List<ItemStream> streams) {
+		setStreams(streams);
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link ItemStream}s.
+	 *
+	 * @param streams array of {@link ItemStream}.
+	 */
+	public CompositeItemStream(ItemStream... streams) {
+		setStreams(streams);
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -40,6 +41,28 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 	private List<ItemWriter<? super T>> delegates;
 
 	private boolean ignoreItemStream = false;
+
+	public CompositeItemWriter() {
+
+	}
+
+	/**
+	 * Convenience constructor for setting the delegates.
+	 *
+	 * @param delegates the list of delegates to use.
+	 */
+	public CompositeItemWriter(List<ItemWriter<? super T>> delegates) {
+		setDelegates(delegates);
+	}
+
+	/**
+	 * Convenience constructor for setting the delegates.
+	 *
+	 * @param delegates the array of delegates to use.
+	 */
+	public CompositeItemWriter(ItemWriter<? super T>... delegates) {
+		this(Arrays.asList(delegates));
+	}
 
 	/**
 	 * Establishes the policy whether to call the open, close, or update methods for the

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/listener/CompositeRepeatListener.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/listener/CompositeRepeatListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,37 @@ import org.springframework.batch.repeat.RepeatListener;
 public class CompositeRepeatListener implements RepeatListener {
 
 	private List<RepeatListener> listeners = new ArrayList<>();
+
+	public CompositeRepeatListener() {
+
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link RepeatListener}s.
+	 *
+	 * @param listeners {@link List} of RepeatListeners to be used by the CompositeRepeatListener.
+	 */
+	public CompositeRepeatListener(List<RepeatListener> listeners) {
+		setListeners(listeners);
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link RepeatListener}s.
+	 *
+	 * @param listeners array of RepeatListeners to be used by the CompositeRepeatListener.
+	 */
+	public CompositeRepeatListener(RepeatListener... listeners) {
+		setListeners(listeners);
+	}
+
+	/**
+	 * Public setter for the listeners.
+	 *
+	 * @param listeners {@link List} of RepeatListeners to be used by the CompositeRepeatListener.
+	 */
+	public void setListeners(List<RepeatListener> listeners) {
+		this.listeners = listeners;
+	}
 
 	/**
 	 * Public setter for the listeners.


### PR DESCRIPTION
Adds constructors that take a `List` or var args to classes that set a `List` field. 

I did a rudimentary search through the code to find `List<`. So if I'm missing a class, I can easily add the appropriate constructors.

I can create an issue for this if needed. I found it to be fairly trivial since it's only constructor updates. Hence, I didn't update the `@author`. I did update the copyright year.