### PR TITLE
KafkaItemWriter.write should not return until items are confirmed to have been written

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
@@ -43,7 +43,9 @@ public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, Initial
 			K key = itemKeyMapper.convert(item);
 			writeKeyValue(key, item);
 		}
+		flush();
 	}
+	protected void flush() throws Exception {}
 
 	/**
 	 * Subclasses implement this method to write each item to key value store


### PR DESCRIPTION
This PR is for issue #3773.