### PR TITLE
Fix javadoc in ExitStatus

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
@@ -54,8 +54,8 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	public static final ExitStatus COMPLETED = new ExitStatus("COMPLETED");
 
 	/**
-	 * Convenient constant value representing job that did no processing (e.g.
-	 * because it was already complete).
+	 * Convenient constant value representing job that did no processing
+	 * (e.g. because it was already complete).
 	 */
 	public static final ExitStatus NOOP = new ExitStatus("NOOP");
 


### PR DESCRIPTION
Missing end comment  : 
<img width="899" alt="2020-12-02 16_24_17-ExitStatus (spring-batch-core 5 0 0-SNAPSHOT API)" src="https://user-images.githubusercontent.com/1149149/100894624-fabb3180-34bc-11eb-8ced-ea409b4d0310.png">


After fixing the problem :
<img width="894" alt="2020-12-02 16_25_49-ExitStatus (spring-batch-core 5 0 0-SNAPSHOT API)" src="https://user-images.githubusercontent.com/1149149/100894539-e24b1700-34bc-11eb-8435-af8ad1c68d1b.png">
