### PR TITLE
Update BeanWrapperFieldExtractor.java to support delimiter and quote character.

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
@@ -27,16 +27,78 @@ import org.springframework.util.Assert;
 
 /**
  * This is a field extractor for a java bean. Given an array of property names,
- * it will reflectively call getters on the item and return an array of all the
- * values.
+ * a delimiter and a quote character, it will reflectively call getters on the
+ * item and return an array of all the values with eventually the quote character.
  * 
  * @author Dan Garrette
+ * @author ADANSAR Mohamed
  * @since 2.0
  */
 public class BeanWrapperFieldExtractor<T> implements FieldExtractor<T>, InitializingBean {
 
+	/**
+	 * Convenient constant for the common case of a comma delimiter.
+	 */
+	public static final String DELIMITER_COMMA = ",";
+	
+	/**
+	 * Convenient constant for the common case of a " character used to escape delimiters or line endings.
+	 */
+	public static final char DEFAULT_QUOTE_CHARACTER = '"';
+
+	// the delimiter character used when reading input.
+	private String delimiter;
+
+	private char quoteCharacter = DEFAULT_QUOTE_CHARACTER;
+
+	private String quoteString;
+
 	private String[] names;
 
+	/**
+	 * Create a new instance of the {@link BeanWrapperFieldExtractorWithDelimiter} class for the common case where the delimiter is a
+	 * {@link #DELIMITER_COMMA comma}.
+	 *
+	 * @see #BeanWrapperFieldExtractor(String)
+	 * @see #DELIMITER_COMMA
+	 */
+	public BeanWrapperFieldExtractorWithDelimiter() {
+		this(DELIMITER_COMMA);
+	}
+
+	/**
+	 * Create a new instance of the {@link BeanWrapperFieldExtractorWithDelimiter} class.
+	 *
+	 * @param delimiter
+	 *            the desired delimiter
+	 */
+	public BeanWrapperFieldExtractorWithDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+		setQuoteCharacter(DEFAULT_QUOTE_CHARACTER);
+	}
+
+	/**
+	 * Setter for the quoteCharacter. The quote character can be used to extend a field across line endings or to enclose a String which contains the
+	 * delimiter.
+	 *
+	 * @param quoteCharacter
+	 *            the quoteCharacter to set
+	 *
+	 */
+	public void setQuoteCharacter(char quoteCharacter) {
+		this.quoteCharacter = quoteCharacter;
+		this.quoteString = "" + quoteCharacter;
+	}
+	
+	/**
+	 * Setter for the delimiter character.
+  	 *
+	 * @param delimiter
+	 */
+	public void setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+	}
+	
 	/**
 	 * @param names field names to be extracted by the {@link #extract(Object)} method.
 	 */
@@ -54,7 +116,12 @@ public class BeanWrapperFieldExtractor<T> implements FieldExtractor<T>, Initiali
 
 		BeanWrapper bw = new BeanWrapperImpl(item);
 		for (String propertyName : this.names) {
-			values.add(bw.getPropertyValue(propertyName));
+			Object myObject = bw.getPropertyValue(propertyName);
+			if (myObject instanceof String && ((String) myObject).contains(delimiter)) {
+				values.add(quoteString + myObject + quoteString);
+			} else {
+				values.add(myObject);
+          		}
 		}
 		return values.toArray();
 	}


### PR DESCRIPTION
Supporting the quote character like the delimited tokenizer does.
If the value of the item contains the delimiter, the quote character is added to the value of the constructed array.
the quote character can be used to extend a field across line endings or to enclose a String which contains the delimiter.