### PR TITLE
Added support for quotes in for the DelimitedLineAggregator.

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.batch.item.file.transform.FormatterLineAggregator;
 import org.springframework.batch.item.file.transform.LineAggregator;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * A builder implementation for the {@link FlatFileItemWriter}
@@ -415,6 +416,8 @@ public class FlatFileItemWriterBuilder<T> {
 
 		private String delimiter = ",";
 
+		private String quote;
+
 		private FieldExtractor<T> fieldExtractor;
 
 		protected DelimitedBuilder(FlatFileItemWriterBuilder<T> parent) {
@@ -430,6 +433,18 @@ public class FlatFileItemWriterBuilder<T> {
 		 */
 		public DelimitedBuilder<T> delimiter(String delimiter) {
 			this.delimiter = delimiter;
+			return this;
+		}
+
+		/**
+		 * Define the quote for each delimited field.  Default is null (no quote).
+		 *
+		 * @param quote String used as a quote for the aggregate.
+		 * @return The instance of the builder for chaining.
+		 * @see DelimitedLineAggregator#setQuote(String)
+		 */
+		public DelimitedBuilder<T> quote(String quote) {
+			this.quote = quote;
 			return this;
 		}
 
@@ -465,6 +480,9 @@ public class FlatFileItemWriterBuilder<T> {
 			DelimitedLineAggregator<T> delimitedLineAggregator = new DelimitedLineAggregator<>();
 			if (this.delimiter != null) {
 				delimitedLineAggregator.setDelimiter(this.delimiter);
+			}
+			if (StringUtils.hasText(this.quote)) {
+				delimitedLineAggregator.setQuote(this.quote);
 			}
 
 			if (this.fieldExtractor == null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineAggregator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineAggregator.java
@@ -15,18 +15,27 @@
  */
 package org.springframework.batch.item.file.transform;
 
+import java.util.StringJoiner;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
  * A {@link LineAggregator} implementation that converts an object into a
- * delimited list of strings. The default delimiter is a comma.
+ * delimited list of strings. The default delimiter is a comma.  An optional
+ * quote value can be set to add surrounding quotes for each of elements of the list.
+ * Default is null, which means not quotes.
  * 
  * @author Dave Syer
+ * @author Glenn Renfro
  * 
  */
 public class DelimitedLineAggregator<T> extends ExtractorLineAggregator<T> {
 
 	private String delimiter = ",";
+
+	private String quote;
 
 	/**
 	 * Public setter for the delimiter.
@@ -38,7 +47,52 @@ public class DelimitedLineAggregator<T> extends ExtractorLineAggregator<T> {
 
 	@Override
 	public String doAggregate(Object[] fields) {
-		return StringUtils.arrayToDelimitedString(fields, this.delimiter);
+		return arrayToDelimitedString(fields, this.delimiter);
 	}
 
+	public String arrayToDelimitedString(@Nullable Object[] arr, String delim) {
+		if (ObjectUtils.isEmpty(arr)) {
+			return "";
+		} else if (arr.length == 1) {
+			return quote(handleEmbeddedQuote(ObjectUtils.nullSafeToString(arr[0])));
+		} else {
+			StringJoiner sj = new StringJoiner(delim);
+			Object[] var3 = arr;
+			int var4 = arr.length;
+
+			for(int var5 = 0; var5 < var4; ++var5) {
+				Object elem = var3[var5];
+				sj.add(quote(handleEmbeddedQuote(String.valueOf(elem))));
+			}
+
+			return sj.toString();
+		}
+	}
+
+	/**
+	 * Public setter for the quote.
+	 * If quote string is contained in the body of the entry it will be replaced
+	 * with a triple quote. For example a quote of % contained in the element,
+	 * will be replaced with %%%.
+	 * @param quote the quote to set
+	 */
+	public void setQuote(String quote) {
+		this.quote = quote;
+	}
+
+	private String quote(final String str) {
+		String result = str;
+		if (StringUtils.hasText(str) && StringUtils.hasText(this.quote)) {
+			result =  new StringBuffer().append(this.quote).append(str).append(this.quote).toString();
+		}
+		return result;
+	}
+
+	private String handleEmbeddedQuote(final String str) {
+		String result = str;
+		if (StringUtils.hasText(str) && StringUtils.hasText(this.quote)) {
+			result =  str.replace(this.quote, new StringBuffer().append(this.quote).append(this.quote).append(this.quote));
+		}
+		return result;
+	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertTrue;
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  * @author Drummond Dawson
+ * @author Glenn Renfro
  */
 public class FlatFileItemWriterBuilderTests {
 
@@ -145,6 +146,35 @@ public class FlatFileItemWriterBuilderTests {
 		writer.close();
 
 		assertEquals("HEADER$123$456$FOOTER", readLine("UTF-16LE", output));
+	}
+
+	@Test
+	public void testDelimitedOutputWithEmptyDelimiterAndQuote() throws Exception {
+
+		Resource output = new FileSystemResource(File.createTempFile("foo", "txt"));
+
+		FlatFileItemWriter<Foo> writer = new FlatFileItemWriterBuilder<Foo>()
+				.name("foo")
+				.resource(output)
+				.lineSeparator("$")
+				.delimited()
+				.delimiter("")
+				.quote("%")
+				.names("first", "second", "third")
+				.encoding("UTF-16LE")
+				.headerCallback(writer1 -> writer1.append("HEADER"))
+				.footerCallback(writer12 -> writer12.append("FOOTER"))
+				.build();
+
+		ExecutionContext executionContext = new ExecutionContext();
+
+		writer.open(executionContext);
+
+		writer.write(Arrays.asList(new Foo(1, 2, "3"), new Foo(4, 5, "6")));
+
+		writer.close();
+
+		assertEquals("HEADER$%1%%2%%3%$%4%%5%%6%$FOOTER", readLine("UTF-16LE", output));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineAggregatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineAggregatorTests.java
@@ -48,6 +48,30 @@ public class DelimitedLineAggregatorTests {
 	}
 
 	@Test
+	public void testSetDelimiterandQuote() {
+		aggregator.setDelimiter(";");
+		aggregator.setQuote("\"");
+		assertEquals("\"foo\";\"bar\"", aggregator.aggregate(new String[] { "foo", "bar" }));
+	}
+
+	@Test
+	public void testSetDelimiterandQuoteAndEmbeddedQuote() {
+		aggregator.setDelimiter(";");
+		aggregator.setQuote("\"");
+		assertEquals("\"fo\"\"\"o\";\"bar\"", aggregator.aggregate(new String[] { "fo\"o", "bar" }));
+		assertEquals("\"fo\"\"\"o\";\"bar\"\"\"\"", aggregator.aggregate(new String[] { "fo\"o", "bar\"" }));
+	}
+
+	@Test
+	public void testSetDelimiterandQuoteSingleItem() {
+		aggregator.setDelimiter(";");
+		aggregator.setQuote("\"");
+		assertEquals("\"foo\"", aggregator.aggregate(new String[] { "foo" }));
+		aggregator.setQuote("%");
+		assertEquals("%b%%%ar%", aggregator.aggregate(new String[] { "b%ar" }));
+	}
+
+	@Test
 	public void testAggregate() {
 		assertEquals("foo,bar", aggregator.aggregate(new String[] { "foo", "bar" }));
 	}


### PR DESCRIPTION
resolves #1139

We may need to discuss escaping the quotes embedded in the elements.
I chose the triple quote method to handle resolve this.   An example would be fo"o would be replaced with "fo"""o"

