### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 ext {
-	linkHomepage = 'http://projects.spring.io/spring-batch/'
+	linkHomepage = 'https://projects.spring.io/spring-batch/'
 	linkCi       = 'https://build.spring.io/browse/BATCH'
 	linkIssue    = 'https://jira.spring.io/browse/BATCH'
 	linkScmUrl           = 'https://github.com/spring-projects/spring-batch'

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -26,12 +26,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'Spring'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://projects.spring.io/spring-batch/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-batch/ ([https](https://projects.spring.io/spring-batch/) result 200).
* http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).