### PR TITLE
BATCH-2783: Change getUniqueJobParameters() to have a lower chance of repeating

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.test;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -160,7 +161,7 @@ public class JobLauncherTestUtils {
 	 */
 	public JobParameters getUniqueJobParameters() {
 		Map<String, JobParameter> parameters = new HashMap<>();
-		parameters.put("random", new JobParameter((long) (Math.random() * JOB_PARAMETER_MAXIMUM)));
+		parameters.put("random", new JobParameter(new SecureRandom().nextLong()));
 		return new JobParameters(parameters);
 	}
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
@@ -17,7 +17,12 @@ package org.springframework.batch.test;
 
 import org.junit.Test;
 
-import org.springframework.batch.core.*;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
@@ -17,11 +17,7 @@ package org.springframework.batch.test;
 
 import org.junit.Test;
 
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
@@ -35,7 +31,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author mminella
@@ -51,6 +51,18 @@ public class JobLauncherTestUtilsTests {
 		JobExecution execution = testUtils.launchStep("step1");
 
 		assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+	}
+
+	@Test
+	public void getUniqueJobParameters_doesNotRepeatJobParameters() {
+		ApplicationContext context = new AnnotationConfigApplicationContext(TestJobConfiguration.class);
+		JobLauncherTestUtils testUtils = context.getBean(JobLauncherTestUtils.class);
+		Set<JobParameters> jobParametersSeen = new HashSet<>();
+		for (int i = 0; i < 10_000; i++) {
+			JobParameters jobParameters = testUtils.getUniqueJobParameters();
+			assertFalse(jobParametersSeen.contains(jobParameters));
+			jobParametersSeen.add(jobParameters);
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
> ##  Background
> We noticed that integration tests for a batch job (with many tests) were failing intermittently. After debugging, I found that JobLauncherTestUtils.launchJob was occasionally relaunching the same job instance. After looking at the code, I saw that a random number generator was being used which does not guarantee that the number generate would be unique. I believe a UUID would be more appropriate as strongly guarantees that an ID does not repeat (except in highly exceptional cases). This change strongly assures that the JobParameter is unique every time getUniqueJobParameters() is called.
> 
