### PR TITLE
Fixed a refresh bug in the document toggle

### DIFF
--- a/spring-batch-docs/asciidoc/js/DocumentToggle.js
+++ b/spring-batch-docs/asciidoc/js/DocumentToggle.js
@@ -37,6 +37,7 @@ $(document).ready(function(){
         $("*.javaContent > *").addClass("js-toc-ignore");
         $("*.xmlContent > *").removeClass("js-toc-ignore");
         window.dispatchEvent(new Event("tocRefresh"));
+        tocbot.refresh();
         Cookies.set('docToggle', 'xml', { expires: 3652 });
     };
 
@@ -46,6 +47,7 @@ $(document).ready(function(){
         $("*.xmlContent > *").addClass("js-toc-ignore");
         $("*.javaContent > *").removeClass("js-toc-ignore");
         window.dispatchEvent(new Event("tocRefresh"));
+        tocbot.refresh();
         Cookies.set('docToggle', 'java', { expires: 3652 });
     };
 
@@ -55,6 +57,7 @@ $(document).ready(function(){
         $("*.javaContent > *").removeClass("js-toc-ignore");
         $("*.xmlContent > *").removeClass("js-toc-ignore");
         window.dispatchEvent(new Event("tocRefresh"));
+        tocbot.refresh();
         Cookies.set('docToggle', 'both', { expires: 3652 });
     };
 


### PR DESCRIPTION
While working on another feature, I noticed that the document toggle wasn't updating the ToC. I fixed that. (It matters only in the case where entire headings are toggled, but we do have one such case.)