### PR TITLE
Add connection parameter to AbstractCursorItemReader#cleanupOnClose

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
@@ -396,9 +396,9 @@ implements InitializingBean {
 		initialized = false;
 		JdbcUtils.closeResultSet(this.rs);
 		rs = null;
-		cleanupOnClose();
+		cleanupOnClose(con);
 
-		if(this.con != null) {
+		if(this.con != null && !this.con.isClosed()) {
 			this.con.setAutoCommit(this.initialConnectionAutoCommit);
 		}
 
@@ -413,7 +413,22 @@ implements InitializingBean {
 		}
 	}
 
+	/**
+	 * Clean up resources.
+	 * @throws Exception If unable to clean up resources
+	 * @deprecated This method is deprecated in favor of
+	 * {@link AbstractCursorItemReader#cleanupOnClose(java.sql.Connection)} and
+	 * will be removed in a future release
+	 */
+	@Deprecated
 	protected abstract void cleanupOnClose()  throws Exception;
+
+	/**
+	 * Clean up resources.
+	 * @param connection to the database
+	 * @throws Exception If unable to clean up resources
+	 */
+	protected abstract void cleanupOnClose(Connection connection)  throws Exception;
 
 	/**
 	 * Execute the statement to open the cursor.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
@@ -50,6 +50,7 @@ import org.springframework.util.ClassUtils;
  * @author Peter Zozom
  * @author Robert Kasanicky
  * @author Thomas Risberg
+ * @author Mahmoud Ben Hassine
  */
 public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
@@ -143,9 +144,23 @@ public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
 	/**
 	 * Close the cursor and database connection.
+	 * @deprecated This method is deprecated in favor of
+	 * {@link JdbcCursorItemReader#cleanupOnClose(java.sql.Connection)} and will
+	 * be removed in a future release
 	 */
 	@Override
+	@Deprecated
 	protected void cleanupOnClose() throws Exception {
+		JdbcUtils.closeStatement(this.preparedStatement);
+	}
+
+	/**
+	 * Close the cursor and database connection.
+	 * @param connection to the database
+	 */
+	@Override
+	protected void cleanupOnClose(Connection connection) throws Exception {
+		JdbcUtils.closeConnection(connection);
 		JdbcUtils.closeStatement(this.preparedStatement);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
@@ -55,6 +55,7 @@ import org.springframework.util.ClassUtils;
  * </p>
  *
  * @author Thomas Risberg
+ * @author Mahmoud Ben Hassine
  */
 public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 
@@ -239,9 +240,23 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 
 	/**
 	 * Close the cursor and database connection.
+	 * @deprecated This method is deprecated in favor of
+	 * {@link StoredProcedureItemReader#cleanupOnClose(java.sql.Connection)} and
+	 * will be removed in a future release
 	 */
 	@Override
+	@Deprecated
 	protected void cleanupOnClose() throws Exception {
+		JdbcUtils.closeStatement(this.callableStatement);
+	}
+
+	/**
+	 * Close the cursor and database connection.
+	 * @param connection to the database
+	 */
+	@Override
+	protected void cleanupOnClose(Connection connection) throws Exception {
+		JdbcUtils.closeConnection(connection);
 		JdbcUtils.closeStatement(this.callableStatement);
 	}
 


### PR DESCRIPTION
This change makes it possible to (re)use the same connection used in the
openCursor method to clean up resources when the reader is closed.

Resolves [BATCH-1899](https://jira.spring.io/browse/BATCH-1899).