### PR TITLE
Exclude duplicate output paths from asciidoctor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -802,6 +802,7 @@ task docsZip(type: Zip) {
 		classifier = 'docs'
 		description = "Builds -${classifier} archive containing api and reference " +
 			"for deployment at static.springframework.org/spring-batch/reference."
+		duplicatesStrategy = 'fail'
 
 		from('src/dist') {
 			include 'changelog.txt'
@@ -811,13 +812,13 @@ task docsZip(type: Zip) {
 			into 'api'
 		}
 
-		from (asciidoctorPdf) {
+		from (asciidoctorPdf.outputDir) {
 			include "index-single.pdf"
 			rename  'index-single.pdf', 'spring-batch-reference.pdf'
 			into 'reference/pdf'
 		}
 
-		from (asciidoctor) {
+		from (asciidoctor.outputDir) {
 			include "*.html"
 			include "css/**"
 			include "js/**"

--- a/build.gradle
+++ b/build.gradle
@@ -797,7 +797,7 @@ task schemaZip(type: Zip) {
 	}
 }
 
-task docsZip(type: Zip) {
+task docsZip(type: Zip, dependsOn: [asciidoctor, asciidoctorPdf]) {
 		group = 'Distribution'
 		classifier = 'docs'
 		description = "Builds -${classifier} archive containing api and reference " +


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-batch/issues/3917

Root cause seems to be https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/471