### PR TITLE
Improve performance in JdbcStepExecutionDao

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
@@ -97,7 +97,7 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 			" from %PREFIX%JOB_EXECUTION JE, %PREFIX%STEP_EXECUTION SE" +
 			" where " +
 			"      SE.JOB_EXECUTION_ID in (SELECT JOB_EXECUTION_ID from %PREFIX%JOB_EXECUTION " +
-			"where JE.JOB_INSTANCE_ID = ?)" +
+			"where JOB_INSTANCE_ID = ?)" +
 			"      and SE.JOB_EXECUTION_ID = JE.JOB_EXECUTION_ID " +
 			"      and SE.STEP_NAME = ?" +
 			" order by SE.START_TIME desc, SE.STEP_EXECUTION_ID desc";


### PR DESCRIPTION
Optimize SQL in GET_LAST_STEP_EXECUTION to work fast on large amount of records in %PREFIX%JOB_EXECUTION table

Fix for https://github.com/spring-projects/spring-batch/issues/3634

@pivotal-issuemaster This is an Obvious Fix