### PR TITLE
Allow customisation of Deserializer for KafkaConsumer

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  *
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Jean-Francois Larouche
  * @since 4.2
  */
 public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 
+import org.apache.kafka.common.serialization.Deserializer;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.lang.Nullable;
@@ -69,6 +70,10 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 	private Duration pollTimeout = Duration.ofSeconds(DEFAULT_POLL_TIMEOUT);
 
 	private boolean saveState = true;
+
+	private Deserializer<K> keyDeserializer;
+
+	private Deserializer<V> valueDeserializer;
 
 	/**
 	 * Create a new {@link KafkaItemReader}.
@@ -133,6 +138,22 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 	}
 
 	/**
+	 * Set a custom key deserializer.
+	 * @param keyDeserializer custom key deserializer
+	 */
+	public void setKeyDeserializer(Deserializer<K> keyDeserializer) {
+		this.keyDeserializer = keyDeserializer;
+	}
+
+	/**
+	 * Set a custom value deserializer.
+	 * @param valueDeserializer custom value deserializer
+	 */
+	public void setValueDeserializer(Deserializer<V> valueDeserializer) {
+		this.valueDeserializer = valueDeserializer;
+	}
+
+	/**
 	 * The flag that determines whether to save internal state for restarts.
 	 * @return true if the flag was set
 	 */
