### PR TITLE
Replaces deprecated interfaces

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/SpringAutowiredAnnotationBeanPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/jsr/configuration/support/SpringAutowiredAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,12 +46,11 @@ import org.springframework.beans.factory.annotation.InjectionMetadata;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.DependencyDescriptor;
-import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessorAdapter;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.config.SmartInstantiationAwareBeanPostProcessor;
 import org.springframework.beans.factory.support.MergedBeanDefinitionPostProcessor;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.core.BridgeMethodResolver;
-import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
@@ -73,8 +72,8 @@ import org.springframework.util.ReflectionUtils;
  * <li>findAutowiredAnnotation(AccessibleObject ao)</li>
  * </ul>
  */
-class SpringAutowiredAnnotationBeanPostProcessor extends InstantiationAwareBeanPostProcessorAdapter
-        implements MergedBeanDefinitionPostProcessor, PriorityOrdered, BeanFactoryAware {
+class SpringAutowiredAnnotationBeanPostProcessor implements SmartInstantiationAwareBeanPostProcessor,
+        MergedBeanDefinitionPostProcessor, PriorityOrdered, BeanFactoryAware {
 
     protected final Log logger = LogFactory.getLog(getClass());
 
@@ -539,8 +538,7 @@ class SpringAutowiredAnnotationBeanPostProcessor extends InstantiationAwareBeanP
                     Set<String> autowiredBeanNames = new LinkedHashSet<>(paramTypes.length);
                     TypeConverter typeConverter = beanFactory.getTypeConverter();
                     for (int i = 0; i < arguments.length; i++) {
-                        MethodParameter methodParam = new MethodParameter(method, i);
-                        GenericTypeResolver.resolveParameterType(methodParam, bean.getClass());
+                        MethodParameter methodParam = new MethodParameter(method, i).withContainingClass(bean.getClass());
                         descriptors[i] = new DependencyDescriptor(methodParam, this.required);
                         arguments[i] = beanFactory.resolveDependency(
                                 descriptors[i], beanName, autowiredBeanNames, typeConverter);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ public class ScriptItemProcessor<I, O> implements ItemProcessor<I, O>, Initializ
 				"Either a script source or script file must be provided, not both");
 
 		if (scriptSource != null && scriptEvaluator instanceof StandardScriptEvaluator) {
-			Assert.isTrue(!StringUtils.isEmpty(language),
+			Assert.isTrue(StringUtils.hasLength(language),
 					"Language must be provided when using the default ScriptEvaluator and raw source code");
 
 			((StandardScriptEvaluator) scriptEvaluator).setLanguage(language);

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/order/internal/validator/OrderValidator.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/order/internal/validator/OrderValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.batch.sample.domain.order.internal.validator;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -140,7 +141,7 @@ public class OrderValidator implements Validator {
 
 			//discount coefficient = (100.00 - discountPerc) / 100.00
 			BigDecimal coef = BD_100.subtract(lineItem.getDiscountPerc())
-					.divide(BD_100, 4, BigDecimal.ROUND_HALF_UP);
+					.divide(BD_100, 4, RoundingMode.HALF_UP);
 
 			//discountedPrice = (price * coefficient) - discountAmount
 			//at least one of discountPerc and discountAmount is 0 - this is validated by ValidateDiscountsFunction
@@ -154,7 +155,7 @@ public class OrderValidator implements Validator {
 			//total price = singleItemPrice * quantity
 			BigDecimal quantity = new BigDecimal(lineItem.getQuantity());
 			BigDecimal totalPrice = singleItemPrice.multiply(quantity)
-					.setScale(2, BigDecimal.ROUND_HALF_UP);
+					.setScale(2, RoundingMode.HALF_UP);
 
 			//calculatedPrice should equal to item.totalPrice
 			if (totalPrice.compareTo(lineItem.getTotalPrice()) != 0) {


### PR DESCRIPTION
Replaces the deprecated
- type InstantiationAwareBeanPostProcessorAdapter
- type GenericTypeResolver
- method StringUtils::isEmpty
- field BigDecimal::ROUND_HALF_UP

Partially fixes #3838 