### PR TITLE
Make countStepExecutions access batch_job_execution only once

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
@@ -107,11 +107,9 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 			"STEP_EXECUTION_ID=?";
 
 	private static final String COUNT_STEP_EXECUTIONS = "SELECT COUNT(*) " +
-			" from %PREFIX%JOB_EXECUTION JE, %PREFIX%STEP_EXECUTION SE" +
-			" where " +
-			"      SE.JOB_EXECUTION_ID in (SELECT JOB_EXECUTION_ID from %PREFIX%JOB_EXECUTION " +
-			"where JOB_INSTANCE_ID = ?)" +
-			"      and SE.JOB_EXECUTION_ID = JE.JOB_EXECUTION_ID " +
+			" from %PREFIX%JOB_EXECUTION JE JOIN %PREFIX%STEP_EXECUTION SE " +
+			"      on SE.JOB_EXECUTION_ID = JE.JOB_EXECUTION_ID " +
+			"where JE.JOB_INSTANCE_ID = ?" +
 			"      and SE.STEP_NAME = ?";
 
 	private int exitMessageLength = DEFAULT_EXIT_MESSAGE_LENGTH;


### PR DESCRIPTION
Change JdbcStepExecutionDao.COUNT_STEP_EXECUTIONS to access the table
batch_job_execution only once.

JdbcStepExecutionDao.COUNT_STEP_EXECUTIONS accesses batch_job_execution twice.

```sql
SELECT
    COUNT(*)
FROM
    batch_job_execution    je,
    batch_step_execution   se
WHERE
    se.job_execution_id IN (
        SELECT
            job_execution_id
        FROM
            batch_job_execution
        WHERE
            job_instance_id = ?
    )
    AND se.job_execution_id = je.job_execution_id
    AND se.step_name = ?;
```

there is no need for this, the query can be simlified to

```sql
SELECT
    COUNT(*)
FROM
         batch_job_execution je
    JOIN batch_step_execution se ON se.job_execution_id = je.job_execution_id
WHERE
        je.job_instance_id = ?
    AND se.step_name = ?;
```