@@ -142,7 +163,7 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 
 	@Override
 	public void open(ExecutionContext executionContext) {
-		this.kafkaConsumer = new KafkaConsumer<>(this.consumerProperties);
+		this.kafkaConsumer = new KafkaConsumer<>(this.consumerProperties, keyDeserializer, valueDeserializer);
 		this.partitionOffsets = new HashMap<>();
 		for (TopicPartition topicPartition : this.topicPartitions) {
 			this.partitionOffsets.put(topicPartition, 0L);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilder.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
+import org.apache.kafka.common.serialization.Deserializer;
 import org.springframework.batch.item.kafka.KafkaItemReader;
 import org.springframework.util.Assert;
 
@@ -49,6 +50,9 @@ public class KafkaItemReaderBuilder<K, V> {
 
 	private String name;
 
+	private Deserializer<K> keyDeserializer;
+
+	private Deserializer<V> valueDeserializer;
 	/**
 	 * Configure if the state of the {@link org.springframework.batch.item.ItemStreamSupport}
 	 * should be persisted within the {@link org.springframework.batch.item.ExecutionContext}
@@ -125,6 +129,26 @@ public class KafkaItemReaderBuilder<K, V> {
 		return this;
 	}
 
+	/**
+	 * Set a custom key deserializer. Default null.
+	 * @param keyDeserializer custom key deserializer
+	 * @return The current instance of the builder.
+	 */
+	public KafkaItemReaderBuilder<K, V> keyDeserializer(Deserializer<K> keyDeserializer) {
+		this.keyDeserializer = keyDeserializer;
+		return this;
+	}
+
+	/**
+	 * Set a custom value deserializer. Default null.
+	 * @param valueDeserializer custom value deserializer
+	 * @return The current instance of the builder.
+	 */
+	public KafkaItemReaderBuilder<K, V> valueDeserializer(Deserializer<V> valueDeserializer) {
+		this.valueDeserializer = valueDeserializer;
+		return this;
+	}
+
 	public KafkaItemReader<K, V> build() {
 		if (this.saveState) {
 			Assert.hasText(this.name, "A name is required when saveState is set to true");
@@ -148,6 +172,8 @@ public class KafkaItemReaderBuilder<K, V> {
 		reader.setPollTimeout(this.pollTimeout);
 		reader.setSaveState(this.saveState);
 		reader.setName(this.name);
+		reader.setKeyDeserializer(keyDeserializer);
+		reader.setValueDeserializer(valueDeserializer);
 		return reader;
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilder.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  *
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Jean-Francois Larouche
  * @since 4.2
  * @see KafkaItemReader
  */

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.*;
 /**
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Jean-Francois Larouche
  */
 public class KafkaItemReaderTests {
 
@@ -85,14 +86,16 @@ public class KafkaItemReaderTests {
 		try {
 			new KafkaItemReader<>(null, "topic", 0);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("Consumer properties must not be null", exception.getMessage());
 		}
 
 		try {
 			new KafkaItemReader<>(new Properties(), "topic", 0);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("bootstrap.servers property must be provided", exception.getMessage());
 		}
 
@@ -101,7 +104,8 @@ public class KafkaItemReaderTests {
 		try {
 			new KafkaItemReader<>(consumerProperties, "topic", 0);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("group.id property must be provided", exception.getMessage());
 		}
 
@@ -109,7 +113,8 @@ public class KafkaItemReaderTests {
 		try {
 			new KafkaItemReader<>(consumerProperties, "topic", 0);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("key.deserializer property must be provided", exception.getMessage());
 		}
 
@@ -117,7 +122,8 @@ public class KafkaItemReaderTests {
 		try {
 			new KafkaItemReader<>(consumerProperties, "topic", 0);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("value.deserializer property must be provided", exception.getMessage());
 		}
 
@@ -125,14 +131,16 @@ public class KafkaItemReaderTests {
 		try {
 			new KafkaItemReader<>(consumerProperties, "", 0);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("Topic name must not be null or empty", exception.getMessage());
 		}
 
 		try {
 			this.reader = new KafkaItemReader<>(consumerProperties, "topic");
 			fail("Expected exception was not thrown");
-		} catch (Exception exception) {
+		}
+		catch (Exception exception) {
 			assertEquals("At least one partition must be provided", exception.getMessage());
 		}
 
@@ -145,21 +153,24 @@ public class KafkaItemReaderTests {
 		try {
 			this.reader.setPollTimeout(null);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("pollTimeout must not be null", exception.getMessage());
 		}
 
 		try {
 			this.reader.setPollTimeout(Duration.ZERO);
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("pollTimeout must not be zero", exception.getMessage());
 		}
 
 		try {
 			this.reader.setPollTimeout(Duration.ofSeconds(-1));
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException exception) {
+		}
+		catch (IllegalArgumentException exception) {
 			assertEquals("pollTimeout must not be negative", exception.getMessage());
 		}
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
@@ -47,278 +47,278 @@ import static org.junit.Assert.*;
  */
 public class KafkaItemReaderTests {
 
-    @ClassRule
-    public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1);
+	@ClassRule
+	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1);
 
-    private KafkaItemReader<String, String> reader;
-    private KafkaTemplate<String, String> template;
-    private Properties consumerProperties;
+	private KafkaItemReader<String, String> reader;
+	private KafkaTemplate<String, String> template;
+	private Properties consumerProperties;
 
-    @BeforeClass
-    public static void setUpTopics() {
-        embeddedKafka.getEmbeddedKafka().addTopics(
-                new NewTopic("topic1", 1, (short) 1),
-                new NewTopic("topic2", 2, (short) 1),
-                new NewTopic("topic3", 1, (short) 1),
-                new NewTopic("topic4", 2, (short) 1)
-        );
-    }
+	@BeforeClass
+	public static void setUpTopics() {
+		embeddedKafka.getEmbeddedKafka().addTopics(
+				new NewTopic("topic1", 1, (short) 1),
+				new NewTopic("topic2", 2, (short) 1),
+				new NewTopic("topic3", 1, (short) 1),
+				new NewTopic("topic4", 2, (short) 1)
+		);
+	}
 
-    @Before
-    public void setUp() {
-        Map<String, Object> producerProperties = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
-        ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(producerProperties);
-        this.template = new KafkaTemplate<>(producerFactory);
+	@Before
+	public void setUp() {
+		Map<String, Object> producerProperties = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
+		ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(producerProperties);
+		this.template = new KafkaTemplate<>(producerFactory);
 
-        this.consumerProperties = new Properties();
-        this.consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                embeddedKafka.getEmbeddedKafka().getBrokersAsString());
-        this.consumerProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "1");
-        this.consumerProperties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-                StringDeserializer.class.getName());
-        this.consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-                StringDeserializer.class.getName());
-    }
+		this.consumerProperties = new Properties();
+		this.consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+				embeddedKafka.getEmbeddedKafka().getBrokersAsString());
+		this.consumerProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "1");
+		this.consumerProperties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+				StringDeserializer.class.getName());
+		this.consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+				StringDeserializer.class.getName());
+	}
 
-    @Test
-    public void testValidation() {
-        try {
-            new KafkaItemReader<>(null, "topic", 0);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("Consumer properties must not be null", exception.getMessage());
-        }
+	@Test
+	public void testValidation() {
+		try {
+			new KafkaItemReader<>(null, "topic", 0);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("Consumer properties must not be null", exception.getMessage());
+		}
 
-        try {
-            new KafkaItemReader<>(new Properties(), "topic", 0);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("bootstrap.servers property must be provided", exception.getMessage());
-        }
+		try {
+			new KafkaItemReader<>(new Properties(), "topic", 0);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("bootstrap.servers property must be provided", exception.getMessage());
+		}
 
-        Properties consumerProperties = new Properties();
-        consumerProperties.put("bootstrap.servers", embeddedKafka.getEmbeddedKafka());
-        try {
-            new KafkaItemReader<>(consumerProperties, "topic", 0);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("group.id property must be provided", exception.getMessage());
-        }
+		Properties consumerProperties = new Properties();
+		consumerProperties.put("bootstrap.servers", embeddedKafka.getEmbeddedKafka());
+		try {
+			new KafkaItemReader<>(consumerProperties, "topic", 0);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("group.id property must be provided", exception.getMessage());
+		}
 
-        consumerProperties.put("group.id", "1");
-        try {
-            new KafkaItemReader<>(consumerProperties, "topic", 0);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("key.deserializer property must be provided", exception.getMessage());
-        }
+		consumerProperties.put("group.id", "1");
+		try {
+			new KafkaItemReader<>(consumerProperties, "topic", 0);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("key.deserializer property must be provided", exception.getMessage());
+		}
 
-        consumerProperties.put("key.deserializer", StringDeserializer.class.getName());
-        try {
-            new KafkaItemReader<>(consumerProperties, "topic", 0);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("value.deserializer property must be provided", exception.getMessage());
-        }
+		consumerProperties.put("key.deserializer", StringDeserializer.class.getName());
+		try {
+			new KafkaItemReader<>(consumerProperties, "topic", 0);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("value.deserializer property must be provided", exception.getMessage());
+		}
 
-        consumerProperties.put("value.deserializer", StringDeserializer.class.getName());
-        try {
-            new KafkaItemReader<>(consumerProperties, "", 0);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("Topic name must not be null or empty", exception.getMessage());
-        }
+		consumerProperties.put("value.deserializer", StringDeserializer.class.getName());
+		try {
+			new KafkaItemReader<>(consumerProperties, "", 0);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("Topic name must not be null or empty", exception.getMessage());
+		}
 
-        try {
-            this.reader = new KafkaItemReader<>(consumerProperties, "topic");
-            fail("Expected exception was not thrown");
-        } catch (Exception exception) {
-            assertEquals("At least one partition must be provided", exception.getMessage());
-        }
+		try {
+			this.reader = new KafkaItemReader<>(consumerProperties, "topic");
+			fail("Expected exception was not thrown");
+		} catch (Exception exception) {
+			assertEquals("At least one partition must be provided", exception.getMessage());
+		}
 
-        try {
-            this.reader = new KafkaItemReader<>(consumerProperties, "topic", 0);
-        } catch (Exception exception) {
-            fail("Must not throw an exception when configuration is valid");
-        }
+		try {
+			this.reader = new KafkaItemReader<>(consumerProperties, "topic", 0);
+		} catch (Exception exception) {
+			fail("Must not throw an exception when configuration is valid");
+		}
 
-        try {
-            this.reader.setPollTimeout(null);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("pollTimeout must not be null", exception.getMessage());
-        }
+		try {
+			this.reader.setPollTimeout(null);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("pollTimeout must not be null", exception.getMessage());
+		}
 
-        try {
-            this.reader.setPollTimeout(Duration.ZERO);
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("pollTimeout must not be zero", exception.getMessage());
-        }
+		try {
+			this.reader.setPollTimeout(Duration.ZERO);
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("pollTimeout must not be zero", exception.getMessage());
+		}
 
-        try {
-            this.reader.setPollTimeout(Duration.ofSeconds(-1));
-            fail("Expected exception was not thrown");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("pollTimeout must not be negative", exception.getMessage());
-        }
-    }
+		try {
+			this.reader.setPollTimeout(Duration.ofSeconds(-1));
+			fail("Expected exception was not thrown");
+		} catch (IllegalArgumentException exception) {
+			assertEquals("pollTimeout must not be negative", exception.getMessage());
+		}
+	}
 
-    @Test
-    public void testReadFromSinglePartition() {
-        this.template.setDefaultTopic("topic1");
-        this.template.sendDefault("val0");
-        this.template.sendDefault("val1");
-        this.template.sendDefault("val2");
-        this.template.sendDefault("val3");
+	@Test
+	public void testReadFromSinglePartition() {
+		this.template.setDefaultTopic("topic1");
+		this.template.sendDefault("val0");
+		this.template.sendDefault("val1");
+		this.template.sendDefault("val2");
+		this.template.sendDefault("val3");
 
-        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
-        this.reader.setPollTimeout(Duration.ofSeconds(1));
-        this.reader.open(new ExecutionContext());
+		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
+		this.reader.setPollTimeout(Duration.ofSeconds(1));
+		this.reader.open(new ExecutionContext());
 
-        String item = this.reader.read();
-        assertThat(item, is("val0"));
+		String item = this.reader.read();
+		assertThat(item, is("val0"));
 
-        item = this.reader.read();
-        assertThat(item, is("val1"));
+		item = this.reader.read();
+		assertThat(item, is("val1"));
 
-        item = this.reader.read();
-        assertThat(item, is("val2"));
+		item = this.reader.read();
+		assertThat(item, is("val2"));
 
-        item = this.reader.read();
-        assertThat(item, is("val3"));
+		item = this.reader.read();
+		assertThat(item, is("val3"));
 
-        item = this.reader.read();
-        assertNull(item);
+		item = this.reader.read();
+		assertNull(item);
 
-        this.reader.close();
-    }
+		this.reader.close();
+	}
 
-    @Test
-    public void testReadFromMultiplePartitions() {
-        this.template.setDefaultTopic("topic2");
-        this.template.sendDefault("val0");
-        this.template.sendDefault("val1");
-        this.template.sendDefault("val2");
-        this.template.sendDefault("val3");
+	@Test
+	public void testReadFromMultiplePartitions() {
+		this.template.setDefaultTopic("topic2");
+		this.template.sendDefault("val0");
+		this.template.sendDefault("val1");
+		this.template.sendDefault("val2");
+		this.template.sendDefault("val3");
 
-        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic2", 0, 1);
-        this.reader.setPollTimeout(Duration.ofSeconds(1));
-        this.reader.open(new ExecutionContext());
+		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic2", 0, 1);
+		this.reader.setPollTimeout(Duration.ofSeconds(1));
+		this.reader.open(new ExecutionContext());
 
-        List<String> items = new ArrayList<>();
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        assertThat(items, containsInAnyOrder("val0", "val1", "val2", "val3"));
-        String item = this.reader.read();
-        assertNull(item);
+		List<String> items = new ArrayList<>();
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		assertThat(items, containsInAnyOrder("val0", "val1", "val2", "val3"));
+		String item = this.reader.read();
+		assertNull(item);
 
-        this.reader.close();
-    }
+		this.reader.close();
+	}
 
-    @Test
-    public void testReadFromSinglePartitionAfterRestart() {
-        this.template.setDefaultTopic("topic3");
-        this.template.sendDefault("val0");
-        this.template.sendDefault("val1");
-        this.template.sendDefault("val2");
-        this.template.sendDefault("val3");
-        this.template.sendDefault("val4");
+	@Test
+	public void testReadFromSinglePartitionAfterRestart() {
+		this.template.setDefaultTopic("topic3");
+		this.template.sendDefault("val0");
+		this.template.sendDefault("val1");
+		this.template.sendDefault("val2");
+		this.template.sendDefault("val3");
+		this.template.sendDefault("val4");
 
-        ExecutionContext executionContext = new ExecutionContext();
-        Map<TopicPartition, Long> offsets = new HashMap<>();
-        offsets.put(new TopicPartition("topic3", 0), 1L);
-        executionContext.put("topic.partition.offsets", offsets);
+		ExecutionContext executionContext = new ExecutionContext();
+		Map<TopicPartition, Long> offsets = new HashMap<>();
+		offsets.put(new TopicPartition("topic3", 0), 1L);
+		executionContext.put("topic.partition.offsets", offsets);
 
-        // topic3-0: val0, val1, val2, val3, val4
-        //                  ^
-        //                  |
-        //   last committed offset = 1  (should restart from offset = 2)
+		// topic3-0: val0, val1, val2, val3, val4
+		//                  ^
+		//                  |
+		//   last committed offset = 1  (should restart from offset = 2)
 
-        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic3", 0);
-        this.reader.setPollTimeout(Duration.ofSeconds(1));
-        this.reader.open(executionContext);
+		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic3", 0);
+		this.reader.setPollTimeout(Duration.ofSeconds(1));
+		this.reader.open(executionContext);
 
-        List<String> items = new ArrayList<>();
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        assertThat(items, containsInAnyOrder("val2", "val3", "val4"));
-        String item = this.reader.read();
-        assertNull(item);
+		List<String> items = new ArrayList<>();
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		assertThat(items, containsInAnyOrder("val2", "val3", "val4"));
+		String item = this.reader.read();
+		assertNull(item);
 
-        this.reader.close();
-    }
+		this.reader.close();
+	}
 
-    @Test
-    public void testReadFromMultiplePartitionsAfterRestart() throws ExecutionException, InterruptedException {
-        List<ListenableFuture> futures = new ArrayList<>();
-        futures.add(this.template.send("topic4", 0, null, "val0"));
-        futures.add(this.template.send("topic4", 0, null, "val2"));
-        futures.add(this.template.send("topic4", 0, null, "val4"));
-        futures.add(this.template.send("topic4", 0, null, "val6"));
-        futures.add(this.template.send("topic4", 1, null, "val1"));
-        futures.add(this.template.send("topic4", 1, null, "val3"));
-        futures.add(this.template.send("topic4", 1, null, "val5"));
-        futures.add(this.template.send("topic4", 1, null, "val7"));
+	@Test
+	public void testReadFromMultiplePartitionsAfterRestart() throws ExecutionException, InterruptedException {
+		List<ListenableFuture> futures = new ArrayList<>();
+		futures.add(this.template.send("topic4", 0, null, "val0"));
+		futures.add(this.template.send("topic4", 0, null, "val2"));
+		futures.add(this.template.send("topic4", 0, null, "val4"));
+		futures.add(this.template.send("topic4", 0, null, "val6"));
+		futures.add(this.template.send("topic4", 1, null, "val1"));
+		futures.add(this.template.send("topic4", 1, null, "val3"));
+		futures.add(this.template.send("topic4", 1, null, "val5"));
+		futures.add(this.template.send("topic4", 1, null, "val7"));
 
-        for (ListenableFuture future : futures) {
-            future.get();
-        }
+		for (ListenableFuture future : futures) {
+			future.get();
+		}
 
-        ExecutionContext executionContext = new ExecutionContext();
-        Map<TopicPartition, Long> offsets = new HashMap<>();
-        offsets.put(new TopicPartition("topic4", 0), 1L);
-        offsets.put(new TopicPartition("topic4", 1), 2L);
-        executionContext.put("topic.partition.offsets", offsets);
+		ExecutionContext executionContext = new ExecutionContext();
+		Map<TopicPartition, Long> offsets = new HashMap<>();
+		offsets.put(new TopicPartition("topic4", 0), 1L);
+		offsets.put(new TopicPartition("topic4", 1), 2L);
+		executionContext.put("topic.partition.offsets", offsets);
 
-        // topic4-0: val0, val2, val4, val6
-        //                   ^
-        //                   |
-        //   last committed  offset = 1  (should restart from offset = 2)
-        // topic4-1: val1, val3, val5, val7
-        //                         ^
-        //                         |
-        //         last committed  offset = 2  (should restart from offset = 3)
+		// topic4-0: val0, val2, val4, val6
+		//                   ^
+		//                   |
+		//   last committed  offset = 1  (should restart from offset = 2)
+		// topic4-1: val1, val3, val5, val7
+		//                         ^
+		//                         |
+		//         last committed  offset = 2  (should restart from offset = 3)
 
-        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic4", 0, 1);
-        this.reader.setPollTimeout(Duration.ofSeconds(1));
-        this.reader.open(executionContext);
+		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic4", 0, 1);
+		this.reader.setPollTimeout(Duration.ofSeconds(1));
+		this.reader.open(executionContext);
 
-        List<String> items = new ArrayList<>();
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        items.add(this.reader.read());
-        assertThat(items, containsInAnyOrder("val4", "val6", "val7"));
-        String item = this.reader.read();
-        assertNull(item);
+		List<String> items = new ArrayList<>();
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		items.add(this.reader.read());
+		assertThat(items, containsInAnyOrder("val4", "val6", "val7"));
+		String item = this.reader.read();
+		assertNull(item);
 
-        this.reader.close();
-    }
+		this.reader.close();
+	}
 
-    @Test
-    public void testReadCustomDeserializer() {
+	@Test
+	public void testReadCustomDeserializer() {
 
-        Deserializer<String> deserializer = new StringDeserializer() {
-            @Override
-            public String deserialize(String topic, byte[] data) {
-                return "Custom";
-            }
-        };
+		Deserializer<String> deserializer = new StringDeserializer() {
+			@Override
+			public String deserialize(String topic, byte[] data) {
+				return "Custom";
+			}
+		};
 
-        this.template.setDefaultTopic("topic1");
-        this.template.sendDefault("val0");
+		this.template.setDefaultTopic("topic1");
+		this.template.sendDefault("val0");
 
-        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
-        this.reader.setPollTimeout(Duration.ofSeconds(1));
-        this.reader.setValueDeserializer(deserializer);
-        this.reader.open(new ExecutionContext());
+		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
+		this.reader.setPollTimeout(Duration.ofSeconds(1));
+		this.reader.setValueDeserializer(deserializer);
+		this.reader.open(new ExecutionContext());
 
-        String item = this.reader.read();
-        assertThat(item, is("Custom"));
+		String item = this.reader.read();
+		assertThat(item, is("Custom"));
 
-        this.reader.close();
-    }
+		this.reader.close();
+	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
@@ -17,22 +17,18 @@
 package org.springframework.batch.item.kafka;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -43,10 +39,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Mathieu Ouellet
@@ -54,266 +47,278 @@ import static org.junit.Assert.fail;
  */
 public class KafkaItemReaderTests {
 
-	@ClassRule
-	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1);
+    @ClassRule
+    public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1);
 
-	private KafkaItemReader<String, String> reader;
-	private KafkaTemplate<String, String> template;
-	private Properties consumerProperties;
+    private KafkaItemReader<String, String> reader;
+    private KafkaTemplate<String, String> template;
+    private Properties consumerProperties;
 
-	@BeforeClass
-	public static void setUpTopics() {
-		embeddedKafka.getEmbeddedKafka().addTopics(
-				new NewTopic("topic1", 1, (short) 1),
-				new NewTopic("topic2", 2, (short) 1),
-				new NewTopic("topic3", 1, (short) 1),
-				new NewTopic("topic4", 2, (short) 1)
-		);
-	}
+    @BeforeClass
+    public static void setUpTopics() {
+        embeddedKafka.getEmbeddedKafka().addTopics(
+                new NewTopic("topic1", 1, (short) 1),
+                new NewTopic("topic2", 2, (short) 1),
+                new NewTopic("topic3", 1, (short) 1),
+                new NewTopic("topic4", 2, (short) 1)
+        );
+    }
 
-	@Before
-	public void setUp() {
-		Map<String, Object> producerProperties = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
-		ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(producerProperties);
-		this.template = new KafkaTemplate<>(producerFactory);
+    @Before
+    public void setUp() {
+        Map<String, Object> producerProperties = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
+        ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(producerProperties);
+        this.template = new KafkaTemplate<>(producerFactory);
 
-		this.consumerProperties = new Properties();
-		this.consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-				embeddedKafka.getEmbeddedKafka().getBrokersAsString());
-		this.consumerProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "1");
-		this.consumerProperties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-				StringDeserializer.class.getName());
-		this.consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-				StringDeserializer.class.getName());
-	}
+        this.consumerProperties = new Properties();
+        this.consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                embeddedKafka.getEmbeddedKafka().getBrokersAsString());
+        this.consumerProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "1");
+        this.consumerProperties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getName());
+        this.consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getName());
+    }
 
