### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To generate the reference documentation, run:
 
     $ ./mvnw site
 
+NOTE: Generate the project before generating the reference documentation. The reference documentation build picks up content from the project build.
+
 The reference documentation can be found in `spring-batch-docs/target`.
 
 ## Spring Tool Suite (STS)


### PR DESCRIPTION
Add a note to tell people to generate the project before generating the documentation. Running `./mvnw site` first causes a build failure.