### PR TITLE
Don't call wrapper constructors directly

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/CommandLineJobRunner.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/CommandLineJobRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -475,7 +475,7 @@ public class CommandLineJobRunner {
 
 	private Long getLongIdentifier(String jobIdentifier) {
 		try {
-			return new Long(jobIdentifier);
+			return Long.parseLong(jobIdentifier);
 		}
 		catch (NumberFormatException e) {
 			// Not an ID - must be a name

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,7 +348,7 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 					0L, 0D, identifyingFlag};
 		} else if (type == ParameterType.LONG) {
 			args = new Object[] { executionId, key, type, "", new Timestamp(0L),
-					value, new Double(0), identifyingFlag};
+					value, 0.0d, identifyingFlag};
 		} else if (type == ParameterType.DOUBLE) {
 			args = new Object[] { executionId, key, type, "", new Timestamp(0L), 0L,
 					value, identifyingFlag};

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MapExecutionContextDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class MapExecutionContextDao implements ExecutionContextDao {
 			if(them == null) {
 				return 1;
 			}
-			final int idCompare = new Long(this.id).compareTo(new Long(them.id)); // JDK6 Make this Long.compare(x,y)
+			final int idCompare = Long.compare(this.id, them.id);
 			if(idCompare != 0) {
 				return idCompare;
 			}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/EntityTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/EntityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
  */
 public class EntityTests extends TestCase {
 
-	Entity entity = new Entity(new Long(11));
+	Entity entity = new Entity(11L);
 	
 	/**
 	 * Test method for {@link org.springframework.batch.core.Entity#hashCode()}.
@@ -54,7 +54,7 @@ public class EntityTests extends TestCase {
 	 */
 	public void testIncrementVersion() {
 		entity.incrementVersion();
-		assertEquals(new Integer(0), entity.getVersion());
+		assertEquals(Integer.valueOf(0), entity.getVersion());
 	}
 
 	/**
@@ -63,7 +63,7 @@ public class EntityTests extends TestCase {
 	public void testIncrementVersionTwice() {
 		entity.incrementVersion();
 		entity.incrementVersion();
-		assertEquals(new Integer(1), entity.getVersion());
+		assertEquals(Integer.valueOf(1), entity.getVersion());
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobExecutionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobExecutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ import org.springframework.util.SerializationUtils;
  */
 public class JobExecutionTests {
 
-	private JobExecution execution = new JobExecution(new JobInstance(new Long(11), "foo"),
-			new Long(12), new JobParameters(), null);
+	private JobExecution execution = new JobExecution(new JobInstance(11L, "foo"),
+			12L, new JobParameters(), null);
 
 	@Test
 	public void testJobExecution() {
@@ -135,7 +135,7 @@ public class JobExecutionTests {
 	@Test
 	public void testGetJobId() {
 		assertEquals(11, execution.getJobId().longValue());
-		execution = new JobExecution(new JobInstance(new Long(23), "testJob"), null, new JobParameters(), null);
+		execution = new JobExecution(new JobInstance(23L, "testJob"), null, new JobParameters(), null);
 		assertEquals(23, execution.getJobId().longValue());
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobInstanceTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobInstanceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.util.SerializationUtils;
  */
 public class JobInstanceTests {
 
-	private JobInstance instance = new JobInstance(new Long(11), "job");
+	private JobInstance instance = new JobInstance(11L, "job");
 
 	/**
 	 * Test method for
@@ -35,7 +35,7 @@ public class JobInstanceTests {
 	 */
 	@Test
 	public void testGetName() {
-		instance = new JobInstance(new Long(1), "foo");
+		instance = new JobInstance(1L, "foo");
 		assertEquals("foo", instance.getJobName());
 	}
 
@@ -59,7 +59,7 @@ public class JobInstanceTests {
 
 	@Test
 	public void testSerialization() {
-		instance = new JobInstance(new Long(1), "jobName");
+		instance = new JobInstance(1L, "jobName");
 
 		byte[] serialized = SerializationUtils.serialize(instance);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2018 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,9 +96,9 @@ public class JobParametersBuilderTests {
 	@Test
 	public void testNonIdentifyingParameters() {
 		this.parametersBuilder.addDate("SCHEDULE_DATE", date, false);
-		this.parametersBuilder.addLong("LONG", new Long(1), false);
+		this.parametersBuilder.addLong("LONG", 1L, false);
 		this.parametersBuilder.addString("STRING", "string value", false);
-		this.parametersBuilder.addDouble("DOUBLE", new Double(1), false);
+		this.parametersBuilder.addDouble("DOUBLE", 1.0d, false);
 
 		JobParameters parameters = this.parametersBuilder.toJobParameters();
 		assertEquals(date, parameters.getDate("SCHEDULE_DATE"));
@@ -114,9 +114,9 @@ public class JobParametersBuilderTests {
 	@Test
 	public void testToJobRuntimeParameters(){
 		this.parametersBuilder.addDate("SCHEDULE_DATE", date);
-		this.parametersBuilder.addLong("LONG", new Long(1));
+		this.parametersBuilder.addLong("LONG", 1L);
 		this.parametersBuilder.addString("STRING", "string value");
-		this.parametersBuilder.addDouble("DOUBLE", new Double(1));
+		this.parametersBuilder.addDouble("DOUBLE", 1.0d);
 		JobParameters parameters = this.parametersBuilder.toJobParameters();
 		assertEquals(date, parameters.getDate("SCHEDULE_DATE"));
 		assertEquals(1L, parameters.getLong("LONG").longValue());
@@ -149,7 +149,7 @@ public class JobParametersBuilderTests {
 	@Test
 	public void testOrderedTypes(){
 		this.parametersBuilder.addDate("SCHEDULE_DATE", date);
-		this.parametersBuilder.addLong("LONG", new Long(1));
+		this.parametersBuilder.addLong("LONG", 1L);
 		this.parametersBuilder.addString("STRING", "string value");
 		Iterator<String> parameters = this.parametersBuilder.toJobParameters().getParameters().keySet().iterator();
 		assertEquals("SCHEDULE_DATE", parameters.next());
@@ -231,7 +231,7 @@ public class JobParametersBuilderTests {
 		when(this.jobExplorer.getJobInstances("simpleJob",0,1)).thenReturn(this.jobInstanceList);
 		when(this.jobExplorer.getJobExecutions(any())).thenReturn(this.jobExecutionList);
 		initializeForNextJobParameters();
-		this.parametersBuilder.addLong("NON_IDENTIFYING_LONG", new Long(1), false);
+		this.parametersBuilder.addLong("NON_IDENTIFYING_LONG", 1L, false);
 		this.parametersBuilder.getNextJobParameters(this.job);
 		baseJobParametersVerify(this.parametersBuilder.toJobParameters(), 5);
 	}
@@ -255,7 +255,7 @@ public class JobParametersBuilderTests {
 
 	private void initializeForNextJobParameters() {
 		this.parametersBuilder.addDate("SCHEDULE_DATE", date);
-		this.parametersBuilder.addLong("LONG", new Long(1));
+		this.parametersBuilder.addLong("LONG", 1L);
 		this.parametersBuilder.addString("STRING", "string value");
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2018 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,8 +86,8 @@ public class JobParametersTests {
 
 	@Test
 	public void testGetDouble() {
-		assertEquals(new Double(1.1), new Double(parameters.getDouble("double.key1")));
-		assertEquals(new Double(2.2), new Double(parameters.getDouble("double.key2")));
+		assertEquals(Double.valueOf(1.1d), parameters.getDouble("double.key1"));
+		assertEquals(Double.valueOf(2.2d), parameters.getDouble("double.key2"));
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/StepExecutionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/StepExecutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.springframework.util.SerializationUtils;
  */
 public class StepExecutionTests {
 
-	private StepExecution execution = newStepExecution(new StepSupport("stepName"), new Long(23));
+	private StepExecution execution = newStepExecution(new StepSupport("stepName"), 23L);
 
 	private StepExecution blankExecution = newStepExecution(new StepSupport("blank"), null);
 
@@ -199,26 +199,26 @@ public class StepExecutionTests {
 	@Test
 	public void testEqualsWithSameIdentifier() throws Exception {
 		Step step = new StepSupport("stepName");
-		Entity stepExecution1 = newStepExecution(step, new Long(11));
-		Entity stepExecution2 = newStepExecution(step, new Long(11));
+		Entity stepExecution1 = newStepExecution(step, 11L);
+		Entity stepExecution2 = newStepExecution(step, 11L);
 		assertEquals(stepExecution1, stepExecution2);
 	}
 
 	@Test
 	public void testEqualsWithNull() throws Exception {
-		Entity stepExecution = newStepExecution(new StepSupport("stepName"), new Long(11));
+		Entity stepExecution = newStepExecution(new StepSupport("stepName"), 11L);
 		assertFalse(stepExecution.equals(null));
 	}
 
 	@Test
 	public void testEqualsWithNullIdentifiers() throws Exception {
-		Entity stepExecution = newStepExecution(new StepSupport("stepName"), new Long(11));
+		Entity stepExecution = newStepExecution(new StepSupport("stepName"), 11L);
 		assertFalse(stepExecution.equals(blankExecution));
 	}
 
 	@Test
 	public void testEqualsWithNullJob() throws Exception {
-		Entity stepExecution = newStepExecution(new StepSupport("stepName"), new Long(11));
+		Entity stepExecution = newStepExecution(new StepSupport("stepName"), 11L);
 		assertFalse(stepExecution.equals(blankExecution));
 	}
 
@@ -229,16 +229,16 @@ public class StepExecutionTests {
 
 	@Test
 	public void testEqualsWithDifferent() throws Exception {
-		Entity stepExecution = newStepExecution(new StepSupport("foo"), new Long(13));
+		Entity stepExecution = newStepExecution(new StepSupport("foo"), 13L);
 		assertFalse(execution.equals(stepExecution));
 	}
 
 	@Test
 	public void testEqualsWithNullStepId() throws Exception {
 		Step step = new StepSupport("name");
-		execution = newStepExecution(step, new Long(31));
+		execution = newStepExecution(step, 31L);
 		assertEquals("name", execution.getStepName());
-		StepExecution stepExecution = newStepExecution(step, new Long(31));
+		StepExecution stepExecution = newStepExecution(step, 31L);
 		assertEquals(stepExecution.getJobExecutionId(), execution.getJobExecutionId());
 		assertTrue(execution.equals(stepExecution));
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -247,7 +247,7 @@ public class StepParserStepFactoryBeanTests {
 		Object step = fb.getObject();
 		assertTrue(step instanceof TaskletStep);
 		Object throttleLimit = ReflectionTestUtils.getField(ReflectionTestUtils.getField(step, "stepOperations"), "throttleLimit");
-		assertEquals(new Integer(10), throttleLimit);
+		assertEquals(Integer.valueOf(10), throttleLimit);
 		Object tasklet = ReflectionTestUtils.getField(step, "tasklet");
 		assertTrue(tasklet instanceof ChunkOrientedTasklet<?>);
 		assertFalse((Boolean) ReflectionTestUtils.getField(tasklet, "buffering"));

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2009 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ public class StepParserTests {
 		TaskletStep bean = (TaskletStep) factory.getObject();
 		assertEquals("wrong start-limit:", 25, bean.getStartLimit());
 		Object throttleLimit = ReflectionTestUtils.getField(factory, "throttleLimit");
-		assertEquals(new Integer(10), throttleLimit);
+		assertEquals(Integer.valueOf(10), throttleLimit);
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/converter/DefaultJobParametersConverterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/converter/DefaultJobParametersConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,7 +254,7 @@ public class DefaultJobParametersConverterTests {
 	public void testGetProperties() throws Exception {
 
 		JobParameters parameters = new JobParametersBuilder().addDate("schedule.date", dateFormat.parse("01/23/2008"))
-				.addString("job.key", "myKey").addLong("vendor.id", new Long(33243243)).addDouble("double.key", 1.23)
+				.addString("job.key", "myKey").addLong("vendor.id", 33243243L).addDouble("double.key", 1.23)
 				.toJobParameters();
 
 		Properties props = factory.getProperties(parameters);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class CommandLineJobRunnerTests {
 
 	@Before
 	public void setUp() throws Exception {
-		JobExecution jobExecution = new JobExecution(null, new Long(1), null, null);
+		JobExecution jobExecution = new JobExecution(null, 1L, null, null);
 		ExitStatus exitStatus = ExitStatus.COMPLETED;
 		jobExecution.setExitStatus(exitStatus);
 		StubJobLauncher.jobExecution = jobExecution;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/DataFieldMaxValueJobParametersIncrementerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/DataFieldMaxValueJobParametersIncrementerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class DataFieldMaxValueJobParametersIncrementerTests {
 
 		// then
 		Long runId = nextParameters.getLong("run.id");
-		Assert.assertEquals(new Long(10) ,runId);
+		Assert.assertEquals(Long.valueOf(10L) ,runId);
 	}
 
 	@Test
@@ -89,7 +89,7 @@ public class DataFieldMaxValueJobParametersIncrementerTests {
 		// then
 		Long runId = nextParameters.getLong("run.id");
 		String foo = nextParameters.getString("foo");
-		Assert.assertEquals(new Long(10) ,runId);
+		Assert.assertEquals(Long.valueOf(10L) ,runId);
 		Assert.assertEquals("bar" ,foo);
 	}
 
@@ -108,6 +108,6 @@ public class DataFieldMaxValueJobParametersIncrementerTests {
 
 		// then
 		Long runId = nextParameters.getLong("run.id");
-		Assert.assertEquals(new Long(10) ,runId);
+		Assert.assertEquals(Long.valueOf(10L) ,runId);
 	}
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJvmExitCodeMapperTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJvmExitCodeMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,15 +32,15 @@ public class SimpleJvmExitCodeMapperTests extends TestCase {
 	protected void setUp() throws Exception {
 		ecm = new SimpleJvmExitCodeMapper();
 		Map<String, Integer> ecmMap = new HashMap<>();
-		ecmMap.put("MY_CUSTOM_CODE", new Integer(3));
+		ecmMap.put("MY_CUSTOM_CODE", 3);
 		ecm.setMapping(ecmMap);
 
 		ecm2 = new SimpleJvmExitCodeMapper();
 		Map<String, Integer> ecm2Map = new HashMap<>();
-		ecm2Map.put(ExitStatus.COMPLETED.getExitCode(), new Integer(-1));
-		ecm2Map.put(ExitStatus.FAILED.getExitCode(), new Integer(-2));
-		ecm2Map.put(ExitCodeMapper.JOB_NOT_PROVIDED, new Integer(-3));
-		ecm2Map.put(ExitCodeMapper.NO_SUCH_JOB, new Integer(-3));
+		ecm2Map.put(ExitStatus.COMPLETED.getExitCode(), -1);
+		ecm2Map.put(ExitStatus.FAILED.getExitCode(), -2);
+		ecm2Map.put(ExitCodeMapper.JOB_NOT_PROVIDED, -3);
+		ecm2Map.put(ExitCodeMapper.NO_SUCH_JOB, -3);
 		ecm2.setMapping(ecm2Map);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeJobExecutionListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeJobExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class CompositeJobExecutionListenerTests extends TestCase {
 				list.add("foo");
 			}
 		});
-		listener.beforeJob(new JobExecution(new JobInstance(new Long(11L), "testOpenJob"), null));
+		listener.beforeJob(new JobExecution(new JobInstance(11L, "testOpenJob"), null));
 		assertEquals(1, list.size());
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/JobListenerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/JobListenerFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ public class JobListenerFactoryBeanTests {
 			@AfterJob
 			public void aMethod(JobExecution jobExecution) {
 				executed = true;
-				assertEquals(new Long(25), jobExecution.getId());
+				assertEquals(Long.valueOf(25L), jobExecution.getId());
 			}
 		};
 		factoryBean.setDelegate(delegate);
@@ -205,7 +205,7 @@ public class JobListenerFactoryBeanTests {
 			@SuppressWarnings("unused")
 			public void aMethod(JobExecution jobExecution) {
 				executed = true;
-				assertEquals(new Long(25), jobExecution.getId());
+				assertEquals(Long.valueOf(25L), jobExecution.getId());
 			}
 		};
 		factoryBean.setDelegate(delegate);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractExecutionContextDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractExecutionContextDaoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,7 +218,7 @@ public abstract class AbstractExecutionContextDaoTests extends AbstractTransacti
 	public void testStoreInteger() {
 
 		ExecutionContext ec = new ExecutionContext();
-		ec.put("intValue", new Integer(343232));
+		ec.put("intValue", 343232);
 		stepExecution.setExecutionContext(ec);
 		contextDao.saveExecutionContext(stepExecution);
 		ExecutionContext restoredEc = contextDao.getExecutionContext(stepExecution);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractExecutionContextSerializerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractExecutionContextSerializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public abstract class AbstractExecutionContextSerializerTests {
         m1.put("object2", "OBJECT TWO");
         // Use a date after 1971 (otherwise daylight saving screws up)...
         m1.put("object3", new Date(123456790123L));
-        m1.put("object4", new Double(1234567.1234D));
+        m1.put("object4", 1234567.1234D);
 
         Map<String, Object> m2 = serializationRoundTrip(m1);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractStepExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractStepExecutionDaoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -295,11 +295,11 @@ public abstract class AbstractStepExecutionDaoTests extends AbstractTransactiona
 		exec2.setId(exec1.getId());
 
 		exec2.incrementVersion();
-		assertEquals(new Integer(0), exec1.getVersion());
+		assertEquals(Integer.valueOf(0), exec1.getVersion());
 		assertEquals(exec1.getVersion(), exec2.getVersion());
 
 		dao.updateStepExecution(exec1);
-		assertEquals(new Integer(1), exec1.getVersion());
+		assertEquals(Integer.valueOf(1), exec1.getVersion());
 
 		try {
 			dao.updateStepExecution(exec2);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcJobDaoQueryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcJobDaoQueryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class JdbcJobDaoQueryTests extends TestCase {
 				return 1;
 			}
 		});
-		JobExecution jobExecution = new JobExecution(new JobInstance(new Long(11), "testJob"), new JobParameters());
+		JobExecution jobExecution = new JobExecution(new JobInstance(11L, "testJob"), new JobParameters());
 
 		jobExecutionDao.saveJobExecution(jobExecution);
 		assertEquals(1, list.size());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/resource/StepExecutionSimpleCompletionPolicyTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/resource/StepExecutionSimpleCompletionPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class StepExecutionSimpleCompletionPolicyTests extends TestCase {
 	protected void setUp() throws Exception {
 
 		JobParameters jobParameters = new JobParametersBuilder().addLong("commit.interval", 2L).toJobParameters();
-		jobInstance = new JobInstance(new Long(0), "testJob");
+		jobInstance = new JobInstance(0L, "testJob");
 		JobExecution jobExecution = new JobExecution(jobInstance, jobParameters);
 		Step step = new StepSupport("bar");
 		stepExecution = jobExecution.createStepExecution(step.getName());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanNonBufferingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanNonBufferingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public class FaultTolerantStepFactoryBeanNonBufferingTests {
 		factory.setSkipLimit(2);
 		factory.setIsReaderTransactionalQueue(true);
 
-		JobInstance jobInstance = new JobInstance(new Long(1), "skipJob");
+		JobInstance jobInstance = new JobInstance(1L, "skipJob");
 		jobExecution = new JobExecution(jobInstance, new JobParameters());
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/StepExecutorInterruptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/StepExecutorInterruptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class StepExecutorInterruptionTests {
 				}
 
 				if (foo != 1) {
-					return new Double(foo);
+					return foo;
 				}
 				else {
 					return null;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/football/FootballJobIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/football/FootballJobIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class FootballJobIntegrationTests extends AbstractIntegrationTests {
 			logger.info("Processed: " + stepExecution);
 			if (stepExecution.getStepName().equals("playerload")) {
 				// The effect of the retries
-				assertEquals(new Double(Math.ceil(stepExecution.getReadCount() / 10. + 1)).intValue(),
+				assertEquals((int) Math.ceil(stepExecution.getReadCount() / 10. + 1),
 						stepExecution.getCommitCount());
 			}
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/step/SplitJobMapRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/step/SplitJobMapRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class SplitJobMapRepositoryIntegrationTests {
 			}
 
 			try {
-				JobExecution execution = jobLauncher.run(job, new JobParametersBuilder().addLong("count", new Long(i))
+				JobExecution execution = jobLauncher.run(job, new JobParametersBuilder().addLong("count", (long) i)
 						.toJobParameters());
 				assertEquals(BatchStatus.COMPLETED, execution.getStatus());
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/AbstractDelegatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/AbstractDelegatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,7 +296,7 @@ public class AbstractDelegatorTests {
 
 		@SuppressWarnings("unused")
 		public void processNameValuePair(String name, String value) {
-			processedFooNameValuePairs.add(new Foo(name, new Integer(value)));
+			processedFooNameValuePairs.add(new Foo(name, Integer.parseInt(value)));
 		}
 
 		public List<Foo> getProcessedFooNameValuePairs() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingRestartIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingRestartIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ public class JdbcPagingRestartIntegrationTests {
 		List<Map<String, Object>> ids = jdbcTemplate
 				.queryForList("SELECT ID,NAME FROM T_FOOS ORDER BY ID ASC");
 		logger.debug("Ids: "+ids);
-		int startAfterValue = (new Long(ids.get(count - 1).get("ID").toString())).intValue();
+		int startAfterValue = Integer.parseInt(ids.get(count - 1).get("ID").toString());
 		logger.debug("Start after: " + startAfterValue);
 		Map<String, Object> startAfterValues = new LinkedHashMap<>();
 		startAfterValues.put("ID", startAfterValue);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -242,7 +242,7 @@ public class KafkaItemReaderBuilderTests {
 		assertEquals(partitions.get(1).intValue(), topicPartitions.get(1).partition());
 		Map<TopicPartition, Long> partitionOffsetsMap = (Map<TopicPartition, Long>) ReflectionTestUtils.getField(reader, "partitionOffsets");
 		assertEquals(2, partitionOffsetsMap.size());
-		assertEquals(new Long(10), partitionOffsetsMap.get(new TopicPartition(topic, partitions.get(0))));
-		assertEquals(new Long(15), partitionOffsetsMap.get(new TopicPartition(topic, partitions.get(1))));
+		assertEquals(Long.valueOf(10L), partitionOffsetsMap.get(new TopicPartition(topic, partitions.get(0))));
+		assertEquals(Long.valueOf(15L), partitionOffsetsMap.get(new TopicPartition(topic, partitions.get(1))));
 	}
 }

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkResponseTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkResponseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class ChunkResponseTests {
 
 	@Test
 	public void testGetJobId() {
-		assertEquals(new Long(111L), response.getJobId());
+		assertEquals(Long.valueOf(111L), response.getJobId());
 	}
 
 	@Test
@@ -50,7 +50,7 @@ public class ChunkResponseTests {
 	public void testSerializable() throws Exception {
 		ChunkResponse result = (ChunkResponse) SerializationUtils.deserialize(SerializationUtils.serialize(response));
 		assertNotNull(result.getStepContribution());
-		assertEquals(new Long(111L), result.getJobId());
+		assertEquals(Long.valueOf(111L), result.getJobId());
 	}
 
 }

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/SkipSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/SkipSampleFunctionalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2019 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -285,9 +285,9 @@ public class SkipSampleFunctionalTests {
 		assertEquals(new BigDecimal("340.45"), jobExecution.getExecutionContext().get(TradeWriter.TOTAL_AMOUNT_KEY));
 
 		Map<String, Object> step1Execution = getStepExecutionAsMap(jobExecution, "step1");
-		assertEquals(new Long(4), step1Execution.get("COMMIT_COUNT"));
-		assertEquals(new Long(8), step1Execution.get("READ_COUNT"));
-		assertEquals(new Long(7), step1Execution.get("WRITE_COUNT"));
+		assertEquals(Long.valueOf(4L), step1Execution.get("COMMIT_COUNT"));
+		assertEquals(Long.valueOf(8L), step1Execution.get("READ_COUNT"));
+		assertEquals(Long.valueOf(7L), step1Execution.get("WRITE_COUNT"));
 	}
 
 	private void validateLaunchWithoutSkips(JobExecution jobExecution) {


### PR DESCRIPTION
The constructors of the wrapper classes for primitives (Double,
Integer, Long) have been deprecated since JDK 9 and should no longer be
called. Instead the static factory #valueOf should be used.