### PR TITLE
BATCH-2845 fix for XSD documentation

### DIFF
--- a/spring-batch-core/src/main/resources/org/springframework/batch/core/configuration/xml/spring-batch-2.1.xsd
+++ b/spring-batch-core/src/main/resources/org/springframework/batch/core/configuration/xml/spring-batch-2.1.xsd
@@ -497,7 +497,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.PartitionHandler" />
+						<tool:expected-type type="org.springframework.batch.core.partition.PartitionHandler" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -509,7 +509,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.support.StepExecutionAggregator" />
+						<tool:expected-type type="org.springframework.batch.core.partition.support.StepExecutionAggregator" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -521,7 +521,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.support.Partitioner" />
+						<tool:expected-type type="org.springframework.batch.core.partition.support.Partitioner" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -533,7 +533,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.Step" />
+						<tool:expected-type type="org.springframework.batch.core.Step" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -879,7 +879,7 @@ ref"							is not required, and only needs to be specified explicitly
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref" />
-					<tool:expected-type type="org.springframework.core.step.skip.SkipPolicy" />
+					<tool:expected-type type="org.springframework.batch.core.step.skip.SkipPolicy" />
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -890,7 +890,7 @@ ref"							is not required, and only needs to be specified explicitly
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref" />
-					<tool:expected-type type="org.springframework.batch.retry.RetryPolicy" />
+					<tool:expected-type type="org.springframework.retry.RetryPolicy" />
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-batch-core/src/main/resources/org/springframework/batch/core/configuration/xml/spring-batch-2.2.xsd
+++ b/spring-batch-core/src/main/resources/org/springframework/batch/core/configuration/xml/spring-batch-2.2.xsd
@@ -521,7 +521,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.PartitionHandler" />
+						<tool:expected-type type="org.springframework.batch.core.partition.PartitionHandler" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -533,7 +533,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.support.StepExecutionAggregator" />
+						<tool:expected-type type="org.springframework.batch.core.partition.support.StepExecutionAggregator" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -545,7 +545,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.support.Partitioner" />
+						<tool:expected-type type="org.springframework.batch.core.partition.support.Partitioner" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -557,7 +557,7 @@ ref"							is not required, and only needs to be specified explicitly
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.Step" />
+						<tool:expected-type type="org.springframework.batch.core.Step" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -905,7 +905,7 @@ ref"							is not required, and only needs to be specified explicitly
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref" />
-					<tool:expected-type type="org.springframework.core.step.skip.SkipPolicy" />
+					<tool:expected-type type="org.springframework.batch.core.step.skip.SkipPolicy" />
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -916,7 +916,7 @@ ref"							is not required, and only needs to be specified explicitly
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref" />
-					<tool:expected-type type="org.springframework.batch.retry.RetryPolicy" />
+					<tool:expected-type type="org.springframework.retry.RetryPolicy" />
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-batch-core/src/main/resources/org/springframework/batch/core/configuration/xml/spring-batch-3.0.xsd
+++ b/spring-batch-core/src/main/resources/org/springframework/batch/core/configuration/xml/spring-batch-3.0.xsd
@@ -536,7 +536,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.PartitionHandler" />
+						<tool:expected-type type="org.springframework.batch.core.partition.PartitionHandler" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -548,7 +548,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.support.StepExecutionAggregator" />
+						<tool:expected-type type="org.springframework.batch.core.partition.support.StepExecutionAggregator" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -560,7 +560,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.partition.support.Partitioner" />
+						<tool:expected-type type="org.springframework.batch.core.partition.support.Partitioner" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -572,7 +572,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.core.Step" />
+						<tool:expected-type type="org.springframework.batch.core.Step" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -920,7 +920,7 @@
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref" />
-					<tool:expected-type type="org.springframework.core.step.skip.SkipPolicy" />
+					<tool:expected-type type="org.springframework.batch.core.step.skip.SkipPolicy" />
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -931,7 +931,7 @@
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref" />
-					<tool:expected-type type="org.springframework.batch.retry.RetryPolicy" />
+					<tool:expected-type type="org.springframework.retry.RetryPolicy" />
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>


### PR DESCRIPTION
Fix for documentation issue - https://jira.spring.io/browse/BATCH-2845

It looks like the XSDs needed updating with the correct packages for some of the Spring Batch and Spring Retry classes.  No functional impact, but it just causes a minor inconvenience with XSD validation warnings in Intellij when using XML-based configurations.

Contribution on behalf of Comcast Corporation.  Pivotal CLA has been previously signed.