### PR TITLE
Override SimpleStepBuilder.faultTolerant() in FaultTolerantStepBuilder

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -432,6 +432,14 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 		}
 		return this;
 	}
+	
+	/**
+	 * Override parent method to prevent creation of a new FaultTolerantStepBuilder
+	 */
+	@Override
+	public FaultTolerantStepBuilder<I, O> faultTolerant() {
+		return this;
+	}
 
 	protected ChunkProvider<I> createChunkProvider() {
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilderTests.java
@@ -1,0 +1,15 @@
+package org.springframework.batch.core.step.builder;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class FaultTolerantStepBuilderTests {
+
+    @Test
+    public void faultTolerantReturnsSameInstance() {
+        FaultTolerantStepBuilder<Object, Object> builder = new FaultTolerantStepBuilder<>(new StepBuilder("test"));
+        assertEquals(builder, builder.faultTolerant());
+    }
+}


### PR DESCRIPTION
```
		@Bean
		public Step faultTolerantStep(StepBuilderFactory stepBuilderFactory) throws Exception {
			return stepBuilderFactory.get("faultTolerantStep")
					.chunk(2)
					.reader(reader())
					.processor(processor())
					.writer(writer())
					.faultTolerant()
					.listener(chunkListener)
					.skipLimit(1)
					.faultTolerant()
                                        .build()
```

I had a failure in a step configuration when calling .faultTolerant() twice. That led to the problem that the chunkListener was not registered. 
The reason is that calling .faultTolerant() on an existing FaultTolerantStepBuilder creates a new FaultTolerantStepBuilder but not all configurations, like ChunkListeners, are kept.
Although it was a mistake in my job config, i think it would be better to return the current FaultTolerantStepBuilder to prevent such mistakes.
