### PR TITLE
Explicit handling of nested splits in SplitState

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -300,9 +300,9 @@ public class FlowBuilder<Q> {
 		return result;
 	}
 
-	private SplitState createState(Collection<Flow> flows, TaskExecutor executor) {
+	private SplitState createState(Collection<Flow> flows, TaskExecutor executor, SplitState parentSplit) {
 		if (!states.containsKey(flows)) {
-			states.put(flows, new SplitState(flows, prefix + "split" + (splitCounter++)));
+			states.put(flows, new SplitState(flows, prefix + "split" + (splitCounter++), parentSplit));
 		}
 		SplitState result = (SplitState) states.get(flows);
 		if (executor != null) {
@@ -606,7 +606,7 @@ public class FlowBuilder<Q> {
 
 		private final FlowBuilder<Q> parent;
 
-		private TaskExecutor executor;
+		private final TaskExecutor executor;
 
 		/**
 		 * @param parent the parent builder
@@ -626,23 +626,23 @@ public class FlowBuilder<Q> {
 		public FlowBuilder<Q> add(Flow... flows) {
 			Collection<Flow> list = new ArrayList<>(Arrays.asList(flows));
 			String name = "split" + (parent.splitCounter++);
-			int counter = 0;
 			State one = parent.currentState;
-			Flow flow = null;
+
+			if (one instanceof SplitState) {
+				parent.currentState = parent.createState(list, executor, (SplitState) one);
+				return parent;
+			}
+
 			if (!(one == null || one instanceof FlowState)) {
-				FlowBuilder<Flow> stateBuilder = new FlowBuilder<>(name + "_" + (counter++));
+				FlowBuilder<Flow> stateBuilder = new FlowBuilder<>(name + "_0");
 				stateBuilder.currentState = one;
-				flow = stateBuilder.build();
+				list.add(stateBuilder.build());
 			}
 			else if (one instanceof FlowState && parent.states.size() == 1) {
 				list.add(((FlowState) one).getFlows().iterator().next());
 			}
 
-			if (flow != null) {
-				list.add(flow);
-			}
-			State next = parent.createState(list, executor);
-			parent.currentState = next;
+			parent.currentState = parent.createState(list, executor, null);
 			return parent;
 		}
 


### PR DESCRIPTION
Fixes #3857 and allows to control the maximal number of concurrently running steps with the thread pool size of the `TaskExecutor`.

Nested splits are explicitly handled in `SplitState` and do not require dedicated threads. The added test stalls if executed against main.

@benas Do you see a chance to merge this PR (with requested changes, of course) such that it is included in Spring Batch 5.0?