### PR TITLE
Refactor deprecated extractDatabaseMetaData

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/DerbyPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/DerbyPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.database.support;
 
+import java.sql.DatabaseMetaData;
 import javax.sql.DataSource;
 
 import org.springframework.batch.item.database.PagingQueryProvider;
@@ -41,7 +42,7 @@ public class DerbyPagingQueryProvider extends SqlWindowingPagingQueryProvider {
 	@Override
 	public void init(DataSource dataSource) throws Exception {
 		super.init(dataSource);
-		String version = JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductVersion").toString();
+		String version = JdbcUtils.extractDatabaseMetaData(dataSource, DatabaseMetaData::getDatabaseProductVersion);
 		if (!isDerbyVersionSupported(version)) {
 			throw new InvalidDataAccessResourceUsageException("Apache Derby version " + version + " is not supported by this class,  Only version " + MINIMAL_DERBY_VERSION + " or later is supported");
 		}
@@ -52,8 +53,8 @@ public class DerbyPagingQueryProvider extends SqlWindowingPagingQueryProvider {
 		String[] minimalVersionParts = MINIMAL_DERBY_VERSION.split("\\.");
 		String[] versionParts = version.split("[\\. ]");
 		for (int i = 0; i < minimalVersionParts.length; i++) {
-			int minimalVersionPart = Integer.valueOf(minimalVersionParts[i]);
-			int versionPart = Integer.valueOf(versionParts[i]);
+			int minimalVersionPart = Integer.parseInt(minimalVersionParts[i]);
+			int versionPart = Integer.parseInt(versionParts[i]);
 			if (versionPart < minimalVersionPart) {
 				return false;
 			} else if (versionPart > minimalVersionPart) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.jdbc.support.MetaDataAccessException;
 import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
+import java.sql.DatabaseMetaData;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,17 +100,17 @@ public enum DatabaseType {
 	 */
 	public static DatabaseType fromMetaData(DataSource dataSource) throws MetaDataAccessException {
 		String databaseProductName =
-				JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductName").toString();
+				JdbcUtils.extractDatabaseMetaData(dataSource, DatabaseMetaData::getDatabaseProductName);
 		if (StringUtils.hasText(databaseProductName) && databaseProductName.startsWith("DB2")) {
 			String databaseProductVersion =
-					JdbcUtils.extractDatabaseMetaData(dataSource, "getDatabaseProductVersion").toString();
+					JdbcUtils.extractDatabaseMetaData(dataSource, DatabaseMetaData::getDatabaseProductVersion);
 			if (databaseProductVersion.startsWith("ARI")) {
 				databaseProductName = "DB2VSE";
 			}
 			else if (databaseProductVersion.startsWith("DSN")) {
 				databaseProductName = "DB2ZOS";
 			}
-			else if (databaseProductName.indexOf("AS") != -1 && (databaseProductVersion.startsWith("QSQ") ||
+			else if (databaseProductName.contains("AS") && (databaseProductVersion.startsWith("QSQ") ||
 					databaseProductVersion.substring(databaseProductVersion.indexOf('V')).matches("V\\dR\\d[mM]\\d"))) {
 				databaseProductName = "DB2AS400";
 			}


### PR DESCRIPTION
Spring's `JdbcUtils::extractDatabaseMetaData` has been deprecated as of 5.2.9. I have replaced it with its suggested successor.