### PR TITLE
Replace deprecated TransactionSynchronizationAdapter

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -174,8 +174,8 @@ public class TaskletStep extends AbstractStep {
 	 * @param listeners an array of listener objects of known types.
 	 */
 	public void setChunkListeners(ChunkListener[] listeners) {
-		for (ChunkListener listener : listeners) {
-			registerChunkListener(listener);
+		for (int i = 0; i < listeners.length; i++) {
+			registerChunkListener(listeners[i]);
 		}
 	}
 
@@ -191,8 +191,8 @@ public class TaskletStep extends AbstractStep {
 	 * @param streams an array of {@link ItemStream} objects.
 	 */
 	public void setStreams(ItemStream[] streams) {
-		for (ItemStream itemStream : streams) {
-			registerStream(itemStream);
+		for (int i = 0; i < streams.length; i++) {
+			registerStream(streams[i]);
 		}
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionAttribute;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
@@ -175,8 +174,8 @@ public class TaskletStep extends AbstractStep {
 	 * @param listeners an array of listener objects of known types.
 	 */
 	public void setChunkListeners(ChunkListener[] listeners) {
-		for (int i = 0; i < listeners.length; i++) {
-			registerChunkListener(listeners[i]);
+		for (ChunkListener listener : listeners) {
+			registerChunkListener(listener);
 		}
 	}
 
@@ -192,8 +191,8 @@ public class TaskletStep extends AbstractStep {
 	 * @param streams an array of {@link ItemStream} objects.
 	 */
 	public void setStreams(ItemStream[] streams) {
-		for (int i = 0; i < streams.length; i++) {
-			registerStream(streams[i]);
+		for (ItemStream itemStream : streams) {
+			registerStream(itemStream);
 		}
 	}
 
@@ -328,7 +327,7 @@ public class TaskletStep extends AbstractStep {
 	 * @author Dave Syer
 	 *
 	 */
-	private class ChunkTransactionCallback extends TransactionSynchronizationAdapter implements TransactionCallback<RepeatStatus> {
+	private class ChunkTransactionCallback implements TransactionSynchronization, TransactionCallback<RepeatStatus> {
 
 		private final StepExecution stepExecution;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -191,7 +191,7 @@ public class MongoItemWriter<T> implements ItemWriter<T>, InitializingBean {
 		if(!TransactionSynchronizationManager.hasResource(bufferKey)) {
 			TransactionSynchronizationManager.bindResource(bufferKey, new ArrayList<T>());
 
-			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 				@Override
 				public void beforeCommit(boolean readOnly) {
 					List<T> items = (List<T>) TransactionSynchronizationManager.getResource(bufferKey);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
 import org.springframework.batch.item.WriteFailedException;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
@@ -95,7 +95,7 @@ public class TransactionAwareBufferedWriter extends Writer {
 
 			TransactionSynchronizationManager.bindResource(bufferKey, new StringBuilder());
 
-			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 				@Override
 				public void afterCompletion(int status) {
 					clear();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
@@ -194,7 +193,7 @@ public class TransactionAwareProxyFactory<T> {
 		return new TransactionAwareProxyFactory<>(new CopyOnWriteArrayList<>(list)).createInstance();
 	}
 
-	private class TargetSynchronization extends TransactionSynchronizationAdapter {
+	private class TargetSynchronization implements TransactionSynchronization {
 
 		private final T cache;
 
@@ -208,7 +207,6 @@ public class TransactionAwareProxyFactory<T> {
 
         @Override
 		public void afterCompletion(int status) {
-			super.afterCompletion(status);
 			if (status == TransactionSynchronization.STATUS_COMMITTED) {
 				synchronized (target) {
 					commit(cache, target);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ResourcelessTransactionManagerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ResourcelessTransactionManagerTests.java
@@ -152,7 +152,8 @@ public class ResourcelessTransactionManagerTests {
 				return null;
 			});
 			fail("Expected RuntimeException");
-		} catch (RuntimeException e) {
+		}
+		catch (RuntimeException e) {
 			assertEquals("Rollback!", e.getMessage());
 		}
 		assertEquals(TransactionSynchronization.STATUS_ROLLED_BACK, txStatus);
@@ -180,7 +181,8 @@ public class ResourcelessTransactionManagerTests {
 				throw new RuntimeException("Rollback!");
 			});
 			fail("Expected RuntimeException");
-		} catch (RuntimeException e) {
+		}
+		catch (RuntimeException e) {
 			assertEquals("Rollback!", e.getMessage());
 		}
 		assertEquals(TransactionSynchronization.STATUS_ROLLED_BACK, txStatus);


### PR DESCRIPTION
Spring's `TransactionSynchronizationAdapter` has been deprecated as of 5.3. I have replaced the abstract class with the interface `TransactionSynchronization`.