### PR TITLE
Added support for Named Query in JpaPagingItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNamedQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNamedQueryProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.database.orm;
+
+import javax.persistence.Query;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * <p>
+ * This query provider creates JPA named {@link Query}s.
+ * </p>
+ *
+ * @author Mahmoud Ben Hassine
+ * @author Parikshit Dutta
+ * @since 4.3
+ *
+ * @param <E> entity returned by executing the query
+ */
+public class JpaNamedQueryProvider<E> extends AbstractJpaQueryProvider {
+
+	private Class<E> entityClass;
+
+	private String namedQuery;
+
+	@Override
+	public Query createQuery() {
+		return getEntityManager().createNamedQuery(namedQuery, entityClass);
+	}
+
+	/**
+	 * @param namedQuery name of a jpa named query
+	 */
+	public void setNamedQuery(String namedQuery) {
+		this.namedQuery = namedQuery;
+	}
+
+	/**
+	 * @param entityClazz name of a jpa entity class
+	 */
+	public void setEntityClass(Class<E> entityClazz) {
+		this.entityClass = entityClazz;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.isTrue(StringUtils.hasText(namedQuery), "Named query cannot be empty");
+		Assert.notNull(entityClass, "Entity class cannot be NULL");
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNamedQueryIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNamedQueryIntegrationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.database;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.database.orm.JpaNamedQueryProvider;
+import org.springframework.batch.item.sample.Foo;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+/**
+ * Integration Test for {@link JpaPagingItemReader} and {@link JpaNamedQueryProvider}.
+ *
+ * @author Parikshit Dutta
+ */
+public class JpaPagingItemReaderNamedQueryIntegrationTests
+		extends AbstractGenericDataSourceItemReaderIntegrationTests {
+
+	@Override
+	protected ItemReader<Foo> createItemReader() throws Exception {
+		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
+		factoryBean.setDataSource(dataSource);
+		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+		factoryBean.setPersistenceUnitName("bar");
+		factoryBean.afterPropertiesSet();
+
+		EntityManagerFactory entityManagerFactory = factoryBean.getObject();
+
+		JpaNamedQueryProvider<Foo> jpaNamedQueryProvider = new JpaNamedQueryProvider<>();
+		jpaNamedQueryProvider.setNamedQuery("allFoos");
+		jpaNamedQueryProvider.setEntityClass(Foo.class);
+		jpaNamedQueryProvider.afterPropertiesSet();
+
+		JpaPagingItemReader<Foo> inputSource = new JpaPagingItemReader<>();
+		inputSource.setEntityManagerFactory(entityManagerFactory);
+		inputSource.setQueryProvider(jpaNamedQueryProvider);
+		inputSource.afterPropertiesSet();
+		inputSource.setSaveState(true);
+
+		return inputSource;
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 package org.springframework.batch.item.database.builder;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -26,6 +28,7 @@ import org.junit.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.orm.JpaNamedQueryProvider;
 import org.springframework.batch.item.database.orm.JpaNativeQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -48,6 +51,7 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Michael Minella
+ * @author Parikshit Dutta
  */
 public class JpaPagingItemReaderBuilderTests {
 
@@ -132,6 +136,40 @@ public class JpaPagingItemReaderBuilderTests {
 
 		assertEquals(3, i);
 		assertEquals(0, executionContext.size());
+	}
+
+	@Test
+	public void testConfigurationNamedQueryProvider() throws Exception {
+		JpaNamedQueryProvider<Foo> namedQueryProvider = new JpaNamedQueryProvider<>();
+		namedQueryProvider.setNamedQuery("allFoos");
+		namedQueryProvider.setEntityClass(Foo.class);
+		namedQueryProvider.afterPropertiesSet();
+
+		JpaPagingItemReader<Foo> reader = new JpaPagingItemReaderBuilder<Foo>()
+				.name("fooReader")
+				.entityManagerFactory(this.entityManagerFactory)
+				.queryProvider(namedQueryProvider)
+				.build();
+
+		reader.afterPropertiesSet();
+
+		ExecutionContext executionContext = new ExecutionContext();
+		reader.open(executionContext);
+
+		Foo foo;
+		List<Foo> foos = new ArrayList<>();
+
+		while((foo = reader.read()) != null) {
+			foos.add(foo);
+		}
+
+		reader.update(executionContext);
+		reader.close();
+
+		int id = 0;
+		for (Foo testFoo:foos) {
+			assertEquals(++id, testFoo.getId());
+		}
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.database.orm;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import org.springframework.batch.item.sample.Foo;
+
+/**
+ * Test for {@link JpaNamedQueryProvider}s.
+ *
+ * @author Parikshit Dutta
+ */
+public class JpaNamedQueryProviderTests {
+
+	@Test
+	public void testJpaNamedQueryProviderNamedQueryIsProvided() {
+		JpaNamedQueryProvider<Foo> jpaNamedQueryProvider = new JpaNamedQueryProvider<>();
+		jpaNamedQueryProvider.setEntityClass(Foo.class);
+
+		try {
+			jpaNamedQueryProvider.afterPropertiesSet();
+		}
+		catch (Exception exception) {
+			assertEquals("Named query cannot be empty", exception.getMessage());
+		}
+	}
+
+	@Test
+	public void testJpaNamedQueryProviderEntityClassIsProvided() {
+		JpaNamedQueryProvider<Foo> jpaNamedQueryProvider = new JpaNamedQueryProvider<>();
+		jpaNamedQueryProvider.setNamedQuery("allFoos");
+
+		try {
+			jpaNamedQueryProvider.afterPropertiesSet();
+		}
+		catch (Exception exception) {
+			assertEquals("Entity class cannot be NULL", exception.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
- added new query provider to handle named queries, i.e: JpaNamedQueryProvider 
- added respective tests for JpaNamedQueryProvider
- added integration test for JpaPagingItemReader and JpaNamedQueryProvider
- updated JpaPagingItemReaderBuilderTests with respective test to validate builder with newly introduced query provider

Closes BATCH-1926 [#1667]