### PR TITLE
Fix double "the" typo everywhere in source code

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobInterruptedException.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobInterruptedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.batch.core;
 
 
 /**
- * Exception to indicate the the job has been interrupted. The exception state
+ * Exception to indicate the job has been interrupted. The exception state
  * indicated is not normally recoverable by batch application clients, but
  * internally it is useful to force a check. The exception will often be wrapped
  * in a runtime exception (usually {@link UnexpectedJobExecutionException} before

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/JobParameterExecutionContextCopyListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/JobParameterExecutionContextCopyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class JobParameterExecutionContextCopyListener extends StepExecutionListe
 
 	/**
 	 * Copy attributes from the {@link JobParameters} to the {@link Step}
-	 * {@link ExecutionContext}, if not already present. The the key is already
+	 * {@link ExecutionContext}, if not already present. The key is already
 	 * present we assume that a restart is in operation and the previous value
 	 * is needed. If the provided keys are empty defaults to copy all keys in
 	 * the {@link JobParameters}.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Remi Kaeffer
  *
  * @since 4.1
  */
@@ -489,7 +490,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 				}
 			}
 			catch (IOException ioe) {
-				throw new ItemStreamException("Unable to close the the ItemWriter", ioe);
+				throw new ItemStreamException("Unable to close the ItemWriter", ioe);
 			}
 			finally {
 				if (!transactional) {
@@ -505,7 +506,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 				}
 			}
 			catch (IOException ioe) {
-				throw new ItemStreamException("Unable to close the the ItemWriter", ioe);
+				throw new ItemStreamException("Unable to close the ItemWriter", ioe);
 			}
 			finally {
 				try {
@@ -514,7 +515,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 					}
 				}
 				catch (IOException ioe) {
-					throw new ItemStreamException("Unable to close the the ItemWriter", ioe);
+					throw new ItemStreamException("Unable to close the ItemWriter", ioe);
 				}
 			}
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/RethrowOnThresholdExceptionHandler.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/RethrowOnThresholdExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class RethrowOnThresholdExceptionHandler implements ExceptionHandler {
 	private boolean useParent = false;
 
 	/**
-	 * Flag to indicate the the exception counters should be shared between
+	 * Flag to indicate the exception counters should be shared between
 	 * sibling contexts in a nested batch. Default is false.
 	 * 
 	 * @param useParent true if the parent context should be used to store the

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandler.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandler.java
@@ -69,7 +69,7 @@ public class SimpleLimitExceptionHandler implements ExceptionHandler, Initializi
 	}
 
 	/**
-	 * Flag to indicate the the exception counters should be shared between
+	 * Flag to indicate the exception counters should be shared between
 	 * sibling contexts in a nested batch (i.e. inner loop). Default is false.
 	 * Set this flag to true if you want to count exceptions for the whole
 	 * (outer) loop in a typical container.

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/item/MessagingGatewayIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/item/MessagingGatewayIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ public class MessagingGatewayIntegrationTests {
 
 	/**
 	 * This is just used to trap the messages sent by the ItemWriter and make an
-	 * assertion about them in the the test case. In a real application this
+	 * assertion about them in the test case. In a real application this
 	 * would be the output stage and/or business processing.
 	 * 
 	 * @author Dave Syer

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/TradeProcessor.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/TradeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class TradeProcessor implements ItemProcessor<Trade, Trade> {
 	private Trade failedItem = null;
 
 	/**
-	 * Public setter for the the index on which failure should occur.
+	 * Public setter for the index on which failure should occur.
 	 * 
 	 * @param failure the failure to set
 	 */

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/TradeWriter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/TradeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ public class TradeWriter extends ItemStreamSupport implements ItemWriter<Trade> 
 	}
 
 	/**
-	 * Public setter for the the customers on which failure should occur.
+	 * Public setter for the customers on which failure should occur.
 	 * 
 	 * @param failingCustomers The customers to fail on
 	 */


### PR DESCRIPTION
# Fix double "the" typo everywhere in source code

This pull request has for purpose to fix some typo in source code

It's my first contribution, let me know if I have done anything wrong