### PR TITLE
Stop metrics timers after job listeners invocation

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -359,18 +359,18 @@ InitializingBean {
 					execution.setExitStatus(exitStatus.and(newExitStatus));
 				}
 
+				try {
+					listener.afterJob(execution);
+				} catch (Exception e) {
+					logger.error("Exception encountered in afterJob callback", e);
+				}
+
 				timerSample.stop(BatchMetrics.createTimer("job", "Job duration",
 						Tag.of("name", execution.getJobInstance().getJobName()),
 						Tag.of("status", execution.getExitStatus().getExitCode())
 				));
 				longTaskTimerSample.stop();
 				execution.setEndTime(new Date());
-
-				try {
-					listener.afterJob(execution);
-				} catch (Exception e) {
-					logger.error("Exception encountered in afterJob callback", e);
-				}
 
 				jobRepository.update(execution);
 			} finally {


### PR DESCRIPTION
Stop metrics timers and set "end time of job execution" 1) after job listeners invocation and 2) immediately before persisting a job execution object.
