### PR TITLE
Add the constructor with Callable to CallableTaskletAdapter for convenience

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapter.java
@@ -35,6 +35,21 @@ public class CallableTaskletAdapter implements Tasklet, InitializingBean {
 	private Callable<RepeatStatus> callable;
 
 	/**
+	 * Create a new {@link CallableTaskletAdapter} instance.
+	 */
+	public CallableTaskletAdapter() {
+	}
+
+	/**
+	 * Create a new {@link CallableTaskletAdapter} instance.
+	 * @param callable the {@link Callable} to use
+	 */
+	public CallableTaskletAdapter(Callable<RepeatStatus> callable) {
+		setCallable(callable);
+		afterPropertiesSet();
+	}
+
+	/**
 	 * Public setter for the {@link Callable}.
 	 * @param callable the {@link Callable} to set
 	 */
@@ -48,7 +63,7 @@ public class CallableTaskletAdapter implements Tasklet, InitializingBean {
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */
 	@Override
-	public void afterPropertiesSet() throws Exception {
+	public void afterPropertiesSet() {
 		Assert.state(callable != null, "A Callable is required");
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapterTests.java
@@ -25,10 +25,22 @@ import org.springframework.batch.repeat.RepeatStatus;
 
 class CallableTaskletAdapterTests {
 
-	private final CallableTaskletAdapter adapter = new CallableTaskletAdapter();
+	@Test
+	public void testHandleWithConstructor() throws Exception {
+		CallableTaskletAdapter adapter = new CallableTaskletAdapter(
+			new Callable<RepeatStatus>() {
+				@Override
+				public RepeatStatus call() throws Exception {
+					return RepeatStatus.FINISHED;
+				}
+			}
+		);
+		assertEquals(RepeatStatus.FINISHED, adapter.execute(null, null));
+	}
 
 	@Test
-	void testHandle() throws Exception {
+	void testExecuteWithSetter() throws Exception {
+		CallableTaskletAdapter adapter = new CallableTaskletAdapter();
 		adapter.setCallable(new Callable<RepeatStatus>() {
 			@Override
 			public RepeatStatus call() throws Exception {
@@ -40,7 +52,6 @@ class CallableTaskletAdapterTests {
 
 	@Test
 	void testAfterPropertiesSet() {
-		assertThrows(IllegalStateException.class, adapter::afterPropertiesSet);
+		assertThrows(IllegalStateException.class, new CallableTaskletAdapter()::afterPropertiesSet);
 	}
-
 }


### PR DESCRIPTION
This PR adds the constructor with a `Callable<RepeatStatus>` parameter to CallableTaskletAdapter.
It makes CallableTaskletAdapter more convenient.

AS-IS:
```java
    var tasklet = new CallableTaskletAdapter();
    tasklet.setCallable(callable);
```

TO-BE:

```java
    var tasklet = new CallableTaskletAdapter(callable);
```