### PR TITLE
Ability to rely on the offset saved in kafka

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
@@ -35,6 +35,9 @@ import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 /**
  * <p>
  * An {@link org.springframework.batch.item.ItemReader} implementation for Apache Kafka.
@@ -48,6 +51,7 @@ import org.springframework.util.Assert;
  *
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Christian Allard
  * @since 4.2
  */
 public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
@@ -144,11 +148,8 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 	public void open(ExecutionContext executionContext) {
 		this.kafkaConsumer = new KafkaConsumer<>(this.consumerProperties);
 		this.partitionOffsets = new HashMap<>();
-		for (TopicPartition topicPartition : this.topicPartitions) {
-			this.partitionOffsets.put(topicPartition, 0L);
-		}
 		if (this.saveState && executionContext.containsKey(TOPIC_PARTITION_OFFSETS)) {
-			Map<TopicPartition, Long> offsets = (Map<TopicPartition, Long>) executionContext.get(TOPIC_PARTITION_OFFSETS);
+			Map<TopicPartition, Long> offsets = defaultIfNull((Map<TopicPartition, Long>) executionContext.get(TOPIC_PARTITION_OFFSETS), emptyMap());
 			for (Map.Entry<TopicPartition, Long> entry : offsets.entrySet()) {
 				this.partitionOffsets.put(entry.getKey(), entry.getValue() == 0 ? 0 : entry.getValue() + 1);
 			}


### PR DESCRIPTION
Hi,

The problem is that the reader overrides the fetch offsets even when we don't want to rely on the saved state from the execution context.

By removing the initialization of the partition offsets list, the customer relies on the values stored in the broker.

If the topic has not been read yet, the customer can now use the "auto.offset.reset" configuration to apply the corresponding behavior.