-	@Test
-	public void testValidation() {
-		try {
-			new KafkaItemReader<>(null, "topic", 0);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("Consumer properties must not be null", exception.getMessage());
-		}
+    @Test
+    public void testValidation() {
+        try {
+            new KafkaItemReader<>(null, "topic", 0);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("Consumer properties must not be null", exception.getMessage());
+        }
 
-		try {
-			new KafkaItemReader<>(new Properties(), "topic", 0);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("bootstrap.servers property must be provided", exception.getMessage());
-		}
+        try {
+            new KafkaItemReader<>(new Properties(), "topic", 0);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("bootstrap.servers property must be provided", exception.getMessage());
+        }
 
-		Properties consumerProperties = new Properties();
-		consumerProperties.put("bootstrap.servers", embeddedKafka.getEmbeddedKafka());
-		try {
-			new KafkaItemReader<>(consumerProperties, "topic", 0);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("group.id property must be provided", exception.getMessage());
-		}
+        Properties consumerProperties = new Properties();
+        consumerProperties.put("bootstrap.servers", embeddedKafka.getEmbeddedKafka());
+        try {
+            new KafkaItemReader<>(consumerProperties, "topic", 0);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("group.id property must be provided", exception.getMessage());
+        }
 
-		consumerProperties.put("group.id", "1");
-		try {
-			new KafkaItemReader<>(consumerProperties, "topic", 0);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("key.deserializer property must be provided", exception.getMessage());
-		}
+        consumerProperties.put("group.id", "1");
+        try {
+            new KafkaItemReader<>(consumerProperties, "topic", 0);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("key.deserializer property must be provided", exception.getMessage());
+        }
 
-		consumerProperties.put("key.deserializer", StringDeserializer.class.getName());
-		try {
-			new KafkaItemReader<>(consumerProperties, "topic", 0);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("value.deserializer property must be provided", exception.getMessage());
-		}
+        consumerProperties.put("key.deserializer", StringDeserializer.class.getName());
+        try {
+            new KafkaItemReader<>(consumerProperties, "topic", 0);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("value.deserializer property must be provided", exception.getMessage());
+        }
 
-		consumerProperties.put("value.deserializer", StringDeserializer.class.getName());
-		try {
-			new KafkaItemReader<>(consumerProperties, "", 0);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("Topic name must not be null or empty", exception.getMessage());
-		}
+        consumerProperties.put("value.deserializer", StringDeserializer.class.getName());
+        try {
+            new KafkaItemReader<>(consumerProperties, "", 0);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("Topic name must not be null or empty", exception.getMessage());
+        }
 
-		try {
-			this.reader = new KafkaItemReader<>(consumerProperties, "topic");
-			fail("Expected exception was not thrown");
-		}
-		catch (Exception exception) {
-			assertEquals("At least one partition must be provided", exception.getMessage());
-		}
+        try {
+            this.reader = new KafkaItemReader<>(consumerProperties, "topic");
+            fail("Expected exception was not thrown");
+        } catch (Exception exception) {
+            assertEquals("At least one partition must be provided", exception.getMessage());
+        }
 
-		try {
-			this.reader = new KafkaItemReader<>(consumerProperties, "topic", 0);
-		}
-		catch (Exception exception) {
-			fail("Must not throw an exception when configuration is valid");
-		}
+        try {
+            this.reader = new KafkaItemReader<>(consumerProperties, "topic", 0);
+        } catch (Exception exception) {
+            fail("Must not throw an exception when configuration is valid");
+        }
 
-		try {
-			this.reader.setPollTimeout(null);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("pollTimeout must not be null", exception.getMessage());
-		}
+        try {
+            this.reader.setPollTimeout(null);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("pollTimeout must not be null", exception.getMessage());
+        }
 
-		try {
-			this.reader.setPollTimeout(Duration.ZERO);
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("pollTimeout must not be zero", exception.getMessage());
-		}
+        try {
+            this.reader.setPollTimeout(Duration.ZERO);
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("pollTimeout must not be zero", exception.getMessage());
+        }
 
-		try {
-			this.reader.setPollTimeout(Duration.ofSeconds(-1));
-			fail("Expected exception was not thrown");
-		}
-		catch (IllegalArgumentException exception) {
-			assertEquals("pollTimeout must not be negative", exception.getMessage());
-		}
-	}
+        try {
+            this.reader.setPollTimeout(Duration.ofSeconds(-1));
+            fail("Expected exception was not thrown");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("pollTimeout must not be negative", exception.getMessage());
+        }
+    }
 
