### PR TITLE
Make  JobParameters#getParameters() immutable

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParameters.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParameters.java
@@ -17,6 +17,7 @@
 package org.springframework.batch.core;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -191,7 +192,7 @@ public class JobParameters implements Serializable {
 	 * @return an unmodifiable map containing all parameters.
 	 */
 	public Map<String, JobParameter> getParameters(){
-		return new LinkedHashMap<>(parameters);
+		return Collections.unmodifiableMap(parameters);
 	}
 
 	/**


### PR DESCRIPTION
Make  JobParameters#getParameters() immutable and avoid the defensive
copy.
