### PR TITLE
Use default methods in TestExecutionListener

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobScopeTestExecutionListener.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobScopeTestExecutionListener.java
@@ -107,20 +107,6 @@ public class JobScopeTestExecutionListener implements TestExecutionListener {
 			JobSynchronizationManager.close();
 		}
 	}
-
-	/*
-	 * Support for Spring 3.0 (empty).
-	 */
-	@Override
-	public void afterTestClass(TestContext testContext) throws Exception {
-	}
-
-	/*
-	 * Support for Spring 3.0 (empty).
-	 */
-	@Override
-	public void beforeTestClass(TestContext testContext) throws Exception {
-	}
 	
 	/**
 	 * Discover a {@link JobExecution} as a field in the test case or create

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/StepScopeTestExecutionListener.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/StepScopeTestExecutionListener.java
@@ -119,20 +119,6 @@ public class StepScopeTestExecutionListener implements TestExecutionListener {
 			StepSynchronizationManager.close();
 		}
 	}
-
-	/*
-	 * Support for Spring 3.0 (empty).
-	 */
-	@Override
-	public void afterTestClass(TestContext testContext) throws Exception {
-	}
-
-	/*
-	 * Support for Spring 3.0 (empty).
-	 */
-	@Override
-	public void beforeTestClass(TestContext testContext) throws Exception {
-	}
 	
 	/**
 	 * Discover a {@link StepExecution} as a field in the test case or create


### PR DESCRIPTION
`TestExecutionListener` has default methods since Spring 5 (SPR-14432). As we require Spring 5 we can delete the empty implementation methods.