### PR TITLE
Performance improvement for partitions with a large number of steps

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/partition/JsrStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/partition/JsrStepExecutionSplitter.java
@@ -17,12 +17,14 @@ package org.springframework.batch.core.jsr.partition;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.jsr.launch.JsrJobOperator;
 import org.springframework.batch.core.partition.support.SimpleStepExecutionSplitter;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.item.ExecutionContext;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
@@ -78,13 +80,15 @@ public class JsrStepExecutionSplitter extends SimpleStepExecutionSplitter {
 			}
 		});
 		JobExecution jobExecution = stepExecution.getJobExecution();
+		JobInstance jobInstance = stepExecution.getJobExecution().getJobInstance();
+		Collection<StepExecution> allPriorStepExecutions = jobRepository.getStepExecutions(jobInstance);
 
 		for(int i = 0; i < gridSize; i++) {
 			String stepName = this.stepName + ":partition" + i;
 			JobExecution curJobExecution = new JobExecution(jobExecution);
 			StepExecution curStepExecution = new StepExecution(stepName, curJobExecution);
 
-			if(!restoreState || isStartable(curStepExecution, new ExecutionContext())) {
+			if(!restoreState || isStartable(curStepExecution, new ExecutionContext(), allPriorStepExecutions)) {
 				executions.add(curStepExecution);
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/JobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/JobRepository.java
@@ -179,12 +179,26 @@ public interface JobRepository {
 	void updateExecutionContext(JobExecution jobExecution);
 
 	/**
+	 * @return all step executions, from all job executions, for the given job instance.
+	 */
+	Collection<StepExecution> getStepExecutions(JobInstance jobInstance);
+
+	/**
 	 * @param jobInstance {@link JobInstance} instance containing the step executions.
 	 * @param stepName the name of the step execution that might have run.
-	 * @return the last execution of step for the given job instance.
+	 * @return the last execution of step for the given job instance, null otherwise.
 	 */
 	@Nullable
 	StepExecution getLastStepExecution(JobInstance jobInstance, String stepName);
+
+	/**
+	 *
+	 * @param stepExecutions all step executions to filter through
+	 * @param stepName the name of the step execution that might have run.
+	 * @return the last execution of step inside the list, null otherwise.
+	 */
+	@Nullable
+	StepExecution getLastStepExecution(Collection<StepExecution> stepExecutions, String stepName);
 
 	/**
 	 * @param jobInstance {@link JobInstance} instance containing the step executions.

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -217,17 +217,31 @@ public class SimpleJobRepository implements JobRepository {
 	}
 
 	@Override
-	@Nullable
-	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
+	public Collection<StepExecution> getStepExecutions(JobInstance jobInstance) {
 		List<JobExecution> jobExecutions = jobExecutionDao.findJobExecutions(jobInstance);
 		List<StepExecution> stepExecutions = new ArrayList<>(jobExecutions.size());
 
 		for (JobExecution jobExecution : jobExecutions) {
 			stepExecutionDao.addStepExecutions(jobExecution);
-			for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
-				if (stepName.equals(stepExecution.getStepName())) {
-					stepExecutions.add(stepExecution);
-				}
+			stepExecutions.addAll(jobExecution.getStepExecutions());
+		}
+		return stepExecutions;
+	}
+
+	@Override
+	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
+		Collection<StepExecution> stepExecutions = getStepExecutions(jobInstance);
+		return getLastStepExecution(stepExecutions, stepName);
+	}
+
+	@Override
+	public StepExecution getLastStepExecution(Collection<StepExecution> allStepExecutions, String stepName) {
+
+		List<StepExecution> stepExecutions = new ArrayList<StepExecution>();
+
+		for (StepExecution stepExecution : allStepExecutions) {
+			if (stepName.equals(stepExecution.getStepName())) {
+				stepExecutions.add(stepExecution);
 			}
 		}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/DummyJobRepository.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/DummyJobRepository.java
@@ -66,6 +66,11 @@ public class DummyJobRepository implements JobRepository, BeanNameAware {
 	}
 
 	@Override
+	public StepExecution getLastStepExecution(Collection<StepExecution> stepExecutions, String stepName) {
+		return null;
+	}
+
+	@Override
 	public int getStepExecutionCount(JobInstance jobInstance, String stepName) {
 		return 0;
 	}
@@ -89,6 +94,11 @@ public class DummyJobRepository implements JobRepository, BeanNameAware {
 
 	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
+	}
+
+	@Override
+	public Collection<StepExecution> getStepExecutions(JobInstance jobInstance) {
+		return null;
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
@@ -58,6 +58,11 @@ public class JobRepositorySupport implements JobRepository {
 	}
 
 	@Override
+	public StepExecution getLastStepExecution(Collection<StepExecution> stepExecutions, String stepName) {
+		return null;
+	}
+
+	@Override
 	public int getStepExecutionCount(JobInstance jobInstance, String stepName) {
 		return 0;
 	}
@@ -97,6 +102,11 @@ public class JobRepositorySupport implements JobRepository {
 
 	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
+	}
+
+	@Override
+	public Collection<StepExecution> getStepExecutions(JobInstance jobInstance) {
+		return null;
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -511,6 +511,11 @@ public class TaskletStepExceptionTests {
 		}
 
 		@Override
+		public StepExecution getLastStepExecution(Collection<StepExecution> stepExecutions, String stepName) {
+			return null;
+		}
+
+		@Override
 		public int getStepExecutionCount(JobInstance jobInstance, String stepName) {
 			return 0;
 		}
@@ -555,6 +560,11 @@ public class TaskletStepExceptionTests {
 
 		@Override
 		public void updateExecutionContext(JobExecution jobExecution) {
+		}
+
+		@Override
+		public Collection<StepExecution> getStepExecutions(JobInstance jobInstance) {
+			return null;
 		}
 
 		@Override

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobRepositorySupport.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobRepositorySupport.java
@@ -47,6 +47,11 @@ public class JobRepositorySupport implements JobRepository {
 		return null;
 	}
 
+	@Override
+	public StepExecution getLastStepExecution(Collection<StepExecution> stepExecutions, String stepName) {
+		return null;
+	}
+
 	/* (non-Javadoc)
 	 * @see org.springframework.batch.core.repository.JobRepository#getStepExecutionCount(org.springframework.batch.core.JobInstance, org.springframework.batch.core.Step)
 	 */
@@ -73,6 +78,11 @@ public class JobRepositorySupport implements JobRepository {
 	}
 
 	public void updateExecutionContext(JobExecution jobExecution) {
+	}
+
+	@Override
+	public Collection<StepExecution> getStepExecutions(JobInstance jobInstance) {
+		return null;
 	}
 
 	public void add(StepExecution stepExecution) {


### PR DESCRIPTION
New method on JobRepository that enables better performance of SimpleStepExecutionSplitter. By retrieving all step executions at the time of partitioning outside the for loop, the number of calls to the database is reduced.

Also updated JSR version to be performant. Deprecated the older step execution methods and cleaned up the javadocs. Stub implementations provided for common support classes

https://jira.spring.io/browse/BATCH-2716