### PR TITLE
Change default value of comment prefix in FlatFileItemReaderBuilder to be consistent with FlatFileItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * about the problematic line and its line number.
  * 
  * @author Robert Kasanicky
+ * @author Mahmoud Ben Hassine
  */
 public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements
 		ResourceAwareItemReaderItemStream<T>, InitializingBean {
@@ -50,6 +51,8 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 	// default encoding for input files
 	public static final String DEFAULT_CHARSET = Charset.defaultCharset().name();
 
+	public static final String[] DEFAULT_COMMENT_PREFIXES = new String[] { "#" };
+
 	private RecordSeparatorPolicy recordSeparatorPolicy = new SimpleRecordSeparatorPolicy();
 
 	private Resource resource;
@@ -58,7 +61,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 
 	private int lineCount = 0;
 
-	private String[] comments = new String[] { "#" };
+	private String[] comments = DEFAULT_COMMENT_PREFIXES;
 
 	private boolean noInput = false;
 
@@ -134,7 +137,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 
 	/**
 	 * Setter for comment prefixes. Can be used to ignore header lines as well by using e.g. the first couple of column
-	 * names as a prefix.
+	 * names as a prefix. Defaults to {@link #DEFAULT_COMMENT_PREFIXES}.
 	 * 
 	 * @param comments an array of comment line prefixes.
 	 */

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilder.java
@@ -76,7 +76,8 @@ public class FlatFileItemReaderBuilder<T> {
 
 	private Resource resource;
 
-	private List<String> comments = new ArrayList<>();
+	private List<String> comments =
+			new ArrayList<>(Arrays.asList(FlatFileItemReader.DEFAULT_COMMENT_PREFIXES));
 
 	private int linesToSkip = 0;
 
@@ -171,6 +172,7 @@ public class FlatFileItemReaderBuilder<T> {
 
 	/**
 	 * Add a string to the list of Strings that indicate commented lines.
+	 * Defaults to {@link FlatFileItemReader#DEFAULT_COMMENT_PREFIXES}.
 	 *
 	 * @param comment the string to define a commented line.
 	 * @return The current instance of the builder.
@@ -183,7 +185,7 @@ public class FlatFileItemReaderBuilder<T> {
 
 	/**
 	 * An array of Strings that indicate lines that are comments (and therefore skipped by
-	 * the reader.
+	 * the reader). Defaults to {@link FlatFileItemReader#DEFAULT_COMMENT_PREFIXES}.
 	 *
 	 * @param comments an array of strings to identify comments.
 	 * @return The current instance of the builder.

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -254,7 +254,7 @@ public class FlatFileItemReaderBuilderTests {
 	public void testComments() throws Exception {
 		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>()
 				.name("fooReader")
-				.resource(getResource("1,2,3\n@this is a comment\n+so is this\n4,5,6"))
+				.resource(getResource("1,2,3\n@this is a comment\n+so is this\n#so is this too\n4,5,6"))
 				.comments("@", "+")
 				.delimited()
 				.names("first", "second", "third")


### PR DESCRIPTION
Before this PR, the default value of comment prefix in `FlatFileItemReaderBuilder` was not consistent with the one in `FlatFileItemReader`.

This commit changes the default value of comment prefix to `#` in the builder to be consistent with the reader.

Resolves [BATCH-2861](https://jira.spring.io/browse/BATCH-2861).