### PR TITLE
Added support when no Query Limit or Pagesize provided for MongoItemReader and MongoItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemReader.java
@@ -79,6 +79,7 @@ import org.springframework.util.StringUtils;
  * @author Michael Minella
  * @author Takaaki Iida
  * @author Mahmoud Ben Hassine
+ * @author Parikshit Dutta
  */
 public class MongoItemReader<T> extends AbstractPaginatedDataItemReader<T> implements InitializingBean {
 	
@@ -240,10 +241,6 @@ public class MongoItemReader<T> extends AbstractPaginatedDataItemReader<T> imple
 		
 		if (queryString != null) {
 			Assert.state(sort != null, "A sort is required.");
-		}
-
-		if (query != null && query.getLimit() != 0) {
-			log.warn("PageSize in Query object was ignored. Please set it by MongoItemReader.setPageSize().");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilder.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
  * @author Drummond Dawson
+ * @author Parikshit Dutta
  * @since 4.0
  * @see MongoItemReader
  */
@@ -285,9 +286,6 @@ public class MongoItemReaderBuilder<T> {
 
 		if(StringUtils.hasText(this.jsonQuery)) {
 			Assert.notNull(this.sorts, "sorts map is required.");
-		}
-		else {
-			Assert.state(this.query.getLimit() != 0, "PageSize in Query object was ignored.");
 		}
 
 		MongoItemReader<T> reader = new MongoItemReader<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+/**
+ * @author Parikshit Dutta
+ */
 public class MongoItemReaderTests {
 
 	private MongoItemReader<String> reader;
@@ -310,7 +313,46 @@ public class MongoItemReaderTests {
 		assertEquals(100, actualQuery.getLimit());
 		assertEquals(0, actualQuery.getSkip());
 	}
-	
+
+	@Test
+	public void testQueryObjectWithoutLimit() throws Exception {
+		reader = new MongoItemReader<>();
+		reader.setTemplate(template);
+
+		reader.setQuery(new Query());
+		reader.setTargetType(String.class);
+		reader.setPageSize(100);
+
+		reader.afterPropertiesSet();
+
+		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
+		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+
+		assertFalse(reader.doPageRead().hasNext());
+
+		Query actualQuery = queryContainer.getValue();
+		assertEquals(100, actualQuery.getLimit());
+	}
+
+	@Test
+	public void testQueryObjectWithoutLimitAndPageSize() throws Exception {
+		reader = new MongoItemReader<>();
+		reader.setTemplate(template);
+
+		reader.setQuery(new Query());
+		reader.setTargetType(String.class);
+
+		reader.afterPropertiesSet();
+
+		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
+		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+
+		assertFalse(reader.doPageRead().hasNext());
+
+		Query actualQuery = queryContainer.getValue();
+		assertEquals(10, actualQuery.getLimit());
+	}
+
 	@Test
 	public void testQueryObjectWithCollection() throws Exception {
 		reader = new MongoItemReader<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Glenn Renfro
  * @author Drummond Dawson
+ * @author Parikshit Dutta
  */
 public class MongoItemReaderBuilderTests {
 	@Mock
@@ -143,6 +144,41 @@ public class MongoItemReaderBuilderTests {
 		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
 		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
 		assertEquals("collection", collectionContainer.getValue());
+	}
+
+	@Test
+	public void testWithoutQueryLimit() throws Exception {
+		MongoItemReader<String> reader = new MongoItemReaderBuilder<String>().template(this.template)
+				.targetType(String.class)
+				.query(new Query())
+				.sorts(this.sortOptions)
+				.name("mongoReaderBuilderTest")
+				.pageSize(50)
+				.build();
+
+		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+
+		assertNull("reader should not return result", reader.read());
+
+		Query query = this.queryContainer.getValue();
+		assertEquals(50, query.getLimit());
+	}
+
+	@Test
+	public void testWithoutQueryLimitAndPageSize() throws Exception {
+		MongoItemReader<String> reader = new MongoItemReaderBuilder<String>().template(this.template)
+				.targetType(String.class)
+				.query(new Query())
+				.sorts(this.sortOptions)
+				.name("mongoReaderBuilderTest")
+				.build();
+
+		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+
+		assertNull("reader should not return result", reader.read());
+
+		Query query = this.queryContainer.getValue();
+		assertEquals(10, query.getLimit());
 	}
 
 	@Test


### PR DESCRIPTION
Removed redundant logical checks (asserts) from MongoItemReaderBuilder and MongoItemReader to prevent false alarm for not providing the limit for query or pagesize for the reader. 

Also added additional tests to pass respective scenarios.