### PR TITLE
Remove double brace initialization

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/BatchPropertyContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/BatchPropertyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,7 +218,6 @@ public class BatchPropertyContext {
 	 *
 	 * @param properties the step artifact {@link Properties} to add
 	 */
-	@SuppressWarnings("serial")
 	public void setStepArtifactProperties(Map<String, Map<String, Properties>> properties) {
 		Assert.notNull(properties, "Step artifact properties cannot be null");
 
@@ -232,12 +231,10 @@ public class BatchPropertyContext {
 				Map<String, Properties> artifactProperties = stepArtifactProperties.get(stepName);
 
 				if (artifactProperties == null) {
-					stepArtifactProperties.put(stepName, new HashMap<String, Properties>() {{
-						put(artifactName, props);
-					}});
-				} else {
-					artifactProperties.put(artifactName, props);
+					artifactProperties = new HashMap<>();
+					stepArtifactProperties.put(stepName, artifactProperties);
 				}
+				artifactProperties.put(artifactName, props);
 			}
 		}
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/support/BatchPropertyContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/support/BatchPropertyContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.batch.core.jsr.configuration.support;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -65,25 +66,19 @@ public class BatchPropertyContextTests {
 		stepArtifactProperties.setProperty("readerProperty1", "readerProperty1value");
 		stepArtifactProperties.setProperty("readerProperty2", "readerProperty2value");
 
-		this.stepArtifactProperties.put("step1", new HashMap<String, Properties>() {{
-			put("reader", stepArtifactProperties);
-		}});
+		this.stepArtifactProperties.put("step1", Collections.singletonMap("reader", stepArtifactProperties));
 
 		final Properties partitionProperties = new Properties();
 		partitionProperties.setProperty("writerProperty1", "writerProperty1valuePartition0");
 		partitionProperties.setProperty("writerProperty2", "writerProperty2valuePartition0");
 
-		this.partitionProperties.put("step2:partition0", new HashMap<String, Properties>() {{
-			put("writer", partitionProperties);
-		}});
+		this.partitionProperties.put("step2:partition0", Collections.singletonMap("writer", partitionProperties));
 
 		final Properties partitionStepProperties = new Properties();
 		partitionStepProperties.setProperty("writerProperty1Step", "writerProperty1");
 		partitionStepProperties.setProperty("writerProperty2Step", "writerProperty2");
 
-		this.partitionProperties.put("step2", new HashMap<String, Properties>() {{
-			put("writer", partitionStepProperties);
-		}});
+		this.partitionProperties.put("step2", Collections.singletonMap("writer", partitionStepProperties));
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.core.step.builder;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
@@ -58,7 +58,6 @@ import static org.junit.Assert.assertEquals;
  * @author Mahmoud Ben Hassine
  *
  */
-@SuppressWarnings("serial")
 public class StepBuilderTests {
 
 	@Test
@@ -180,15 +179,10 @@ public class StepBuilderTests {
 		jobRepository.add(execution);
 		PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 
-		List<String> items = new ArrayList<String>() {{
-			add("1");
-			add("2");
-			add("3");
-		}};
+		List<String> items = Arrays.asList("1", "2", "3");
 
 		ItemReader<String> reader = new ListItemReader<>(items);
 
-		@SuppressWarnings("unchecked")
 		SimpleStepBuilder<String, String> builder = new StepBuilder("step")
 											 .repository(jobRepository)
 											 .transactionManager(transactionManager)
@@ -219,16 +213,11 @@ public class StepBuilderTests {
 		jobRepository.add(execution);
 		PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 
-		List<Long> items = new ArrayList<Long>() {{
-			add(1L);
-			add(2L);
-			add(3L);
-		}};
+		List<Long> items = Arrays.asList(1L, 2L, 3L);
 
 		ItemReader<Long> reader = new ListItemReader<>(items);
 
 		ListItemWriter<String> itemWriter = new ListItemWriter<>();
-		@SuppressWarnings("unchecked")
 		SimpleStepBuilder<Object, String> builder = new StepBuilder("step")
 											 .repository(jobRepository)
 											 .transactionManager(transactionManager)

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.batch.item.data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -198,12 +199,9 @@ public class MongoItemReaderTests {
 		assertEquals("{ $natural : 1}", query.getHint());
 	}
 
-	@SuppressWarnings("serial")
 	@Test
 	public void testQueryWithParameters() {
-		reader.setParameterValues(new ArrayList<Object>(){{
-			add("foo");
-		}});
+		reader.setParameterValues(Collections.singletonList("foo"));
 
 		reader.setQuery("{ name : ?0 }");
 		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
@@ -219,12 +217,9 @@ public class MongoItemReaderTests {
 		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
 	}
 
-	@SuppressWarnings("serial")
 	@Test
 	public void testQueryWithCollection() {
-		reader.setParameterValues(new ArrayList<Object>(){{
-			add("foo");
-		}});
+		reader.setParameterValues(Collections.singletonList("foo"));
 
 		reader.setQuery("{ name : ?0 }");
 		reader.setCollection("collection");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.batch.item.data;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,7 +58,6 @@ import static org.mockito.ArgumentMatchers.eq;
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
  */
-@SuppressWarnings("serial")
 public class MongoItemWriterTests {
 
 	private MongoItemWriter<Object> writer;
@@ -101,10 +101,7 @@ public class MongoItemWriterTests {
 
 	@Test
 	public void testWriteNoTransactionNoCollection() throws Exception {
-		List<Item> items = new ArrayList<Item>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		List<Item> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.write(items);
 
@@ -114,10 +111,7 @@ public class MongoItemWriterTests {
 
 	@Test
 	public void testWriteNoTransactionWithCollection() throws Exception {
-		List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.setCollection("collection");
 
@@ -137,10 +131,7 @@ public class MongoItemWriterTests {
 
 	@Test
 	public void testWriteTransactionNoCollection() throws Exception {
-		final List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		final List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		new TransactionTemplate(transactionManager).execute((TransactionCallback<Void>) status -> {
 			try {
@@ -158,10 +149,7 @@ public class MongoItemWriterTests {
 
 	@Test
 	public void testWriteTransactionWithCollection() throws Exception {
-		final List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		final List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.setCollection("collection");
 
@@ -181,10 +169,7 @@ public class MongoItemWriterTests {
 
 	@Test
 	public void testWriteTransactionFails() throws Exception {
-		final List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		final List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.setCollection("collection");
 
@@ -213,10 +198,7 @@ public class MongoItemWriterTests {
 	 */
 	@Test
 	public void testWriteTransactionReadOnly() throws Exception {
-		final List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		final List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.setCollection("collection");
 
@@ -242,10 +224,7 @@ public class MongoItemWriterTests {
 	@Test
 	public void testRemoveNoObjectIdNoCollection() throws Exception {
 		writer.setDelete(true);
-		List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.write(items);
 
@@ -256,10 +235,7 @@ public class MongoItemWriterTests {
 	@Test
 	public void testRemoveNoObjectIdWithCollection() throws Exception {
 		writer.setDelete(true);
-		List<Object> items = new ArrayList<Object>() {{
-			add(new Item("Foo"));
-			add(new Item("Bar"));
-		}};
+		List<Object> items = Arrays.asList(new Item("Foo"), new Item("Bar"));
 
 		writer.setCollection("collection");
 		writer.write(items);
@@ -271,10 +247,7 @@ public class MongoItemWriterTests {
 	@Test
 	public void testRemoveNoTransactionNoCollection() throws Exception {
 		writer.setDelete(true);
-		List<Object> items = new ArrayList<Object>() {{
-			add(new Item(1));
-			add(new Item(2));
-		}};
+		List<Object> items = Arrays.asList(new Item(1), new Item(2));
 
 		writer.write(items);
 
@@ -285,10 +258,7 @@ public class MongoItemWriterTests {
 	@Test
 	public void testRemoveNoTransactionWithCollection() throws Exception {
 		writer.setDelete(true);
-		List<Object> items = new ArrayList<Object>() {{
-			add(new Item(1));
-			add(new Item(2));
-		}};
+		List<Object> items = Arrays.asList(new Item(1), new Item(2));
 
 		writer.setCollection("collection");
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.springframework.batch.item.database;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
@@ -131,7 +130,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		writer.write(Collections.singletonList(new Foo("bar")));
 	}
 
-	@SuppressWarnings({ "rawtypes", "serial", "unchecked" })
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testWriteAndFlushMap() throws Exception {
 		JdbcBatchItemWriter<Map<String, Object>> mapWriter = new JdbcBatchItemWriter<>();
@@ -145,14 +144,13 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		when(namedParameterJdbcOperations.batchUpdate(eq(sql),
 				captor.capture()))
 				.thenReturn(new int[] {1});
-		mapWriter.write(Collections.singletonList(new HashMap<String, Object>() {{put("foo", "bar");}}));
+		mapWriter.write(Collections.singletonList(Collections.singletonMap("foo", "bar")));
 
 		assertEquals(1, captor.getValue().length);
 		Map<String, Object> results = captor.getValue()[0];
 		assertEquals("bar", results.get("foo"));
 	}
 
-	@SuppressWarnings({ "rawtypes", "serial", "unchecked" })
 	@Test
 	public void testWriteAndFlushMapWithItemSqlParameterSourceProvider() throws Exception {
 		JdbcBatchItemWriter<Map<String, Object>> mapWriter = new JdbcBatchItemWriter<>();
@@ -172,7 +170,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		when(namedParameterJdbcOperations.batchUpdate(any(String.class),
 				captor.capture()))
 				.thenReturn(new int[] {1});
-		mapWriter.write(Collections.singletonList(new HashMap<String, Object>() {{put("foo", "bar");}}));
+		mapWriter.write(Collections.singletonList(Collections.singletonMap("foo", "bar")));
 
 		assertEquals(1, captor.getValue().length);
 		SqlParameterSource results = captor.getValue()[0];

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,15 +42,13 @@ public class CompositeItemProcessorTests {
 	private ItemProcessor<Object, Object> processor1;
 	private ItemProcessor<Object, Object> processor2;
 
-	@SuppressWarnings({ "unchecked", "serial" })
+	@SuppressWarnings("unchecked")
 	@Before
 	public void setUp() throws Exception {
 		processor1 = mock(ItemProcessor.class);
 		processor2 = mock(ItemProcessor.class);
 
-		composite.setDelegates(new ArrayList<ItemProcessor<Object,Object>>() {{
-			add(processor1); add(processor2);
-		}});
+		composite.setDelegates(Arrays.asList(processor1, processor2));
 
 		composite.afterPropertiesSet();
 	}
@@ -76,14 +75,13 @@ public class CompositeItemProcessorTests {
 	 * Test that the CompositeItemProcessor can work with generic types for the ItemProcessor delegates.
 	 */
 	@Test
-	@SuppressWarnings({"unchecked", "serial"})
+	@SuppressWarnings("unchecked")
 	public void testItemProcessorGenerics() throws Exception {
 		CompositeItemProcessor<String, String> composite = new CompositeItemProcessor<>();
 		final ItemProcessor<String, Integer> processor1 = mock(ItemProcessor.class);
 		final ItemProcessor<Integer, String> processor2 = mock(ItemProcessor.class);
-		composite.setDelegates(new ArrayList<ItemProcessor<?,?>>() {{
-			add(processor1); add(processor2);
-		}});
+		composite.setDelegates(Arrays.asList(processor1, processor2));
+
 		composite.afterPropertiesSet();
 
 		when(processor1.process("input")).thenReturn(5);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemReaderAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemReaderAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.springframework.batch.jsr.item;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.batch.api.chunk.ItemReader;
 
@@ -110,16 +110,11 @@ public class ItemReaderAdapterTests {
 	}
 
 	@Test
-	@SuppressWarnings("serial")
 	public void testCheckpointChange() throws Exception {
 		ItemReaderAdapter<String> adapter = new ItemReaderAdapter<>(new ItemReader() {
 
 			private CheckpointContainer container = null;
-			private List<String> items = new ArrayList<String>() {{
-				add("foo");
-				add("bar");
-				add("baz");
-			}};
+			private List<String> items = Arrays.asList("foo", "bar", "baz");
 
 			@Override
 			public Object readItem() throws Exception {


### PR DESCRIPTION
Remove double brace collection initialization as it is considered bad
practice [1] [2].

> However, it is quite obscure, and it costs an extra class at each usage. It also holds hidden references to the enclosing instance and to any captured objects. This may cause memory leaks or problems with serialization. For these reasons, this technique is best avoided.

> I think the example of "double-brace initialization" should be even more clearly labeled as pure evil. :-) You could also mention all the horrible consequences if anyone ever serializes such a collection.

 [1] https://mail.openjdk.java.net/pipermail/core-libs-dev/2015-September/035441.html
 [2] https://openjdk.java.net/jeps/269