### PR TITLE
Instead of creating unnecessary collection objects, change them to immutable or static collections.

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/OrderedComposite.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/OrderedComposite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ class OrderedComposite<S> {
 	 * @return an iterator over the list of items
 	 */
 	public Iterator<S> iterator() {
-		return new ArrayList<>(list).iterator();
+		return Collections.unmodifiableList(list).iterator();
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ public class StepContext extends SynchronizedAttributeAccessor {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public Map<String, Object> getPartitionPlan() {
-		Map<String, Object> partitionPlanProperties = new HashMap<>();
+		Map<String, Object> partitionPlanProperties = Collections.emptyMap();
 
 		if(propertyContext != null) {
 			Map partitionProperties = propertyContext.getStepProperties(getStepName());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/scope/context/StepContextTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/scope/context/StepContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,14 @@ public class StepContextTests {
 
 		Map<String, Object> plan = context.getPartitionPlan();
 		assertEquals("value1", plan.get("key1"));
+	}
+
+	@Test
+	public void testGetPartitionPlanWhenPropertyContextIsNull() {
+		context = new StepContext(stepExecution, null);
+
+		Map<String, Object> plan = context.getPartitionPlan();
+		assertEquals(0, plan.size());
 	}
 
 	@Test


### PR DESCRIPTION
If a collection is created but not added, it can be refactored into an immutable (static empty) collection.
But in this case, I excluded it. For example, when using new ArrayList to convert Set to List ..

Is there something I missed?