### PR TITLE
Added comparator for state transitions when using java config

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.batch.core.job.flow.Flow;
 import org.springframework.batch.core.job.flow.FlowExecutionStatus;
 import org.springframework.batch.core.job.flow.JobExecutionDecider;
 import org.springframework.batch.core.job.flow.State;
+import org.springframework.batch.core.job.flow.support.DefaultStateTransitionComparator;
 import org.springframework.batch.core.job.flow.support.SimpleFlow;
 import org.springframework.batch.core.job.flow.support.StateTransition;
 import org.springframework.batch.core.job.flow.support.state.DecisionState;
@@ -44,6 +45,7 @@ import org.springframework.core.task.TaskExecutor;
  * conditional transitions that depend on the exit status of the previous step.
  *
  * @author Dave Syer
+ * @author Michael Minella
  *
  * @since 2.2
  *
@@ -244,6 +246,7 @@ public class FlowBuilder<Q> {
 		}
 		addDanglingEndStates();
 		flow.setStateTransitions(transitions);
+		flow.setStateTransitionComparator(new DefaultStateTransitionComparator());
 		dirty = false;
 		return flow;
 	}


### PR DESCRIPTION
Spring Batch orders the transitions as it goes from state to state based
on specificity.  The XML configuration has always had this
functionality.  However, when creating the JSR-352 implementation, the
mechanism for which this occured was refactored.  That occured at about
the same time as the java builders were introduced.  Because of this
crossing of paths, the java configuration option for defining jobs has
never correctly sorted the transitions.  This PR applys the sorting
algorithm to the java configuration, making XML and java configuration
behave the same.

Resolves #3638