### PR TITLE
Poll the count of running step executions

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
@@ -16,6 +16,9 @@
 
 package org.springframework.batch.core;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Enumeration representing the status of an Execution.
  * 
@@ -39,6 +42,8 @@ public enum BatchStatus {
 	 */
 	COMPLETED, STARTING, STARTED, STOPPING, STOPPED, FAILED, ABANDONED, UNKNOWN;
 
+	public static final List<BatchStatus> RUNNING_STATUSES = Arrays.asList(STARTING, STARTED);
+
 	public static BatchStatus max(BatchStatus status1, BatchStatus status2) {
 		return status1.isGreaterThan(status2) ? status1 : status2;
 	}
@@ -49,7 +54,7 @@ public enum BatchStatus {
 	 * @return true if the status is STARTING, STARTED
 	 */
 	public boolean isRunning() {
-		return this == STARTING || this == STARTED;
+		return RUNNING_STATUSES.contains(this);
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
@@ -15,15 +15,17 @@
  */
 package org.springframework.batch.core.explore;
 
-import java.util.List;
-import java.util.Set;
-
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Entry point for browsing executions of running or historical jobs and steps.
@@ -88,6 +90,14 @@ public interface JobExplorer {
 	 */
 	@Nullable
 	StepExecution getStepExecution(@Nullable Long jobExecutionId, @Nullable Long stepExecutionId);
+
+	/**
+	 * Retrieve number of step executions that match the step execution ids and the batch statuses
+	 * @param stepExecutionIds given step execution ids
+	 * @param matchingBatchStatuses given batch statuses to match against
+	 * @return number of {@link StepExecution} matching the criteria
+	 */
+	int getStepExecutionCount(Collection<Long> stepExecutionIds, Collection<BatchStatus> matchingBatchStatuses);
 
 	/**
 	 * @param instanceId {@link Long} id for the jobInstance to obtain.
@@ -164,4 +174,11 @@ public interface JobExplorer {
 	 */
 	int getJobInstanceCount(@Nullable String jobName) throws NoSuchJobException;
 
+	/**
+	 * Find step executions in bulk
+	 * @param jobExecutionId given job execution id
+	 * @param stepExecutionIds given step execution ids
+	 * @return collection of {@link StepExecution}
+	 */
+	Collection<StepExecution> getStepExecutions(Long jobExecutionId, Collection<Long> stepExecutionIds);
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
@@ -16,12 +16,13 @@
 
 package org.springframework.batch.core.repository.dao;
 
-import java.util.Collection;
-
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.lang.Nullable;
+
+import java.util.Collection;
 
 public interface StepExecutionDao {
 
@@ -86,6 +87,22 @@ public interface StepExecutionDao {
 	 */
 	void addStepExecutions(JobExecution jobExecution);
 
+	/**
+	 * Count {@link StepExecution} that match the ids and statuses of them - avoid loading them into memory
+	 * @param stepExecutionIds given step execution ids
+	 * @param matchingBatchStatuses
+	 * @return
+	 */
+    int countStepExecutions(Collection<Long> stepExecutionIds, Collection<BatchStatus> matchingBatchStatuses);
+
+	/**
+	 * Get a collection of {@link StepExecution} matching job execution and step execution ids.
+	 * @param jobExecution the parent job execution
+	 * @param stepExecutionIds the step execution ids
+	 * @return collection of {@link StepExecution}
+	 */
+	@Nullable
+	Collection<StepExecution> getStepExecutions(JobExecution jobExecution, Collection<Long> stepExecutionIds);
 	/**
 	 * Counts all the {@link StepExecution} for a given step name.
 	 *

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
@@ -15,28 +15,10 @@
  */
 package org.springframework.batch.core.launch.support;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobInstance;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.converter.DefaultJobParametersConverter;
 import org.springframework.batch.core.converter.JobParametersConverter;
 import org.springframework.batch.core.explore.JobExplorer;
@@ -48,6 +30,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -539,6 +525,11 @@ public class CommandLineJobRunnerTests {
 		}
 
 		@Override
+		public int getStepExecutionCount(Collection<Long> stepExecutionIds, Collection<BatchStatus> matchingBatchStatuses) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public List<String> getJobNames() {
 			throw new UnsupportedOperationException();
 		}
@@ -566,6 +557,10 @@ public class CommandLineJobRunnerTests {
 			}
 		}
 
+		@Override
+		public Collection<StepExecution> getStepExecutions(Long jobExecutionId, Collection<Long> stepExecutionIds) {
+			throw new UnsupportedOperationException();
+		}
 	}
 
 	public static class StubJobParametersConverter implements JobParametersConverter {

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
@@ -1,12 +1,6 @@
 package org.springframework.batch.integration.partition;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.concurrent.TimeoutException;
-
 import org.junit.Test;
-
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
@@ -18,15 +12,16 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  *
@@ -154,8 +149,8 @@ public class MessageChannelPartitionHandlerTests {
 		stepExecutions.add(partition2);
 		stepExecutions.add(partition3);
 		when(stepExecutionSplitter.split(any(StepExecution.class), eq(1))).thenReturn(stepExecutions);
-		when(jobExplorer.getStepExecution(eq(5L), any(Long.class))).thenReturn(partition2, partition1, partition3, partition3, partition3, partition3, partition4);
-
+		when(jobExplorer.getStepExecutionCount(any(), any())).thenReturn(3, 2, 0);
+		when(jobExplorer.getStepExecutions(eq(5L), any())).thenReturn(Arrays.asList(partition1, partition2, partition4));
 		//set
 		messageChannelPartitionHandler.setMessagingOperations(operations);
 		messageChannelPartitionHandler.setJobExplorer(jobExplorer);
@@ -198,7 +193,8 @@ public class MessageChannelPartitionHandlerTests {
 		stepExecutions.add(partition2);
 		stepExecutions.add(partition3);
 		when(stepExecutionSplitter.split(any(StepExecution.class), eq(1))).thenReturn(stepExecutions);
-		when(jobExplorer.getStepExecution(eq(5L), any(Long.class))).thenReturn(partition2, partition1, partition3);
+		when(jobExplorer.getStepExecutionCount(any(), any())).thenReturn(2);
+		when(jobExplorer.getStepExecutions(eq(5L), any())).thenReturn(Arrays.asList(partition1, partition2, partition3));
 
 		//set
 		messageChannelPartitionHandler.setMessagingOperations(operations);


### PR DESCRIPTION
In a combination of short poll interval and large number of step executions that take a long time to run, memory consumption can go high - each step execution has its own reference to a job execution, which refers step executions for the job. This means that the job executions are different instances, resulting in creating a lot of objects.
Instead, we query the database to get the number of step executions that are still running. Once all of them are finished, we then would fetch all steps and assign the same job execution that can be a shared instance.

Closes #3790 