-	@Test
-	public void testReadFromSinglePartition() {
-		this.template.setDefaultTopic("topic1");
-		this.template.sendDefault("val0");
-		this.template.sendDefault("val1");
-		this.template.sendDefault("val2");
-		this.template.sendDefault("val3");
+    @Test
+    public void testReadFromSinglePartition() {
+        this.template.setDefaultTopic("topic1");
+        this.template.sendDefault("val0");
+        this.template.sendDefault("val1");
+        this.template.sendDefault("val2");
+        this.template.sendDefault("val3");
 
-		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
-		this.reader.setPollTimeout(Duration.ofSeconds(1));
-		this.reader.open(new ExecutionContext());
+        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
+        this.reader.setPollTimeout(Duration.ofSeconds(1));
+        this.reader.open(new ExecutionContext());
 
-		String item = this.reader.read();
-		assertThat(item, is("val0"));
+        String item = this.reader.read();
+        assertThat(item, is("val0"));
 
-		item = this.reader.read();
-		assertThat(item, is("val1"));
+        item = this.reader.read();
+        assertThat(item, is("val1"));
 
-		item = this.reader.read();
-		assertThat(item, is("val2"));
+        item = this.reader.read();
+        assertThat(item, is("val2"));
 
-		item = this.reader.read();
-		assertThat(item, is("val3"));
+        item = this.reader.read();
+        assertThat(item, is("val3"));
 
-		item = this.reader.read();
-		assertNull(item);
+        item = this.reader.read();
+        assertNull(item);
 
-		this.reader.close();
-	}
+        this.reader.close();
+    }
 
