### PR TITLE
Use `Collections#emptyList` in MongoItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemReader.java
@@ -17,6 +17,7 @@
 package org.springframework.batch.item.data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class MongoItemReader<T> extends AbstractPaginatedDataItemReader<T> imple
 	private String hint;
 	private String fields;
 	private String collection;
-	private List<Object> parameterValues = new ArrayList<>();
+	private List<Object> parameterValues = Collections.emptyList();
 
 	public MongoItemReader() {
 		super();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilder.java
@@ -16,8 +16,8 @@
 
 package org.springframework.batch.item.data.builder;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +53,7 @@ public class MongoItemReaderBuilder<T> {
 
 	private String collection;
 
-	private List<Object> parameterValues = new ArrayList<>();
+	private List<Object> parameterValues = Collections.emptyList();
 
 	protected int pageSize = 10;
 


### PR DESCRIPTION
This PR provides a small patch for memory saving by using a empty list instead of allocating the `ArrayList`.