### PR TITLE
Add documentation for how an ItemProcessor.process can never receive …

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemProcessor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item;
 
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
 /**
@@ -36,12 +37,13 @@ public interface ItemProcessor<I, O> {
 	 * processing.  If the returned result is null, it is assumed that processing of the item
 	 * should not continue.
 	 * 
-	 * @param item to be processed
+	 * @param item to be processed.  A {@code null} will never reach this method because the only possible sources 
+	 * are ItemReader (which indicates no more items) and ItemProcessor (which indicates a filtered item). 
 	 * @return potentially modified or new item for continued processing, {@code null} if processing of the
 	 *  provided item should not continue.
 	 *
 	 * @throws Exception thrown if exception occurs during processing.
 	 */
 	@Nullable
-	O process(I item) throws Exception;
+	O process(@NonNull I item) throws Exception;
 }


### PR DESCRIPTION
…a null item.

I realized this while working on a task.  I think it could prompt someone to save an unnecessary null check in an ItemProcessor.  Let me know if my logic is incorrect or could be better worded.