### PR TITLE
BATCH-2844: Support empty delimiter in DelimitedBuilder of FlatFileItemWriterBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.springframework.batch.item.file.transform.FormatterLineAggregator;
 import org.springframework.batch.item.file.transform.LineAggregator;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * A builder implementation for the {@link FlatFileItemWriter}
@@ -459,9 +458,7 @@ public class FlatFileItemWriterBuilder<T> {
 					"A list of field names or a field extractor is required");
 
 			DelimitedLineAggregator<T> delimitedLineAggregator = new DelimitedLineAggregator<>();
-			if (StringUtils.hasLength(this.delimiter)) {
-				delimitedLineAggregator.setDelimiter(this.delimiter);
-			}
+			delimitedLineAggregator.setDelimiter(this.delimiter);
 
 			if (this.fieldExtractor == null) {
 				BeanWrapperFieldExtractor<T> beanWrapperFieldExtractor = new BeanWrapperFieldExtractor<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,6 +117,34 @@ public class FlatFileItemWriterBuilderTests {
 		writer.close();
 
 		assertEquals("HEADER$1,2,3$4,5,6$FOOTER", readLine("UTF-16LE", output));
+	}
+
+	@Test
+	public void testDelimitedOutputWithEmptyDelimiter() throws Exception {
+
+		Resource output = new FileSystemResource(File.createTempFile("foo", "txt"));
+
+		FlatFileItemWriter<Foo> writer = new FlatFileItemWriterBuilder<Foo>()
+				.name("foo")
+				.resource(output)
+				.lineSeparator("$")
+				.delimited()
+				.delimiter("")
+				.names("first", "second", "third")
+				.encoding("UTF-16LE")
+				.headerCallback(writer1 -> writer1.append("HEADER"))
+				.footerCallback(writer12 -> writer12.append("FOOTER"))
+				.build();
+
+		ExecutionContext executionContext = new ExecutionContext();
+
+		writer.open(executionContext);
+
+		writer.write(Arrays.asList(new Foo(1, 2, "3"), new Foo(4, 5, "6")));
+
+		writer.close();
+
+		assertEquals("HEADER$123$456$FOOTER", readLine("UTF-16LE", output));
 	}
 
 	@Test


### PR DESCRIPTION
Previously, if supplying an empty delimiter `""`, to the `delimited().delimiter()` of `DelimitedBuilder` from the parent `FlatFileItemWriterBuilder`, it would be ignored and instead use the default delimiter `","`.