### PR TITLE
BATCH-2805 Fix . hibernate.default_batch_fetch_size option does not work in JpaPagingItemReader. 

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
@@ -81,6 +81,7 @@ import org.springframework.util.ClassUtils;
  * @author Thomas Risberg
  * @author Dave Syer
  * @author Will Schipp
+ * @author jojoldu
  * @since 2.0
  */
 public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
@@ -185,14 +186,7 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 	@Override
 	@SuppressWarnings("unchecked")
 	protected void doReadPage() {
-
-		EntityTransaction tx = null;
-		
 		if (transacted) {
-			tx = entityManager.getTransaction();
-			tx.begin();
-			
-			entityManager.flush();
 			entityManager.clear();
 		}//end if
 
@@ -219,7 +213,6 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 			}//end if
 		} else {
 			results.addAll(query.getResultList());
-			tx.commit();
 		}//end if
 	}
 


### PR DESCRIPTION
Unlike JpaRepository, the ```hibernate.default_batch_fetch_size``` options does not work with JpaPagingItemReader.
(Below is the result of my test code)

![image](https://user-images.githubusercontent.com/7760496/55875096-22b29e80-5bcf-11e9-9f3d-ac0710af45bc.png)

In other words, using JpaPagingItemReader causes an N + 1 problem.

As you can see, the JpaPagingItemReader has a transaction scope inside doReadPage().

So I deleted the contents of the transaction to raise this range in chunk units.

![image](https://user-images.githubusercontent.com/7760496/55920233-0dbc2680-5c34-11e9-9092-c4497bc10fe1.png)

I do not see any more problems.

Send PR