### PR TITLE
Fix: Javadoc for FaultTolerantChunkProvider updated

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProvider.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProvider.java
@@ -29,7 +29,7 @@ import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.classify.Classifier;
 
 /**
- * FaultTolerant implementation of the {@link ChunkProcessor} interface, that
+ * FaultTolerant implementation of the {@link ChunkProvider} interface, that
  * allows for skipping or retry of items that cause exceptions during reading or
  * processing.
  * 


### PR DESCRIPTION
FaultTolerantChunkProvider is an implementation of ChunkProvider, not ChunkProcssor.
So, fixed it.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md