-	@Test
-	public void testReadFromMultiplePartitions() {
-		this.template.setDefaultTopic("topic2");
-		this.template.sendDefault("val0");
-		this.template.sendDefault("val1");
-		this.template.sendDefault("val2");
-		this.template.sendDefault("val3");
+    @Test
+    public void testReadFromMultiplePartitions() {
+        this.template.setDefaultTopic("topic2");
+        this.template.sendDefault("val0");
+        this.template.sendDefault("val1");
+        this.template.sendDefault("val2");
+        this.template.sendDefault("val3");
 
-		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic2", 0, 1);
-		this.reader.setPollTimeout(Duration.ofSeconds(1));
-		this.reader.open(new ExecutionContext());
+        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic2", 0, 1);
+        this.reader.setPollTimeout(Duration.ofSeconds(1));
+        this.reader.open(new ExecutionContext());
 
-		List<String> items = new ArrayList<>();
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		assertThat(items, containsInAnyOrder("val0", "val1", "val2", "val3"));
-		String item = this.reader.read();
-		assertNull(item);
+        List<String> items = new ArrayList<>();
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        assertThat(items, containsInAnyOrder("val0", "val1", "val2", "val3"));
+        String item = this.reader.read();
+        assertNull(item);
 
-		this.reader.close();
-	}
+        this.reader.close();
+    }
 
