### PR TITLE
Updated StaxEventItemReaderBuilder To Make Resource Optional

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilder.java
@@ -21,6 +21,9 @@ import java.util.List;
 
 import javax.xml.stream.XMLInputFactory;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.batch.item.xml.StaxEventItemReader;
 import org.springframework.batch.item.xml.StaxUtils;
 import org.springframework.core.io.Resource;
@@ -34,9 +37,12 @@ import org.springframework.util.StringUtils;
  * @author Michael Minella
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
+ * @author Parikshit Dutta
  * @since 4.0
  */
 public class StaxEventItemReaderBuilder<T> {
+
+	protected Log logger = LogFactory.getLog(getClass());
 
 	private boolean strict = true;
 
@@ -215,9 +221,12 @@ public class StaxEventItemReaderBuilder<T> {
 	 * @return a new instance of the {@link StaxEventItemReader}
 	 */
 	public StaxEventItemReader<T> build() {
-		Assert.notNull(this.resource, "A resource is required.");
-
 		StaxEventItemReader<T> reader = new StaxEventItemReader<>();
+
+		if(this.resource == null) {
+			logger.debug("The resource is null.  This is only a valid scenario when " +
+					"injecting resource later as in when using the MultiResourceItemReader");
+		}
 
 		if (this.saveState) {
 			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilderTests.java
@@ -35,11 +35,13 @@ import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Parikshit Dutta
  */
 public class StaxEventItemReaderBuilderTests {
 
@@ -58,13 +60,6 @@ public class StaxEventItemReaderBuilderTests {
 
 	@Test
 	public void testValidation() {
-		try {
-			new StaxEventItemReaderBuilder<Foo>().build();
-			fail("Validation of the missing resource failed");
-		}
-		catch (IllegalArgumentException ignore) {
-		}
-
 		try {
 			new StaxEventItemReaderBuilder<Foo>()
 					.resource(this.resource)
@@ -86,6 +81,16 @@ public class StaxEventItemReaderBuilderTests {
 		catch (IllegalArgumentException iae) {
 			assertEquals("At least one fragment root element is required", iae.getMessage());
 		}
+	}
+
+	@Test
+	public void testBuildWithoutProvidingResource() {
+		StaxEventItemReader<Foo> reader = new StaxEventItemReaderBuilder<Foo>()
+				.name("fooReader")
+				.addFragmentRootElements("foo")
+				.build();
+
+		assertNotNull(reader);
 	}
 
 	@Test


### PR DESCRIPTION
- updated StaxEventItemReaderBuilder to build without Resource (optional now)
- added respective test to validate Resource can be null at build
- updated existing testValidation test case to pass the scenario

Fixes BATCH-3736 [#3736]