### PR TITLE
Add @Nullable to StepExecution::endTime

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/StepExecution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/StepExecution.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -34,6 +35,7 @@ import org.springframework.util.Assert;
  * @author Lucas Ward
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  *
  */
 @SuppressWarnings("serial")
@@ -159,6 +161,7 @@ public class StepExecution extends Entity {
 	 *
 	 * @return the time that this execution ended
 	 */
+	@Nullable
 	public Date getEndTime() {
 		return endTime;
 	}


### PR DESCRIPTION
StepExecution::endTime is initialized as null at creation. But it's not marked as `@Nullable`.
When step is in execution, endTime is null. So i used [null safe calls](https://kotlinlang.org/docs/null-safety.html#safe-calls) but it give me a warning like this.

<img width="667" alt="Screen Shot 2021-12-09 at 7 59 18 PM" src="https://user-images.githubusercontent.com/24649991/145384262-df895fc8-4ff8-40c3-a3b4-d99b80d26503.png">

Marking`@Nullable` can remove the warning.

<img width="598" alt="Screen Shot 2021-12-09 at 8 07 05 PM" src="https://user-images.githubusercontent.com/24649991/145385390-d2401519-ad72-4766-b67d-bbada9b1d9e3.png">

