### PR TITLE
Simplify BatchTestContextCustomizerFactory

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
@@ -32,8 +32,7 @@ public class BatchTestContextCustomizerFactory implements ContextCustomizerFacto
 
 	@Override
 	public ContextCustomizer createContextCustomizer(Class<?> testClass, List<ContextConfigurationAttributes> configAttributes) {
-		SpringBatchTest springBatchTest = AnnotatedElementUtils.findMergedAnnotation(testClass, SpringBatchTest.class);
-		if (springBatchTest != null) {
+		if (AnnotatedElementUtils.hasAnnotation(testClass, SpringBatchTest.class)) {
 			return new BatchTestContextCustomizer();
 		}
 		return null;


### PR DESCRIPTION
Since `@SpringBatchTest` is effectively a marker annotation from the perspective of `BatchTestContextCustomizerFactory`, there is no need to retrieve the merged, synthesized annotation.

Checking for the presence of `@SpringBatchTest` is sufficient.