### PR TITLE
Fix misused 'end()' in examples

### DIFF
--- a/spring-batch-docs/src/main/asciidoc/domain.adoc
+++ b/spring-batch-docs/src/main/asciidoc/domain.adoc
@@ -77,7 +77,6 @@ public Job footballJob() {
                      .start(playerLoad())
                      .next(gameLoad())
                      .next(playerSummarization())
-                     .end()
                      .build();
 }
 ----
@@ -113,7 +112,6 @@ public Job footballJob() {
                      .start(playerLoad())
                      .next(gameLoad())
                      .next(playerSummarization())
-                     .end()
                      .build();
 }
 ----

--- a/spring-batch-docs/src/main/asciidoc/job.adoc
+++ b/spring-batch-docs/src/main/asciidoc/job.adoc
@@ -41,7 +41,6 @@ public Job footballJob() {
                      .start(playerLoad())
                      .next(gameLoad())
                      .next(playerSummarization())
-                     .end()
                      .build();
 }
 ----
@@ -106,7 +105,6 @@ public Job footballJob() {
                      .start(playerLoad())
                      .next(gameLoad())
                      .next(playerSummarization())
-                     .end()
                      .build();
 }
 ----

--- a/spring-batch-docs/src/main/asciidoc/processor.adoc
+++ b/spring-batch-docs/src/main/asciidoc/processor.adoc
@@ -110,7 +110,6 @@ objects, throwing an exception if any other type is provided. Similarly, the
 public Job ioSampleJob() {
 	return this.jobBuilderFactory.get("ioSampleJob")
 				.start(step1())
-				.end()
 				.build();
 }
 
@@ -216,7 +215,6 @@ Just as with the previous example, the composite processor can be configured int
 public Job ioSampleJob() {
 	return this.jobBuilderFactory.get("ioSampleJob")
 				.start(step1())
-				.end()
 				.build();
 }
 

--- a/spring-batch-docs/src/main/asciidoc/readersAndWriters.adoc
+++ b/spring-batch-docs/src/main/asciidoc/readersAndWriters.adoc
@@ -178,7 +178,6 @@ The following example shows how to inject a delegate as a stream in XML:
 public Job ioSampleJob() {
 	return this.jobBuilderFactory.get("ioSampleJob")
 				.start(step1())
-				.end()
 				.build();
 }
 


### PR DESCRIPTION
`use()` can be used in `FlowJobBuilder` usage. Similar with https://github.com/spring-projects/spring-batch/pull/3889.