### PR TITLE
Reduce naming collisions in consecutive tests

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,8 @@ import org.springframework.batch.core.Step;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.util.ClassUtils;
@@ -31,9 +30,6 @@ import javax.sql.DataSource;
 
 @Configuration
 public class DataSourceConfiguration {
-
-	@Autowired
-	private Environment environment;
 
 	@Autowired
 	private ResourceLoader resourceLoader;
@@ -48,7 +44,9 @@ public class DataSourceConfiguration {
 
 	@Bean
 	public DataSource dataSource() {
-		return new EmbeddedDatabaseFactory().getDatabase();
+		return new EmbeddedDatabaseBuilder()
+				.generateUniqueName(true)
+				.build();
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public abstract class TransactionManagerConfigurationTests {
 		return new EmbeddedDatabaseBuilder()
 				.addScript("classpath:org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("classpath:org/springframework/batch/core/schema-hsqldb.sql")
+				.generateUniqueName(true)
 				.build();
 	}
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/RegisterMultiListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/RegisterMultiListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.lang.Nullable;
@@ -73,9 +72,6 @@ public class RegisterMultiListenerTests {
 
 	@Autowired
 	private CallChecker callChecker;
-
-	@Autowired
-	private EmbeddedDatabase dataSource;
 
 	private GenericApplicationContext context;
 
@@ -206,6 +202,7 @@ public class RegisterMultiListenerTests {
 			.addScript("classpath:org/springframework/batch/core/schema-drop-hsqldb.sql")
 			.addScript("classpath:org/springframework/batch/core/schema-hsqldb.sql")
 			.setType(EmbeddedDatabaseType.HSQL)
+			.generateUniqueName(true)
 			.build());
 		}
 
@@ -236,6 +233,7 @@ public class RegisterMultiListenerTests {
 			.addScript("classpath:org/springframework/batch/core/schema-drop-hsqldb.sql")
 			.addScript("classpath:org/springframework/batch/core/schema-hsqldb.sql")
 			.setType(EmbeddedDatabaseType.HSQL)
+			.generateUniqueName(true)
 			.build());
 		}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/concurrent/ConcurrentTransactionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/concurrent/ConcurrentTransactionTests.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import javax.sql.DataSource;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -68,7 +67,6 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = ConcurrentTransactionTests.ConcurrentJobConfiguration.class)
-@Ignore // FIXME https://github.com/spring-projects/spring-batch/issues/3851
 public class ConcurrentTransactionTests {
 
 	@Autowired
@@ -149,6 +147,7 @@ public class ConcurrentTransactionTests {
 			databasePopulator.addScript(defaultResourceLoader.getResource("classpath:org/springframework/batch/core/schema-drop-hsqldb.sql"));
 			databasePopulator.addScript(defaultResourceLoader.getResource("classpath:org/springframework/batch/core/schema-hsqldb.sql"));
 			embeddedDatabaseFactory.setDatabasePopulator(databasePopulator);
+			embeddedDatabaseFactory.setGenerateUniqueDatabaseName(true);
 
 			return embeddedDatabaseFactory.getDatabase();
 		}

--- a/spring-batch-docs/src/main/asciidoc/step.adoc
+++ b/spring-batch-docs/src/main/asciidoc/step.adoc
@@ -2422,7 +2422,7 @@ The following example shows an example of binding to job scope in XML:
 [role="javaContent"]
 The following example shows an example of binding to job scope in Java:
 
-.Java Configurtation
+.Java Configuration
 [source, java, role="javaContent"]
 ----
 @JobScope

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/config/DatasourceTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/config/DatasourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,32 +24,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.junit.runner.RunWith;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
-
-import javax.sql.DataSource;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
 public class DatasourceTests {
 
-	private JdbcTemplate jdbcTemplate;
-
 	@Autowired
-	public void setDataSource(DataSource dataSource) {
-		this.jdbcTemplate = new JdbcTemplate(dataSource);
-	}
-	
-	@BeforeClass
-	public static void init() {
-		System.setProperty("batch.business.schema.script", "classpath:/org/springframework/batch/jms/init.sql");
-	}
-
-	@AfterClass
-	public static void cleanup() {
-		System.clearProperty("batch.business.schema.script");
-	}
+	private JdbcTemplate jdbcTemplate;
 
 	@Transactional @Test
 	public void testTemplate() throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerIntegrationTests.java
@@ -32,7 +32,6 @@ import javax.jms.TextMessage;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,7 +55,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
 @DirtiesContext
-@Ignore //FIXME https://github.com/spring-projects/spring-batch/issues/3852
 public class BatchMessageListenerContainerIntegrationTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,7 @@ public class JpaItemWriterIntegrationTests {
 		public DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder()
 					.setType(EmbeddedDatabaseType.HSQL)
+					.generateUniqueName(true)
 					.build();
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNativeQueryIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNativeQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ public class JpaPagingItemReaderNativeQueryIntegrationTests extends AbstractPagi
             return new EmbeddedDatabaseBuilder()
                     .setType(EmbeddedDatabaseType.HSQL)
                     .addScript("org/springframework/batch/item/database/init-foo-schema-hsqldb.sql")
+                    .generateUniqueName(true)
                     .build();
         }
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateCursorItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
@@ -235,7 +235,9 @@ public class HibernateCursorItemReaderBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernatePagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernatePagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
@@ -219,7 +219,9 @@ public class HibernatePagingItemReaderBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcBatchItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcBatchItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -263,7 +263,7 @@ public class JdbcBatchItemWriterBuilderTests {
 
 		assertEquals(1, (int) template.queryForObject(
 				"select count(*) from foo where first = ? and second = ? and third = ?",
-				new Object[] {i, i1, nine}, Integer.class));
+				Integer.class, i, i1, nine));
 	}
 
 	public static class Foo {
@@ -313,7 +313,9 @@ public class JdbcBatchItemWriterBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.PreparedStatementSetter;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -418,7 +418,9 @@ public class JdbcCursorItemReaderBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -431,7 +431,9 @@ public class JdbcPagingItemReaderBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaCursorItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -234,7 +234,9 @@ public class JpaCursorItemReaderBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -253,7 +253,9 @@ public class JpaPagingItemReaderBuilderTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return new EmbeddedDatabaseFactory().getDatabase();
+			return new EmbeddedDatabaseBuilder()
+					.generateUniqueName(true)
+					.build();
 		}
 
 		@Bean

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jms/ExternalRetryInBatchTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jms/ExternalRetryInBatchTests.java
@@ -18,7 +18,6 @@ package org.springframework.batch.jms;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
@@ -45,7 +44,6 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +52,6 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
-@Ignore //FIXME https://github.com/spring-projects/spring-batch/issues/3852
 public class ExternalRetryInBatchTests {
 
 	@Autowired
@@ -67,15 +64,11 @@ public class ExternalRetryInBatchTests {
 
 	private ItemReader<String> provider;
 
+	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 	@Autowired
 	private PlatformTransactionManager transactionManager;
-
-	@Autowired
-	public void setDataSource(DataSource dataSource) {
-		jdbcTemplate = new JdbcTemplate(dataSource);
-	}
 
 	@Before
 	public void onSetUp() throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/AsynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/AsynchronousTests.java
@@ -22,16 +22,13 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-import javax.sql.DataSource;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.batch.container.jms.BatchMessageListenerContainer;
-import org.springframework.batch.jms.ExternalRetryInBatchTests;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jms.core.JmsTemplate;
@@ -39,7 +36,6 @@ import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.util.ClassUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -48,13 +44,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
 @DirtiesContext
-@Ignore //FIXME https://github.com/spring-projects/spring-batch/issues/3852
 public class AsynchronousTests {
-
-	protected String[] getConfigLocations() {
-		return new String[] { ClassUtils.addResourcePathToPackagePath(ExternalRetryInBatchTests.class,
-				"jms-context.xml") };
-	}
 
 	@Autowired
 	private BatchMessageListenerContainer container;
@@ -62,12 +52,8 @@ public class AsynchronousTests {
 	@Autowired
 	private JmsTemplate jmsTemplate;
 
-	private JdbcTemplate jdbcTemplate;
-
 	@Autowired
-	public void setDataSource(DataSource dataSource) {
-		this.jdbcTemplate = new JdbcTemplate(dataSource);
-	}
+	private JdbcTemplate jdbcTemplate;
 
 	@Before
 	public void onSetUp() throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/SynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/SynchronousTests.java
@@ -25,9 +25,7 @@ import java.util.List;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.jms.Session;
-import javax.sql.DataSource;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,7 +53,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
 @DirtiesContext
-@Ignore //FIXME https://github.com/spring-projects/spring-batch/issues/3852
 public class SynchronousTests implements ApplicationContextAware {
 
 	@Autowired
@@ -67,6 +64,7 @@ public class SynchronousTests implements ApplicationContextAware {
 	@Autowired
 	private PlatformTransactionManager transactionManager;
 
+	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 	private ApplicationContext applicationContext;
@@ -76,11 +74,6 @@ public class SynchronousTests implements ApplicationContextAware {
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
-	}
-
-	@Autowired
-	public void setDataSource(DataSource dataSource) {
-		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}
 
 	@BeforeTransaction

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/ExternalRetryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/ExternalRetryTests.java
@@ -17,7 +17,6 @@
 package org.springframework.batch.retry.jms;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
@@ -38,7 +37,6 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -48,7 +46,6 @@ import static org.junit.Assert.fail;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
-@Ignore //FIXME https://github.com/spring-projects/spring-batch/issues/3852
 public class ExternalRetryTests {
 
 	@Autowired
@@ -58,15 +55,11 @@ public class ExternalRetryTests {
 
 	private ItemReader<String> provider;
 
+	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 	@Autowired
 	private PlatformTransactionManager transactionManager;
-
-	@Autowired
-	public void setDataSource(DataSource dataSource) {
-		jdbcTemplate = new JdbcTemplate(dataSource);
-	}
 
 	@Before
 	public void onSetUp() throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/SynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/SynchronousTests.java
@@ -17,11 +17,9 @@
 package org.springframework.batch.retry.jms;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.jms.JmsItemReader;
-import org.springframework.batch.jms.ExternalRetryInBatchTests;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jms.core.JmsTemplate;
@@ -37,9 +35,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.ClassUtils;
 
-import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +46,6 @@ import static org.junit.Assert.fail;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
-@Ignore //FIXME https://github.com/spring-projects/spring-batch/issues/3852
 public class SynchronousTests {
 
 	@Autowired
@@ -61,17 +56,8 @@ public class SynchronousTests {
 
 	private RetryTemplate retryTemplate;
 
-	private JdbcTemplate jdbcTemplate;
-
 	@Autowired
-	public void setDataSource(DataSource dataSource) {
-		this.jdbcTemplate = new JdbcTemplate(dataSource);
-	}
-
-	protected String[] getConfigLocations() {
-		return new String[] { ClassUtils.addResourcePathToPackagePath(ExternalRetryInBatchTests.class,
-				"jms-context.xml") };
-	}
+	private JdbcTemplate jdbcTemplate;
 
 	@BeforeTransaction
 	public void onSetUpBeforeTransaction() throws Exception {

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/JsonSupportIntegrationTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/JsonSupportIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ public class JsonSupportIntegrationTests {
 		public JsonFileItemWriter<Trade> itemWriter() {
 			return new JsonFileItemWriterBuilder<Trade>()
 					.resource(new FileSystemResource(OUTPUT_FILE_DIRECTORY + "trades.json"))
+					.lineSeparator("\n")
 					.jsonObjectMarshaller(new JacksonJsonObjectMarshaller<>())
 					.name("tradesJsonFileItemWriter")
 					.build();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/RemotePartitioningJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/RemotePartitioningJobFunctionalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ public abstract class RemotePartitioningJobFunctionalTests {
 		this.embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql")
+				.generateUniqueName(true)
 				.build();
 		this.workerApplicationContext = new AnnotationConfigApplicationContext(getWorkerConfigurationClass());
 	}


### PR DESCRIPTION
fixes https://github.com/spring-projects/spring-batch/issues/3851
fixes https://github.com/spring-projects/spring-batch/issues/3852

The root cause is that there are too many embedded databases with the same name. The issue is described here: https://github.com/spring-projects/spring-framework/issues/13491

I'm using Windows 10 with Oracle JDK 14.0.2 and it works on my machine: 😉 
- the build passes, when started form the command line,
- the tests pass when started per module in Eclipse, which triggers the test classes in a fixed but non-alphabetical order

Simply removing the ignore annotations on the master branch led to consistently reproducible errors.