### PR TITLE
Improve the performance of step partitioning

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.batch.core.repository.dao;
 import java.util.Collection;
 
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.lang.Nullable;
 
@@ -64,6 +65,19 @@ public interface StepExecutionDao {
 	 */
 	@Nullable
 	StepExecution getStepExecution(JobExecution jobExecution, Long stepExecutionId);
+
+	/**
+	 * Retrieve the last {@link StepExecution} for a given {@link JobInstance}
+	 * ordered by starting time and then id.
+	 *
+	 * @param jobInstance the parent {@link JobInstance}
+	 * @param stepName the name of the step
+	 * @return a {@link StepExecution}
+	 */
+	@Nullable
+	default StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Retrieve all the {@link StepExecution} for the parent {@link JobExecution}.

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -219,32 +218,7 @@ public class SimpleJobRepository implements JobRepository {
 	@Override
 	@Nullable
 	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
-		List<JobExecution> jobExecutions = jobExecutionDao.findJobExecutions(jobInstance);
-		List<StepExecution> stepExecutions = new ArrayList<>(jobExecutions.size());
-
-		for (JobExecution jobExecution : jobExecutions) {
-			stepExecutionDao.addStepExecutions(jobExecution);
-			for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
-				if (stepName.equals(stepExecution.getStepName())) {
-					stepExecutions.add(stepExecution);
-				}
-			}
-		}
-
-		StepExecution latest = null;
-		for (StepExecution stepExecution : stepExecutions) {
-			if (latest == null) {
-				latest = stepExecution;
-			}
-			if (latest.getStartTime().getTime() < stepExecution.getStartTime().getTime()) {
-				latest = stepExecution;
-			}
-			// Use step execution ID as the tie breaker if start time is identical
-			if (latest.getStartTime().getTime() == stepExecution.getStartTime().getTime() && 
-			        latest.getId() < stepExecution.getId()) {
-				latest = stepExecution;
-			}
-		}
+		StepExecution latest = stepExecutionDao.getLastStepExecution(jobInstance, stepName);
 
 		if (latest != null) {
 			ExecutionContext stepExecutionContext = ecDao.getExecutionContext(latest);


### PR DESCRIPTION
This PR improves the performance of splitting a step execution by 20x (See benchmark [here](https://github.com/benas/spring-batch-sandbox/tree/master/batch2716)). It moves the logic of finding the last step execution of a job instance to the database (instead of doing it in memory).

This PR is functionally the same as #725. However, it does **not**:

* Load all step executions and all job executions of a given job instance in memory to get the last step execution
* change the signature of `SimpleStepExecutionSplitter#isStartable` (which is a breaking change)

This PR resolves [BATCH-2716](https://jira.spring.io/browse/BATCH-2716).