### PR TITLE
BATCH-2849 Account For Different Whitespaces In Keyword Removal

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -242,9 +242,9 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 
 	private String removeKeyWord(String keyWord, String clause) {
 		String temp = clause.trim();
-		String keyWordString = keyWord + " ";
-		if (temp.toLowerCase().startsWith(keyWordString) && temp.length() > keyWordString.length()) {
-			return temp.substring(keyWordString.length());
+		int len = keyWord.length();
+		if (temp.toLowerCase().startsWith(keyWord) && Character.isWhitespace(temp.charAt(len)) && temp.length() > len + 1) {
+			return temp.substring(len + 1);
 		}
 		else {
 			return temp;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Benjamin Hetz
  * @since 2.0
  */
 public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvider {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
@@ -105,6 +105,51 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 	}
 	
 	@Test
+	public void testRemoveKeyWordsFollowedBySpaceChar() {
+		String selectWithSpace = "SELECT id, 'yes', false";
+		String fromWithSpace = "FROM test.verification_table";
+		String whereWithSpace = "WHERE TRUE";
+		pagingQueryProvider.setSelectClause( selectWithSpace );
+		pagingQueryProvider.setFromClause( fromWithSpace );
+		pagingQueryProvider.setWhereClause( whereWithSpace );
+		
+		
+		assertEquals("id, 'yes', false", pagingQueryProvider.getSelectClause());
+		assertEquals("test.verification_table", pagingQueryProvider.getFromClause());
+		assertEquals("TRUE", pagingQueryProvider.getWhereClause());
+	}
+
+	@Test
+	public void testRemoveKeyWordsFollowedByTabChar() {
+		String selectWithSpace = "SELECT\tid, 'yes', false";
+		String fromWithSpace = "FROM\ttest.verification_table";
+		String whereWithSpace = "WHERE\tTRUE";
+		pagingQueryProvider.setSelectClause( selectWithSpace );
+		pagingQueryProvider.setFromClause( fromWithSpace );
+		pagingQueryProvider.setWhereClause( whereWithSpace );
+
+
+		assertEquals("id, 'yes', false", pagingQueryProvider.getSelectClause());
+		assertEquals("test.verification_table", pagingQueryProvider.getFromClause());
+		assertEquals("TRUE", pagingQueryProvider.getWhereClause());
+	}
+
+	@Test
+	public void testRemoveKeyWordsFollowedByNewLineChar() {
+		String selectWithSpace = "SELECT\nid, 'yes', false";
+		String fromWithSpace = "FROM\ntest.verification_table";
+		String whereWithSpace = "WHERE\nTRUE";
+		pagingQueryProvider.setSelectClause( selectWithSpace );
+		pagingQueryProvider.setFromClause( fromWithSpace );
+		pagingQueryProvider.setWhereClause( whereWithSpace );
+
+
+		assertEquals("id, 'yes', false", pagingQueryProvider.getSelectClause());
+		assertEquals("test.verification_table", pagingQueryProvider.getFromClause());
+		assertEquals("TRUE", pagingQueryProvider.getWhereClause());
+	}
+	
+	@Test
 	public abstract void testGenerateFirstPageQuery();
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
@@ -106,12 +106,12 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 	
 	@Test
 	public void testRemoveKeyWordsFollowedBySpaceChar() {
-		String selectWithSpace = "SELECT id, 'yes', false";
-		String fromWithSpace = "FROM test.verification_table";
-		String whereWithSpace = "WHERE TRUE";
-		pagingQueryProvider.setSelectClause( selectWithSpace );
-		pagingQueryProvider.setFromClause( fromWithSpace );
-		pagingQueryProvider.setWhereClause( whereWithSpace );
+		String selectClause = "SELECT id, 'yes', false";
+		String fromClause = "FROM test.verification_table";
+		String whereClause = "WHERE TRUE";
+		pagingQueryProvider.setSelectClause( selectClause );
+		pagingQueryProvider.setFromClause( fromClause );
+		pagingQueryProvider.setWhereClause( whereClause );
 		
 		
 		assertEquals("id, 'yes', false", pagingQueryProvider.getSelectClause());
@@ -121,12 +121,12 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 
 	@Test
 	public void testRemoveKeyWordsFollowedByTabChar() {
-		String selectWithSpace = "SELECT\tid, 'yes', false";
-		String fromWithSpace = "FROM\ttest.verification_table";
-		String whereWithSpace = "WHERE\tTRUE";
-		pagingQueryProvider.setSelectClause( selectWithSpace );
-		pagingQueryProvider.setFromClause( fromWithSpace );
-		pagingQueryProvider.setWhereClause( whereWithSpace );
+		String selectClause = "SELECT\tid, 'yes', false";
+		String fromClause = "FROM\ttest.verification_table";
+		String whereClause = "WHERE\tTRUE";
+		pagingQueryProvider.setSelectClause( selectClause );
+		pagingQueryProvider.setFromClause( fromClause );
+		pagingQueryProvider.setWhereClause( whereClause );
 
 
 		assertEquals("id, 'yes', false", pagingQueryProvider.getSelectClause());
@@ -136,12 +136,12 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 
 	@Test
 	public void testRemoveKeyWordsFollowedByNewLineChar() {
-		String selectWithSpace = "SELECT\nid, 'yes', false";
-		String fromWithSpace = "FROM\ntest.verification_table";
-		String whereWithSpace = "WHERE\nTRUE";
-		pagingQueryProvider.setSelectClause( selectWithSpace );
-		pagingQueryProvider.setFromClause( fromWithSpace );
-		pagingQueryProvider.setWhereClause( whereWithSpace );
+		String selectClause = "SELECT\nid, 'yes', false";
+		String fromClause = "FROM\ntest.verification_table";
+		String whereClause = "WHERE\nTRUE";
+		pagingQueryProvider.setSelectClause( selectClause );
+		pagingQueryProvider.setFromClause( fromClause );
+		pagingQueryProvider.setWhereClause( whereClause );
 
 
 		assertEquals("id, 'yes', false", pagingQueryProvider.getSelectClause());


### PR DESCRIPTION
Modify `removeKeyWord(...)` such that the keyword is removed regardless
of what kind of whitespace follows. This is especially useful for those
who read in SQL from a file which has been formatted such that keywords
live on their own lines.

Add unit tests for trimming whitespace.

Resolves [BATCH-2849](https://jira.spring.io/browse/BATCH-2849)