### PR TITLE
Adjust `H2PagingQueryProvider` to work with v2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<commons-dbcp2.version>2.9.0</commons-dbcp2.version>
 		<slf4j.version>1.7.32</slf4j.version>
 		<hsqldb.version>2.6.1</hsqldb.version>
-		<h2.version>2.0.206</h2.version>
+		<h2.version>2.1.210</h2.version>
 		<sqlite.version>3.36.0.3</sqlite.version>
 		<derby.version>10.14.2.0</derby.version>
 		<artemis.version>2.19.0</artemis.version>

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,22 +20,23 @@ package org.springframework.batch.item.database.support;
  * H2 implementation of a {@link org.springframework.batch.item.database.PagingQueryProvider} using database specific features.
  *
  * @author Dave Syer
+ * @author Henning Pöttker
  * @since 2.1
  */
 public class H2PagingQueryProvider extends AbstractSqlPagingQueryProvider {
 
 	@Override
 	public String generateFirstPageQuery(int pageSize) {
-		return SqlPagingQueryUtils.generateTopSqlQuery(this, false, buildTopClause(pageSize));
+		return SqlPagingQueryUtils.generateLimitSqlQuery(this, false, buildLimitClause(pageSize));
 	}
 
 	@Override
 	public String generateRemainingPagesQuery(int pageSize) {
-		return SqlPagingQueryUtils.generateTopSqlQuery(this, true, buildTopClause(pageSize));
+		return SqlPagingQueryUtils.generateLimitSqlQuery(this, true, buildLimitClause(pageSize));
 	}
 
-	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+	private String buildLimitClause(int pageSize) {
+		return new StringBuilder().append("FETCH NEXT ").append(pageSize).append(" ROWS ONLY").toString();
 	}
 
 	@Override
@@ -44,8 +45,10 @@ public class H2PagingQueryProvider extends AbstractSqlPagingQueryProvider {
 		int offset = (page * pageSize) - 1;
 		offset = offset<0 ? 0 : offset;
 
-		String topClause = new StringBuilder().append("LIMIT ").append(offset).append(" 1").toString();
-		return SqlPagingQueryUtils.generateTopJumpToQuery(this, topClause);
+		String limitClause = new StringBuilder().append("OFFSET ")
+				.append(offset).append(" ROWS FETCH NEXT 1 ROWS ONLY")
+				.toString();
+		return SqlPagingQueryUtils.generateLimitJumpToQuery(this, limitClause);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderIntegrationTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.item.database.support;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import org.springframework.batch.item.database.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Henning Pöttker
+ */
+@RunWith(Parameterized.class)
+public class H2PagingQueryProviderIntegrationTests {
+
+	private final String compatibilityMode;
+
+	public H2PagingQueryProviderIntegrationTests(String compatibilityMode) {
+		this.compatibilityMode = compatibilityMode;
+	}
+
+	@Test
+	public void testQueryProvider() {
+		String connectionUrl = String.format("jdbc:h2:mem:%s;MODE=%s", UUID.randomUUID(), compatibilityMode);
+		DataSource dataSource = new SimpleDriverDataSource(new org.h2.Driver(), connectionUrl, "sa", "");
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		PlatformTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+		TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+		transactionTemplate.executeWithoutResult(status -> {
+			jdbcTemplate.execute("CREATE TABLE TEST_TABLE (ID BIGINT NOT NULL, STRING VARCHAR(16) NOT NULL)");
+			jdbcTemplate.execute("INSERT INTO TEST_TABLE (ID, STRING) VALUES (1, 'Spring')");
+			jdbcTemplate.execute("INSERT INTO TEST_TABLE (ID, STRING) VALUES (2, 'Batch')");
+			jdbcTemplate.execute("INSERT INTO TEST_TABLE (ID, STRING) VALUES (3, 'Infrastructure')");
+
+			H2PagingQueryProvider queryProvider = new H2PagingQueryProvider();
+			queryProvider.setSelectClause("STRING");
+			queryProvider.setFromClause("TEST_TABLE");
+			Map<String, Order> sortKeys = new HashMap<>();
+			sortKeys.put("ID", Order.ASCENDING);
+			queryProvider.setSortKeys(sortKeys);
+
+			List<String> firstPage = jdbcTemplate.queryForList(
+					queryProvider.generateFirstPageQuery(2),
+					String.class
+			);
+			assertArrayEquals("firstPage", new String[]{"Spring", "Batch"}, firstPage.toArray());
+
+			List<String> secondPage = jdbcTemplate.queryForList(
+					queryProvider.generateRemainingPagesQuery(2),
+					String.class,
+					2
+			);
+			assertArrayEquals("secondPage", new String[]{"Infrastructure"}, secondPage.toArray());
+
+			Integer secondItem = jdbcTemplate.queryForObject(
+					queryProvider.generateJumpToItemQuery(3, 2),
+					Integer.class
+			);
+			assertEquals(Integer.valueOf(2), secondItem);
+		});
+	}
+
+	@Parameters
+	public static List<Object[]> data() throws Exception {
+		return Arrays.stream(org.h2.engine.Mode.ModeEnum.values())
+				.map(mode -> new Object[]{mode.toString()})
+				.collect(Collectors.toList());
+	}
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.Test;
  * @author Thomas Risberg
  * @author Dave Syer
  * @author Michael Minella
+ * @author Henning Pöttker
  */
 public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTests {
 
@@ -33,28 +34,29 @@ public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTe
 	@Test
 	@Override
 	public void testGenerateFirstPageQuery() {
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC";
+		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC FETCH NEXT 100 ROWS ONLY";
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
 		assertEquals(sql, s);
 	}
 
 	@Test @Override
 	public void testGenerateRemainingPagesQuery() {
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE (bar = 1) AND ((id > ?)) ORDER BY id ASC";
+		String sql = "SELECT id, name, age FROM foo WHERE (bar = 1) AND ((id > ?)) "
+        + "ORDER BY id ASC FETCH NEXT 100 ROWS ONLY";
 		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
 		assertEquals(sql, s);
 	}
 
 	@Test @Override
 	public void testGenerateJumpToItemQuery() {
-		String sql = "SELECT LIMIT 99 1 id FROM foo WHERE bar = 1 ORDER BY id ASC";
+		String sql = "SELECT id FROM foo WHERE bar = 1 ORDER BY id ASC OFFSET 99 ROWS FETCH NEXT 1 ROWS ONLY";
 		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
 		assertEquals(sql, s);
 	}
 
 	@Test @Override
 	public void testGenerateJumpToItemQueryForFirstPage() {
-		String sql = "SELECT LIMIT 0 1 id FROM foo WHERE bar = 1 ORDER BY id ASC";
+		String sql = "SELECT id FROM foo WHERE bar = 1 ORDER BY id ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY";
 		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
 		assertEquals(sql, s);
 	}
@@ -63,7 +65,7 @@ public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTe
 	@Test
 	public void testGenerateFirstPageQueryWithGroupBy() {
 		pagingQueryProvider.setGroupClause("dep");
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 GROUP BY dep ORDER BY id ASC";
+		String sql = "SELECT id, name, age FROM foo WHERE bar = 1 GROUP BY dep ORDER BY id ASC FETCH NEXT 100 ROWS ONLY";
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
 		assertEquals(sql, s);
 	}
@@ -72,7 +74,8 @@ public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTe
 	@Test
 	public void testGenerateRemainingPagesQueryWithGroupBy() {
 		pagingQueryProvider.setGroupClause("dep");
-		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE (bar = 1) AND ((id > ?)) GROUP BY dep ORDER BY id ASC";
+		String sql = "SELECT id, name, age FROM foo WHERE (bar = 1) AND ((id > ?)) GROUP BY dep "
+				+ "ORDER BY id ASC FETCH NEXT 100 ROWS ONLY";
 		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
 		assertEquals(sql, s);
 	}
@@ -81,7 +84,7 @@ public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTe
 	@Test
 	public void testGenerateJumpToItemQueryWithGroupBy() {
 		pagingQueryProvider.setGroupClause("dep");
-		String sql = "SELECT LIMIT 99 1 id FROM foo WHERE bar = 1 GROUP BY dep ORDER BY id ASC";
+		String sql = "SELECT id FROM foo WHERE bar = 1 GROUP BY dep ORDER BY id ASC OFFSET 99 ROWS FETCH NEXT 1 ROWS ONLY";
 		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
 		assertEquals(sql, s);
 	}
@@ -90,28 +93,29 @@ public class H2PagingQueryProviderTests extends AbstractSqlPagingQueryProviderTe
 	@Test
 	public void testGenerateJumpToItemQueryForFirstPageWithGroupBy() {
 		pagingQueryProvider.setGroupClause("dep");
-		String sql = "SELECT LIMIT 0 1 id FROM foo WHERE bar = 1 GROUP BY dep ORDER BY id ASC";
+		String sql = "SELECT id FROM foo WHERE bar = 1 GROUP BY dep ORDER BY id ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY";
 		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
 		assertEquals(sql, s);
 	}
 
 	@Override
 	public String getFirstPageSqlWithMultipleSortKeys() {
-		return "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
+		return "SELECT id, name, age FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC FETCH NEXT 100 ROWS ONLY";
 	}
 
 	@Override
 	public String getRemainingSqlWithMultipleSortKeys() {
-		return "SELECT TOP 100 id, name, age FROM foo WHERE (bar = 1) AND ((name > ?) OR (name = ? AND id < ?)) ORDER BY name ASC, id DESC";
+		return "SELECT id, name, age FROM foo WHERE (bar = 1) AND ((name > ?) OR (name = ? AND id < ?)) "
+				+ "ORDER BY name ASC, id DESC FETCH NEXT 100 ROWS ONLY";
 	}
 
 	@Override
 	public String getJumpToItemQueryWithMultipleSortKeys() {
-		return "SELECT LIMIT 99 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
+		return "SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC OFFSET 99 ROWS FETCH NEXT 1 ROWS ONLY";
 	}
 
 	@Override
 	public String getJumpToItemQueryForFirstPageWithMultipleSortKeys() {
-		return "SELECT LIMIT 0 1 name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC";
+		return "SELECT name, id FROM foo WHERE bar = 1 ORDER BY name ASC, id DESC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY";
 	}
 }


### PR DESCRIPTION
Adjusts the `H2PagingQueryProvider` to work with both H2 1.4.x and 2.x.

This is a follow-up on #4043 and fixes the analogous issue to spring-cloud/spring-cloud-task/pull/822. The build also succeeds with with version 1.4.200 of H2.