### PR TITLE
Add usePersist chain method to JpaItemWriterBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilder.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
 public class JpaItemWriterBuilder<T> {
 
 	private EntityManagerFactory entityManagerFactory;
+	private boolean usePersist = false;
 
 	/**
 	 * The JPA {@link EntityManagerFactory} to obtain an entity manager from. Required.
@@ -45,6 +46,19 @@ public class JpaItemWriterBuilder<T> {
 	}
 
 	/**
+	 * Set whether the entity manager should perform a persist instead of a merge.
+	 *
+	 * @param usePersist defaults to false
+	 * @return this instance for method chaining
+	 * @see JpaItemWriter#setUsePersist(boolean)
+	 */
+	public JpaItemWriterBuilder<T> usePersist(boolean usePersist) {
+		this.usePersist = usePersist;
+
+		return this;
+	}
+
+	/**
 	 * Returns a fully built {@link JpaItemWriter}.
 	 *
 	 * @return the writer
@@ -55,6 +69,7 @@ public class JpaItemWriterBuilder<T> {
 
 		JpaItemWriter<T> writer = new JpaItemWriter<>();
 		writer.setEntityManagerFactory(this.entityManagerFactory);
+		writer.setUsePersist(this.usePersist);
 
 		return writer;
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilderTests.java
@@ -84,4 +84,22 @@ public class JpaItemWriterBuilderTests {
 			assertEquals("Incorrect message", "EntityManagerFactory must be provided", ise.getMessage());
 		}
 	}
+
+	@Test
+	public void testPersist() throws Exception {
+		JpaItemWriter<String> itemWriter = new JpaItemWriterBuilder<String>()
+				.entityManagerFactory(this.entityManagerFactory)
+				.usePersist(true)
+				.build();
+
+		itemWriter.afterPropertiesSet();
+
+		List<String> items = Arrays.asList("foo", "bar");
+
+		itemWriter.write(items);
+
+		verify(this.entityManager).persist(items.get(0));
+		verify(this.entityManager).persist(items.get(1));
+	}
+
 }


### PR DESCRIPTION
Hi!

I found that commit "BATCH-2462 Allow JpaItemWriter to support persist rather than merge for improved performance." have not appropriate change in builder.
I add new chain method to builder "usePersist" by analogy from original commit.