### PR TITLE
BATCH-3838: Remove some deprecated APIs from tests

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -23,9 +23,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.SimpleJob;
@@ -34,6 +32,7 @@ import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,9 +57,6 @@ public class JobParametersBuilderTests {
 	private List<JobExecution> jobExecutionList;
 
 	private Date date = new Date(System.currentTimeMillis());
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Before
 	public void initialize() {
@@ -204,10 +200,10 @@ public class JobParametersBuilderTests {
 
 	@Test
 	public void testGetNextJobParametersNoIncrementer(){
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("No job parameters incrementer found for job=simpleJob");
 		initializeForNextJobParameters();
-		this.parametersBuilder.getNextJobParameters(this.job);
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
+				() -> this.parametersBuilder.getNextJobParameters(this.job));
+		assertEquals("No job parameters incrementer found for job=simpleJob", expectedException.getMessage());
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/JobScopeConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/JobScopeConfigurationTests.java
@@ -17,14 +17,14 @@
 package org.springframework.batch.core.configuration.annotation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Callable;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -56,9 +56,6 @@ public class JobScopeConfigurationTests {
 	private ConfigurableApplicationContext context;
 
 	private JobExecution jobExecution;
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	@Test
 	public void testXmlJobScopeWithProxyTargetClass() throws Exception {
@@ -116,20 +113,22 @@ public class JobScopeConfigurationTests {
 	public void testIntentionallyBlowUpOnMissingContextWithProxyTargetClass() throws Exception {
 		init(JobScopeConfigurationRequiringProxyTargetClass.class);
 		JobSynchronizationManager.release();
-		expected.expect(BeanCreationException.class);
-		expected.expectMessage("job scope");
-		SimpleHolder value = context.getBean(SimpleHolder.class);
-		assertEquals("JOB", value.call());
+		final Exception expectedException = Assert.assertThrows(BeanCreationException.class, () -> {
+			SimpleHolder value = context.getBean(SimpleHolder.class);
+			assertEquals("JOB", value.call());
+		});
+		assertTrue(expectedException.getMessage().contains("job scope"));
 	}
 
 	@Test
 	public void testIntentionallyBlowupWithForcedInterface() throws Exception {
 		init(JobScopeConfigurationForcingInterfaceProxy.class);
 		JobSynchronizationManager.release();
-		expected.expect(BeanCreationException.class);
-		expected.expectMessage("job scope");
-		SimpleHolder value = context.getBean(SimpleHolder.class);
-		assertEquals("JOB", value.call());
+		final Exception expectedException = Assert.assertThrows(BeanCreationException.class, () -> {
+			SimpleHolder value = context.getBean(SimpleHolder.class);
+			assertEquals("JOB", value.call());
+		});
+		assertTrue(expectedException.getMessage().contains("job scope"));
 	}
 
 	@Test
@@ -144,11 +143,12 @@ public class JobScopeConfigurationTests {
 	public void testIntentionallyBlowUpOnMissingContextWithInterface() throws Exception {
 		init(JobScopeConfigurationWithDefaults.class);
 		JobSynchronizationManager.release();
-		expected.expect(BeanCreationException.class);
-		expected.expectMessage("job scope");
-		@SuppressWarnings("unchecked")
-		Callable<String> value = context.getBean(Callable.class);
-		assertEquals("JOB", value.call());
+		final Exception expectedException = Assert.assertThrows(BeanCreationException.class, () -> {
+			@SuppressWarnings("unchecked")
+			Callable<String> value = context.getBean(Callable.class);
+			assertEquals("JOB", value.call());
+		});
+		assertTrue(expectedException.getMessage().contains("job scope"));
 	}
 
 	public void init(Class<?>... config) throws Exception {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/StepScopeConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/StepScopeConfigurationTests.java
@@ -17,10 +17,9 @@
 package org.springframework.batch.core.configuration.annotation;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.ChunkContext;
@@ -42,6 +41,7 @@ import org.springframework.lang.Nullable;
 import java.util.concurrent.Callable;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dave Syer
@@ -54,9 +54,6 @@ public class StepScopeConfigurationTests {
 	private ConfigurableApplicationContext context;
 
 	private StepExecution stepExecution;
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	@Test
 	public void testXmlStepScopeWithProxyTargetClass() throws Exception {
@@ -114,20 +111,23 @@ public class StepScopeConfigurationTests {
 	public void testIntentionallyBlowUpOnMissingContextWithProxyTargetClass() throws Exception {
 		init(StepScopeConfigurationRequiringProxyTargetClass.class);
 		StepSynchronizationManager.release();
-		expected.expect(BeanCreationException.class);
-		expected.expectMessage("step scope");
-		SimpleHolder value = context.getBean(SimpleHolder.class);
-		assertEquals("STEP", value.call());
+
+		final Exception expectedException = Assert.assertThrows(BeanCreationException.class, () -> {
+			SimpleHolder value = context.getBean(SimpleHolder.class);
+			assertEquals("STEP", value.call());
+		});
+		assertTrue(expectedException.getMessage().contains("step scope"));
 	}
 
 	@Test
 	public void testIntentionallyBlowupWithForcedInterface() throws Exception {
 		init(StepScopeConfigurationForcingInterfaceProxy.class);
 		StepSynchronizationManager.release();
-		expected.expect(BeanCreationException.class);
-		expected.expectMessage("step scope");
-		SimpleHolder value = context.getBean(SimpleHolder.class);
-		assertEquals("STEP", value.call());
+		final Exception expectedException = Assert.assertThrows(BeanCreationException.class, () -> {
+			SimpleHolder value = context.getBean(SimpleHolder.class);
+			assertEquals("STEP", value.call());
+		});
+		assertTrue(expectedException.getMessage().contains("step scope"));
 	}
 
 	@Test
@@ -142,11 +142,13 @@ public class StepScopeConfigurationTests {
 	public void testIntentionallyBlowUpOnMissingContextWithInterface() throws Exception {
 		init(StepScopeConfigurationWithDefaults.class);
 		StepSynchronizationManager.release();
-		expected.expect(BeanCreationException.class);
-		expected.expectMessage("step scope");
-		@SuppressWarnings("unchecked")
-		Callable<String> value = context.getBean(Callable.class);
-		assertEquals("STEP", value.call());
+
+		final Exception expectedException = Assert.assertThrows(BeanCreationException.class, () -> {
+			@SuppressWarnings("unchecked")
+			Callable<String> value = context.getBean(Callable.class);
+			assertEquals("STEP", value.call());
+		});
+		assertTrue(expectedException.getMessage().contains("step scope"));
 	}
 
 	public void init(Class<?>... config) throws Exception {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ChunkListenerAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ChunkListenerAdapterTests.java
@@ -39,7 +39,7 @@ public class ChunkListenerAdapterTests {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		adapter = new ChunkListenerAdapter(delegate);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ItemProcessListenerAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ItemProcessListenerAdapterTests.java
@@ -34,7 +34,7 @@ public class ItemProcessListenerAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		adapter = new ItemProcessListenerAdapter<>(delegate);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ItemReadListenerAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ItemReadListenerAdapterTests.java
@@ -34,7 +34,7 @@ public class ItemReadListenerAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		adapter = new ItemReadListenerAdapter<>(delegate);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ItemWriteListenerAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/ItemWriteListenerAdapterTests.java
@@ -39,7 +39,7 @@ public class ItemWriteListenerAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		adapter = new ItemWriteListenerAdapter<>(delegate);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/JobListenerAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/JobListenerAdapterTests.java
@@ -34,7 +34,7 @@ public class JobListenerAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		adapter = new JobListenerAdapter(delegate);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/JsrJobContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/JsrJobContextTests.java
@@ -42,7 +42,7 @@ public class JsrJobContextTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		Properties properties = new Properties();
 		properties.put("jobLevelProperty1", "jobLevelValue1");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/JsrStepContextFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/JsrStepContextFactoryBeanTests.java
@@ -60,7 +60,7 @@ public class JsrStepContextFactoryBeanTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		factory = new JsrStepContextFactoryBean();
 		factory.setBatchPropertyContext(propertyContext);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/StepListenerAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/StepListenerAdapterTests.java
@@ -40,7 +40,7 @@ public class StepListenerAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		adapter = new StepListenerAdapter(delegate);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrSplitParsingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/configuration/xml/JsrSplitParsingTests.java
@@ -16,9 +16,7 @@
 package org.springframework.batch.core.jsr.configuration.xml;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.batch.core.jsr.AbstractJsrTestCase;
 import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -31,9 +29,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class JsrSplitParsingTests extends AbstractJsrTestCase {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Test
 	public void testOneFlowInSplit() {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/launch/JsrJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/launch/JsrJobOperatorTests.java
@@ -90,7 +90,7 @@ public class JsrJobOperatorTests extends AbstractJsrTestCase {
 	@Before
 	public void setup() throws Exception {
 
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		parameterConverter = new JobParametersConverterSupport();
 		jsrJobOperator = new JsrJobOperator(jobExplorer, jobRepository, parameterConverter, new ResourcelessTransactionManager());
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/step/batchlet/BatchletAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/jsr/step/batchlet/BatchletAdapterTests.java
@@ -42,7 +42,7 @@ public class BatchletAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		adapter = new BatchletAdapter(delegate);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
@@ -26,11 +26,10 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-import org.junit.rules.ExpectedException;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ChunkListener;
@@ -79,9 +78,6 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link FaultTolerantStepFactoryBean}.
  */
 public class FaultTolerantStepFactoryBeanTests {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -142,25 +138,29 @@ public class FaultTolerantStepFactoryBeanTests {
 	}
 
 	@Test
-	public void testMandatoryReader() throws Exception {
+	public void testMandatoryReader() {
+		// given
 		factory = new FaultTolerantStepFactoryBean<>();
 		factory.setItemWriter(writer);
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("ItemReader must be provided");
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, factory::getObject);
 
-		factory.getObject();
+		// then
+		assertEquals("ItemReader must be provided", expectedException.getMessage());
 	}
 
 	@Test
 	public void testMandatoryWriter() throws Exception {
+		// given
 		factory = new FaultTolerantStepFactoryBean<>();
 		factory.setItemReader(reader);
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("ItemWriter must be provided");
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, factory::getObject);
 
-		factory.getObject();
+		// then
+		assertEquals("ItemWriter must be provided", expectedException.getMessage());
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
@@ -26,10 +26,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ItemProcessListener;
@@ -66,9 +65,6 @@ import org.springframework.lang.Nullable;
  */
 public class SimpleStepFactoryBeanTests {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
 	private List<Exception> listened = new ArrayList<>();
 
 	private SimpleJobRepository repository = new SimpleJobRepository(new MapJobInstanceDao(), new MapJobExecutionDao(),
@@ -99,25 +95,29 @@ public class SimpleStepFactoryBeanTests {
 	}
 
 	@Test
-	public void testMandatoryReader() throws Exception {
+	public void testMandatoryReader() {
+		// given
 		SimpleStepFactoryBean<String, String> factory = new SimpleStepFactoryBean<>();
 		factory.setItemWriter(writer);
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("ItemReader must be provided");
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, factory::getObject);
 
-		factory.getObject();
+		// then
+		assertEquals("ItemReader must be provided", expectedException.getMessage());
 	}
 
 	@Test
-	public void testMandatoryWriter() throws Exception {
+	public void testMandatoryWriter() {
+		// given
 		SimpleStepFactoryBean<String, String> factory = new SimpleStepFactoryBean<>();
 		factory.setItemReader(reader);
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("ItemWriter must be provided");
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, factory::getObject);
 
-		factory.getObject();
+		// then
+		assertEquals("ItemWriter must be provided", expectedException.getMessage());
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
@@ -61,7 +61,7 @@ public class SystemCommandTaskletIntegrationTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		initializeTasklet();
 		tasklet.afterPropertiesSet();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
@@ -40,7 +40,7 @@ public class AmqpItemReaderBuilderTests {
 
 	@Before
 	public void setup() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/GemfireItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/GemfireItemWriterTests.java
@@ -17,7 +17,7 @@ package org.springframework.batch.item.data;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,7 @@ public class GemfireItemWriterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		writer = new GemfireItemWriter<>();
 		writer.setTemplate(template);
 		writer.setItemKeyMapper(new SpELItemKeyMapper<>("bar.val"));
@@ -125,7 +125,7 @@ public class GemfireItemWriterTests {
 	@Test
 	public void testWriteNoTransactionNoItems() throws Exception {
 		writer.write(null);
-		verifyZeroInteractions(template);
+		verifyNoInteractions(template);
 	}
 
 	static class Foo {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
@@ -51,7 +51,7 @@ public class MongoItemReaderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		reader = new MongoItemReader<>();
 
 		sortOptions = new HashMap<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
@@ -25,12 +25,13 @@ import org.junit.Test;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
+
 import org.mockito.MockitoAnnotations;
 
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
@@ -72,7 +73,7 @@ public class MongoItemWriterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
 		when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
 
@@ -131,8 +132,8 @@ public class MongoItemWriterTests {
 	public void testWriteNoTransactionNoItems() throws Exception {
 		writer.write(null);
 
-		verifyZeroInteractions(template);
-		verifyZeroInteractions(bulkOperations);
+		verifyNoInteractions(template);
+		verifyNoInteractions(bulkOperations);
 	}
 
 	@Test
@@ -203,8 +204,8 @@ public class MongoItemWriterTests {
 			fail("Unexpected exception was thrown");
 		}
 
-		verifyZeroInteractions(template);
-		verifyZeroInteractions(bulkOperations);
+		verifyNoInteractions(template);
+		verifyNoInteractions(bulkOperations);
 	}
 
 	/**
@@ -235,8 +236,8 @@ public class MongoItemWriterTests {
 			fail("Unexpected exception was thrown");
 		}
 
-		verifyZeroInteractions(template);
-		verifyZeroInteractions(bulkOperations);
+		verifyNoInteractions(template);
+		verifyNoInteractions(bulkOperations);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemReaderTests.java
@@ -47,7 +47,7 @@ public class Neo4jItemReaderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	private Neo4jItemReader<String> buildSessionBasedReader() throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemWriterTests.java
@@ -28,7 +28,7 @@ import org.neo4j.ogm.session.SessionFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class Neo4jItemWriterTests {
@@ -42,7 +42,7 @@ public class Neo4jItemWriterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test
@@ -80,7 +80,7 @@ public class Neo4jItemWriterTests {
 
 		writer.write(null);
 
-		verifyZeroInteractions(this.session);
+		verifyNoInteractions(this.session);
 	}
 
 	@Test
@@ -93,7 +93,7 @@ public class Neo4jItemWriterTests {
 		when(this.sessionFactory.openSession()).thenReturn(this.session);
 		writer.write(null);
 
-		verifyZeroInteractions(this.session);
+		verifyNoInteractions(this.session);
 	}
 
 	@Test
@@ -106,7 +106,7 @@ public class Neo4jItemWriterTests {
 		when(this.sessionFactory.openSession()).thenReturn(this.session);
 		writer.write(new ArrayList<>());
 
-		verifyZeroInteractions(this.session);
+		verifyNoInteractions(this.session);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
@@ -60,7 +60,7 @@ public class RepositoryItemReaderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		sorts = Collections.singletonMap("id", Direction.ASC);
 		reader = new RepositoryItemReader<>();
 		reader.setRepository(repository);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTests.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ public class RepositoryItemWriterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		writer = new RepositoryItemWriter<>();
 		writer.setMethodName("save");
 		writer.setRepository(repository);
@@ -77,7 +77,7 @@ public class RepositoryItemWriterTests {
 
 		writer.write(new ArrayList<>());
 
-		verifyZeroInteractions(repository);
+		verifyNoInteractions(repository);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/GemfireItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/GemfireItemWriterBuilderTests.java
@@ -46,7 +46,7 @@ public class GemfireItemWriterBuilderTests {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		this.items = Arrays.asList(new GemfireItemWriterBuilderTests.Foo(new GemfireItemWriterBuilderTests.Bar("val1")),
 				new GemfireItemWriterBuilderTests.Foo(new GemfireItemWriterBuilderTests.Bar("val2")));
 		this.itemKeyMapper = new SpELItemKeyMapper<>("bar.val");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
@@ -53,7 +53,7 @@ public class MongoItemReaderBuilderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		this.sortOptions = new HashMap<>();
 		this.sortOptions.put("name", Sort.Direction.DESC);
 		this.queryContainer = ArgumentCaptor.forClass(Query.class);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilderTests.java
@@ -65,7 +65,7 @@ public class MongoItemWriterBuilderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
 		when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemReaderBuilderTests.java
@@ -50,7 +50,7 @@ public class Neo4jItemReaderBuilderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemWriterBuilderTests.java
@@ -46,7 +46,7 @@ public class Neo4jItemWriterBuilderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilderTests.java
@@ -62,7 +62,7 @@ public class RepositoryItemReaderBuilderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		this.sorts = new HashMap<>();
 		this.sorts.put("id", Sort.Direction.ASC);
 		this.pageRequestContainer = ArgumentCaptor.forClass(PageRequest.class);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemWriterBuilderTests.java
@@ -42,7 +42,7 @@ public class RepositoryItemWriterBuilderTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateItemWriterBuilderTests.java
@@ -47,7 +47,7 @@ public class HibernateItemWriterBuilderTests {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		when(this.sessionFactory.getCurrentSession()).thenReturn(this.session);
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilderTests.java
@@ -47,7 +47,7 @@ public class JpaItemWriterBuilderTests {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		TransactionSynchronizationManager.bindResource(this.entityManagerFactory,
 				new EntityManagerHolder(this.entityManager));
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderTests.java
@@ -18,10 +18,8 @@ package org.springframework.batch.item.json;
 
 import java.io.InputStream;
 
-import org.hamcrest.Matchers;
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -34,6 +32,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -41,9 +40,6 @@ import static org.junit.Assert.fail;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JsonItemReaderTests {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Mock
 	private JsonObjectReader<String> jsonObjectReader;
@@ -70,31 +66,29 @@ public class JsonItemReaderTests {
 	@Test
 	public void testNonExistentResource() {
 		// given
-		this.expectedException.expect(ItemStreamException.class);
-		this.expectedException.expectMessage("Failed to initialize the reader");
-		this.expectedException.expectCause(Matchers.instanceOf(IllegalStateException.class));
 		this.itemReader = new JsonItemReader<>(new NonExistentResource(), this.jsonObjectReader);
 
 		// when
-		this.itemReader.open(new ExecutionContext());
+		final Exception expectedException = Assert.assertThrows(ItemStreamException.class,
+				() -> this.itemReader.open(new ExecutionContext()));
 
 		// then
-		// expected exception
+		assertEquals("Failed to initialize the reader", expectedException.getMessage());
+		assertTrue(expectedException.getCause() instanceof IllegalStateException);
 	}
 
 	@Test
 	public void testNonReadableResource() {
 		// given
-		this.expectedException.expect(ItemStreamException.class);
-		this.expectedException.expectMessage("Failed to initialize the reader");
-		this.expectedException.expectCause(Matchers.instanceOf(IllegalStateException.class));
 		this.itemReader = new JsonItemReader<>(new NonReadableResource(), this.jsonObjectReader);
 
 		// when
-		this.itemReader.open(new ExecutionContext());
+		final Exception expectedException = Assert.assertThrows(ItemStreamException.class,
+				() -> this.itemReader.open(new ExecutionContext()));
 
 		// then
-		// expected exception
+		assertEquals("Failed to initialize the reader", expectedException.getMessage());
+		assertTrue(expectedException.getCause() instanceof IllegalStateException);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonItemReaderBuilderTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonItemReaderBuilderTest.java
@@ -42,7 +42,7 @@ public class JsonItemReaderBuilderTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
@@ -26,14 +26,14 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import org.springframework.batch.item.kafka.KafkaItemReader;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -44,9 +44,6 @@ import static org.junit.Assert.fail;
  * @author Mahmoud Ben Hassine
  */
 public class KafkaItemReaderBuilderTests {
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	private Properties consumerProperties;
 
@@ -63,13 +60,16 @@ public class KafkaItemReaderBuilderTests {
 
 	@Test
 	public void testNullConsumerProperties() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Consumer properties must not be null");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
-				.consumerProperties(null)
-				.build();
+				.consumerProperties(null);
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("Consumer properties must not be null");
 	}
 
 	@Test
@@ -133,78 +133,96 @@ public class KafkaItemReaderBuilderTests {
 
 	@Test
 	public void testNullTopicName() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Topic name must not be null or empty");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
 				.consumerProperties(this.consumerProperties)
-				.topic(null)
-				.build();
+				.topic(null);
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("Topic name must not be null or empty");
 	}
 
 	@Test
 	public void testEmptyTopicName() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Topic name must not be null or empty");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
 				.consumerProperties(this.consumerProperties)
-				.topic("")
-				.build();
+				.topic("");
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("Topic name must not be null or empty");
 	}
 
 	@Test
 	public void testNullPollTimeout() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("pollTimeout must not be null");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
 				.consumerProperties(this.consumerProperties)
 				.topic("test")
-				.pollTimeout(null)
-				.build();
+				.pollTimeout(null);
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("pollTimeout must not be null");
 	}
 
 	@Test
 	public void testNegativePollTimeout() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("pollTimeout must not be negative");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
 				.consumerProperties(this.consumerProperties)
 				.topic("test")
-				.pollTimeout(Duration.ofSeconds(-1))
-				.build();
+				.pollTimeout(Duration.ofSeconds(-1));
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("pollTimeout must not be negative");
 	}
 
 	@Test
 	public void testZeroPollTimeout() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("pollTimeout must not be zero");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
 				.consumerProperties(this.consumerProperties)
 				.topic("test")
-				.pollTimeout(Duration.ZERO)
-				.build();
+				.pollTimeout(Duration.ZERO);
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("pollTimeout must not be zero");
 	}
 
 	@Test
 	public void testEmptyPartitions() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("At least one partition must be provided");
-
-		new KafkaItemReaderBuilder<>()
+		// given
+		final KafkaItemReaderBuilder<Object, Object> builder = new KafkaItemReaderBuilder<>()
 				.name("kafkaItemReader")
 				.consumerProperties(this.consumerProperties)
 				.topic("test")
-				.pollTimeout(Duration.ofSeconds(10))
-				.build();
+				.pollTimeout(Duration.ofSeconds(10));
+
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("At least one partition must be provided");
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilderTests.java
@@ -16,10 +16,9 @@
 
 package org.springframework.batch.item.kafka.builder;
 
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -28,6 +27,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -37,9 +37,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class KafkaItemWriterBuilderTests {
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	@Mock
 	private KafkaTemplate<String, String> kafkaTemplate;
 
@@ -47,24 +44,32 @@ public class KafkaItemWriterBuilderTests {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		this.itemKeyMapper = new KafkaItemKeyMapper();
 	}
 
 	@Test
 	public void testNullKafkaTemplate() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("kafkaTemplate is required.");
+		// given
+		final KafkaItemWriterBuilder<String, String> builder = new KafkaItemWriterBuilder<String, String>().itemKeyMapper(this.itemKeyMapper);
 
-		new KafkaItemWriterBuilder<String, String>().itemKeyMapper(this.itemKeyMapper).build();
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("kafkaTemplate is required.");
 	}
 
 	@Test
 	public void testNullItemKeyMapper() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("itemKeyMapper is required.");
+		// given
+		final KafkaItemWriterBuilder<String, String> builder = new KafkaItemWriterBuilder<String, String>().kafkaTemplate(this.kafkaTemplate);
 
-		new KafkaItemWriterBuilder<String, String>().kafkaTemplate(this.kafkaTemplate).build();
+		// when
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertThat(expectedException).hasMessage("itemKeyMapper is required.");
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
@@ -16,9 +16,7 @@
 package org.springframework.batch.item.support;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamWriter;
@@ -28,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * Common parent class for {@link SynchronizedItemStreamWriterTests} and
@@ -38,9 +36,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
  *
  */
 public abstract class AbstractSynchronizedItemStreamWriterTests {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Mock
 	protected ItemStreamWriter<Object> delegate;
@@ -53,7 +48,7 @@ public abstract class AbstractSynchronizedItemStreamWriterTests {
 
 	@Before
 	public void init() {
-		initMocks(this);
+		openMocks(this);
 		synchronizedItemStreamWriter = createNewSynchronizedItemStreamWriter();
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
@@ -18,6 +18,9 @@ package org.springframework.batch.item.support;
 import org.junit.Test;
 import org.springframework.beans.factory.InitializingBean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  *
  * @author Dimitrios Liapis
@@ -34,9 +37,9 @@ public class SynchronizedItemStreamWriterTests extends AbstractSynchronizedItemS
 	}
 
 	@Test
-	public void testDelegateIsNotNullWhenPropertiesSet() throws Exception {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("A delegate item writer is required");
-		((InitializingBean) new SynchronizedItemStreamWriter<>()).afterPropertiesSet();
+	public void testDelegateIsNotNullWhenPropertiesSet() {
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
+				() -> ((InitializingBean) new SynchronizedItemStreamWriter<>()).afterPropertiesSet());
+		assertEquals("A delegate item writer is required", expectedException.getMessage());
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemProcessorBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemProcessorBuilderTests.java
@@ -48,7 +48,7 @@ public class CompositeItemProcessorBuilderTests {
 
 	@Before
 	public void setup() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		this.processors = new ArrayList<>();
 		this.processors.add(processor1);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
@@ -19,6 +19,9 @@ import org.junit.Test;
 import org.springframework.batch.item.support.AbstractSynchronizedItemStreamWriterTests;
 import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  *
  * @author Dimitrios Liapis
@@ -36,8 +39,13 @@ public class SynchronizedItemStreamWriterBuilderTests extends AbstractSynchroniz
 
 	@Test
 	public void testBuilderDelegateIsNotNull() {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("A delegate item writer is required");
-		new SynchronizedItemStreamWriterBuilder<>().build();
+		// given
+		final SynchronizedItemStreamWriterBuilder<Object> builder = new SynchronizedItemStreamWriterBuilder<>();
+
+		// when
+		final Exception expectedException = assertThrows(IllegalArgumentException.class, builder::build);
+
+		// then
+		assertEquals("A delegate item writer is required", expectedException.getMessage());
 	}
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilderTests.java
@@ -56,7 +56,7 @@ public class StaxEventItemReaderBuilderTests {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemProcessorAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemProcessorAdapterTests.java
@@ -33,7 +33,7 @@ public class ItemProcessorAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		adapter = new ItemProcessorAdapter<>(delegate);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemReaderAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemReaderAdapterTests.java
@@ -43,7 +43,7 @@ public class ItemReaderAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		adapter = new ItemReaderAdapter<>(delegate);
 		adapter.setName("jsrReader");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemWriterAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jsr/item/ItemWriterAdapterTests.java
@@ -43,7 +43,7 @@ public class ItemWriterAdapterTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 
 		adapter = new ItemWriterAdapter<>(delegate);
 		adapter.setName("jsrWriter");

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTest.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTest.java
@@ -20,9 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import org.springframework.batch.core.ChunkListener;
@@ -62,6 +60,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -75,9 +74,6 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {RemoteChunkingManagerStepBuilderTest.BatchConfiguration.class})
 public class RemoteChunkingManagerStepBuilderTest {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
 	@Autowired
 	private JobRepository jobRepository;
 	@Autowired
@@ -90,76 +86,66 @@ public class RemoteChunkingManagerStepBuilderTest {
 	@Test
 	public void inputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("inputChannel must not be null");
+		final RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>("step")
+				.inputChannel(null);
 
 		// when
-		TaskletStep step = new RemoteChunkingManagerStepBuilder<String, String>("step")
-				.inputChannel(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("inputChannel must not be null");
 	}
 
 	@Test
 	public void outputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("outputChannel must not be null");
+		final RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>("step")
+				.outputChannel(null);
 
 		// when
-		TaskletStep step = new RemoteChunkingManagerStepBuilder<String, String>("step")
-				.outputChannel(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("outputChannel must not be null");
 	}
 
 	@Test
 	public void messagingTemplateMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("messagingTemplate must not be null");
+		final RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>("step")
+				.messagingTemplate(null);
 
 		// when
-		TaskletStep step = new RemoteChunkingManagerStepBuilder<String, String>("step")
-				.messagingTemplate(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("messagingTemplate must not be null");
 	}
 
 	@Test
 	public void maxWaitTimeoutsMustBeGreaterThanZero() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("maxWaitTimeouts must be greater than zero");
+		final RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>("step")
+				.maxWaitTimeouts(-1);
 
 		// when
-		TaskletStep step = new RemoteChunkingManagerStepBuilder<String, String>("step")
-				.maxWaitTimeouts(-1)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("maxWaitTimeouts must be greater than zero");
 	}
 
 	@Test
 	public void throttleLimitMustNotBeGreaterThanZero() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("throttleLimit must be greater than zero");
+		final RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>("step")
+				.throttleLimit(-1L);
 
 		// when
-		TaskletStep step = new RemoteChunkingManagerStepBuilder<String, String>("step")
-				.throttleLimit(-1L)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("throttleLimit must be greater than zero");
 	}
 
 	@Test
@@ -167,14 +153,11 @@ public class RemoteChunkingManagerStepBuilderTest {
 		// given
 		RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<>("step");
 
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An InputChannel must be provided");
-
 		// when
-		TaskletStep step = builder.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("An InputChannel must be provided");
 	}
 
 	@Test
@@ -185,37 +168,32 @@ public class RemoteChunkingManagerStepBuilderTest {
 				.outputChannel(new DirectChannel())
 				.messagingTemplate(new MessagingTemplate());
 
-		this.expectedException.expect(IllegalStateException.class);
-		this.expectedException.expectMessage("You must specify either an outputChannel or a messagingTemplate but not both.");
-
 		// when
-		TaskletStep step = builder.build();
+		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("You must specify either an outputChannel or a messagingTemplate but not both.");
 	}
 
 	@Test
 	public void testUnsupportedOperationExceptionWhenSpecifyingAnItemWriter() {
 		// given
-		this.expectedException.expect(UnsupportedOperationException.class);
-		this.expectedException.expectMessage("When configuring a manager " +
-				"step for remote chunking, the item writer will be automatically " +
-				"set to an instance of ChunkMessageChannelItemWriter. " +
-				"The item writer must not be provided in this case.");
-
-		// when
-		TaskletStep step = new RemoteChunkingManagerStepBuilder<String, String>("step")
+		final RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>("step")
 				.reader(this.itemReader)
 				.writer(items -> { })
 				.repository(this.jobRepository)
 				.transactionManager(this.transactionManager)
 				.inputChannel(this.inputChannel)
-				.outputChannel(this.outputChannel)
-				.build();
+				.outputChannel(this.outputChannel);
+
+		// when
+		final Exception expectedException = Assert.assertThrows(UnsupportedOperationException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("When configuring a manager " +
+				"step for remote chunking, the item writer will be automatically " +
+				"set to an instance of ChunkMessageChannelItemWriter. " +
+				"The item writer must not be provided in this case.");
 	}
 
 	@Test

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilderTest.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilderTest.java
@@ -16,9 +16,7 @@
 package org.springframework.batch.integration.chunk;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
@@ -26,13 +24,12 @@ import org.springframework.batch.item.support.PassThroughItemProcessor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Mahmoud Ben Hassine
  */
 public class RemoteChunkingWorkerBuilderTest {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	private ItemProcessor<String, String> itemProcessor = new PassThroughItemProcessor<>();
 	private ItemWriter<String> itemWriter = items -> { };
@@ -40,61 +37,53 @@ public class RemoteChunkingWorkerBuilderTest {
 	@Test
 	public void itemProcessorMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("itemProcessor must not be null");
+		final RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
+				.itemProcessor(null);
 
 		// when
-		IntegrationFlow integrationFlow = new RemoteChunkingWorkerBuilder<String, String>()
-				.itemProcessor(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("itemProcessor must not be null");
 	}
 
 	@Test
 	public void itemWriterMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("itemWriter must not be null");
+		final RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
+				.itemWriter(null);
 
 		// when
-		IntegrationFlow integrationFlow = new RemoteChunkingWorkerBuilder<String, String>()
-				.itemWriter(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("itemWriter must not be null");
 	}
 
 	@Test
 	public void inputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("inputChannel must not be null");
+		final RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
+				.inputChannel(null);
 
 		// when
-		IntegrationFlow integrationFlow = new RemoteChunkingWorkerBuilder<String, String>()
-				.inputChannel(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("inputChannel must not be null");
 	}
 
 	@Test
 	public void outputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("outputChannel must not be null");
+		final RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
+				.outputChannel(null);
 
 		// when
-		IntegrationFlow integrationFlow = new RemoteChunkingWorkerBuilder<String, String>()
-				.outputChannel(null)
-				.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("outputChannel must not be null");
 	}
 
 	@Test
@@ -102,14 +91,11 @@ public class RemoteChunkingWorkerBuilderTest {
 		// given
 		RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<>();
 
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An ItemWriter must be provided");
-
 		// when
-		builder.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("An ItemWriter must be provided");
 	}
 
 	@Test
@@ -118,14 +104,11 @@ public class RemoteChunkingWorkerBuilderTest {
 		RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
 				.itemWriter(items -> { });
 
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An InputChannel must be provided");
-
 		// when
-		builder.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("An InputChannel must be provided");
 	}
 
 	@Test
@@ -135,14 +118,12 @@ public class RemoteChunkingWorkerBuilderTest {
 				.itemWriter(items -> { })
 				.inputChannel(new DirectChannel());
 
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An OutputChannel must be provided");
 
 		// when
-		builder.build();
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("An OutputChannel must be provided");
 	}
 
 	@Test

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningMasterStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningMasterStepBuilderTests.java
@@ -17,9 +17,7 @@
 package org.springframework.batch.integration.partition;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
@@ -37,6 +35,7 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 /**
@@ -46,75 +45,72 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
 @ContextConfiguration(classes = {RemotePartitioningMasterStepBuilderTests.BatchConfiguration.class})
 public class RemotePartitioningMasterStepBuilderTests {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
 	@Autowired
 	private JobRepository jobRepository;
 
 	@Test
 	public void inputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("inputChannel must not be null");
+		final RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
 
 		// when
-		new RemotePartitioningMasterStepBuilder("step").inputChannel(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+				() -> builder.inputChannel(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("inputChannel must not be null");
 	}
 
 	@Test
 	public void outputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("outputChannel must not be null");
+		final RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
 
 		// when
-		new RemotePartitioningMasterStepBuilder("step").outputChannel(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+				() -> builder.outputChannel(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("outputChannel must not be null");
 	}
 
 	@Test
 	public void messagingTemplateMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("messagingTemplate must not be null");
+		final RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
 
 		// when
-		new RemotePartitioningMasterStepBuilder("step").messagingTemplate(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+				() -> builder.messagingTemplate(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("messagingTemplate must not be null");
 	}
 
 	@Test
 	public void jobExplorerMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("jobExplorer must not be null");
+		final RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
 
 		// when
-		new RemotePartitioningMasterStepBuilder("step").jobExplorer(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+				() -> builder.jobExplorer(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("jobExplorer must not be null");
 	}
 
 	@Test
 	public void pollIntervalMustBeGreaterThanZero() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The poll interval must be greater than zero");
+		final RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
 
 		// when
-		new RemotePartitioningMasterStepBuilder("step").pollInterval(-1);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+				() -> builder.pollInterval(-1));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("The poll interval must be greater than zero");
 	}
 
 	@Test
@@ -124,32 +120,30 @@ public class RemotePartitioningMasterStepBuilderTests {
 				.outputChannel(new DirectChannel())
 				.messagingTemplate(new MessagingTemplate());
 
-		this.expectedException.expect(IllegalStateException.class);
-		this.expectedException.expectMessage("You must specify either an outputChannel or a messagingTemplate but not both.");
-
 		// when
-		Step step = builder.build();
+		final Exception expectedException = Assert.assertThrows(IllegalStateException.class,
+				builder::build);
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("You must specify either an outputChannel or a messagingTemplate but not both.");
 	}
 
 	@Test
 	public void testUnsupportedOperationExceptionWhenSpecifyingPartitionHandler() {
 		// given
 		PartitionHandler partitionHandler = Mockito.mock(PartitionHandler.class);
-		this.expectedException.expect(UnsupportedOperationException.class);
-		this.expectedException.expectMessage("When configuring a master step " +
+		final RemotePartitioningMasterStepBuilder builder = new RemotePartitioningMasterStepBuilder("step");
+
+		// when
+		final Exception expectedException = Assert.assertThrows(UnsupportedOperationException.class,
+				() -> builder.partitionHandler(partitionHandler));
+
+		// then
+		assertThat(expectedException).hasMessage("When configuring a master step " +
 				"for remote partitioning using the RemotePartitioningMasterStepBuilder, " +
 				"the partition handler will be automatically set to an instance " +
 				"of MessageChannelPartitionHandler. The partition handler must " +
 				"not be provided in this case.");
-
-		// when
-		new RemotePartitioningMasterStepBuilder("step").partitionHandler(partitionHandler);
-
-		// then
-		// expected exception
 	}
 
 	@Test

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilderTests.java
@@ -16,21 +16,19 @@
 
 package org.springframework.batch.integration.partition;
 
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.integration.channel.DirectChannel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Mahmoud Ben Hassine
  */
 public class RemotePartitioningWorkerStepBuilderTests {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Mock
 	private Tasklet tasklet;
@@ -38,95 +36,87 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	@Test
 	public void inputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("inputChannel must not be null");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step").inputChannel(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.inputChannel(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("inputChannel must not be null");
 	}
 
 	@Test
 	public void outputChannelMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("outputChannel must not be null");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step").outputChannel(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.outputChannel(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("outputChannel must not be null");
 	}
 
 	@Test
 	public void jobExplorerMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("jobExplorer must not be null");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step").jobExplorer(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.jobExplorer(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("jobExplorer must not be null");
 	}
 
 	@Test
 	public void stepLocatorMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("stepLocator must not be null");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step").stepLocator(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.stepLocator(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("stepLocator must not be null");
 	}
 
 	@Test
 	public void beanFactoryMustNotBeNull() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("beanFactory must not be null");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step").beanFactory(null);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.beanFactory(null));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("beanFactory must not be null");
 	}
 
 	@Test
 	public void testMandatoryInputChannel() {
 		// given
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("An InputChannel must be provided");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step").tasklet(this.tasklet);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.tasklet(this.tasklet));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("An InputChannel must be provided");
 	}
 
 	@Test
 	public void testMandatoryJobExplorer() {
 		// given
 		DirectChannel inputChannel = new DirectChannel();
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("A JobExplorer must be provided");
+		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step")
+				.inputChannel(inputChannel);
 
 		// when
-		new RemotePartitioningWorkerStepBuilder("step")
-				.inputChannel(inputChannel)
-				.tasklet(this.tasklet);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, () -> builder.tasklet(this.tasklet));
 
 		// then
-		// expected exception
+		assertThat(expectedException).hasMessage("A JobExplorer must be provided");
 	}
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTest.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTest.java
@@ -16,22 +16,19 @@
 package org.springframework.batch.test.context;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.context.MergedContextConfiguration;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * @author Mahmoud Ben Hassine
  */
 public class BatchTestContextCustomizerTest {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	private BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer();
 
@@ -54,13 +51,12 @@ public class BatchTestContextCustomizerTest {
 		// given
 		ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
 		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
-		this.expectedException.expect(IllegalArgumentException.class);
-		this.expectedException.expectMessage("The bean factory must be an instance of BeanDefinitionRegistry");
 
 		// when
-		this.contextCustomizer.customizeContext(context, mergedConfig);
+		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+				() -> this.contextCustomizer.customizeContext(context, mergedConfig));
 
 		// then
-		// expected exception
+		assertEquals("The bean factory must be an instance of BeanDefinitionRegistry", expectedException.getMessage());
 	}
 }


### PR DESCRIPTION
The following deprecated APIs are not in use anymore in the project's tests:
- `org.junit.rules.ExpectedException#none`
- `org.mockito.MockitoAnnotations#initMocks`
- `org.mockito.Mockito#verifyZeroInteractions`


Partial implementation of #3838 