### PR TITLE
Use ExecutionContext map constructor

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcExecutionContextDao.java
@@ -351,7 +351,6 @@ public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implem
 
 		@Override
 		public ExecutionContext mapRow(ResultSet rs, int i) throws SQLException {
-			ExecutionContext executionContext = new ExecutionContext();
 			String serializedContext = rs.getString("SERIALIZED_CONTEXT");
 			if (serializedContext == null) {
 				serializedContext = rs.getString("SHORT_CONTEXT");
@@ -365,10 +364,7 @@ public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implem
 			catch (IOException ioe) {
 				throw new IllegalArgumentException("Unable to deserialize the execution context", ioe);
 			}
-			for (Map.Entry<String, Object> entry : map.entrySet()) {
-				executionContext.put(entry.getKey(), entry.getValue());
-			}
-			return executionContext;
+			return new ExecutionContext(map);
 		}
 
 	}


### PR DESCRIPTION
Use ExecutionContext map constructor to simplify
ExecutionContextRowMapper.mapRow.
