### PR TITLE
BATCH-2837: Support empty or no comments in FlatFileItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilder.java
@@ -512,10 +512,7 @@ public class FlatFileItemReaderBuilder<T> {
 		}
 
 		reader.setLinesToSkip(this.linesToSkip);
-
-		if(!this.comments.isEmpty()) {
-			reader.setComments(this.comments.toArray(new String[this.comments.size()]));
-		}
+		reader.setComments(this.comments.toArray(new String[this.comments.size()]));
 
 		reader.setSkippedLinesCallback(this.skippedLinesCallback);
 		reader.setRecordSeparatorPolicy(this.recordSeparatorPolicy);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -274,6 +274,51 @@ public class FlatFileItemReaderBuilderTests {
 	}
 
 	@Test
+	public void testEmptyComments() throws Exception {
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>()
+				.name("fooReader")
+				.resource(getResource("1,2,3\n4,5,6"))
+				.comments(new String[]{})
+				.delimited()
+				.names("first", "second", "third")
+				.targetType(Foo.class)
+				.build();
+
+		reader.open(new ExecutionContext());
+		Foo item = reader.read();
+		assertEquals(1, item.getFirst());
+		assertEquals(2, item.getSecond());
+		assertEquals("3", item.getThird());
+		item = reader.read();
+		assertEquals(4, item.getFirst());
+		assertEquals(5, item.getSecond());
+		assertEquals("6", item.getThird());
+		assertNull(reader.read());
+	}
+
+	@Test
+	public void testDefaultComments() throws Exception {
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>()
+				.name("fooReader")
+				.resource(getResource("1,2,3\n4,5,6"))
+				.delimited()
+				.names("first", "second", "third")
+				.targetType(Foo.class)
+				.build();
+
+		reader.open(new ExecutionContext());
+		Foo item = reader.read();
+		assertEquals(1, item.getFirst());
+		assertEquals(2, item.getSecond());
+		assertEquals("3", item.getThird());
+		item = reader.read();
+		assertEquals(4, item.getFirst());
+		assertEquals(5, item.getSecond());
+		assertEquals("6", item.getThird());
+		assertNull(reader.read());
+	}
+
+	@Test
 	public void testPrototypeBean() throws Exception {
 		BeanFactory factory = new AnnotationConfigApplicationContext(Beans.class);
 


### PR DESCRIPTION
Previously, if supplying empty comments or no comments to `comments()` of the `FlatFileItemReaderBuilder`, the comments would be ignored and instead use the default comments `"#"` provided by the `FlatFileItemReader`.

Resolves BATCH-2837