### PR TITLE
Collection's empty data check using CollectionUtils.isEmpty

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateItemReaderHelper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateItemReaderHelper.java
@@ -28,6 +28,7 @@ import org.hibernate.StatelessSession;
 import org.springframework.batch.item.database.orm.HibernateQueryProvider;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -36,7 +37,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
+ * @author June Young. Park
  */
 public class HibernateItemReaderHelper<T> implements InitializingBean {
 
@@ -84,7 +85,7 @@ public class HibernateItemReaderHelper<T> implements InitializingBean {
 	 */
 	public void setUseStatelessSession(boolean useStatelessSession) {
 		Assert.state(statefulSession == null && statelessSession == null,
-				"The useStatelessSession flag can only be set before a session is initialized.");
+			"The useStatelessSession flag can only be set before a session is initialized.");
 		this.useStatelessSession = useStatelessSession;
 	}
 
@@ -103,7 +104,7 @@ public class HibernateItemReaderHelper<T> implements InitializingBean {
 		if (queryProvider == null) {
 			Assert.notNull(sessionFactory, "session factory must be set");
 			Assert.state(StringUtils.hasText(queryString) ^ StringUtils.hasText(queryName),
-					"queryString or queryName must be set");
+				"queryString or queryName must be set");
 		}
 	}
 
@@ -117,7 +118,7 @@ public class HibernateItemReaderHelper<T> implements InitializingBean {
 	 */
 	public ScrollableResults getForwardOnlyCursor(int fetchSize, Map<String, Object> parameterValues) {
 		Query<? extends T> query = createQuery();
-		if (parameterValues != null) {
+		if (!CollectionUtils.isEmpty(parameterValues)) {
 			query.setProperties(parameterValues);
 		}
 		return query.setFetchSize(fetchSize).scroll(ScrollMode.FORWARD_ONLY);
@@ -215,7 +216,7 @@ public class HibernateItemReaderHelper<T> implements InitializingBean {
 		clear();
 
 		Query<? extends T> query = createQuery();
-		if (parameterValues != null) {
+		if (!CollectionUtils.isEmpty(parameterValues)) {
 			query.setProperties(parameterValues);
 		}
 		return query.setFetchSize(fetchSize).setFirstResult(page * pageSize).setMaxResults(pageSize).list();


### PR DESCRIPTION
This PR is a small patch.
Collection's empty data check using `CollectionUtils.isEmpty` instead of `target != null` :)

#4021