### PR TITLE
Better sizes for StringBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractNeo4jItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractNeo4jItemReader.java
@@ -172,7 +172,7 @@ public abstract class AbstractNeo4jItemReader<T> extends
 	}
 
 	protected String generateLimitCypherQuery() {
-		StringBuilder query = new StringBuilder();
+		StringBuilder query = new StringBuilder(128);
 
 		query.append("START ").append(startStatement);
 		query.append(matchStatement != null ? " MATCH " + matchStatement : "");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -190,7 +190,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 		Assert.hasLength(selectClause, "selectClause must be specified");
 		Assert.hasLength(fromClause, "fromClause must be specified");
 		Assert.notEmpty(sortKeys, "sortKey must be specified");
-		StringBuilder sql = new StringBuilder();
+		StringBuilder sql = new StringBuilder(64);
 		sql.append("SELECT ").append(selectClause);
 		sql.append(" FROM ").append(fromClause);
 		if (whereClause != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
@@ -98,7 +98,7 @@ public class SqlPagingQueryUtils {
 	 */
 	public static String generateTopSqlQuery(AbstractSqlPagingQueryProvider provider, boolean remainingPageQuery,
 			String topClause) {
-		StringBuilder sql = new StringBuilder();
+		StringBuilder sql = new StringBuilder(128);
 		sql.append("SELECT ").append(topClause).append(" ").append(provider.getSelectClause());
 		sql.append(" FROM ").append(provider.getFromClause());
 		buildWhereClause(provider, remainingPageQuery, sql);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PropertyMatches.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PropertyMatches.java
@@ -99,7 +99,7 @@ final class PropertyMatches {
 	 * indicating the possible property matches.
 	 */
 	public String buildErrorMessage() {
-		StringBuilder buf = new StringBuilder();
+		StringBuilder buf = new StringBuilder(128);
 		buf.append("Bean property '");
 		buf.append(this.propertyName);
 		buf.append("' is not writable or has an invalid setter method. ");


### PR DESCRIPTION
StringBuilder by default has a size of 16, however there
are some places that already create larger strings already.
For efficiency and garbage reduction it would be better to have
larger sizes to begin with.