### PR TITLE
Add getDataSource method to DefaultBatchConfigurer

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 
 	protected JobRepository createJobRepository() throws Exception {
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
-		factory.setDataSource(dataSource);
+		factory.setDataSource(getDataSource());
 		factory.setTransactionManager(getTransactionManager());
 		factory.afterPropertiesSet();
 		return factory.getObject();
@@ -137,8 +137,12 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 
 	protected JobExplorer createJobExplorer() throws Exception {
 		JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
-		jobExplorerFactoryBean.setDataSource(this.dataSource);
+		jobExplorerFactoryBean.setDataSource(getDataSource());
 		jobExplorerFactoryBean.afterPropertiesSet();
 		return jobExplorerFactoryBean.getObject();
+	}
+
+	protected DataSource getDataSource() {
+		return dataSource;
 	}
 }


### PR DESCRIPTION
When customizing createJobRepository using DefaultBatchConfiguer (according to [official docs](https://docs.spring.io/spring-batch/docs/current/reference/html/job.html#javaConfig)), it force us to use DataSource bean explicitly.

```java
@Bean
public BatchConfigurer batchConfigurer(DataSource dataSource) {
	return new DefaultBatchConfigurer() {
		@Override
		protected JobRepository createJobRepository() throws Exception {
			JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
			factory.setDataSource(dataSource);
			factory.setTransactionManager(getTransactionManager());
			factory.setTablePrefix("SYSTEM.TEST_");
			factory.afterPropertiesSet();
			return factory.getObject();
		}
	};
}
```

Using `getDataSource()` method, we can use like this.

```java
@Bean
public BatchConfigurer batchConfigurer() {
	return new DefaultBatchConfigurer() {
		@Override
		protected JobRepository createJobRepository() throws Exception {
			JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
			factory.setDataSource(getDataSource());
			factory.setTransactionManager(getTransactionManager());
			factory.setTablePrefix("SYSTEM.TEST_");
			factory.afterPropertiesSet();
			return factory.getObject();
		}
	};
}
```