### PR TITLE
[BATCH-3654] Add topic to KafkaItemWriter

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.util.Assert;
  * A builder implementation for the {@link KafkaItemWriter}
  *
  * @author Mathieu Ouellet
+ * @author Takaaki Shimbo
  * @since 4.2
  */
 public class KafkaItemWriterBuilder<K, V> {
@@ -34,6 +35,8 @@ public class KafkaItemWriterBuilder<K, V> {
 	private Converter<V, K> itemKeyMapper;
 
 	private boolean delete;
+
+	private String topic;
 
 	/**
 	 * Establish the KafkaTemplate to be used by the KafkaItemWriter.
@@ -72,6 +75,21 @@ public class KafkaItemWriterBuilder<K, V> {
 	}
 
 	/**
+	 * Set the topic that the record will be appended to.
+	 * If this value is not set, the default topic of #{@link KafkaTemplate} is used.
+	 *
+	 * @param topic name that the record will be appended to.
+	 * @return The current instance of the builder.
+	 * @author Takaaki Shimbo
+	 * @since 4.3
+	 * @see KafkaItemWriter#setTopic(String)
+	 */
+	public KafkaItemWriterBuilder<K, V> topic(String topic) {
+		this.topic = topic;
+		return this;
+	}
+
+	/**
 	 * Validates and builds a {@link KafkaItemWriter}.
 	 * @return a {@link KafkaItemWriter}
 	 */
@@ -83,6 +101,7 @@ public class KafkaItemWriterBuilder<K, V> {
 		writer.setKafkaTemplate(this.kafkaTemplate);
 		writer.setItemKeyMapper(this.itemKeyMapper);
 		writer.setDelete(this.delete);
+		writer.setTopic(this.topic);
 		return writer;
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -31,6 +31,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * @author Takaaki Shimbo
+ */
 public class KafkaItemWriterTests {
 
 	@Mock
@@ -39,6 +42,10 @@ public class KafkaItemWriterTests {
 	private KafkaItemKeyMapper itemKeyMapper;
 
 	private KafkaItemWriter<String, String> writer;
+
+	private String defaultTopic = "defaultTopic";
+
+	private String topic = "topic";
 
 	@Before
 	public void setUp() throws Exception {
@@ -83,24 +90,47 @@ public class KafkaItemWriterTests {
 	}
 
 	@Test
-	public void testBasicWrite() throws Exception {
+	public void testBasicWriteWithDefaultTopic() throws Exception {
 		List<String> items = Arrays.asList("val1", "val2");
 
 		this.writer.write(items);
 
-		verify(this.kafkaTemplate).sendDefault(items.get(0), items.get(0));
-		verify(this.kafkaTemplate).sendDefault(items.get(1), items.get(1));
+		verify(this.kafkaTemplate).send(defaultTopic, items.get(0), items.get(0));
+		verify(this.kafkaTemplate).send(defaultTopic, items.get(1), items.get(1));
 	}
 
 	@Test
-	public void testBasicDelete() throws Exception {
+	public void testBasicDeleteWithDefaultTopic() throws Exception {
 		List<String> items = Arrays.asList("val1", "val2");
 		this.writer.setDelete(true);
 
 		this.writer.write(items);
 
-		verify(this.kafkaTemplate).sendDefault(items.get(0), null);
-		verify(this.kafkaTemplate).sendDefault(items.get(1), null);
+		verify(this.kafkaTemplate).send(defaultTopic, items.get(0), null);
+		verify(this.kafkaTemplate).send(defaultTopic, items.get(1), null);
+	}
+
+	@Test
+	public void testBasicWriteWithSetTopic() throws Exception {
+		List<String> items = Arrays.asList("val1", "val2");
+		this.writer.setTopic(topic);
+
+		this.writer.write(items);
+
+		verify(this.kafkaTemplate).send(topic, items.get(0), items.get(0));
+		verify(this.kafkaTemplate).send(topic, items.get(1), items.get(1));
+	}
+
+	@Test
+	public void testBasicDeleteWithSetTopic() throws Exception {
+		List<String> items = Arrays.asList("val1", "val2");
+		this.writer.setDelete(true);
+		this.writer.setTopic(topic);
+
+		this.writer.write(items);
+
+		verify(this.kafkaTemplate).send(topic, items.get(0), null);
+		verify(this.kafkaTemplate).send(topic, items.get(1), null);
 	}
 
 	static class KafkaItemKeyMapper implements Converter<String, String> {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mathieu Ouellet
+ * @author Takaaki Shimbo
  */
 public class KafkaItemWriterBuilderTests {
 
@@ -70,15 +71,20 @@ public class KafkaItemWriterBuilderTests {
 	public void testKafkaItemWriterBuild() {
 		// given
 		boolean delete = true;
+		String topic = "topic";
 
 		// when
 		KafkaItemWriter<String, String> writer = new KafkaItemWriterBuilder<String, String>()
-				.kafkaTemplate(this.kafkaTemplate).itemKeyMapper(this.itemKeyMapper).delete(delete).build();
-
+				.kafkaTemplate(this.kafkaTemplate)
+				.itemKeyMapper(this.itemKeyMapper)
+				.topic(topic)
+				.delete(delete)
+				.build();
 		// then
 		assertTrue((Boolean) ReflectionTestUtils.getField(writer, "delete"));
 		assertEquals(this.itemKeyMapper, ReflectionTestUtils.getField(writer, "itemKeyMapper"));
 		assertEquals(this.kafkaTemplate, ReflectionTestUtils.getField(writer, "kafkaTemplate"));
+		assertEquals(topic, ReflectionTestUtils.getField(writer, "topic"));
 	}
 
 	static class KafkaItemKeyMapper implements Converter<String, String> {


### PR DESCRIPTION
This PR makes it possible to set a topic other than the default topic of `KafkaTemplate` to `KafkaItemWriter`.
We can use `KafkaItemWriter` as a thread-safe kafka producer by setting a topic.