### PR TITLE
BATCH-2847: Add getUniqueJobParametersBuilder() in JobLauncherTestUtils

### DIFF
--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/AbstractIoSampleTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/AbstractIoSampleTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -89,6 +90,10 @@ public abstract class AbstractIoSampleTests {
 
 	protected JobParameters getUniqueJobParameters() {
 		return jobLauncherTestUtils.getUniqueJobParameters();
+	}
+
+	protected JobParametersBuilder getUniqueJobParametersBuilder() {
+		return jobLauncherTestUtils.getUniqueJobParametersBuilder();
 	}
 
 	/**

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/DelimitedFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/DelimitedFunctionalTests.java
@@ -38,7 +38,7 @@ public class DelimitedFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected void pointReaderToOutput(ItemReader<CustomerCredit> reader) {
-		JobParameters jobParameters = new JobParametersBuilder(super.getUniqueJobParameters()).addString("inputFile",
+		JobParameters jobParameters = super.getUniqueJobParametersBuilder().addString("inputFile",
 				"file:./build/test-outputs/delimitedOutput.csv").toJobParameters();
 		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
 		StepSynchronizationManager.close();
@@ -47,7 +47,7 @@ public class DelimitedFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected JobParameters getUniqueJobParameters() {
-		return new JobParametersBuilder(super.getUniqueJobParameters()).addString("inputFile",
+		return super.getUniqueJobParametersBuilder().addString("inputFile",
 				"data/iosample/input/delimited.csv").addString("outputFile",
 				"file:./build/test-outputs/delimitedOutput.csv").toJobParameters();
 	}

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/FixedLengthFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/FixedLengthFunctionalTests.java
@@ -33,7 +33,7 @@ public class FixedLengthFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected void pointReaderToOutput(ItemReader<CustomerCredit> reader) {
-		JobParameters jobParameters = new JobParametersBuilder(super.getUniqueJobParameters()).addString("inputFile",
+		JobParameters jobParameters = super.getUniqueJobParametersBuilder().addString("inputFile",
 				"file:./build/test-outputs/fixedLengthOutput.txt").toJobParameters();
 		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
 		StepSynchronizationManager.close();
@@ -42,7 +42,7 @@ public class FixedLengthFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected JobParameters getUniqueJobParameters() {
-		return new JobParametersBuilder(super.getUniqueJobParameters()).addString("inputFile",
+		return super.getUniqueJobParametersBuilder().addString("inputFile",
 				"data/iosample/input/fixedLength.txt").addString("outputFile",
 				"file:./build/test-outputs/fixedLengthOutput.txt").toJobParameters();
 	}

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/JdbcPagingFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/JdbcPagingFunctionalTests.java
@@ -38,7 +38,7 @@ public class JdbcPagingFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected void pointReaderToOutput(ItemReader<CustomerCredit> reader) {
-		JobParameters jobParameters = new JobParametersBuilder(super.getUniqueJobParameters()).addDouble("credit", 0.)
+		JobParameters jobParameters = super.getUniqueJobParametersBuilder().addDouble("credit", 0.)
 				.toJobParameters();
 		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
 		StepSynchronizationManager.close();
@@ -47,7 +47,7 @@ public class JdbcPagingFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected JobParameters getUniqueJobParameters() {
-		return new JobParametersBuilder(super.getUniqueJobParameters()).addDouble("credit", 10000.).toJobParameters();
+		return super.getUniqueJobParametersBuilder().addDouble("credit", 10000.).toJobParameters();
 	}
 
 }

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/MultiResourceFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/MultiResourceFunctionalTests.java
@@ -37,7 +37,7 @@ public class MultiResourceFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected void pointReaderToOutput(ItemReader<CustomerCredit> reader) {
-		JobParameters jobParameters = new JobParametersBuilder(super.getUniqueJobParameters()).addString(
+		JobParameters jobParameters = super.getUniqueJobParametersBuilder().addString(
 				"input.file.path", "file:build/test-outputs/multiResourceOutput.csv.*").toJobParameters();
 		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
 		StepSynchronizationManager.close();
@@ -46,7 +46,7 @@ public class MultiResourceFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected JobParameters getUniqueJobParameters() {
-		JobParametersBuilder builder = new JobParametersBuilder(super.getUniqueJobParameters());
+		JobParametersBuilder builder = super.getUniqueJobParametersBuilder();
 		return builder.addString("input.file.path", "classpath:data/iosample/input/delimited*.csv").addString(
 				"output.file.path", "file:build/test-outputs/multiResourceOutput.csv").toJobParameters();
 	}

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/RepositoryFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/RepositoryFunctionalTests.java
@@ -32,7 +32,7 @@ public class RepositoryFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected void pointReaderToOutput(ItemReader<CustomerCredit> reader) {
-		JobParameters jobParameters = new JobParametersBuilder(super.getUniqueJobParameters()).addDouble("credit", 0.)
+		JobParameters jobParameters = super.getUniqueJobParametersBuilder().addDouble("credit", 0.)
 				.toJobParameters();
 		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution(jobParameters);
 		StepSynchronizationManager.close();
@@ -41,6 +41,6 @@ public class RepositoryFunctionalTests extends AbstractIoSampleTests {
 
 	@Override
 	protected JobParameters getUniqueJobParameters() {
-		return new JobParametersBuilder(super.getUniqueJobParameters()).addString("credit", "10000").toJobParameters();
+		return super.getUniqueJobParametersBuilder().addString("credit", "10000").toJobParameters();
 	}
 }

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
@@ -25,6 +25,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.job.SimpleJob;
@@ -163,6 +164,14 @@ public class JobLauncherTestUtils {
 		parameters.put("random", new JobParameter((long) (Math.random() * JOB_PARAMETER_MAXIMUM)));
 		return new JobParameters(parameters);
 	}
+
+    /**
+     * @return a new JobParametersBuilder object containing only a parameter for the
+     * current timestamp, to ensure that the job instance will be unique.
+     */
+    public JobParametersBuilder getUniqueJobParametersBuilder() {
+        return new JobParametersBuilder(this.getUniqueJobParameters());
+    }
 
 	/**
 	 * Convenient method for subclasses to grab a {@link StepRunner} for running


### PR DESCRIPTION
JobLauncherTestUtils often uses the getUniqueJobParameters method.
But it seems a bit cumbersome to use this method with other JobParameters.
In the same case, I use it like this:


```
new JobParametersBuilder(jobLauncherTestUtils.getUniqueJobParameters())
.addString()
.addDouble()
```

I want to make this convenient.

```
jobLauncherTestUtils.getUniqueJobParametersBuilder()
.addString()
.addDouble()
```
