### PR TITLE
Add method StepExecutionDao.countStepExecutions to eliminate for-loop in SimpleJobRepository.getStepExecutionCount

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapStepExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,5 +171,18 @@ public class MapStepExecutionDao implements StepExecutionDao {
 		for (StepExecution stepExecution: stepExecutions) {
 			saveStepExecution(stepExecution);
 		}
+	}
+
+	@Override
+	public int countStepExecutions(JobInstance jobInstance, String stepName) {
+		int count = 0;
+
+		for (StepExecution stepExecution : executionsByStepExecutionId.values()) {
+			if (stepExecution.getStepName().equals(stepName) && stepExecution.getJobExecution().getJobInstance()
+					.getInstanceId() == jobInstance.getInstanceId()) {
+				count++;
+			}
+		}
+		return count;
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,4 +86,15 @@ public interface StepExecutionDao {
 	 */
 	void addStepExecutions(JobExecution jobExecution);
 
+	/**
+	 * Counts all the {@link StepExecution} for a given step name.
+	 *
+	 * @param jobInstance the parent {@link JobInstance}
+	 * @param stepName the name of the step
+	 * @since 4.3
+	 * @return the count of {@link StepExecution}s for a given step
+	 */
+	default int countStepExecutions(JobInstance jobInstance, String stepName) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import java.util.List;
  * @author Robert Kasanicky
  * @author David Turanski
  * @author Mahmoud Ben Hassine
+ * @author Baris Cubukcuoglu
  *
  * @see JobRepository
  * @see JobInstanceDao
@@ -235,17 +236,7 @@ public class SimpleJobRepository implements JobRepository {
 	 */
 	@Override
 	public int getStepExecutionCount(JobInstance jobInstance, String stepName) {
-		int count = 0;
-		List<JobExecution> jobExecutions = jobExecutionDao.findJobExecutions(jobInstance);
-		for (JobExecution jobExecution : jobExecutions) {
-			stepExecutionDao.addStepExecutions(jobExecution);
-			for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
-				if (stepName.equals(stepExecution.getStepName())) {
-					count++;
-				}
-			}
-		}
-		return count;
+		return stepExecutionDao.countStepExecutions(jobInstance, stepName);
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDaoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.repository.dao;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -75,4 +76,16 @@ public class JdbcStepExecutionDaoTests extends AbstractStepExecutionDaoTests {
 				.length() < stepExecution.getExitStatus().getExitDescription().length());
 	}
 
+	@Transactional
+	@Test
+	public void testCountStepExecutions() {
+		// Given
+		dao.saveStepExecution(stepExecution);
+
+		// When
+		int result = dao.countStepExecutions(jobInstance, stepExecution.getStepName());
+
+		// Then
+		assertEquals(1, result);
+	}
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/MapStepExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/MapStepExecutionDaoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,4 +117,26 @@ public class MapStepExecutionDaoTests extends AbstractStepExecutionDaoTests {
 		assertEquals(BatchStatus.COMPLETED, jobStepExecution.getStatus());
 	}
 
+	@Test
+	public void testCountStepExecutions() {
+		// Given
+		StepExecutionDao tested = new MapStepExecutionDao();
+		JobExecution jobExecution = new JobExecution(jobInstance, 88L, null, null);
+
+		StepExecution firstStepExecution = new StepExecution("Step one", jobExecution);
+		firstStepExecution.setStatus(BatchStatus.STARTED);
+
+		tested.saveStepExecution(firstStepExecution);
+
+		StepExecution secondStepExecution = new StepExecution("Step two", jobExecution);
+		secondStepExecution.setStatus(BatchStatus.STARTED);
+
+		tested.saveStepExecution(secondStepExecution);
+
+		// When
+		int result = tested.countStepExecutions(jobInstance, firstStepExecution.getStepName());
+
+		// Then
+		assertEquals(1, result);
+	}
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 package org.springframework.batch.core.repository.support;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,6 +57,7 @@ import org.springframework.batch.core.step.StepSupport;
  * @author Lucas Ward
  * @author Will Schipp
  * @author Dimitrios Liapis
+ * @author Baris Cubukcuoglu
  *
  */
 public class SimpleJobRepositoryTests {
@@ -272,4 +274,16 @@ public class SimpleJobRepositoryTests {
 		jobRepository.createJobExecution("foo", new JobParameters());
 	}
 
+	@Test
+	public void testGetStepExecutionCount() {
+		// Given
+		int expectedResult = 1;
+		when(stepExecutionDao.countStepExecutions(jobInstance, "stepName")).thenReturn(expectedResult);
+
+		// When
+		int actualResult = jobRepository.getStepExecutionCount(jobInstance, "stepName");
+
+		// Then
+		assertEquals(expectedResult, actualResult);
+	}
 }


### PR DESCRIPTION
In order to eliminate the high amount of CPU utilization, this PR adds a new API method `StepExecutionDao.countStepExecutions`. For implementation `JdbcStepExecutionDao` this method counts the step executions in the underlying database. For `MapStepExecutionDao` this method iterates the ConcurrentHashMap to find the right JobExecutions according to the given JobInstance. Furthermore, this PR has some unit tests to verify the proper functionality. 

Fixes:
https://github.com/spring-projects/spring-batch/issues/3657