### PR TITLE
Do not throw NPE for job instances without executions

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -116,6 +116,10 @@ public class SimpleJobRepository implements JobRepository {
 
 			List<JobExecution> executions = jobExecutionDao.findJobExecutions(jobInstance);
 
+			if (executions.isEmpty()) {
+				throw new IllegalStateException("Cannot find any job execution for job instance: " + jobInstance);
+			}
+
 			// check for running executions and find the last started
 			for (JobExecution execution : executions) {
 				if (execution.isRunning() || execution.isStopping()) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -270,6 +271,14 @@ public class SimpleJobRepositoryTests {
 
 		when(jobInstanceDao.getJobInstance("foo", new JobParameters())).thenReturn(jobInstance);
 		when(jobExecutionDao.findJobExecutions(jobInstance)).thenReturn(Arrays.asList(jobExecution));
+
+		jobRepository.createJobExecution("foo", new JobParameters());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCreateJobExecutionInstanceWithoutExecutions() throws Exception {
+		when(jobInstanceDao.getJobInstance("foo", new JobParameters())).thenReturn(jobInstance);
+		when(jobExecutionDao.findJobExecutions(jobInstance)).thenReturn(Collections.emptyList());
 
 		jobRepository.createJobExecution("foo", new JobParameters());
 	}


### PR DESCRIPTION
When working with Spring Cloud Dataflow, it does occasionally happen that the database contains batch job instances without any batch job executions. When launching an execution for such an instance, this currently leads to a `NullPointerException`.

See for example:
- https://github.com/spring-cloud/spring-cloud-dataflow/issues/4233
- https://github.com/spring-cloud/spring-cloud-dataflow/issues/4142

Spring Batch should handle such a situation more gracefully and throw an exception with a hint to the problem.