### PR TITLE
ListItemWriter's iteration add can be replaced with addAll

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ListItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ListItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,7 @@ public class ListItemWriter<T> implements ItemWriter<T> {
 
 	@Override
 	public void write(List<? extends T> items) throws Exception {
-		for (T item : items) {
-			writtenItems.add(item);
-		}
+		writtenItems.addAll(items);
 	}
 
 	public List<? extends T> getWrittenItems() {


### PR DESCRIPTION
`ListItemWriter` iterates through the items and adds for each. This can be replaced with an `addAll`.