### PR TITLE
Incorrect code examples in documentation

### DIFF
--- a/spring-batch-docs/src/main/asciidoc/step.adoc
+++ b/spring-batch-docs/src/main/asciidoc/step.adoc
@@ -352,7 +352,6 @@ value of 10 as it would be defined in Java:
 public Job sampleJob() {
     return this.jobBuilderFactory.get("sampleJob")
                      .start(step1())
-                     .end()
                      .build();
 }
 
@@ -507,7 +506,6 @@ public Job footballJob() {
 				.start(playerLoad())
 				.next(gameLoad())
 				.next(playerSummarization())
-				.end()
 				.build();
 }
 


### PR DESCRIPTION
This example code fails the build. `end()` method is not exists