### PR TITLE
Added support for 'standalone' attribute in StaxEventItemWriter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ allprojects {
 		servletApiVersion = '4.0.1'
 		sqlfireclientVersion = '1.0.3'
 		sqliteVersion = '3.32.3.2'
-		woodstoxVersion = '6.2.0'
+		woodstoxVersion = '6.2.1'
 		xmlunitVersion = '2.7.0'
 		xstreamVersion = '1.4.12'
 		jrubyVersion = '1.7.27'

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ import org.springframework.util.StringUtils;
  * @author Peter Zozom
  * @author Robert Kasanicky
  * @author Michael Minella
- * 
+ * @author Parikshit Dutta
  */
 public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T> implements
 ResourceAwareItemWriterItemStream<T>, InitializingBean {
@@ -84,6 +84,9 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 
 	// default encoding
 	public static final String DEFAULT_XML_VERSION = "1.0";
+
+	// default standalone document declaration, value not set
+	public static final Boolean DEFAULT_STANDALONE_DOCUMENT = null;
 
 	// default root tag name
 	public static final String DEFAULT_ROOT_TAG_NAME = "root";
@@ -108,6 +111,9 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 
 	// XML version
 	private String version = DEFAULT_XML_VERSION;
+
+	// standalone header attribute
+	private Boolean standalone = DEFAULT_STANDALONE_DOCUMENT;
 
 	// name of the root tag
 	private String rootTagName = DEFAULT_ROOT_TAG_NAME;
@@ -268,6 +274,29 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 	 */
 	public void setVersion(String version) {
 		this.version = version;
+	}
+
+	/**
+	 * Get used standalone document declaration.
+	 *
+	 * @return the standalone document declaration used
+	 *
+	 * @since 4.3
+	 */
+	public Boolean getStandalone() {
+		return standalone;
+	}
+
+	/**
+	 * Set standalone document declaration to be used for output XML. If not set,
+	 * standalone document declaration will be omitted.
+	 *
+	 * @param standalone the XML standalone document declaration to be used
+	 *
+	 * @since 4.3
+	 */
+	public void setStandalone(Boolean standalone) {
+		this.standalone = standalone;
 	}
 
 	/**
@@ -606,7 +635,12 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 		XMLEventFactory factory = createXmlEventFactory();
 
 		// write start document
-		writer.add(factory.createStartDocument(getEncoding(), getVersion()));
+		if (getStandalone()==null) {
+			writer.add(factory.createStartDocument(getEncoding(), getVersion()));
+		}
+		else {
+			writer.add(factory.createStartDocument(getEncoding(), getVersion(), getStandalone()));
+		}
 
 		// write root tag
 		writer.add(factory.createStartElement(getRootTagNamespacePrefix(), getRootTagNamespace(), getRootTagName()));

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  * A builder for the {@link StaxEventItemWriter}.
  *
  * @author Michael Minella
+ * @author Parikshit Dutta
  * @since 4.0
  * @see StaxEventItemWriter
  */
@@ -49,6 +50,8 @@ public class StaxEventItemWriterBuilder<T> {
 	private String encoding = StaxEventItemWriter.DEFAULT_ENCODING;
 
 	private String version = StaxEventItemWriter.DEFAULT_XML_VERSION;
+
+	private Boolean standalone = StaxEventItemWriter.DEFAULT_STANDALONE_DOCUMENT;
 
 	private String rootTagName = StaxEventItemWriter.DEFAULT_ROOT_TAG_NAME;
 
@@ -188,10 +191,25 @@ public class StaxEventItemWriterBuilder<T> {
 	 *
 	 * @param version XML version
 	 * @return the current instance of the builder
-	 * @see StaxEventItemWriter#version
+	 * @see StaxEventItemWriter#setVersion(String)
 	 */
 	public StaxEventItemWriterBuilder<T> version(String version) {
 		this.version = version;
+
+		return this;
+	}
+
+	/**
+	 * Standalone document declaration for the output document. Defaults to null.
+	 *
+	 * @param standalone Boolean standalone document declaration
+	 * @return the current instance of the builder
+	 * @see StaxEventItemWriter#setStandalone(Boolean)
+	 *
+	 * @since 4.3
+	 */
+	public StaxEventItemWriterBuilder<T> standalone(Boolean standalone) {
+		this.standalone = standalone;
 
 		return this;
 	}
@@ -278,6 +296,7 @@ public class StaxEventItemWriterBuilder<T> {
 		writer.setTransactional(this.transactional);
 		writer.setVersion(this.version);
 		writer.setName(this.name);
+		writer.setStandalone(this.standalone);
 
 		return writer;
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link StaxEventItemWriter}.
+ *
+ * @author Parikshit Dutta
  */
 public class StaxEventItemWriterTests {
 
@@ -135,6 +137,35 @@ public class StaxEventItemWriterTests {
 		StaxEventItemWriter<String> writer = new StaxEventItemWriter<>();
 
 		writer.write(Collections.singletonList("foo"));
+	}
+
+	@Test
+	public void testStandaloneDeclarationInHeaderWhenNotSet() throws Exception {
+		writer.open(executionContext);
+		writer.write(items);
+		writer.close();
+		String content = getOutputFileContent(writer.getEncoding(), false);
+		assertFalse(content.contains("standalone="));
+	}
+
+	@Test
+	public void testStandaloneDeclarationInHeaderWhenSetToTrue() throws Exception {
+		writer.setStandalone(true);
+		writer.open(executionContext);
+		writer.write(items);
+		writer.close();
+		String content = getOutputFileContent(writer.getEncoding(), false);
+		assertTrue(content.contains("standalone='yes'"));
+	}
+
+	@Test
+	public void testStandaloneDeclarationInHeaderWhenSetToFalse() throws Exception {
+		writer.setStandalone(false);
+		writer.open(executionContext);
+		writer.write(items);
+		writer.close();
+		String content = getOutputFileContent(writer.getEncoding(), false);
+		assertTrue(content.contains("standalone='no'"));
 	}
 
 	/**
@@ -982,11 +1013,27 @@ public class StaxEventItemWriterTests {
 	 * @return output file content as String
 	 */
 	private String getOutputFileContent(String encoding) throws IOException {
-		String value = FileUtils.readFileToString(resource.getFile(), encoding);
-		value = value.replace("<?xml version='1.0' encoding='" + encoding + "'?>", "");
-		return value;
+		return getOutputFileContent(encoding, true);
 	}
 
+	/**
+	 * @param encoding the encoding
+	 * @param discardHeader the flag to strip XML header
+	 * @return output file content as String
+	 */
+	private String getOutputFileContent(String encoding, boolean discardHeader) throws IOException {
+		String value = FileUtils.readFileToString(resource.getFile(), encoding);
+		if (discardHeader) {
+			// standalone is omitted if not explicitly set, meaning it will be 'yes'/'no' or no standalone attribute
+			if (value.contains("standalone")) {
+				boolean standalone = value.contains("standalone='yes'");
+				return value.replace("<?xml version='1.0' encoding='" + encoding + "' " +
+						(standalone ? "standalone='yes'" : "standalone='no'") + "?>", "");
+			}
+			return value.replace("<?xml version='1.0' encoding='" + encoding + "'?>", "");
+		}
+		return value;
+	}
 
 	/**
 	 * @return new instance of fully configured writer


### PR DESCRIPTION
- updated woodstox version from '6.2.0' to '6.2.1' as mentioned: https://github.com/spring-projects/spring-batch/issues/758#issuecomment-677382726
- added setter for standalone attribute in StaxEventItemWriter
- added relevant tests in StaxEventItemWriterTests
- added builder method for standalone attribute in StaxEventItemWriterBuilder
- added relevant tests in StaxEventItemWriterBuilderTests

Closes BATCH-2856 [#758 ]