### PR TITLE
Update Asciidoctor version and restore the dynamic ToC

### DIFF
--- a/spring-batch-docs/pom.xml
+++ b/spring-batch-docs/pom.xml
@@ -87,6 +87,7 @@
                             <backend>html5</backend>
                             <doctype>book</doctype>
                             <attributes>
+                                <docinfodir>${project.build.directory}/asciidoc</docinfodir>
                                 <docinfo>shared</docinfo>
                                 <stylesdir>css/</stylesdir>
                                 <stylesheet>spring.css</stylesheet>


### PR DESCRIPTION
Update Asciidoctor to the latest version. Also, prior commits had
removed the scripts that enable the dynamic ToC. A new line in the
docs pom restores the scripts.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md