### PR TITLE
Updated spring-doc-resources version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ allprojects {
 		jaxbImplVersion = '2.3.0.1'
 		micrometerVersion = '1.3.3'
 		prometheusPushgatewayVersion = '0.8.0'
-		docResourcesVersion = '0.2.0.RELEASE'
+		docResourcesVersion = '0.2.1.RELEASE'
 		assertjVersion='3.15.0'
 		mongoDbDriverSyncVersion='4.0.0-beta1'
 	}


### PR DESCRIPTION
Updated the spring-doc-resources version from 0.2.0 to 0.2.1
to get a bug fix (setting the display width for HTML output).