### PR TITLE
Make ScopeConfiguration publicly accessible

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import org.springframework.batch.core.configuration.support.MapJobRegistry;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
-import org.springframework.batch.core.scope.JobScope;
-import org.springframework.batch.core.scope.StepScope;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -129,36 +127,4 @@ public abstract class AbstractBatchConfiguration implements ImportAware, Initial
 		return this.configurer;
 	}
 
-}
-
-/**
- * Extract job/step scope configuration into a separate unit.
- * 
- * @author Dave Syer
- * 
- */
-@Configuration(proxyBeanMethods = false)
-class ScopeConfiguration {
-
-	private static StepScope stepScope;
-
-	private static JobScope jobScope;
-
-	static {
-		jobScope = new JobScope();
-		jobScope.setAutoProxy(false);
-
-		stepScope = new StepScope();
-		stepScope.setAutoProxy(false);
-	}
-
-	@Bean
-	public static StepScope stepScope() {
-		return stepScope;
-	}
-
-	@Bean
-	public static JobScope jobScope() {
-		return jobScope;
-	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/ScopeConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/ScopeConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.configuration.annotation;
+
+import org.springframework.batch.core.scope.JobScope;
+import org.springframework.batch.core.scope.StepScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@code Configuration} class that provides {@link StepScope} and {@link JobScope}.
+ *
+ * @author Dave Syer
+ */
+@Configuration(proxyBeanMethods = false)
+public class ScopeConfiguration {
+
+	private static StepScope stepScope;
+
+	private static JobScope jobScope;
+
+	static {
+		jobScope = new JobScope();
+		jobScope.setAutoProxy(false);
+
+		stepScope = new StepScope();
+		stepScope.setAutoProxy(false);
+	}
+
+	@Bean
+	public static StepScope stepScope() {
+		return stepScope;
+	}
+
+	@Bean
+	public static JobScope jobScope() {
+		return jobScope;
+	}
+}


### PR DESCRIPTION
Splitting the batch infrastructure and the actual job configurations into parent and child contexts, respectively, can be beneficial. Interestingly, this is not mentioned in the Spring Batch but [Spring Framework documentation](https://docs.spring.io/spring-framework/docs/current/reference/html/testing.html#testcontext-ctx-management-ctx-hierarchies).

Unfortunately, custom scopes such as `StepScope` and `JobScope` are not visible in child contexts (https://github.com/spring-projects/spring-framework/issues/11749). Thus, the two scopes are only visible in the context that contains the annotation `@EnableBatchProcessing`, which would be the parent context in the above scenario. This leads to failing jobs in the child contexts if they use step or job scoped beans.

With this change, it is possible for users to import `ScopeConfiguration` into child contexts and use job and step scope within them as usual.