### PR TITLE
Fix HippyMethodInvoker by not considering unsuitable candidates

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/HippyMethodInvokerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/HippyMethodInvokerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2012 the original author or authors.
+ * Copyright 2010-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class HippyMethodInvokerTests {
 		HippyMethodInvoker invoker = new HippyMethodInvoker();
 		invoker.setTargetMethod("duplicate");
 		invoker.setTargetObject(new PlainPojo());
-		invoker.setArguments(new Object[] { "2", "foo" });
+		invoker.setArguments("2", "foo");
 		invoker.prepare();
 		assertEquals("foo.2", invoker.invoke());
 	}
@@ -95,9 +95,36 @@ public class HippyMethodInvokerTests {
 		assertEquals(target.foo(arg), Set.class);
 
 		invoker.setTargetObject(target);
-		invoker.setArguments(new Object[] { arg });
+		invoker.setArguments(arg);
 		invoker.prepare();
 		assertEquals(invoker.invoke(), Set.class);
+
+	}
+
+	@Test
+	public void testOverloadedMethodWithTwoArgumentsAndOneExactMatch() throws Exception {
+
+		HippyMethodInvoker invoker = new HippyMethodInvoker();
+		invoker.setTargetMethod("foo");
+		@SuppressWarnings("unused")
+		class OverloadingPojo {
+			public Class<?> foo(String arg1, Number arg2) {
+				return Number.class;
+			}
+			public Class<?> foo(String arg1, List<?> arg2) {
+				return List.class;
+			}
+		}
+
+		String exactArg = "string";
+		Integer inexactArg = 0;
+		OverloadingPojo target = new OverloadingPojo();
+		assertEquals(target.foo(exactArg, inexactArg), Number.class);
+
+		invoker.setTargetObject(target);
+		invoker.setArguments(exactArg, inexactArg);
+		invoker.prepare();
+		assertEquals(invoker.invoke(), Number.class);
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-batch/issues/3794

The `HippyMethodInvoker` currently calculates the `typeDifferenceWeight` based not on all required arguments but only those that are actually assignable. If a candidate method has one argument that's an exact match and another that does not match at all, this logic yields a perfect `typeDifferenceWeight` of 0 which prevents actually suitable candidates from being considered.

The idea is to not consider candidate methods with unassignable arguments since these lead to an `IllegalArgumentException` if selected anyways.