### PR TITLE
Provide constructors for injection

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/GsonJsonObjectMarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/GsonJsonObjectMarshaller.java
@@ -30,9 +30,18 @@ public class GsonJsonObjectMarshaller<T> implements JsonObjectMarshaller<T> {
 
 	private Gson gson = new Gson();
 
+	public GsonJsonObjectMarshaller() {
+		this.gson=new Gson();
+	}
+	
+	public GsonJsonObjectMarshaller(Gson gson) {
+		this.gson=gson;
+	}
+	
 	/**
 	 * Set the {@link Gson} object to use.
 	 * @param gson object to use
+	 * @see #GsonJsonObjectMarshaller(Gson)    
 	 */
 	public void setGson(Gson gson) {
 		this.gson = gson;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/GsonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/GsonJsonObjectReader.java
@@ -42,11 +42,11 @@ import org.springframework.util.Assert;
  */
 public class GsonJsonObjectReader<T> implements JsonObjectReader<T> {
 
-	private Class<? extends T> itemType;
+	private final Class<? extends T> itemType;
 
 	private JsonReader jsonReader;
 
-	private Gson mapper = new Gson();
+	private Gson mapper;
 
 	private InputStream inputStream;
 
@@ -55,12 +55,19 @@ public class GsonJsonObjectReader<T> implements JsonObjectReader<T> {
 	 * @param itemType the target item type
 	 */
 	public GsonJsonObjectReader(Class<? extends T> itemType) {
+		this.mapper = new Gson();
+		this.itemType = itemType;
+	}
+
+	public GsonJsonObjectReader(Gson mapper, Class<? extends T> itemType) {
+		this.mapper = mapper;
 		this.itemType = itemType;
 	}
 
 	/**
 	 * Set the object mapper to use to map Json objects to domain objects.
 	 * @param mapper the object mapper to use
+	 * @see #GsonJsonObjectReader(Gson, Class)
 	 */
 	public void setMapper(Gson mapper) {
 		Assert.notNull(mapper, "The mapper must not be null");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JacksonJsonObjectMarshaller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JacksonJsonObjectMarshaller.java
@@ -31,11 +31,20 @@ import org.springframework.batch.item.ItemStreamException;
  */
 public class JacksonJsonObjectMarshaller<T> implements JsonObjectMarshaller<T> {
 
-	private ObjectMapper objectMapper = new ObjectMapper();
+	private ObjectMapper objectMapper;
+
+	public JacksonJsonObjectMarshaller() {
+		this.objectMapper = new ObjectMapper();
+	}
+
+	public JacksonJsonObjectMarshaller(ObjectMapper objectMapper) {
+		this.objectMapper=objectMapper;
+	}
 
 	/**
 	 * Set the {@link ObjectMapper} to use.
 	 * @param objectMapper to use
+	 * @see #JacksonJsonObjectMarshaller(ObjectMapper)
 	 */
 	public void setObjectMapper(ObjectMapper objectMapper) {
 		this.objectMapper = objectMapper;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JacksonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JacksonJsonObjectReader.java
@@ -39,11 +39,11 @@ import org.springframework.util.Assert;
  */
 public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 
-	private Class<? extends T> itemType;
+	private final Class<? extends T> itemType;
 
 	private JsonParser jsonParser;
 
-	private ObjectMapper mapper = new ObjectMapper();
+	private ObjectMapper mapper;
 
 	private InputStream inputStream;
 
@@ -52,12 +52,19 @@ public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 	 * @param itemType the target item type
 	 */
 	public JacksonJsonObjectReader(Class<? extends T> itemType) {
+		this.mapper=new ObjectMapper();
 		this.itemType = itemType;
+	}
+
+	public JacksonJsonObjectReader(ObjectMapper mapper, Class<? extends T> itemType) {
+		this.mapper= mapper;
+		this.itemType=itemType;
 	}
 
 	/**
 	 * Set the object mapper to use to map Json objects to domain objects.
 	 * @param mapper the object mapper to use
+	 * @see #JacksonJsonObjectReader(ObjectMapper, Class)
 	 */
 	public void setMapper(ObjectMapper mapper) {
 		Assert.notNull(mapper, "The mapper must not be null");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/GsonJsonFileItemWriterFunctionalTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/GsonJsonFileItemWriterFunctionalTests.java
@@ -34,9 +34,7 @@ public class GsonJsonFileItemWriterFunctionalTests extends JsonFileItemWriterFun
 	@Override
 	protected JsonObjectMarshaller<Trade> getJsonObjectMarshallerWithPrettyPrint() {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
-		GsonJsonObjectMarshaller<Trade> jsonObjectMarshaller = new GsonJsonObjectMarshaller<>();
-		jsonObjectMarshaller.setGson(gson);
-		return jsonObjectMarshaller;
+		return new GsonJsonObjectMarshaller<>(gson);
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JacksonJsonFileItemWriterFunctionalTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JacksonJsonFileItemWriterFunctionalTests.java
@@ -35,9 +35,7 @@ public class JacksonJsonFileItemWriterFunctionalTests extends JsonFileItemWriter
 	protected JsonObjectMarshaller<Trade> getJsonObjectMarshallerWithPrettyPrint() {
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-		JacksonJsonObjectMarshaller<Trade> jsonObjectMarshaller = new JacksonJsonObjectMarshaller<>();
-		jsonObjectMarshaller.setObjectMapper(objectMapper);
-		return jsonObjectMarshaller;
+		return new JacksonJsonObjectMarshaller<>(objectMapper);
 	}
 
 	@Override


### PR DESCRIPTION
Currently when reading/writing JSON and using the reader/marshaller provided
and you want a custom Gson or ObjectMapper instance it still creates the not
needed instance. Move the construction to a constructor and provide a constructor
to directly pass in the pre-configured Gson or ObjectMapper instance.

The same approach is used in Spring itself where Gson or ObjectMapper instances
can be passed in.