### PR TITLE
Remove unnecessary expressions in AsyncItemWriter

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -71,7 +71,7 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 			catch (ExecutionException e) {
 				Throwable cause = e.getCause();
 
-				if(cause != null && cause instanceof Exception) {
+				if(cause instanceof Exception) {
 					logger.debug("An exception was thrown while processing an item", e);
 
 					throw (Exception) cause;

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -81,8 +81,10 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 				}
 			}
 		}
-		
-		delegate.write(list);
+
+		if (!list.isEmpty()) {
+			delegate.write(list);
+		}
 	}
 
 	@Override

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -65,7 +65,7 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 				T item = future.get();
 
 				if(item != null) {
-					list.add(future.get());
+					list.add(item);
 				}
 			}
 			catch (ExecutionException e) {


### PR DESCRIPTION
1. Modify unnecessary parameter expression, list.add(future.get()) to list.add(item)
2. Modify unnecessary conditional expression, if (cause != null  && cause instanceof Exception) to if (cause instanceof Exception)
3. Add conditional expression when list is empty
```
1. Unwrapped future's value have alreay been assigned to the item variable. So, 'item' variable should be delivered instead of future.get() in the list.add method.

2. The getCause method of the Throwable Object returns null if the cause is nonexistent or unknown. And instanceOf operator always returns false if the object is null. So, 'cause != null' expression is unnecessary.

3. While looking at Future related to asynchronous processing, I found that it was in use in AsyncItem (Processor, Writer) of spring-batch.
Looking at the internal implementation, it was written in violation of the processor's default behavior, null return, so I modified the code so that if items are empty in AsyncItemWriter, nothing is returned.
```