### PR TITLE
Added isXXXEnabled for logging statements

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobFactoryRegistrationListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobFactoryRegistrationListener.java
@@ -54,7 +54,9 @@ public class JobFactoryRegistrationListener {
 	 * @throws Exception if there is a problem
 	 */
 	public void bind(JobFactory jobFactory, Map<String, ?> params) throws Exception {
-		logger.info("Binding JobFactory: " + jobFactory.getJobName());
+		if (logger.isInfoEnabled()) {
+			logger.info("Binding JobFactory: " + jobFactory.getJobName());
+		}
 		jobRegistry.register(jobFactory);
 	}
 
@@ -66,7 +68,9 @@ public class JobFactoryRegistrationListener {
 	 * @throws Exception if there is a problem
 	 */
 	public void unbind(JobFactory jobFactory, Map<String, ?> params) throws Exception {
-		logger.info("Unbinding JobFactory: " + jobFactory.getJobName());
+		if (logger.isInfoEnabled()) {
+			logger.info("Unbinding JobFactory: " + jobFactory.getJobName());
+		}
 		jobRegistry.unregister(jobFactory.getJobName());
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -337,8 +337,10 @@ InitializingBean {
 			}
 
 		} catch (JobInterruptedException e) {
-			logger.info("Encountered interruption executing job: "
-					+ e.getMessage());
+			if (logger.isInfoEnabled()) {
+				logger.info("Encountered interruption executing job: "
+						+ e.getMessage());
+			}
 			if (logger.isDebugEnabled()) {
 				logger.debug("Full exception", e);
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleStepHandler.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleStepHandler.java
@@ -116,9 +116,11 @@ public class SimpleStepHandler implements StepHandler, InitializingBean {
 		if (stepExecutionPartOfExistingJobExecution(execution, lastStepExecution)) {
 			// If the last execution of this step was in the same job, it's
 			// probably intentional so we want to run it again...
-			logger.info(String.format("Duplicate step [%s] detected in execution of job=[%s]. "
-					+ "If either step fails, both will be executed again on restart.", step.getName(), jobInstance
-					.getJobName()));
+			if (logger.isInfoEnabled()) {
+				logger.info(String.format("Duplicate step [%s] detected in execution of job=[%s]. "
+						+ "If either step fails, both will be executed again on restart.", step.getName(), jobInstance
+						.getJobName()));
+			}
 			lastStepExecution = null;
 		}
 		StepExecution currentStepExecution = lastStepExecution;
@@ -143,7 +145,9 @@ public class SimpleStepHandler implements StepHandler, InitializingBean {
 
 			jobRepository.add(currentStepExecution);
 
-			logger.info("Executing step: [" + step.getName() + "]");
+			if (logger.isInfoEnabled()) {
+				logger.info("Executing step: [" + step.getName() + "]");
+			}
 			try {
 				step.execute(currentStepExecution);
 				currentStepExecution.getExecutionContext().put("batch.executed", true);
@@ -215,7 +219,9 @@ public class SimpleStepHandler implements StepHandler, InitializingBean {
 				|| stepStatus == BatchStatus.ABANDONED) {
 			// step is complete, false should be returned, indicating that the
 			// step should not be started
-			logger.info("Step already complete or not restartable, so no action to execute: " + lastStepExecution);
+			if (logger.isInfoEnabled()) {
+				logger.info("Step already complete or not restartable, so no action to execute: " + lastStepExecution);
+			}
 			return false;
 		}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/BatchParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/BatchParser.java
@@ -71,7 +71,9 @@ public class BatchParser extends AbstractBeanDefinitionParser {
 				if(!registry.containsBeanDefinition(beanName)) {
 					registry.registerBeanDefinition(beanName, beanDefinition);
 				} else {
-					logger.info("Ignoring batch.xml bean definition for " + beanName + " because another bean of the same name has been registered");
+					if (logger.isInfoEnabled()) {
+						logger.info("Ignoring batch.xml bean definition for " + beanName + " because another bean of the same name has been registered");
+					}
 				}
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/JsrBeanDefinitionDocumentReader.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/xml/JsrBeanDefinitionDocumentReader.java
@@ -182,7 +182,7 @@ public class JsrBeanDefinitionDocumentReader extends DefaultBeanDefinitionDocume
 	}
 
 	private String resolveValue(String value) {
-		StringBuffer valueBuffer = new StringBuffer();
+		StringBuilder valueBuffer = new StringBuilder();
 		Matcher jobParameterMatcher = OPERATOR_PATTERN.matcher(value);
 
 		while (jobParameterMatcher.find()) {
@@ -200,7 +200,7 @@ public class JsrBeanDefinitionDocumentReader extends DefaultBeanDefinitionDocume
 
 				String resolvedProperty = properties.getProperty(extractedProperty, NULL);
 
-				if (NULL.equals(resolvedProperty)) {
+				if (NULL.equals(resolvedProperty) && LOG.isInfoEnabled()) {
 					LOG.info(propertyType + " with key of: " + extractedProperty + " could not be resolved. Possible configuration error?");
 				}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/job/JsrStepHandler.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/job/JsrStepHandler.java
@@ -93,7 +93,9 @@ public class JsrStepHandler extends SimpleStepHandler {
 
 				if(CollectionUtils.isEmpty(jobExecution.getStepExecutions()) && lastJobExecution.getStatus() == BatchStatus.STOPPED && StringUtils.hasText(restartStep)) {
 					if(!restartStep.equals(step.getName()) && !jobExecution.getExecutionContext().containsKey("batch.startedStep")) {
-						logger.info("Job was stopped and should restart at step " + restartStep + ".  The current step is " + step.getName());
+						if (logger.isInfoEnabled()) {
+							logger.info("Job was stopped and should restart at step " + restartStep + ".  The current step is " + step.getName());
+						}
 						return false;
 					} else {
 						// Indicates the starting point for execution evaluation per JSR-352
@@ -113,7 +115,9 @@ public class JsrStepHandler extends SimpleStepHandler {
 				|| stepStatus == BatchStatus.ABANDONED) {
 			// step is complete, false should be returned, indicating that the
 			// step should not be started
-			logger.info("Step already complete or not restartable, so no action to execute: " + lastStepExecution);
+			if (logger.isInfoEnabled()) {
+				logger.info("Step already complete or not restartable, so no action to execute: " + lastStepExecution);
+			}
 			return false;
 		}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/step/builder/JsrPartitionStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/step/builder/JsrPartitionStepBuilder.java
@@ -94,8 +94,10 @@ public class JsrPartitionStepBuilder extends PartitionStepBuilder {
 					name = getStep().getName();
 				}
 				catch (Exception e) {
-					logger.info("Ignored exception from step asking for name and allowStartIfComplete flag. "
-							+ "Using default from enclosing PartitionStep (" + name + "," + allowStartIfComplete + ").");
+					if (logger.isInfoEnabled()) {
+						logger.info("Ignored exception from step asking for name and allowStartIfComplete flag. "
+								+ "Using default from enclosing PartitionStep (" + name + "," + allowStartIfComplete + ").");
+					}
 				}
 			}
 			SimpleStepExecutionSplitter splitter = new SimpleStepExecutionSplitter();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/JobRegistryBackgroundJobRunner.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/JobRegistryBackgroundJobRunner.java
@@ -131,7 +131,9 @@ public class JobRegistryBackgroundJobRunner {
 			for (int j = 0; j < resources.length; j++) {
 
 				Resource path = resources[j];
-				logger.info("Registering Job definitions from " + Arrays.toString(resources));
+				if (logger.isInfoEnabled()) {
+					logger.info("Registering Job definitions from " + Arrays.toString(resources));
+				}
 
 				GenericApplicationContextFactory factory = new GenericApplicationContextFactory(path);
 				factory.setApplicationContext(parentContext);
@@ -199,8 +201,9 @@ public class JobRegistryBackgroundJobRunner {
 		final JobRegistryBackgroundJobRunner launcher = new JobRegistryBackgroundJobRunner(args[0]);
 		errors.clear();
 
-		logger.info("Starting job registry in parent context from XML at: [" + args[0] + "]");
-
+		if (logger.isInfoEnabled()) {
+			logger.info("Starting job registry in parent context from XML at: [" + args[0] + "]");
+		}
 		new Thread(new Runnable() {
 			@Override
 			public void run() {
@@ -221,7 +224,9 @@ public class JobRegistryBackgroundJobRunner {
 
 		synchronized (errors) {
 			if (!errors.isEmpty()) {
-				logger.info(errors.size() + " errors detected on startup of parent context.  Rethrowing.");
+				if (logger.isInfoEnabled()) {
+					logger.info(errors.size() + " errors detected on startup of parent context.  Rethrowing.");
+				}
 				throw errors.get(0);
 			}
 		}
@@ -231,7 +236,9 @@ public class JobRegistryBackgroundJobRunner {
 		final String[] paths = new String[args.length - 1];
 		System.arraycopy(args, 1, paths, 0, paths.length);
 
-		logger.info("Parent context started.  Registering jobs from paths: " + Arrays.asList(paths));
+		if (logger.isInfoEnabled()) {
+			logger.info("Parent context started.  Registering jobs from paths: " + Arrays.asList(paths));
+		}
 		launcher.register(paths);
 
 		if (System.getProperty(EMBEDDED) != null) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobLauncher.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobLauncher.java
@@ -142,18 +142,24 @@ public class SimpleJobLauncher implements JobLauncher, InitializingBean {
 				@Override
 				public void run() {
 					try {
-						logger.info("Job: [" + job + "] launched with the following parameters: [" + jobParameters
-								+ "]");
+						if (logger.isInfoEnabled()) {
+							logger.info("Job: [" + job + "] launched with the following parameters: [" + jobParameters
+									+ "]");
+						}
 						job.execute(jobExecution);
-						Duration jobExecutionDuration = BatchMetrics.calculateDuration(jobExecution.getStartTime(), jobExecution.getEndTime());
-						logger.info("Job: [" + job + "] completed with the following parameters: [" + jobParameters
-								+ "] and the following status: [" + jobExecution.getStatus() + "]"
-								+ (jobExecutionDuration == null ? "" : " in " + BatchMetrics.formatDuration(jobExecutionDuration)));
+						if (logger.isInfoEnabled()) {
+							Duration jobExecutionDuration = BatchMetrics.calculateDuration(jobExecution.getStartTime(), jobExecution.getEndTime());
+							logger.info("Job: [" + job + "] completed with the following parameters: [" + jobParameters
+									+ "] and the following status: [" + jobExecution.getStatus() + "]"
+									+ (jobExecutionDuration == null ? "" : " in " + BatchMetrics.formatDuration(jobExecutionDuration)));
+						}
 					}
 					catch (Throwable t) {
-						logger.info("Job: [" + job
-								+ "] failed unexpectedly and fatally with the following parameters: [" + jobParameters
-								+ "]", t);
+						if (logger.isInfoEnabled()) {
+							logger.info("Job: [" + job
+									+ "] failed unexpectedly and fatally with the following parameters: [" + jobParameters
+									+ "]", t);
+						}
 						rethrow(t);
 					}
 				}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -267,15 +267,18 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 	@Override
 	public Long restart(long executionId) throws JobInstanceAlreadyCompleteException, NoSuchJobExecutionException, NoSuchJobException, JobRestartException, JobParametersInvalidException {
 
-		logger.info("Checking status of job execution with id=" + executionId);
-
+		if (logger.isInfoEnabled()) {
+			logger.info("Checking status of job execution with id=" + executionId);
+		}
 		JobExecution jobExecution = findExecutionById(executionId);
 
 		String jobName = jobExecution.getJobInstance().getJobName();
 		Job job = jobRegistry.getJob(jobName);
 		JobParameters parameters = jobExecution.getJobParameters();
 
-		logger.info(String.format("Attempting to resume job with name=%s and parameters=%s", jobName, parameters));
+		if (logger.isInfoEnabled()) {
+			logger.info(String.format("Attempting to resume job with name=%s and parameters=%s", jobName, parameters));
+		}
 		try {
 			return jobLauncher.run(job, parameters).getId();
 		}
@@ -295,8 +298,9 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 	 */
 	@Override
 	public Long start(String jobName, String parameters) throws NoSuchJobException, JobInstanceAlreadyExistsException, JobParametersInvalidException {
-
-		logger.info("Checking status of job with name=" + jobName);
+		if (logger.isInfoEnabled()) {
+			logger.info("Checking status of job with name=" + jobName);
+		}
 
 		JobParameters jobParameters = jobParametersConverter.getJobParameters(PropertiesConverter
 				.stringToProperties(parameters));
@@ -308,8 +312,9 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		}
 
 		Job job = jobRegistry.getJob(jobName);
-
-		logger.info(String.format("Attempting to launch job with name=%s and parameters=%s", jobName, parameters));
+		if (logger.isInfoEnabled()) {
+			logger.info(String.format("Attempting to launch job with name=%s and parameters=%s", jobName, parameters));
+		}
 		try {
 			return jobLauncher.run(job, jobParameters).getId();
 		}
@@ -336,15 +341,17 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 	@Override
 	public Long startNextInstance(String jobName) throws NoSuchJobException,
 	UnexpectedJobExecutionException, JobParametersInvalidException {
-
-		logger.info("Locating parameters for next instance of job with name=" + jobName);
+		if (logger.isInfoEnabled()) {
+			logger.info("Locating parameters for next instance of job with name=" + jobName);
+		}
 
 		Job job = jobRegistry.getJob(jobName);
 		JobParameters parameters = new JobParametersBuilder(jobExplorer)
 				.getNextJobParameters(job)
 				.toJobParameters();
-
-		logger.info(String.format("Attempting to launch job with name=%s and parameters=%s", jobName, parameters));
+		if (logger.isInfoEnabled()) {
+			logger.info(String.format("Attempting to launch job with name=%s and parameters=%s", jobName, parameters));
+		}
 		try {
 			return jobLauncher.run(job, parameters).getId();
 		}
@@ -424,8 +431,9 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 			throw new JobExecutionAlreadyRunningException(
 					"JobExecution is running or complete and therefore cannot be aborted");
 		}
-
-		logger.info("Aborting job execution: " + jobExecution);
+		if (logger.isInfoEnabled()) {
+			logger.info("Aborting job execution: " + jobExecution);
+		}
 		jobExecution.upgradeStatus(BatchStatus.ABANDONED);
 		jobExecution.setEndTime(new Date());
 		jobRepository.update(jobExecution);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java
@@ -181,7 +181,9 @@ public class JobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean i
 
 		if (databaseType == null) {
 			databaseType = DatabaseType.fromMetaData(dataSource).name();
-			logger.info("No database type set, using meta data indicating: " + databaseType);
+			if (logger.isInfoEnabled()) {
+				logger.info("No database type set, using meta data indicating: " + databaseType);
+			}
 		}
 
 		if (lobHandler == null && databaseType.equalsIgnoreCase(DatabaseType.ORACLE.toString())) {
@@ -194,7 +196,7 @@ public class JobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean i
 			serializer = defaultSerializer;
 		}
 
-		Assert.isTrue(incrementerFactory.isSupportedIncrementerType(databaseType), "'" + databaseType
+		Assert.isTrue(incrementerFactory.isSupportedIncrementerType(databaseType), () -> "'" + databaseType
 				+ "' is an unsupported database type.  The supported database types are "
 				+ StringUtils.arrayToCommaDelimitedString(incrementerFactory.getSupportedIncrementerTypes()));
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
@@ -269,8 +269,9 @@ public abstract class AbstractStep implements Step, InitializingBean, BeanNameAw
 			stepExecution.setEndTime(new Date());
 			stepExecution.setExitStatus(exitStatus);
 			Duration stepExecutionDuration = BatchMetrics.calculateDuration(stepExecution.getStartTime(), stepExecution.getEndTime());
-			logger.info("Step: [" + stepExecution.getStepName() + "] executed in " + BatchMetrics.formatDuration(stepExecutionDuration));
-
+			if (logger.isInfoEnabled()) {
+				logger.info("Step: [" + stepExecution.getStepName() + "] executed in " + BatchMetrics.formatDuration(stepExecutionDuration));
+			}
 			try {
 				getJobRepository().update(stepExecution);
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/PartitionStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/PartitionStepBuilder.java
@@ -189,8 +189,10 @@ public class PartitionStepBuilder extends StepBuilderHelper<PartitionStepBuilder
 					name = this.step.getName();
 				}
 				catch (Exception e) {
-					logger.info("Ignored exception from step asking for name and allowStartIfComplete flag. "
-							+ "Using default from enclosing PartitionStep (" + name + "," + allowStartIfComplete + ").");
+					if (logger.isInfoEnabled()) {
+						logger.info("Ignored exception from step asking for name and allowStartIfComplete flag. "
+								+ "Using default from enclosing PartitionStep (" + name + "," + allowStartIfComplete + ").");
+					}
 				}
 			}
 			SimpleStepExecutionSplitter splitter = new SimpleStepExecutionSplitter();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/SimpleStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/SimpleStepBuilder.java
@@ -388,7 +388,9 @@ public class SimpleStepBuilder<I, O> extends AbstractTaskletStepBuilder<SimpleSt
 			return completionPolicy;
 		}
 		if (chunkSize == 0) {
-			logger.info("Setting commit interval to default value (" + DEFAULT_COMMIT_INTERVAL + ")");
+			if (logger.isInfoEnabled()) {
+				logger.info("Setting commit interval to default value (" + DEFAULT_COMMIT_INTERVAL + ")");
+			}
 			chunkSize = DEFAULT_COMMIT_INTERVAL;
 		}
 		return new SimpleCompletionPolicy(chunkSize);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractNeo4jItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractNeo4jItemReader.java
@@ -184,9 +184,7 @@ public abstract class AbstractNeo4jItemReader<T> extends
 
 		String resultingQuery = query.toString();
 
-		if (logger.isDebugEnabled()) {
-			logger.debug(resultingQuery);
-		}
+		logger.debug(resultingQuery);
 
 		return resultingQuery;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
@@ -123,7 +123,7 @@ public class DefaultFieldSet implements FieldSet {
 		if (names == null) {
 			throw new IllegalStateException("Field names are not known");
 		}
-		return names.toArray(new String[names.size()]);
+		return names.toArray(new String[0]);
 	}
 
 	/*

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkMessageChannelItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkMessageChannelItemWriter.java
@@ -193,7 +193,9 @@ public class ChunkMessageChannelItemWriter<T> extends StepExecutionListenerSuppo
 		int count = 0;
 		int maxCount = maxWaitTimeouts;
 		Throwable failure = null;
-		logger.info("Waiting for " + localState.getExpecting() + " results");
+		if (logger.isInfoEnabled()) {
+			logger.info("Waiting for " + localState.getExpecting() + " results");
+		}
 		while (localState.getExpecting() > 0 && count++ < maxCount) {
 			try {
 				getNextResult();

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/InfiniteLoopWriter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/InfiniteLoopWriter.java
@@ -61,6 +61,8 @@ public class InfiniteLoopWriter extends StepExecutionListenerSupport implements 
 		}
 
 		stepExecution.setWriteCount(++count);
-		LOG.info("Executing infinite loop, at count=" + count);
+		if (logger.isInfoEnabled()) {
+			LOG.info("Executing infinite loop, at count=" + count);
+		}
 	}
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/LogAdvice.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/LogAdvice.java
@@ -28,7 +28,9 @@ import org.apache.commons.logging.LogFactory;
 public class LogAdvice {
     private static Log log = LogFactory.getLog(LogAdvice.class);
 
-    public void doStronglyTypedLogging(Object item){
-    	log.info("Processed: " + item);
+    public void doStronglyTypedLogging(Object item) {
+        if (logger.isInfoEnabled()) {
+            log.info("Processed: " + item);
+        }
     }
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemReader.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemReader.java
@@ -110,8 +110,9 @@ InitializingBean, DisposableBean {
 				id = keys.next();
 			}
 		}
-		logger.debug("Retrieved key from list: " + id);
-
+		if (logger.isDebugEnabled()) {
+			logger.debug("Retrieved key from list: " + id);
+		}
 		if (id == null) {
 			return null;
 		}

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/multiline/AggregateItemReader.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/multiline/AggregateItemReader.java
@@ -90,7 +90,9 @@ public class AggregateItemReader<T> implements ItemReader<List<T>> {
 		}
 
 		// add a simple record to the current collection
-		LOG.debug("Mapping: " + value);
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Mapping: " + value);
+		}
 		holder.addRecord(value.getItem());
 		return true;
 	}

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/order/internal/OrderItemReader.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/order/internal/OrderItemReader.java
@@ -68,8 +68,9 @@ public class OrderItemReader implements ItemReader<Order> {
 			process(fieldSetReader.read());
 		}
 
-		log.info("Mapped: " + order);
-
+		if (log.isInfoEnabled()) {
+			log.info("Mapped: " + order);
+		}
 		Order result = order;
 		order = null;
 
@@ -144,7 +145,9 @@ public class OrderItemReader implements ItemReader<Order> {
 			order.getLineItems().add(itemMapper.mapFieldSet(fieldSet));
 		}
 		else {
-			log.debug("Could not map LINE_ID=" + lineId);
+			if (log.isDebugEnabled()) {
+				log.debug("Could not map LINE_ID=" + lineId);
+			}
 		}
 	}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/person/internal/PersonWriter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/person/internal/PersonWriter.java
@@ -28,6 +28,8 @@ public class PersonWriter implements ItemWriter<Person> {
  
     @Override
 	public void write(List<? extends Person> data) {
-        log.debug("Processing: " + data);
+        if (log.isDebugEnabled()) {
+            log.debug("Processing: " + data);
+        }
     }
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/JdbcTradeDao.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/JdbcTradeDao.java
@@ -55,7 +55,9 @@ public class JdbcTradeDao implements TradeDao {
     @Override
 	public void writeTrade(Trade trade) {
         Long id = incrementer.nextLongValue();
-        log.debug("Processing: " + trade);
+        if (log.isDebugEnabled()) {
+            log.debug("Processing: " + trade);
+        }
         jdbcTemplate.update(INSERT_TRADE_RECORD,
 				id, trade.getIsin(), trade.getQuantity(), trade.getPrice(),
 				trade.getCustomer());

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleBatchlet.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleBatchlet.java
@@ -39,8 +39,9 @@ public class JsrSampleBatchlet extends AbstractBatchlet {
 
 	@Override
 	public String process() throws Exception {
-		LOG.info("Calling remote service at: " + remoteServiceURL);
-
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Calling remote service at: " + remoteServiceURL);
+		}
 		Thread.sleep(2000);
 
 		LOG.info("Remote service call complete");

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleItemProcessor.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleItemProcessor.java
@@ -35,8 +35,9 @@ public class JsrSampleItemProcessor implements ItemProcessor {
 	public Object processItem(Object o) throws Exception {
 		String person = (String) o;
 
-		LOG.info("Transforming person: " + person + " to uppercase");
-
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Transforming person: " + person + " to uppercase");
+		}
 		return person.toUpperCase();
 	}
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleItemReader.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleItemReader.java
@@ -48,8 +48,9 @@ public class JsrSampleItemReader extends AbstractItemReader {
 		if(people.iterator().hasNext()) {
 			person = people.iterator().next();
 			people.remove(person);
-
-			LOG.info("Read person: " + person);
+			if (LOG.isInfoEnabled()) {
+				LOG.info("Read person: " + person);
+			}
 		}
 
 		return person;

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleItemWriter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleItemWriter.java
@@ -35,7 +35,9 @@ public class JsrSampleItemWriter extends AbstractItemWriter {
 	@Override
 	public void writeItems(List<Object> people) throws Exception {
 		for(Object person : people) {
-			LOG.info("Writing person: " + person);
+			if (LOG.isInfoEnabled()) {
+				LOG.info("Writing person: " + person);
+			}
 		}
 	}
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleTasklet.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/jsr352/JsrSampleTasklet.java
@@ -44,7 +44,9 @@ public class JsrSampleTasklet implements Tasklet {
 	@Nullable
 	@Override
 	public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) throws Exception {
-		LOG.info("Calling remote service at: " + remoteServiceURL);
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Calling remote service at: " + remoteServiceURL);
+		}
 
 		Thread.sleep(2000);
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/quartz/JobLauncherDetails.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/quartz/JobLauncherDetails.java
@@ -66,7 +66,9 @@ public class JobLauncherDetails extends QuartzJobBean {
 	protected void executeInternal(JobExecutionContext context) {
 		Map<String, Object> jobDataMap = context.getMergedJobDataMap();
 		String jobName = (String) jobDataMap.get(JOB_NAME);
-		log.info("Quartz trigger firing with Spring Batch jobName="+jobName);
+		if (log.isInfoEnabled()) {
+			log.info("Quartz trigger firing with Spring Batch jobName=" + jobName);
+		}
 		JobParameters jobParameters = getJobParametersFromJobMap(jobDataMap);
 		try {
 			jobLauncher.run(jobLocator.getJob(jobName), jobParameters);

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
@@ -144,7 +144,7 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 						jdbcTemplate.execute(trimmedScript);
 					}
 					catch (DataAccessException e) {
-						if (this.ignoreFailedDrop && trimmedScript.toLowerCase().startsWith("drop")) {
+						if (this.ignoreFailedDrop && trimmedScript.toLowerCase().startsWith("drop") && logger.isDebugEnabled()) {
 							logger.debug("DROP script failed (ignoring): " + trimmedScript);
 						}
 						else {


### PR DESCRIPTION
Guarded the logging statements which do concatenation of strings
or calling toString on objects. When a log level isn't enabled
this still would produce garbage that would need to be collected.

Guarded all logging up to info, warn and error can be assumed to be
enabled on a production system.