### PR TITLE
Remove Reflection from StepScopeTestExecutionListener

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/StepScopeTestExecutionListener.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/StepScopeTestExecutionListener.java
@@ -65,10 +65,6 @@ import org.springframework.util.ReflectionUtils.MethodCallback;
  */
 public class StepScopeTestExecutionListener implements TestExecutionListener {
 	private static final String STEP_EXECUTION = StepScopeTestExecutionListener.class.getName() + ".STEP_EXECUTION";
-	private static final String SET_ATTRIBUTE_METHOD_NAME = "setAttribute";
-	private static final String HAS_ATTRIBUTE_METHOD_NAME = "hasAttribute";
-	private static final String GET_ATTRIBUTE_METHOD_NAME = "getAttribute";
-	private static final String GET_TEST_INSTANCE_METHOD = "getTestInstance";
 
 	/**
 	 * Set up a {@link StepExecution} as a test context attribute.
@@ -82,8 +78,7 @@ public class StepScopeTestExecutionListener implements TestExecutionListener {
 		StepExecution stepExecution = getStepExecution(testContext);
 
 		if (stepExecution != null) {
-			Method method = TestContext.class.getMethod(SET_ATTRIBUTE_METHOD_NAME, String.class, Object.class);
-			ReflectionUtils.invokeMethod(method, testContext, STEP_EXECUTION, stepExecution);
+			testContext.setAttribute(STEP_EXECUTION, stepExecution);
 		}
 	}
 
@@ -94,12 +89,9 @@ public class StepScopeTestExecutionListener implements TestExecutionListener {
 	 */
 	@Override
 	public void beforeTestMethod(TestContext testContext) throws Exception {
-		Method hasAttributeMethod = TestContext.class.getMethod(HAS_ATTRIBUTE_METHOD_NAME, String.class);
-		Boolean hasAttribute = (Boolean) ReflectionUtils.invokeMethod(hasAttributeMethod, testContext, STEP_EXECUTION);
 
-		if (hasAttribute) {
-			Method method = TestContext.class.getMethod(GET_ATTRIBUTE_METHOD_NAME, String.class);
-			StepExecution stepExecution = (StepExecution) ReflectionUtils.invokeMethod(method, testContext, STEP_EXECUTION);
+		if (testContext.hasAttribute(STEP_EXECUTION)) {
+			StepExecution stepExecution = (StepExecution) testContext.getAttribute(STEP_EXECUTION);
 
 			StepSynchronizationManager.register(stepExecution);
 		}
@@ -112,10 +104,8 @@ public class StepScopeTestExecutionListener implements TestExecutionListener {
 	 */
 	@Override
 	public void afterTestMethod(TestContext testContext) throws Exception {
-		Method method = TestContext.class.getMethod(HAS_ATTRIBUTE_METHOD_NAME, String.class);
-		Boolean hasAttribute = (Boolean) ReflectionUtils.invokeMethod(method, testContext, STEP_EXECUTION);
 
-		if (hasAttribute) {
+		if (testContext.hasAttribute(STEP_EXECUTION)) {
 			StepSynchronizationManager.close();
 		}
 	}
@@ -142,14 +132,7 @@ public class StepScopeTestExecutionListener implements TestExecutionListener {
 	 * @return a {@link StepExecution}
 	 */
 	protected StepExecution getStepExecution(TestContext testContext) {
-		Object target;
-
-		try {
-			Method method = TestContext.class.getMethod(GET_TEST_INSTANCE_METHOD);
-			target = ReflectionUtils.invokeMethod(method, testContext);
-		} catch (NoSuchMethodException e) {
-			throw new IllegalStateException("No such method " + GET_TEST_INSTANCE_METHOD + " on provided TestContext", e);
-		}
+		Object target = testContext.getTestInstance();
 
 		ExtractorMethodCallback method = new ExtractorMethodCallback(StepExecution.class, "getStepExecution");
 		ReflectionUtils.doWithMethods(target.getClass(), method);


### PR DESCRIPTION
`StepScopeTestExecutionListener` uses reflection to call methods on `TestContext`. This seems to have been introduced to support Spring 3 and 4 at the same time. This is no longer required as we currently require Spring 5.

This can be seen as `JobScopeTestExecutionListener` does not use reflection and calls methods on `TestContext` directly.