### PR TITLE
Jackson2ExecutionContextStringSerializer trust result of `Arrays.asList()` by default.

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializer.java
@@ -255,6 +255,7 @@ public class Jackson2ExecutionContextStringSerializer implements ExecutionContex
     static class TrustedTypeIdResolver implements TypeIdResolver {
         private static final Set<String> TRUSTED_CLASS_NAMES = Collections.unmodifiableSet(new HashSet(Arrays.asList(
                 "java.util.ArrayList",
+                "java.util.Arrays$ArrayList",
                 "java.util.LinkedList",
                 "java.util.Collections$EmptyList",
                 "java.util.Collections$EmptyMap",

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializerTests.java
@@ -19,7 +19,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -162,4 +164,23 @@ public class Jackson2ExecutionContextStringSerializerTests extends AbstractExecu
 	}
 
 	public static class UnmappedDomesticNumber extends UnmappedPhoneNumber{}
+
+	@Test
+	public void arrayAsListSerializationTest() throws IOException {
+
+		Jackson2ExecutionContextStringSerializer j = new Jackson2ExecutionContextStringSerializer();
+		Map<String, Object> context = new HashMap<>(1);
+		context.put("Arrays.asList", Arrays.asList("foo", "bar"));
+
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		j.serialize(context, os);
+
+		InputStream in = new ByteArrayInputStream(os.toByteArray());
+
+		context = j.deserialize(in);
+		
+		String[] expectedValue = { "foo", "bar" };
+		List<String> deserializedValue = (List<String>) context.get("Arrays.asList");
+		Assert.assertArrayEquals(expectedValue, deserializedValue.toArray(new String[0]));
+	}
 }


### PR DESCRIPTION
fix #3830

- add `java.util.Arrays$ArrayList`(result of `Arrays.asList(...)`) to `Jackson2ExecutionContextStringSerializer`'s default trusted classes list.
- add test for serializing and deserializing result of `Arrays.asList(...)` by `Jackson2ExecutionContextStringSerializer `.