-	@Test
-	public void testReadFromSinglePartitionAfterRestart() {
-		this.template.setDefaultTopic("topic3");
-		this.template.sendDefault("val0");
-		this.template.sendDefault("val1");
-		this.template.sendDefault("val2");
-		this.template.sendDefault("val3");
-		this.template.sendDefault("val4");
+    @Test
+    public void testReadFromSinglePartitionAfterRestart() {
+        this.template.setDefaultTopic("topic3");
+        this.template.sendDefault("val0");
+        this.template.sendDefault("val1");
+        this.template.sendDefault("val2");
+        this.template.sendDefault("val3");
+        this.template.sendDefault("val4");
 
-		ExecutionContext executionContext = new ExecutionContext();
-		Map<TopicPartition, Long> offsets = new HashMap<>();
-		offsets.put(new TopicPartition("topic3", 0), 1L);
-		executionContext.put("topic.partition.offsets", offsets);
+        ExecutionContext executionContext = new ExecutionContext();
+        Map<TopicPartition, Long> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("topic3", 0), 1L);
+        executionContext.put("topic.partition.offsets", offsets);
 
-		// topic3-0: val0, val1, val2, val3, val4
-		//                  ^
-		//                  |
-		//   last committed offset = 1  (should restart from offset = 2)
+        // topic3-0: val0, val1, val2, val3, val4
+        //                  ^
+        //                  |
+        //   last committed offset = 1  (should restart from offset = 2)
 
-		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic3", 0);
-		this.reader.setPollTimeout(Duration.ofSeconds(1));
-		this.reader.open(executionContext);
+        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic3", 0);
+        this.reader.setPollTimeout(Duration.ofSeconds(1));
+        this.reader.open(executionContext);
 
-		List<String> items = new ArrayList<>();
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		assertThat(items, containsInAnyOrder("val2", "val3", "val4"));
-		String item = this.reader.read();
-		assertNull(item);
+        List<String> items = new ArrayList<>();
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        assertThat(items, containsInAnyOrder("val2", "val3", "val4"));
+        String item = this.reader.read();
+        assertNull(item);
 
-		this.reader.close();
-	}
+        this.reader.close();
+    }
 
