### PR TITLE
BATCH-2857 Added CompositeItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemFetcher.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemFetcher.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item;
+
+import com.mongodb.lang.Nullable;
+import org.springframework.batch.item.support.CompositeItemReader;
+import org.springframework.lang.NonNull;
+
+/**
+ * Interface for item fetching. Given an item as input, this interface provides
+ * an extension point which allows reader to fetch additional data.
+ * It should be noted that while it's possible to return different type than the one provided,
+ * it's not strictly necessary. Furthermore,
+ * returning {@code null} indicates that the item should not be continued to be processed.
+ *
+ * @author Wiktor Kęska
+ *
+ * @param <I> type of input item
+ * @param <O> type of output item
+ */
+public interface ItemFetcher<I, O> {
+
+  /**
+   * Fetch data for provided item, returning a potentially modified or new item for continued
+   * fetching. If the returned result is {@code null}, it is assumed that fetching of the item
+   * should not continue.
+   *
+   * A {@code null} item will never reach this method because the only possible sources are:
+   * <ul>
+   *     <li>an {@link CompositeItemReader} (which indicates no more items)</li>
+   *     <li>a previous {@link ItemFetcher} in a composite reader (which indicates a filtered item)</li>
+   * </ul>
+   *
+   * @param item for with to fetch, never {@code null}.
+   * @return potentially modified or new item for continued fetching, {@code null} if fetching of the
+   *  provided item should not continue.
+   * @throws Exception thrown if exception occurs during fetching.
+   */
+  @Nullable
+  O fetch(@NonNull I item) throws Exception;
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.support;
+
+import org.springframework.batch.item.*;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+/**
+ * Composite {@link ItemReader} that passes the item through a sequence of
+ * injected <code>ItemFetcher</code>s (return value of previous
+ * fetcher is the entry value of the next).<br>
+ * <br>
+ *
+ * Note the user is responsible for injecting a chain of {@link ItemFetcher}s
+ * that conforms to declared input and output types.
+ *
+ * @author Wiktor Kęska
+ */
+public class CompositeItemReader<I, O> extends AbstractItemStreamItemReader<O>
+    implements InitializingBean {
+
+  private AbstractItemStreamItemReader<I> reader;
+  private List<? extends ItemFetcher<?, ?>> itemFetchers;
+
+  @Override
+  public O read() throws Exception {
+    Object item = reader.read();
+
+    for (ItemFetcher<?, ?> fetcher : itemFetchers) {
+      if (item == null) {
+        return null;
+      }
+
+      item = fetchItem(fetcher, item);
+    }
+    return (O) item;
+  }
+
+  private <T> Object fetchItem(ItemFetcher<T, ?> fetcher, Object input) throws Exception {
+    return fetcher.fetch((T) input);
+  }
+
+  @Override
+  public void close() {
+    reader.close();
+  }
+
+  @Override
+  public void open(ExecutionContext executionContext) {
+    reader.open(executionContext);
+  }
+
+  @Override
+  public void update(ExecutionContext executionContext) {
+    reader.update(executionContext);
+  }
+
+  /**
+   * Establishes the {@link AbstractItemStreamItemReader<I>} reader that will read base items.
+   * @param reader {@link AbstractItemStreamItemReader<I>} reader that will read base items.
+   */
+  public void setReader(AbstractItemStreamItemReader<I> reader) {
+    this.reader = reader;
+  }
+
+  /**
+   * Establishes the {@link ItemFetcher} fecthers that will fetch additional value
+   * for reader result.
+   * @param fetchers list of {@link ItemFetcher} fetchers that will fetch value for item.
+   */
+  public void setFetchers(List<? extends ItemFetcher<?, ?>> fetchers) {
+    this.itemFetchers = fetchers;
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    Assert.notNull(reader, "The 'reader' may not be null");
+
+    Assert.notNull(itemFetchers, "The 'itemFetchers' may not be null");
+    Assert.notEmpty(itemFetchers, "The 'itemFetchers' may not be empty");
+  }
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/CompositeItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/CompositeItemReaderBuilder.java
@@ -1,0 +1,80 @@
+package org.springframework.batch.item.support.builder;
+
+import org.springframework.batch.item.ItemFetcher;
+import org.springframework.batch.item.support.AbstractItemStreamItemReader;
+import org.springframework.batch.item.support.CompositeItemReader;
+import org.springframework.util.Assert;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Creates a fully qualified {@link CompositeItemReader}.
+ *
+ * @author Wiktor Kęska
+ */
+class CompositeItemReaderBuilder<I, O> {
+
+  private List<? extends ItemFetcher<?, ?>> fetchers;
+  private AbstractItemStreamItemReader<I> reader;
+
+  /**
+   * The reader to read base value.
+   *
+   * @param reader the reader to use. The reader must not be null.
+   *
+   * @return this instance for method chaining.
+   *
+   * @see CompositeItemReader#setReader(AbstractItemStreamItemReader)
+   */
+  public CompositeItemReaderBuilder<I, O>  reader(AbstractItemStreamItemReader<I> reader) {
+    this.reader = reader;
+
+    return this;
+  }
+
+  /**
+   * The list of item fetchers to fetch additional values.
+   *
+   * @param fetchers the list of fetchers to use. The fetchers list must not be null
+   * nor be empty.
+   * @return this instance for method chaining.
+   *
+   * @see CompositeItemReader#setFetchers(List)
+   */
+  public CompositeItemReaderBuilder<I, O>  fetchers(List<? extends ItemFetcher<?, ?>> fetchers) {
+    this.fetchers = fetchers;
+
+    return this;
+  }
+
+  /**
+   * The list of item fetchers to fetch additional values.
+   *
+   * @param fetchers the list of fetchers to use. The fetchers list must not be null
+   * nor be empty.
+   * @return this instance for method chaining.
+   *
+   * @see CompositeItemReader#setFetchers(List)
+   */
+  public CompositeItemReaderBuilder<I, O>  fetchers(ItemFetcher<?, ?>... fetchers) {
+    return fetchers(Arrays.asList(fetchers));
+  }
+
+  /**
+   * Returns a fully constructed {@link CompositeItemReader}.
+   *
+   * @return a new {@link CompositeItemReader}
+   */
+  public CompositeItemReader<I, O> build() {
+    Assert.notNull(reader, "A reader is required.");
+
+    Assert.notNull(fetchers, "A list of fetchers is required.");
+    Assert.notEmpty(fetchers, "The fetchers list must have one or more fetcher.");
+
+    CompositeItemReader<I, O> compositeItemReader = new CompositeItemReader<>();
+    compositeItemReader.setReader(reader);
+    compositeItemReader.setFetchers(fetchers);
+    return compositeItemReader;
+  }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemReaderTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemReaderTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.support;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemFetcher;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.sample.Foo;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+/**
+ * Tests for {@link CompositeItemReader}.
+ *
+ * @author Wiktor Kęska
+ */
+class CompositeItemReaderTest {
+  private static final String FOOS = "1 \n 2 \n 3 \n 4 \n 5 \n";
+  private CompositeItemReader<Foo, Foo> compositeItemReader;
+
+  protected FlatFileItemReader<Foo> getItemReader() throws Exception {
+    FlatFileItemReader<Foo> tested = new FlatFileItemReader<>();
+    Resource resource = new ByteArrayResource(FOOS.getBytes());
+    tested.setResource(resource);
+    tested.setLineMapper((line, lineNumber) -> {
+      Foo foo = new Foo();
+      foo.setId(Integer.parseInt(line.trim()));
+      return foo;
+    });
+
+    tested.setSaveState(true);
+    tested.afterPropertiesSet();
+    return tested;
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    compositeItemReader = new CompositeItemReader<>();
+    compositeItemReader.setReader(getItemReader());
+    compositeItemReader.setFetchers(List.of(new NameFetcher(), new ValueFetcher()));
+
+    compositeItemReader.open(new ExecutionContext());
+    compositeItemReader.afterPropertiesSet();
+  }
+
+  /**
+   * Regular usage scenario - item is passed through the fetchers chain,
+   * return value of Foo witch fetched additional values.
+   */
+  @Test
+  void shouldFetchItems() throws Exception {
+    var item = compositeItemReader.read();
+    assertThat(item).isNotNull();
+    assertReadedItem(item, "One", 11);
+
+    item = compositeItemReader.read();
+    assertThat(item).isNotNull();
+    assertReadedItem(item, "Two", 12);
+
+    item = compositeItemReader.read();
+    assertThat(item).isNotNull();
+    assertReadedItem(item, "Three", 13);
+
+    item = compositeItemReader.read();
+    assertThat(item).isNotNull();
+    assertReadedItem(item, "Four", 14);
+
+    item = compositeItemReader.read();
+    assertThat(item).isNotNull();
+    assertReadedItem(item, "Five", 15);
+
+    item = compositeItemReader.read();
+
+    assertThat(item).isNull();
+  }
+
+  /**
+   * The list of transformers must not be null or empty and
+   * can contain only instances of {@link ItemProcessor}.
+   */
+  @Test
+  public void testAfterPropertiesSet() throws Exception {
+
+    // fetchers not set
+    compositeItemReader.setFetchers(null);
+    try {
+      compositeItemReader.afterPropertiesSet();
+      Assertions.fail();
+    }
+    catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // fetchers are empty list
+    compositeItemReader.setFetchers(new ArrayList<ItemFetcher<Object,Object>>());
+    try {
+      compositeItemReader.afterPropertiesSet();
+      Assertions.fail();
+    }
+    catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // reader not set
+    compositeItemReader.setReader(null);
+    try {
+      compositeItemReader.afterPropertiesSet();
+      Assertions.fail();
+    }
+    catch (IllegalArgumentException e) {
+      // expected
+    }
+
+  }
+
+  private void assertReadedItem(Foo item, String expectedName, Integer expectedValue) {
+    assertThat(item.getName()).isEqualTo(expectedName);
+    assertThat(item.getValue()).isEqualTo(expectedValue);
+  }
+
+  private static class NameFetcher implements ItemFetcher<Foo, Foo>{
+
+    private static Map<Integer, String> numbers;
+
+    NameFetcher() {
+      numbers = new HashMap<>();
+      numbers.put(1, "One");
+      numbers.put(2, "Two");
+      numbers.put(3, "Three");
+      numbers.put(4, "Four");
+      numbers.put(5, "Five");
+    }
+
+    @Override
+    public Foo fetch(Foo item) {
+      item.setName(numbers.get(item.getId()));
+      return item;
+    }
+  }
+
+  private static class ValueFetcher implements ItemFetcher<Foo, Foo>{
+
+    private static Map<Integer, Integer> numbers;
+
+    ValueFetcher() {
+      numbers = new HashMap<>();
+      numbers.put(1, 11);
+      numbers.put(2, 12);
+      numbers.put(3, 13);
+      numbers.put(4, 14);
+      numbers.put(5, 15);
+    }
+
+    @Override
+    public Foo fetch(Foo item) {
+      item.setValue(numbers.get(item.getId()));
+      return item;
+    }
+  }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemReaderBuilderTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemReaderBuilderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.support.builder;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.springframework.batch.item.ItemFetcher;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.support.AbstractItemStreamItemReader;
+import org.springframework.batch.item.support.CompositeItemProcessor;
+import org.springframework.batch.item.support.CompositeItemReader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Wiktor Kęska
+ */
+public class CompositeItemReaderBuilderTest {
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule().silent();
+
+  @Mock
+  private ItemFetcher<Object, Object> fetcher1;
+
+  @Mock
+  private ItemFetcher<Object, Object> fetcher2;
+
+  @Mock
+  private AbstractItemStreamItemReader<Object> reader;
+
+  private List<ItemFetcher<Object, Object>> fetchers;
+
+  @Before
+  public void setup() {
+    this.fetchers = new ArrayList<>();
+    this.fetchers.add(fetcher1);
+    this.fetchers.add(fetcher2);
+  }
+
+
+  @Test
+  public void testFetch() throws Exception {
+    Object item = new Object();
+    Object itemAfterFirstFetch = new Object();
+    Object itemAfterSecondFetch = new Object();
+    CompositeItemReader<Object, Object> composite = new CompositeItemReaderBuilder<>()
+        .reader(this.reader)
+        .fetchers(this.fetcher1, this.fetcher2)
+        .build();
+
+    when(reader.read()).thenReturn(item);
+    when(fetcher1.fetch(item)).thenReturn(itemAfterFirstFetch);
+    when(fetcher2.fetch(itemAfterFirstFetch)).thenReturn(itemAfterSecondFetch);
+
+    assertSame(itemAfterSecondFetch, composite.read());
+  }
+
+  @Test
+  public void testFetchVarargs() throws Exception {
+    Object item = new Object();
+    Object itemAfterFirstFetch = new Object();
+    Object itemAfterSecondFetch = new Object();
+    CompositeItemReader<Object, Object> composite = new CompositeItemReaderBuilder<>()
+        .reader(this.reader)
+        .fetchers(fetchers)
+        .build();
+
+    when(reader.read()).thenReturn(item);
+    when(fetcher1.fetch(item)).thenReturn(itemAfterFirstFetch);
+    when(fetcher2.fetch(itemAfterFirstFetch)).thenReturn(itemAfterSecondFetch);
+
+    assertSame(itemAfterSecondFetch, composite.read());
+  }
+
+  @Test
+  public void testNullOrEmptyFetchers() throws Exception {
+    var compositeReader = new CompositeItemReaderBuilder<>();
+    validateExceptionMessage(compositeReader,"A reader is required.");
+    compositeReader.reader(reader);
+    validateExceptionMessage(compositeReader,"A list of fetchers is required.");
+    compositeReader.fetchers(List.of());
+    validateExceptionMessage(compositeReader,"The fetchers list must have one or more fetcher.");
+  }
+
+  private void validateExceptionMessage(CompositeItemReaderBuilder<?, ?> builder, String message) {
+    try {
+      builder.build();
+      fail("IllegalArgumentException should have been thrown");
+    }
+    catch (IllegalArgumentException iae) {
+      assertEquals("IllegalArgumentException message did not match the expected result.", message,
+          iae.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
As mentioned in BATCH-2857 there was a need for CompositeItemReader. For scenarios like reading from multiple data sources or reading from different tables without using `GROUP BY` in a query as it decreases performance.
My solution passes data from a reader which could be for example Cursor reader and passes it to chained fetchers for fetching additional values.