### PR TITLE
Remove the unconditional exposure of the transaction manager as a bean

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
@@ -86,7 +86,6 @@ public abstract class AbstractBatchConfiguration implements ImportAware, Initial
 		return this.jobRegistry;
 	}
 
-	@Bean
 	public abstract PlatformTransactionManager transactionManager() throws Exception;
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
@@ -102,7 +102,6 @@ import org.springframework.transaction.PlatformTransactionManager;
  * <li>a {@link JobLauncher} (bean name "jobLauncher")</li>
  * <li>a {@link JobRegistry} (bean name "jobRegistry")</li>
  * <li>a {@link org.springframework.batch.core.explore.JobExplorer} (bean name "jobExplorer")</li>
- * <li>a {@link PlatformTransactionManager} (bean name "transactionManager")</li>
  * <li>a {@link JobBuilderFactory} (bean name "jobBuilders") as a convenience to prevent you from having to inject the
  * job repository into every job, as in the examples above</li>
  * <li>a {@link StepBuilderFactory} (bean name "stepBuilders") as a convenience to prevent you from having to inject the

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/ModularBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/ModularBatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * available by implementing the {@link BatchConfigurer} interface.
  *
  * @author Dave Syer
+ * @author Mahmoud Ben Hassine
  * @since 2.2
  * @see EnableBatchProcessing
  */
@@ -61,7 +62,6 @@ public class ModularBatchConfiguration extends AbstractBatchConfiguration {
 	}
 
 	@Override
-	@Bean
 	public PlatformTransactionManager transactionManager() throws Exception {
 		return getConfigurer(configurers).getTransactionManager();
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/SimpleBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/SimpleBatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * {@link BatchConfigurer}.
  *
  * @author Dave Syer
+ * @author Mahmoud Ben Hassine
  * @since 2.2
  * @see EnableBatchProcessing
  */
@@ -87,7 +88,6 @@ public class SimpleBatchConfiguration extends AbstractBatchConfiguration {
 	}
 
 	@Override
-	@Bean
 	public PlatformTransactionManager transactionManager() throws Exception {
 		return createLazyProxy(transactionManager, PlatformTransactionManager.class);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
@@ -47,6 +48,11 @@ public class DataSourceConfiguration {
 		return new EmbeddedDatabaseBuilder()
 				.generateUniqueName(true)
 				.build();
+	}
+
+	@Bean
+	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+		return new DataSourceTransactionManager(dataSource);
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
@@ -50,13 +50,10 @@ public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends 
 	@Test
 	public void testConfigurationWithDataSourceAndNoTransactionManager() throws Exception {
 		ApplicationContext applicationContext = new AnnotationConfigApplicationContext(BatchConfigurationWithDataSourceAndNoTransactionManager.class);
-		Assert.assertTrue(applicationContext.containsBean("transactionManager"));
-		PlatformTransactionManager platformTransactionManager = applicationContext.getBean(PlatformTransactionManager.class);
-		Object targetObject = AopTestUtils.getTargetObject(platformTransactionManager);
-		Assert.assertTrue(targetObject instanceof DataSourceTransactionManager);
-		DataSourceTransactionManager dataSourceTransactionManager = (DataSourceTransactionManager) targetObject;
+		PlatformTransactionManager platformTransactionManager = getTransactionManagerSetOnJobRepository(applicationContext.getBean(JobRepository.class));
+		Assert.assertTrue(platformTransactionManager instanceof DataSourceTransactionManager);
+		DataSourceTransactionManager dataSourceTransactionManager = (DataSourceTransactionManager) platformTransactionManager;
 		Assert.assertEquals(applicationContext.getBean(DataSource.class), dataSourceTransactionManager.getDataSource());
-		Assert.assertSame(getTransactionManagerSetOnJobRepository(applicationContext.getBean(JobRepository.class)), dataSourceTransactionManager);
 	}
 
 	@Test

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTest.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTest.java
@@ -52,6 +52,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.PollableChannel;
@@ -348,6 +349,11 @@ public class RemoteChunkingManagerStepBuilderTest {
 					.addScript("/org/springframework/batch/core/schema-hsqldb.sql")
 					.generateUniqueName(true)
 					.build();
+		}
+
+		@Bean
+		public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+			return new DataSourceTransactionManager(dataSource);
 		}
 
 	}

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/DataSourceConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/DataSourceConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
 /**
@@ -39,6 +40,11 @@ public class DataSourceConfiguration {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql")
 				.generateUniqueName(true)
 				.build();
+	}
+
+	@Bean
+	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+		return new DataSourceTransactionManager(dataSource);
 	}
 
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/DataSourceConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/DataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -48,6 +49,11 @@ public class DataSourceConfiguration {
 		dataSource.setUsername(username);
 		dataSource.setPassword(password);
 		return dataSource;
+	}
+
+	@Bean
+	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+		return new DataSourceTransactionManager(dataSource);
 	}
 
 }


### PR DESCRIPTION
This PR addresses Issue #816. It removes the unconditional exposure of the transaction manager as a bean in the application context. The transaction manager is still taken from the `BatchConfigurer` and set where needed (ie on `JobRepository` and `StepBuilderFactory`) as previously done, but is not exposed anymore as a bean to prevent any clash with a user-defined transaction manager if any.

If no transaction manager is provided, a `DataSourceTransactionManager` will be configured by default as required by batch (without being exposed as a bean). Note that a `DataSource` will be mandatory starting from v5, so this seems a reasonable default to me.

Moreover, this change makes the Java config style consistent with the XML config style, where the transaction manager is not exposed as a bean by the `<batch:*>` namespace.