### PR TITLE
Optimize ExitStatus#addExitDescription

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
@@ -246,18 +246,19 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	 * description.
 	 */
 	public ExitStatus addExitDescription(String description) {
-		StringBuilder buffer = new StringBuilder();
-		boolean changed = StringUtils.hasText(description) && !exitDescription.equals(description);
 		if (StringUtils.hasText(exitDescription)) {
-			buffer.append(exitDescription);
-			if (changed) {
+			if (StringUtils.hasText(description) && !exitDescription.equals(description)) {
+				StringBuilder buffer = new StringBuilder(description.length() + 2 + exitDescription.length());
+				buffer.append(exitDescription);
 				buffer.append("; ");
+				buffer.append(description);
+				return new ExitStatus(exitCode, buffer.toString());
 			}
+			return this;
 		}
-		if (changed) {
-			buffer.append(description);
+		else {
+			return new ExitStatus(exitCode, description);
 		}
-		return new ExitStatus(exitCode, buffer.toString());
 	}
 
 	/**


### PR DESCRIPTION
Optimize ExitStatus#addExitDescription by reducing string allocations
through:

- avoid string allocation when the current description is empty
- avoid string allocation when the given description is empty
- avoid intermediate string allocation by allocating the correct buffer size

When profiling the string allocations in `ExitStatus#addExitDescription` where showing up. They were mostly showing up through `ExitStatus#and(ExitStatus)`.

![ExitStatus-addExitDescription](https://user-images.githubusercontent.com/471021/130474439-6a110777-fd6f-4be2-b89b-cfd6b9d327e2.png)