-	@Test
-	public void testReadFromMultiplePartitionsAfterRestart() throws ExecutionException, InterruptedException {
-		List<ListenableFuture> futures = new ArrayList<>();
-		futures.add(this.template.send("topic4", 0, null, "val0"));
-		futures.add(this.template.send("topic4", 0, null, "val2"));
-		futures.add(this.template.send("topic4", 0, null, "val4"));
-		futures.add(this.template.send("topic4", 0, null, "val6"));
-		futures.add(this.template.send("topic4", 1, null, "val1"));
-		futures.add(this.template.send("topic4", 1, null, "val3"));
-		futures.add(this.template.send("topic4", 1, null, "val5"));
-		futures.add(this.template.send("topic4", 1, null, "val7"));
+    @Test
+    public void testReadFromMultiplePartitionsAfterRestart() throws ExecutionException, InterruptedException {
+        List<ListenableFuture> futures = new ArrayList<>();
+        futures.add(this.template.send("topic4", 0, null, "val0"));
+        futures.add(this.template.send("topic4", 0, null, "val2"));
+        futures.add(this.template.send("topic4", 0, null, "val4"));
+        futures.add(this.template.send("topic4", 0, null, "val6"));
+        futures.add(this.template.send("topic4", 1, null, "val1"));
+        futures.add(this.template.send("topic4", 1, null, "val3"));
+        futures.add(this.template.send("topic4", 1, null, "val5"));
+        futures.add(this.template.send("topic4", 1, null, "val7"));
 
-		for (ListenableFuture future : futures) {
-			future.get();
-		}
+        for (ListenableFuture future : futures) {
+            future.get();
+        }
 
-		ExecutionContext executionContext = new ExecutionContext();
-		Map<TopicPartition, Long> offsets = new HashMap<>();
-		offsets.put(new TopicPartition("topic4", 0), 1L);
-		offsets.put(new TopicPartition("topic4", 1), 2L);
-		executionContext.put("topic.partition.offsets", offsets);
+        ExecutionContext executionContext = new ExecutionContext();
+        Map<TopicPartition, Long> offsets = new HashMap<>();
+        offsets.put(new TopicPartition("topic4", 0), 1L);
+        offsets.put(new TopicPartition("topic4", 1), 2L);
+        executionContext.put("topic.partition.offsets", offsets);
 
-		// topic4-0: val0, val2, val4, val6
-		//                   ^
-		//                   |
-		//   last committed  offset = 1  (should restart from offset = 2)
-		// topic4-1: val1, val3, val5, val7
-		//                         ^
-		//                         |
-		//         last committed  offset = 2  (should restart from offset = 3)
+        // topic4-0: val0, val2, val4, val6
+        //                   ^
+        //                   |
+        //   last committed  offset = 1  (should restart from offset = 2)
+        // topic4-1: val1, val3, val5, val7
+        //                         ^
+        //                         |
+        //         last committed  offset = 2  (should restart from offset = 3)
 
-		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic4", 0, 1);
-		this.reader.setPollTimeout(Duration.ofSeconds(1));
-		this.reader.open(executionContext);
+        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic4", 0, 1);
+        this.reader.setPollTimeout(Duration.ofSeconds(1));
+        this.reader.open(executionContext);
 
-		List<String> items = new ArrayList<>();
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		items.add(this.reader.read());
-		assertThat(items, containsInAnyOrder("val4", "val6", "val7"));
-		String item = this.reader.read();
-		assertNull(item);
+        List<String> items = new ArrayList<>();
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        items.add(this.reader.read());
+        assertThat(items, containsInAnyOrder("val4", "val6", "val7"));
+        String item = this.reader.read();
+        assertNull(item);
 
-		this.reader.close();
-	}
+        this.reader.close();
+    }
 
