### PR TITLE
Add new methods to get the last job instance/execution in JobInstance/JobExecution DAOs

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParametersBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.batch.core;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -256,20 +255,19 @@ public class JobParametersBuilder {
 
 		String name = job.getName();
 		JobParameters nextParameters;
-		List<JobInstance> lastInstances = this.jobExplorer.getJobInstances(name, 0, 1);
+		JobInstance lastInstance = this.jobExplorer.getLastJobInstance(name);
 		JobParametersIncrementer incrementer = job.getJobParametersIncrementer();
-		if (lastInstances.isEmpty()) {
+		if (lastInstance == null) {
 			// Start from a completely clean sheet
 			nextParameters = incrementer.getNext(new JobParameters());
 		}
 		else {
-			List<JobExecution> previousExecutions = this.jobExplorer.getJobExecutions(lastInstances.get(0));
-			if (previousExecutions.isEmpty()) {
+			JobExecution previousExecution = this.jobExplorer.getLastJobExecution(lastInstance);
+			if (previousExecution == null) {
 				// Normally this will not happen - an instance exists with no executions
 				nextParameters = incrementer.getNext(new JobParameters());
 			}
 			else {
-				JobExecution previousExecution = previousExecutions.get(0);
 				nextParameters = incrementer.getNext(previousExecution.getJobParameters());
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,16 @@ public interface JobExplorer {
 	List<JobInstance> getJobInstances(String jobName, int start, int count);
 
 	/**
+	 * Find the last job instance for the given job.
+	 * @param jobName name of the job
+	 * @return the last job instance if any or null otherwise
+	 */
+	@Nullable
+	default JobInstance getLastJobInstance(String jobName) {
+		return null;
+	}
+
+	/**
 	 * Retrieve a {@link JobExecution} by its id. The complete object graph for
 	 * this execution should be returned (unless otherwise indicated) including
 	 * the parent {@link JobInstance} and associated {@link ExecutionContext}
@@ -94,6 +104,18 @@ public interface JobExplorer {
 	 * @return the set of all executions for the specified {@link JobInstance}
 	 */
 	List<JobExecution> getJobExecutions(JobInstance jobInstance);
+
+	/**
+	 * Find the last {@link JobExecution} to have been created for a given
+	 * {@link JobInstance}.
+	 * @param jobInstance the {@link JobInstance}
+	 * @return the last {@link JobExecution} to execute for this instance or
+	 * {@code null} if no job execution is found for the given job instance.
+	 */
+	@Nullable
+	default JobExecution getLastJobExecution(JobInstance jobInstance) {
+		return null;
+	}
 
 	/**
 	 * Retrieve running job executions. The corresponding step executions may

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
@@ -50,13 +50,15 @@ public interface JobExplorer {
 	List<JobInstance> getJobInstances(String jobName, int start, int count);
 
 	/**
-	 * Find the last job instance for the given job.
+	 * Find the last job instance by Id for the given job.
 	 * @param jobName name of the job
-	 * @return the last job instance if any or null otherwise
+	 * @return the last job instance by Id if any or null otherwise
+	 *
+	 * @since 4.2
 	 */
 	@Nullable
 	default JobInstance getLastJobInstance(String jobName) {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	/**
@@ -106,15 +108,17 @@ public interface JobExplorer {
 	List<JobExecution> getJobExecutions(JobInstance jobInstance);
 
 	/**
-	 * Find the last {@link JobExecution} to have been created for a given
+	 * Find the last {@link JobExecution} that has been created for a given
 	 * {@link JobInstance}.
 	 * @param jobInstance the {@link JobInstance}
-	 * @return the last {@link JobExecution} to execute for this instance or
+	 * @return the last {@link JobExecution} that has been created for this instance or
 	 * {@code null} if no job execution is found for the given job instance.
+	 *
+	 * @since 4.2
 	 */
 	@Nullable
 	default JobExecution getLastJobExecution(JobInstance jobInstance) {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/SimpleJobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/SimpleJobExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,18 @@ public class SimpleJobExplorer implements JobExplorer {
 	 * (non-Javadoc)
 	 *
 	 * @see
+	 * org.springframework.batch.core.explore.JobExplorer#getLastJobExecution(
+	 * org.springframework.batch.core.JobInstance)
+	 */
+	@Nullable
+	public JobExecution getLastJobExecution(JobInstance jobInstance) {
+		return jobExecutionDao.getLastJobExecution(jobInstance);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see
 	 * org.springframework.batch.core.explore.JobExplorer#findRunningJobExecutions
 	 * (java.lang.String)
 	 */
@@ -161,6 +173,18 @@ public class SimpleJobExplorer implements JobExplorer {
 	@Override
 	public JobInstance getJobInstance(@Nullable Long instanceId) {
 		return jobInstanceDao.getJobInstance(instanceId);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see
+	 * org.springframework.batch.core.explore.JobExplorer#getLastJobInstance(java
+	 * .lang.String)
+	 */
+	@Override
+	public JobInstance getLastJobInstance(String jobName) {
+		return jobInstanceDao.getLastJobInstance(jobName);
 	}
 
 	/*

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JobInstanceDao.java
@@ -97,13 +97,15 @@ public interface JobInstanceDao {
 	List<JobInstance> getJobInstances(String jobName, int start, int count);
 
 	/**
-	 * Fetch the last job instance for the given job.
+	 * Fetch the last job instance by Id for the given job.
 	 * @param jobName name of the job
-	 * @return the last job instance if any or null otherwise
+	 * @return the last job instance by Id if any or null otherwise
+	 *
+	 * @since 4.2
 	 */
 	@Nullable
 	default JobInstance getLastJobInstance(String jobName) {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JobInstanceDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,16 @@ public interface JobInstanceDao {
 	 * @return the job instances with this name or empty if none
 	 */
 	List<JobInstance> getJobInstances(String jobName, int start, int count);
+
+	/**
+	 * Fetch the last job instance for the given job.
+	 * @param jobName name of the job
+	 * @return the last job instance if any or null otherwise
+	 */
+	@Nullable
+	default JobInstance getLastJobInstance(String jobName) {
+		return null;
+	}
 
 	/**
 	 * Retrieve the names of all job instances sorted alphabetically - i.e. jobs

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapJobInstanceDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,13 @@ public class MapJobInstanceDao implements JobInstanceDao {
 		sortDescending(result);
 
 		return subset(result, start, count);
+	}
+
+	@Override
+	@Nullable
+	public JobInstance getLastJobInstance(String jobName) {
+		List<JobInstance> jobInstances = getJobInstances(jobName, 0, 1);
+		return jobInstances.isEmpty() ? null : jobInstances.get(0);
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.batch.core.repository.dao.StepExecutionDao;
  * @author Dave Syer
  * @author Will Schipp
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  *
  */
 public class SimpleJobExplorerTests {
@@ -80,6 +81,13 @@ public class SimpleJobExplorerTests {
 				jobInstance);
 		stepExecutionDao.addStepExecutions(jobExecution);
 		jobExplorer.getJobExecution(123L);
+	}
+
+	@Test
+	public void testGetLastJobExecution() {
+		when(jobExecutionDao.getLastJobExecution(jobInstance)).thenReturn(jobExecution);
+		JobExecution lastJobExecution = jobExplorer.getLastJobExecution(jobInstance);
+		assertEquals(jobExecution, lastJobExecution);
 	}
 
 	@Test
@@ -154,6 +162,13 @@ public class SimpleJobExplorerTests {
 	public void testGetLastJobInstances() throws Exception {
 		jobInstanceDao.getJobInstances("foo", 0, 1);
 		jobExplorer.getJobInstances("foo", 0, 1);
+	}
+
+	@Test
+	public void testGetLastJobInstance() {
+		when(jobInstanceDao.getLastJobInstance("foo")).thenReturn(jobInstance);
+		JobInstance lastJobInstance = jobExplorer.getLastJobInstance("foo");
+		assertEquals(jobInstance, lastJobInstance);
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
@@ -506,6 +506,16 @@ public class CommandLineJobRunnerTests {
 		}
 
 		@Override
+		public JobInstance getLastJobInstance(String jobName) {
+			return null;
+		}
+
+		@Override
+		public JobExecution getLastJobExecution(JobInstance jobInstance) {
+			return null;
+		}
+
+		@Override
 		public List<JobInstance> getJobInstances(String jobName, int start, int count) {
 			if (jobInstances == null) {
 				return new ArrayList<>();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobInstanceDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobInstanceDaoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,33 @@ public abstract class AbstractJobInstanceDaoTests {
 		assertTrue("Last instance should be first on the list", jobInstances.get(0).getId() > jobInstances.get(1)
 				.getId());
 
+	}
+
+	@Transactional
+	@Test
+	public void testGetLastInstance() throws Exception {
+		testCreateAndRetrieve();
+
+		// unrelated job instance that should be ignored by the query
+		dao.createJobInstance("anotherJob", new JobParameters());
+
+		// we need two instances of the same job to check ordering
+		dao.createJobInstance(fooJob, new JobParameters());
+
+		List<JobInstance> jobInstances = dao.getJobInstances(fooJob, 0, 2);
+		assertEquals(2, jobInstances.size());
+		JobInstance lastJobInstance = dao.getLastJobInstance(fooJob);
+		assertNotNull(lastJobInstance);
+		assertEquals(fooJob, lastJobInstance.getJobName());
+		assertEquals("Last instance should be first on the list",
+				jobInstances.get(0), lastJobInstance);
+	}
+
+	@Transactional
+	@Test
+	public void testGetLastInstanceWhenNoInstance() {
+		JobInstance lastJobInstance = dao.getLastJobInstance("NonExistingJob");
+		assertNull(lastJobInstance);
 	}
 
 	/**


### PR DESCRIPTION
Before this PR, getting the last job instance/execution required to load all job instances/executions from the database and filter them on the client side in memory.

This PR introduces new methods that use database queries to get the last job instance/execution without the need to load all job instances/executions (filtering is done on the database side). This change improves memory consumption as well as the performance of starting the next instance of a job.

Resolves [BATCH-1784](https://jira.spring.io/browse/BATCH-1784)