### PR TITLE
Implemented BulkOperations API for Remove Operations in MongoItemWriter

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilderTests.java
@@ -23,12 +23,21 @@ import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import org.mockito.MockitoAnnotations;
 
 import org.springframework.batch.item.data.MongoItemWriter;
+import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Query;
 
 import static org.junit.Assert.assertEquals;
@@ -36,14 +45,11 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
+ * @author Parikshit Dutta
  */
 public class MongoItemWriterBuilderTests {
 	@Mock
@@ -51,60 +57,63 @@ public class MongoItemWriterBuilderTests {
 	@Mock
 	private BulkOperations bulkOperations;
 	@Mock
+	DbRefResolver dbRefResolver;
 	private MongoConverter mongoConverter;
 
-	private List<String> items;
+	private List<Item> saveItems;
+	private List<Item> removeItems;
 
 	@Before
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 		when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
 		when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
-		when(this.template.getConverter()).thenReturn(this.mongoConverter);
-		this.items = Arrays.asList("foo", "bar");
+
+		MappingContext mappingContext = new MongoMappingContext();
+		mongoConverter = spy(new MappingMongoConverter(this.dbRefResolver, mappingContext));
+		when(this.template.getConverter()).thenReturn(mongoConverter);
+
+		this.saveItems = Arrays.asList(new Item("Foo"), new Item("Bar"));
+		this.removeItems = Arrays.asList(new Item(1), new Item(2));
 	}
 
 	@Test
 	public void testBasicWrite() throws Exception {
-		MongoItemWriter<String> writer = new MongoItemWriterBuilder<String>().template(this.template).build();
-		writer.write(this.items);
+		MongoItemWriter<Item> writer = new MongoItemWriterBuilder<Item>().template(this.template).build();
+		writer.write(this.saveItems);
 
 		verify(this.template).bulkOps(any(), any(Class.class));
-		verify(this.mongoConverter).write(eq(this.items.get(0)), any(Document.class));
-		verify(this.mongoConverter).write(eq(this.items.get(1)), any(Document.class));
+		verify(this.mongoConverter).write(eq(this.saveItems.get(0)), any(Document.class));
+		verify(this.mongoConverter).write(eq(this.saveItems.get(1)), any(Document.class));
 		verify(this.bulkOperations, times(2)).replaceOne(any(Query.class), any(Object.class), any());
-		verify(this.template, never()).remove(this.items.get(0));
-		verify(this.template, never()).remove(this.items.get(1));
-	}
-
-	@Test
-	public void testDelete() throws Exception {
-		MongoItemWriter<String> writer = new MongoItemWriterBuilder<String>().template(this.template)
-				.delete(true)
-				.build();
-
-		writer.write(this.items);
-
-		verify(this.template).remove(this.items.get(0));
-		verify(this.template).remove(this.items.get(1));
-		verify(this.template, never()).bulkOps(any(), any(Class.class));
-		verify(this.mongoConverter, never()).write(any(), any());
+		verify(this.bulkOperations, never()).remove(any(Query.class));
 	}
 
 	@Test
 	public void testWriteToCollection() throws Exception {
-		MongoItemWriter<String> writer = new MongoItemWriterBuilder<String>().collection("collection")
+		MongoItemWriter<Item> writer = new MongoItemWriterBuilder<Item>().collection("collection")
 				.template(this.template)
 				.build();
 
-		writer.write(this.items);
+		writer.write(this.saveItems);
 
 		verify(this.template).bulkOps(any(), eq("collection"));
-		verify(this.mongoConverter).write(eq(this.items.get(0)), any(Document.class));
-		verify(this.mongoConverter).write(eq(this.items.get(1)), any(Document.class));
+		verify(this.mongoConverter).write(eq(this.saveItems.get(0)), any(Document.class));
+		verify(this.mongoConverter).write(eq(this.saveItems.get(1)), any(Document.class));
 		verify(this.bulkOperations, times(2)).replaceOne(any(Query.class), any(Object.class), any());
-		verify(this.template, never()).remove(this.items.get(0), "collection");
-		verify(this.template, never()).remove(this.items.get(1), "collection");
+		verify(this.bulkOperations, never()).remove(any(Query.class));
+	}
+
+	@Test
+	public void testDelete() throws Exception {
+		MongoItemWriter<Item> writer = new MongoItemWriterBuilder<Item>().template(this.template)
+				.delete(true)
+				.build();
+
+		writer.write(this.removeItems);
+
+		verify(this.template).bulkOps(any(), any(Class.class));
+		verify(this.bulkOperations, times(2)).remove(any(Query.class));
 	}
 
 	@Test
@@ -117,5 +126,16 @@ public class MongoItemWriterBuilderTests {
 			assertEquals("IllegalArgumentException message did not match the expected result.", "template is required.",
 					iae.getMessage());
 		}
+	}
+}
+
+class Item {
+	Integer id;
+	String name;
+	public Item(Integer id){
+		this.id = id;
+	}
+	public Item(String name) {
+		this.name = name;
 	}
 }


### PR DESCRIPTION
- implemented BulkOperations API for Remove Operations in MongoItemWriter
- added / updated respective tests in MongoItemWriterTests to validate done changes
- updated respective tests in MongoItemWriterBuilderTests to validate done changes

Closes BATCH-3737 [#3737]