+    @Test
+    public void testReadCustomDeserializer() {
+
+        Deserializer<String> deserializer = new StringDeserializer() {
+            @Override
+            public String deserialize(String topic, byte[] data) {
+                return "Custom";
+            }
+        };
+
+        this.template.setDefaultTopic("topic1");
+        this.template.sendDefault("val0");
+
+        this.reader = new KafkaItemReader<>(this.consumerProperties, "topic1", 0);
+        this.reader.setPollTimeout(Duration.ofSeconds(1));
+        this.reader.setValueDeserializer(deserializer);
+        this.reader.open(new ExecutionContext());
+
+        String item = this.reader.read();
+        assertThat(item, is("Custom"));
+
+        this.reader.close();
+    }
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -213,6 +214,7 @@ public class KafkaItemReaderBuilderTests {
 		Duration pollTimeout = Duration.ofSeconds(100);
 		String topic = "test";
 		List<Integer> partitions = Arrays.asList(0, 1);
+		Deserializer<String> deserializer = new StringDeserializer();
 
 		// when
 		KafkaItemReader<String, String> reader = new KafkaItemReaderBuilder<String, String>()
@@ -222,6 +224,8 @@ public class KafkaItemReaderBuilderTests {
 				.partitions(partitions)
 				.pollTimeout(pollTimeout)
 				.saveState(saveState)
+				.keyDeserializer(deserializer)
+				.valueDeserializer(deserializer)
 				.build();
 
 		// then
@@ -234,5 +238,7 @@ public class KafkaItemReaderBuilderTests {
 		assertEquals(partitions.get(0).intValue(), topicPartitions.get(0).partition());
 		assertEquals(topic, topicPartitions.get(1).topic());
 		assertEquals(partitions.get(1).intValue(), topicPartitions.get(1).partition());
+		assertEquals(deserializer, ReflectionTestUtils.getField(reader, "keyDeserializer"));
+		assertEquals(deserializer, ReflectionTestUtils.getField(reader, "valueDeserializer"));
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Jean-Francois Larouche
  */
 public class KafkaItemReaderBuilderTests {
 


### PR DESCRIPTION
Hi,

I have a case where i need a full integration test with EmbeddedKafka

To make the integration test work, i need to use MockSchemaRegistryClient from io.confluent, because our serializers are KafkaAvroSerializer/Deserializer.

Those 2 needs a schemaRegistry, and the only way to mock it is to explicitly create them with the mock.
```
    @Bean
    KafkaAvroDeserializer kafkaAvroDeserializer() {
        KafkaAvroDeserializer deserializer = new KafkaAvroDeserializer(schemaRegistryClient(), props.buildConsumerProperties());
        return deserializer;
    }
```
Exposing Deserializer in KafkaItemReaderBuilder make customization possible, since KafkaConsumer constructor allow it. (KafkaItemReader line 167)
This is not only for test case but any deserialiser could be configured to use Spring injected beans.

Producer do not have this problem since it goes through a KafkaTemplate
