### PR TITLE
Fix for reading fixed length resources without line ending

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FixedLengthBufferedReaderFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FixedLengthBufferedReaderFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.file;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.core.io.Resource;
+
+/**
+ * The {@link BufferedReaderFactory} strategy provides custom implementation of {@link BufferedReader}, that splits a
+ * stream based on a fixed line length (rather than the usual convention based on plain text).
+ *
+ * @author Parikshit Dutta
+ *
+ * @since 4.3
+ */
+public class FixedLengthBufferedReaderFactory implements BufferedReaderFactory {
+
+	/**
+	 * The default line length value.
+	 */
+	private static final int DEFAULT_LINE_LENGTH = 32;
+	private int lineLength = DEFAULT_LINE_LENGTH;
+
+	/**
+	 * @param lineLength {@link int} indicating what defines the length of a "line".
+	 */
+	public void setLineLength(int lineLength) {
+		this.lineLength = lineLength;
+	}
+
+	@Override
+	public BufferedReader create(Resource resource, String encoding) throws UnsupportedEncodingException, IOException {
+		return new FixedLengthBufferedReader(new InputStreamReader(resource.getInputStream(), encoding), lineLength);
+	}
+
+	/**
+	 * BufferedReader extension that reads lines based on a given length, rather
+	 * than the usual plain text conventions.
+	 *
+	 * @author Parikshit Dutta
+	 *
+	 */
+	private final class FixedLengthBufferedReader extends BufferedReader {
+
+		private int length;
+
+		/**
+		 * @param in A reader
+		 * @param length A integer to determine the read length
+		 */
+		private FixedLengthBufferedReader(Reader in, int length) {
+			super(in);
+			this.length = length;
+		}
+
+		@Override
+		public String readLine() throws IOException {
+
+			StringBuilder buffer = null;
+
+			synchronized (lock) {
+
+				int next = read();
+				if (next == -1) {
+					return null;
+				}
+
+				buffer = new StringBuilder();
+				buffer.append((char)next);
+
+				for (int i = 1; i < length; i++) {
+					next = read();
+					if (next != -1) {
+						buffer.append((char)next);
+					} else {
+						break;
+					}
+				}
+			}
+
+			if (buffer != null && buffer.length() > 0) {
+				return buffer.toString();
+			}
+			return null;
+		}
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FixedLengthBufferedReaderFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FixedLengthBufferedReaderFactoryTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.file;
+
+import java.io.BufferedReader;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Parikshit Dutta
+ *
+ */
+public class FixedLengthBufferedReaderFactoryTests {
+
+	private Resource inputResource =
+			new ByteArrayResource("Sale012019 1   00000011000000000Sale022020 2   00000022000000000".getBytes());
+
+	private Resource inputResource24Bytes =
+			new ByteArrayResource("Sale012019 1   000000110Sale022020 2   000000220".getBytes());
+
+	@Test
+	public void testCreateWithDefaultLineLength() throws Exception {
+
+		FixedLengthBufferedReaderFactory factory = new FixedLengthBufferedReaderFactory();
+
+		BufferedReader reader = factory.create(inputResource, "UTF-8");
+		assertEquals("Sale012019 1   00000011000000000", reader.readLine());
+		assertEquals("Sale022020 2   00000022000000000", reader.readLine());
+		assertEquals(null, reader.readLine());
+	}
+
+	@Test
+	public void testCreateWithUserDefinedLineLength() throws Exception {
+
+		FixedLengthBufferedReaderFactory factory = new FixedLengthBufferedReaderFactory();
+		factory.setLineLength(24);
+
+		BufferedReader reader = factory.create(inputResource24Bytes, "UTF-8");
+		assertEquals("Sale012019 1   000000110", reader.readLine());
+		assertEquals("Sale022020 2   000000220", reader.readLine());
+		assertEquals(null, reader.readLine());
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -23,7 +23,9 @@ import java.util.List;
 import org.junit.Test;
 
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.file.FixedLengthBufferedReaderFactory;
 import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.mapping.PassThroughLineMapper;
 import org.springframework.batch.item.file.separator.DefaultRecordSeparatorPolicy;
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
@@ -49,6 +51,7 @@ import static org.junit.Assert.fail;
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  * @author Drummond Dawson
+ * @author Parikshit Dutta
  */
 public class FlatFileItemReaderBuilderTests {
 
@@ -445,6 +448,26 @@ public class FlatFileItemReaderBuilderTests {
 		assertNull(reader.read());
 	}
 
+	@Test
+	public void testFixedLengthBufferedReaderSetFactory() throws Exception {
+		FlatFileItemReader<String> reader = new FlatFileItemReaderBuilder<String>()
+				.name("stringReader")
+				.resource(getResource("Sale012019 1   00000011000000000Sale022020 2   00000022000000000"))
+				.bufferedReaderFactory(new FixedLengthBufferedReaderFactory())
+				.lineMapper(new PassThroughLineMapper())
+				.targetType(String.class)
+				.build();
+
+		reader.open(new ExecutionContext());
+
+		String fistItem = reader.read();
+		assertEquals("Sale012019 1   00000011000000000", fistItem);
+
+		String secondItem = reader.read();
+		assertEquals("Sale022020 2   00000022000000000", secondItem);
+
+		assertNull(reader.read());
+	}
 
 	@Test
 	public void testName() throws Exception {


### PR DESCRIPTION
New FixedLengthBufferedReaderFactory introduced
Respective tests for FixedLengthBufferedReaderFactory added
Updated FlatFileItemReaderBuilderTests to test FixedLengthBufferedReaderFactory implementation

Fixes BATCH-1064 [ #1064 ]