### PR TITLE
Throw IllegalStateException from afterPropertiesSet

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultJobLoader.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultJobLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,6 +283,6 @@ public class DefaultJobLoader implements JobLoader, InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() {
-		Assert.notNull(jobRegistry, "Job registry could not be null.");
+		Assert.state(jobRegistry != null, "Job registry could not be null.");
 	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistryBeanPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistryBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ DisposableBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(jobRegistry, "JobRegistry must not be null");
+		Assert.state(jobRegistry != null, "JobRegistry must not be null");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.batch.core.job.flow.support.state.StepState;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Convenience factory for SimpleFlow instances for use in XML namespace. It
@@ -98,7 +99,7 @@ public class SimpleFlowFactoryBean implements FactoryBean<SimpleFlow>, Initializ
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.hasText(name, "The flow must have a name");
+		Assert.state(StringUtils.hasText(name), "The flow must have a name");
 
 		if(flowType == null) {
 			flowType = SimpleFlow.class;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ implements InitializingBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 
-		Assert.notNull(dataSource, "DataSource must not be null.");
+		Assert.state(dataSource != null, "DataSource must not be null.");
 
 		if (jdbcOperations == null) {
 			jdbcOperations = new JdbcTemplate(dataSource);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(jobRepository, "JobRepository must be set");
+		Assert.state(jobRepository != null, "JobRepository must be set");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/CompositeJobParametersValidator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/CompositeJobParametersValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2018 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ public class CompositeJobParametersValidator implements JobParametersValidator, 
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(validators, "The 'validators' may not be null");
-		Assert.notEmpty(validators, "The 'validators' may not be empty");
+		Assert.state(validators != null, "The 'validators' may not be null");
+		Assert.state(!validators.isEmpty(), "The 'validators' may not be empty");
 	}
 
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,10 +105,10 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(jobLauncher, "JobLauncher must be provided");
-		Assert.notNull(jobRegistry, "JobLocator must be provided");
-		Assert.notNull(jobExplorer, "JobExplorer must be provided");
-		Assert.notNull(jobRepository, "JobRepository must be provided");
+		Assert.state(jobLauncher != null, "JobLauncher must be provided");
+		Assert.state(jobRegistry != null, "JobLocator must be provided");
+		Assert.state(jobExplorer != null, "JobExplorer must be provided");
+		Assert.state(jobRepository != null, "JobRepository must be provided");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/AbstractListenerFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/AbstractListenerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,7 +197,7 @@ public abstract class AbstractListenerFactoryBean<T> implements FactoryBean<Obje
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(delegate, "Delegate must not be null");
+		Assert.state(delegate != null, "Delegate must not be null");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/ExecutionContextPromotionListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/ExecutionContextPromotionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.batch.support.PatternMatcher;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * This class can be used to automatically promote items from the {@link Step}
@@ -76,10 +77,10 @@ public class ExecutionContextPromotionListener implements StepExecutionListener,
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.keys, "The 'keys' property must be provided");
-		Assert.notEmpty(this.keys, "The 'keys' property must not be empty");
-		Assert.notNull(this.statuses, "The 'statuses' property must be provided");
-		Assert.notEmpty(this.statuses, "The 'statuses' property must not be empty");
+		Assert.state(this.keys != null, "The 'keys' property must be provided");
+		Assert.state(!ObjectUtils.isEmpty(this.keys), "The 'keys' property must not be empty");
+		Assert.state(this.statuses != null, "The 'statuses' property must be provided");
+		Assert.state(!ObjectUtils.isEmpty(this.statuses), "The 'statuses' property must not be empty");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/PartitionStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/PartitionStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,8 +81,8 @@ public class PartitionStep extends AbstractStep {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(stepExecutionSplitter, "StepExecutionSplitter must be provided");
-		Assert.notNull(partitionHandler, "PartitionHandler must be provided");
+		Assert.state(stepExecutionSplitter != null, "StepExecutionSplitter must be provided");
+		Assert.state(partitionHandler != null, "PartitionHandler must be provided");
 		super.afterPropertiesSet();
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/AbstractJdbcBatchMetadataDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/AbstractJdbcBatchMetadataDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public abstract class AbstractJdbcBatchMetadataDao implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(jdbcTemplate, "JdbcOperations is required");
+		Assert.state(jdbcTemplate != null, "JdbcOperations is required");
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(jobExecutionIncrementer, "The jobExecutionIncrementer must not be null.");
+		Assert.state(jobExecutionIncrementer != null, "The jobExecutionIncrementer must not be null.");
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -325,7 +325,7 @@ JobInstanceDao, InitializingBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(jobInstanceIncrementer, "jobInstanceIncrementer is required");
+		Assert.state(jobInstanceIncrementer != null, "jobInstanceIncrementer is required");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
@@ -130,7 +130,7 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(stepExecutionIncrementer, "StepExecutionIncrementer cannot be null.");
+		Assert.state(stepExecutionIncrementer != null, "StepExecutionIncrementer cannot be null.");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/AbstractJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/AbstractJobRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ public abstract class AbstractJobRepositoryFactoryBean implements FactoryBean<Jo
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(transactionManager, "TransactionManager must not be null.");
+		Assert.state(transactionManager != null, "TransactionManager must not be null.");
 
 		initializeProxy();
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ public class JobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean i
 	@Override
 	public void afterPropertiesSet() throws Exception {
 
-		Assert.notNull(dataSource, "DataSource must not be null.");
+		Assert.state(dataSource != null, "DataSource must not be null.");
 
 		if (jdbcOperations == null) {
 			jdbcOperations = new JdbcTemplate(dataSource);	
@@ -197,12 +197,12 @@ public class JobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean i
 			serializer = defaultSerializer;
 		}
 
-		Assert.isTrue(incrementerFactory.isSupportedIncrementerType(databaseType), () -> "'" + databaseType
+		Assert.state(incrementerFactory.isSupportedIncrementerType(databaseType), () -> "'" + databaseType
 				+ "' is an unsupported database type.  The supported database types are "
 				+ StringUtils.arrayToCommaDelimitedString(incrementerFactory.getSupportedIncrementerTypes()));
 
 		if(lobType != null) {
-			Assert.isTrue(isValidTypes(lobType), "lobType must be a value from the java.sql.Types class");
+			Assert.state(isValidTypes(lobType), "lobType must be a value from the java.sql.Types class");
 		}
 
 		super.afterPropertiesSet();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class SimpleChunkProcessor<I, O> implements ChunkProcessor<I>, Initializi
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(itemWriter, "ItemWriter must be set");
+		Assert.state(itemWriter != null, "ItemWriter must be set");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class CallableTaskletAdapter implements Tasklet, InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(callable, "A Callable is required");
+		Assert.state(callable != null, "A Callable is required");
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link Tasklet} that executes a system command.
@@ -175,10 +176,10 @@ public class SystemCommandTasklet implements StepExecutionListener, StoppableTas
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.hasLength(command, "'command' property value is required");
-		Assert.notNull(systemProcessExitCodeMapper, "SystemProcessExitCodeMapper must be set");
-		Assert.isTrue(timeout > 0, "timeout value must be greater than zero");
-		Assert.notNull(taskExecutor, "taskExecutor is required");
+		Assert.state(StringUtils.hasLength(command), "'command' property value is required");
+		Assert.state(systemProcessExitCodeMapper != null, "SystemProcessExitCodeMapper must be set");
+		Assert.state(timeout > 0, "timeout value must be greater than zero");
+		Assert.state(taskExecutor != null, "taskExecutor is required");
 		stoppable = jobExplorer != null;
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobRegistryBeanPostProcessorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobRegistryBeanPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ public class JobRegistryBeanPostProcessorTests {
 	public void testInitializationFails() throws Exception {
 		try {
 			processor.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			assertTrue(e.getMessage().contains("JobRegistry"));
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public class JobExplorerFactoryBeanTests {
 			factory.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException ex) {
+		catch (IllegalStateException ex) {
 			// expected
 			String message = ex.getMessage();
 			assertTrue("Wrong message: " + message, message.indexOf("DataSource") >= 0);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/CompositeJobParametersValidatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/CompositeJobParametersValidatorTests.java
@@ -36,13 +36,13 @@ public class CompositeJobParametersValidatorTests {
 		compositeJobParametersValidator = new CompositeJobParametersValidator();
 	}
 	
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testValidatorsCanNotBeNull() throws Exception{
 		compositeJobParametersValidator.setValidators(null);
 		compositeJobParametersValidator.afterPropertiesSet();
 	}
 	
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testValidatorsCanNotBeEmpty() throws Exception{
 		compositeJobParametersValidator.setValidators(new ArrayList<>());
 		compositeJobParametersValidator.afterPropertiesSet();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ public class ExtendedAbstractJobTests {
 			job.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			assertTrue(e.getMessage().contains("JobRepository"));
 		}
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,9 +142,9 @@ public class SimpleJobOperatorTests {
 		jobOperator = new SimpleJobOperator();
 		try {
 			jobOperator.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/ExecutionContextPromotionListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/ExecutionContextPromotionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2010 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -251,7 +251,7 @@ public class ExecutionContextPromotionListenerTests {
 	 * 
 	 * EXPECTED: IllegalArgumentException
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalStateException.class)
 	public void keysMustBeSet() throws Exception {
 		ExecutionContextPromotionListener listener = new ExecutionContextPromotionListener();
 		// didn't set the keys, same as listener.setKeys(null);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,7 @@ public class JobRepositoryFactoryBeanTests {
 			factory.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException ex) {
+		catch (IllegalStateException ex) {
 			// expected
 			String message = ex.getMessage();
 			assertTrue("Wrong message: " + message, message.contains("DataSource"));
@@ -243,7 +243,7 @@ public class JobRepositoryFactoryBeanTests {
 			factory.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException ex) {
+		catch (IllegalStateException ex) {
 			// expected
 			String message = ex.getMessage();
 			assertTrue("Wrong message: " + message, message.contains("TransactionManager"));
@@ -261,7 +261,7 @@ public class JobRepositoryFactoryBeanTests {
 			factory.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException ex) {
+		catch (IllegalStateException ex) {
 			// expected
 			String message = ex.getMessage();
 			assertTrue("Wrong message: " + message, message.contains("foo"));
@@ -354,7 +354,7 @@ public class JobRepositoryFactoryBeanTests {
 		}
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testInvalidCustomLobType() throws Exception {
 		factory.setClobType(Integer.MAX_VALUE);
 		testCreateRepository();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/CallableTaskletAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ public class CallableTaskletAdapterTests {
 	public void testAfterPropertiesSet() throws Exception {
 		try {
 			adapter.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class DataSourceInitializer implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(dataSource, "A DataSource is required");
+		Assert.state(dataSource != null, "A DataSource is required");
 		initialize();
 	}
 

--- a/spring-batch-docs/src/main/asciidoc/step.adoc
+++ b/spring-batch-docs/src/main/asciidoc/step.adoc
@@ -1403,7 +1403,7 @@ public class FileDeletingTasklet implements Tasklet, InitializingBean {
     }
 
     public void afterPropertiesSet() throws Exception {
-        Assert.notNull(directory, "directory must be set");
+        Assert.state(directory != null, "directory must be set");
     }
 }
 ----

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -89,7 +89,7 @@ public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, Initial
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(itemKeyMapper, "itemKeyMapper requires a Converter type.");
+		Assert.state(itemKeyMapper != null, "itemKeyMapper requires a Converter type.");
 		init();
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.MethodInvoker;
+import org.springframework.util.StringUtils;
 
 /**
  * Superclass for delegating classes which dynamically call a custom method of
@@ -133,8 +134,8 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(targetObject, "targetObject must not be null");
-		Assert.hasLength(targetMethod, "targetMethod must not be empty");
+		Assert.state(targetObject != null, "targetObject must not be null");
+		Assert.state(StringUtils.hasText(targetMethod), "targetMethod must not be empty");
 		Assert.state(targetClassDeclaresTargetMethod(),
 				"target class must declare a method with matching name and parameter types");
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Delegates processing to a custom method - extracts property values from item
@@ -62,7 +63,7 @@ ItemWriter<T> {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notEmpty(fieldsUsedAsTargetMethodArguments, "fieldsUsedAsTargetMethodArguments must not be empty");
+		Assert.state(!ObjectUtils.isEmpty(fieldsUsedAsTargetMethodArguments), "fieldsUsedAsTargetMethodArguments must not be empty");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MethodInvoker;
+import org.springframework.util.StringUtils;
 
 /**
  * <p>
@@ -130,7 +131,7 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(repository != null, "A CrudRepository implementation is required");
 		if (this.methodName != null) {
-			Assert.hasText(this.methodName, "methodName must not be empty.");
+			Assert.state(StringUtils.hasText(this.methodName), "methodName must not be empty.");
 		}
 		else {
 			logger.debug("No method name provided, CrudRepository.saveAll will be used.");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ implements InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(dataSource, "DataSource must be provided");
+		Assert.state(dataSource != null, "DataSource must be provided");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingIt
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.isTrue(pageSize > 0, "pageSize must be greater than zero");
+		Assert.state(pageSize > 0, "pageSize must be greater than zero");
 	}
 
 	@Nullable

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,7 +326,7 @@ public class ExtendedConnectionDataSourceProxy implements SmartDataSource, Initi
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(dataSource, "DataSource is required");
+		Assert.state(dataSource != null, "DataSource is required");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateItemReaderHelper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/HibernateItemReaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public class HibernateItemReaderHelper<T> implements InitializingBean {
 		Assert.state(sessionFactory != null, "A SessionFactory must be provided");
 
 		if (queryProvider == null) {
-			Assert.notNull(sessionFactory, "session factory must be set");
+			Assert.state(sessionFactory != null, "session factory must be set");
 			Assert.state(StringUtils.hasText(queryString) ^ StringUtils.hasText(queryName),
 					"queryString or queryName must be set");
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcBatchItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcBatchItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,8 +140,8 @@ public class JdbcBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() {
-		Assert.notNull(namedParameterJdbcTemplate, "A DataSource or a NamedParameterJdbcTemplate is required.");
-		Assert.notNull(sql, "An SQL statement is required.");
+		Assert.state(namedParameterJdbcTemplate != null, "A DataSource or a NamedParameterJdbcTemplate is required.");
+		Assert.state(sql != null, "An SQL statement is required.");
 		List<String> namedParameters = new ArrayList<>();
 		parameterCount = JdbcParameterUtils.countParameterPlaceholders(sql, namedParameters);
 		if (namedParameters.size() > 0) {
@@ -151,7 +151,7 @@ public class JdbcBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 			usingNamedParameters = true;
 		}
 		if (!usingNamedParameters) {
-			Assert.notNull(itemPreparedStatementSetter, "Using SQL statement with '?' placeholders requires an ItemPreparedStatementSetter");
+			Assert.state(itemPreparedStatementSetter != null, "Using SQL statement with '?' placeholders requires an ItemPreparedStatementSetter");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,8 +106,8 @@ public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(sql, "The SQL query must be provided");
-		Assert.notNull(rowMapper, "RowMapper must be provided");
+		Assert.state(sql != null, "The SQL query must be provided");
+		Assert.state(rowMapper != null, "RowMapper must be provided");
 	}
 
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcPagingItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,14 +165,14 @@ public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> impleme
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(dataSource, "DataSource may not be null");
+		Assert.state(dataSource != null, "DataSource may not be null");
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		if (fetchSize != VALUE_NOT_SET) {
 			jdbcTemplate.setFetchSize(fetchSize);
 		}
 		jdbcTemplate.setMaxRows(getPageSize());
 		namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
-		Assert.notNull(queryProvider, "QueryProvider may not be null");
+		Assert.state(queryProvider != null, "QueryProvider may not be null");
 		queryProvider.init(dataSource);
 		this.firstPageSql = queryProvider.generateFirstPageQuery(getPageSize());
 		this.remainingPagesSql = queryProvider.generateRemainingPagesQuery(getPageSize());

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaCursorItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link org.springframework.batch.item.ItemStreamReader} implementation based
@@ -101,9 +102,9 @@ public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemRe
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.entityManagerFactory, "EntityManagerFactory is required");
+		Assert.state(this.entityManagerFactory != null, "EntityManagerFactory is required");
 		if (this.queryProvider == null) {
-			Assert.hasLength(this.queryString, "Query string is required when queryProvider is null");
+			Assert.state(StringUtils.hasLength(this.queryString), "Query string is required when queryProvider is null");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class JpaItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(entityManagerFactory, "An EntityManagerFactory is required");
+		Assert.state(entityManagerFactory != null, "An EntityManagerFactory is required");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.batch.item.database.orm.JpaQueryProvider;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * <p>
@@ -148,8 +149,8 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 		super.afterPropertiesSet();
 
 		if (queryProvider == null) {
-			Assert.notNull(entityManagerFactory, "EntityManager is required when queryProvider is null");
-			Assert.hasLength(queryString, "Query string is required when queryProvider is null");
+			Assert.state(entityManagerFactory != null, "EntityManager is required when queryProvider is null");
+			Assert.state(StringUtils.hasLength(queryString), "Query string is required when queryProvider is null");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,8 +149,8 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(procedureName, "The name of the stored procedure must be provided");
-		Assert.notNull(rowMapper, "RowMapper must be provided");
+		Assert.state(procedureName != null, "The name of the stored procedure must be provided");
+		Assert.state(rowMapper != null, "RowMapper must be provided");
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/HibernateNativeQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/HibernateNativeQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class HibernateNativeQueryProvider<E> extends AbstractHibernateQueryProvi
 	}
 
 	public void afterPropertiesSet() throws Exception {
-		Assert.isTrue(StringUtils.hasText(sqlQuery), "Native SQL query cannot be empty");
-		Assert.notNull(entityClass, "Entity class cannot be NULL");
+		Assert.state(StringUtils.hasText(sqlQuery), "Native SQL query cannot be empty");
+		Assert.state(entityClass != null, "Entity class cannot be NULL");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNamedQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNamedQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class JpaNamedQueryProvider<E> extends AbstractJpaQueryProvider {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.isTrue(StringUtils.hasText(this.namedQuery), "Named query cannot be empty");
-		Assert.notNull(this.entityClass, "Entity class cannot be NULL");
+		Assert.state(StringUtils.hasText(this.namedQuery), "Named query cannot be empty");
+		Assert.state(this.entityClass != null, "Entity class cannot be NULL");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNativeQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNativeQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class JpaNativeQueryProvider<E> extends AbstractJpaQueryProvider {
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.isTrue(StringUtils.hasText(sqlQuery), "Native SQL query cannot be empty");
-		Assert.notNull(entityClass, "Entity class cannot be NULL");
+		Assert.state(StringUtils.hasText(sqlQuery), "Native SQL query cannot be empty");
+		Assert.state(entityClass != null, "Entity class cannot be NULL");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -281,7 +281,7 @@ public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemRea
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(lineMapper, "LineMapper is required");
+		Assert.state(lineMapper != null, "LineMapper is required");
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class FlatFileItemWriter<T> extends AbstractFileItemWriter<T> {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(lineAggregator, "A LineAggregator must be provided.");
+		Assert.state(lineAggregator != null, "A LineAggregator must be provided.");
 		if (append) {
 			shouldDeleteIfExists = false;
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/DefaultLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/DefaultLineMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ public class DefaultLineMapper<T> implements LineMapper<T>, InitializingBean {
 
     @Override
 	public void afterPropertiesSet() {
-		Assert.notNull(tokenizer, "The LineTokenizer must be set");
-		Assert.notNull(fieldSetMapper, "The FieldSetMapper must be set");
+		Assert.state(tokenizer != null, "The LineTokenizer must be set");
+		Assert.state(fieldSetMapper != null, "The FieldSetMapper must be set");
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class PatternMatchingCompositeLineMapper<T> implements LineMapper<T>, Ini
     @Override
 	public void afterPropertiesSet() throws Exception {
 		this.tokenizer.afterPropertiesSet();
-		Assert.isTrue(this.patternMatcher != null, "The 'patternMatcher' property must be non-null");
+		Assert.state(this.patternMatcher != null, "The 'patternMatcher' property must be non-null");
 	}
 
 	public void setTokenizers(Map<String, LineTokenizer> tokenizers) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,6 @@ public class BeanWrapperFieldExtractor<T> implements FieldExtractor<T>, Initiali
 
     @Override
 	public void afterPropertiesSet() {
-		Assert.notNull(names, "The 'names' property must be set.");
+		Assert.state(names != null, "The 'names' property must be set.");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,6 +283,6 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.hasLength(this.delimiter, "A delimiter is required");
+		Assert.state(StringUtils.hasLength(this.delimiter), "A delimiter is required");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class PatternMatchingCompositeLineTokenizer implements LineTokenizer, Ini
 	 */
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.isTrue(this.tokenizers != null, "The 'tokenizers' property must be non-empty");
+		Assert.state(this.tokenizers != null, "The 'tokenizers' property must be non-empty");
 	}
 
 	public void setTokenizers(Map<String, LineTokenizer> tokenizers) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,6 @@ public class JmsItemReader<T> implements ItemReader<T>, InitializingBean {
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.jmsTemplate, "The 'jmsTemplate' is required.");
+		Assert.state(this.jmsTemplate != null, "The 'jmsTemplate' is required.");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,8 @@ public class KafkaItemWriter<K, T> extends KeyValueItemWriter<K, T> {
 
 	@Override
 	protected void init() {
-		Assert.notNull(this.kafkaTemplate, "KafkaTemplate must not be null.");
-		Assert.notNull(this.kafkaTemplate.getDefaultTopic(), "KafkaTemplate must have the default topic set.");
+		Assert.state(this.kafkaTemplate != null, "KafkaTemplate must not be null.");
+		Assert.state(this.kafkaTemplate.getDefaultTopic() != null, "KafkaTemplate must have the default topic set.");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/LdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/LdifReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2019 the original author or authors.
+ * Copyright 2005-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,8 +168,8 @@ public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAtt
 	}
 
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(resource, "A resource is required to parse.");
-		Assert.notNull(ldifParser, "A parser is required");
+		Assert.state(resource != null, "A resource is required to parse.");
+		Assert.state(ldifParser != null, "A parser is required");
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/MappingLdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/MappingLdifReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2019 the original author or authors.
+ * Copyright 2005-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,8 +167,8 @@ public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemRead
 	}
 
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(resource, "A resource is required to parse.");
-		Assert.notNull(ldifParser, "A parser is required");
+		Assert.state(resource != null, "A resource is required to parse.");
+		Assert.state(ldifParser != null, "A parser is required");
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ public class CompositeItemProcessor<I, O> implements ItemProcessor<I, O>, Initia
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(delegates, "The 'delegates' may not be null");
-		Assert.notEmpty(delegates, "The 'delegates' may not be empty");
+		Assert.state(delegates != null, "The 'delegates' may not be null");
+		Assert.state(!delegates.isEmpty(), "The 'delegates' may not be empty");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,8 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(delegates, "The 'delegates' may not be null");
-		Assert.notEmpty(delegates, "The 'delegates' may not be empty");
+		Assert.state(delegates != null, "The 'delegates' may not be null");
+		Assert.state(!delegates.isEmpty(), "The 'delegates' may not be empty");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ public class ScriptItemProcessor<I, O> implements ItemProcessor<I, O>, Initializ
 				"Either a script source or script file must be provided, not both");
 
 		if (scriptSource != null && scriptEvaluator instanceof StandardScriptEvaluator) {
-			Assert.isTrue(StringUtils.hasLength(language),
+			Assert.state(StringUtils.hasLength(language),
 					"Language must be provided when using the default ScriptEvaluator and raw source code");
 
 			((StandardScriptEvaluator) scriptEvaluator).setLanguage(language);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,6 @@ public class SynchronizedItemStreamReader<T> implements ItemStreamReader<T>, Ini
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.delegate, "A delegate item reader is required");
+		Assert.state(this.delegate != null, "A delegate item reader is required");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
@@ -84,6 +84,6 @@ public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, Ini
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.delegate, "A delegate item writer is required");
+		Assert.state(this.delegate != null, "A delegate item writer is required");
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/SpringValidator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/SpringValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class SpringValidator<T> implements Validator<T>, InitializingBean {
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(validator, "validator must be set");
+		Assert.state(validator != null, "validator must be set");
 
 	}
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/ValidatingItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/ValidatingItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public class ValidatingItemProcessor<T> implements ItemProcessor<T, T>, Initiali
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(validator, "Validator must not be null.");
+		Assert.state(validator != null, "Validator must not be null.");
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,10 +157,10 @@ ResourceAwareItemReaderItemStream<T>, InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(unmarshaller, "The Unmarshaller must not be null.");
-		Assert.notEmpty(fragmentRootElementNames, "The FragmentRootElementNames must not be empty");
+		Assert.state(unmarshaller != null, "The Unmarshaller must not be null.");
+		Assert.state(!fragmentRootElementNames.isEmpty(), "The FragmentRootElementNames must not be empty");
 		for (QName fragmentRootElementName : fragmentRootElementNames) {
-			Assert.hasText(fragmentRootElementName.getLocalPart(), "The FragmentRootElementNames must not contain empty elements");
+			Assert.state(StringUtils.hasText(fragmentRootElementName.getLocalPart()), "The FragmentRootElementNames must not contain empty elements");
 		}		
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -388,7 +388,7 @@ ResourceAwareItemWriterItemStream<T>, InitializingBean {
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(marshaller, "A Marshaller is required");
+		Assert.state(marshaller != null, "A Marshaller is required");
 		if (rootTagName.contains("{")) {
 			rootTagNamespace = rootTagName.replaceAll("\\{(.*)\\}.*", "$1");
 			rootTagName = rootTagName.replaceAll("\\{.*\\}(.*)", "$1");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/GemfireItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/GemfireItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,14 +57,14 @@ public class GemfireItemWriterTests {
 		try {
 			writer.afterPropertiesSet();
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException iae) {
+		} catch (IllegalStateException ise) {
 		}
 
 		writer.setTemplate(template);
 		try {
 			writer.afterPropertiesSet();
 			fail("Expected exception was not thrown");
-		} catch (IllegalArgumentException iae) {
+		} catch (IllegalStateException ise) {
 		}
 
 		writer.setItemKeyMapper(new SpELItemKeyMapper<>("foo"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,8 +67,8 @@ public class RepositoryItemWriterTests {
 
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
-		} catch (IllegalArgumentException e) {
+			fail("Expected IllegalStateException");
+		} catch (IllegalStateException e) {
 			// expected
 			assertEquals("Wrong message for exception: " + e.getMessage(), "methodName must not be empty.", e.getMessage());
 		}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ public class ExtendedConnectionDataSourceProxyTests {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalStateException.class)
 	public void delegateIsRequired() throws Exception {
 
 		ExtendedConnectionDataSourceProxy tested = new ExtendedConnectionDataSourceProxy(null);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterClassicTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterClassicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,9 +86,9 @@ public class JdbcBatchItemWriterClassicTests {
 		writer = new JdbcBatchItemWriter<>();
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			String message = e.getMessage();
 			assertTrue("Message does not contain ' NamedParameterJdbcTemplate'.", message.indexOf("NamedParameterJdbcTemplate") >= 0);
@@ -96,9 +96,9 @@ public class JdbcBatchItemWriterClassicTests {
 		writer.setJdbcTemplate(new NamedParameterJdbcTemplate(jdbcTemplate));
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			String message = e.getMessage().toLowerCase();
 			assertTrue("Message does not contain 'sql'.", message.indexOf("sql") >= 0);
@@ -106,9 +106,9 @@ public class JdbcBatchItemWriterClassicTests {
 		writer.setSql("select * from foo where id = ?");
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			String message = e.getMessage();
 			assertTrue("Message does not contain 'ItemPreparedStatementSetter'.", message.indexOf("ItemPreparedStatementSetter") >= 0);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,9 +100,9 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		writer = new JdbcBatchItemWriter<>();
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			String message = e.getMessage();
 			assertTrue("Message does not contain 'NamedParameterJdbcTemplate'.", message.contains("NamedParameterJdbcTemplate"));
@@ -110,9 +110,9 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		writer.setJdbcTemplate(namedParameterJdbcOperations);
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			String message = e.getMessage().toLowerCase();
 			assertTrue("Message does not contain 'sql'.", message.contains("sql"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,9 +61,9 @@ public class JpaItemWriterTests {
 		writer = new JpaItemWriter<>();
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 			assertTrue("Wrong message for exception: " + e.getMessage(),
 					e.getMessage().indexOf("EntityManagerFactory") >= 0);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -550,9 +550,9 @@ public class FlatFileItemWriterTests {
 		writer = new FlatFileItemWriter<>();
 		try {
 			writer.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/DefaultLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/DefaultLineMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,13 @@ public class DefaultLineMapperTests {
 
 	private DefaultLineMapper<String> tested = new DefaultLineMapper<>();
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testMandatoryTokenizer() throws Exception {
 		tested.afterPropertiesSet();
 		tested.mapLine("foo", 1);
 	}
 	
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testMandatoryMapper() throws Exception {
 		tested.setLineTokenizer(new DelimitedLineTokenizer());
 		tested.afterPropertiesSet();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public class DelimitedLineTokenizerTests {
 		tokenizer.tokenize("a b c");
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testDelimitedLineTokenizerEmptyString() throws Exception {
 		DelimitedLineTokenizer tokenizer = new DelimitedLineTokenizer("");
 		tokenizer.afterPropertiesSet();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class PatternMatchingCompositeLineTokenizerTests {
 
 	private PatternMatchingCompositeLineTokenizer tokenizer = new PatternMatchingCompositeLineTokenizer();
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalStateException.class)
 	public void testNoTokenizers() throws Exception {
 		tokenizer.afterPropertiesSet();
 		tokenizer.tokenize("a line");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class KafkaItemWriterTests {
 			this.writer.afterPropertiesSet();
 			fail("Expected exception was not thrown");
 		}
-		catch (IllegalArgumentException exception) {
+		catch (IllegalStateException exception) {
 			assertEquals("itemKeyMapper requires a Converter type.", exception.getMessage());
 		}
 
@@ -81,7 +81,7 @@ public class KafkaItemWriterTests {
 			this.writer.afterPropertiesSet();
 			fail("Expected exception was not thrown");
 		}
-		catch (IllegalArgumentException exception) {
+		catch (IllegalStateException exception) {
 			assertEquals("KafkaTemplate must not be null.", exception.getMessage());
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class CompositeItemProcessorTests {
 			composite.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 
@@ -115,7 +115,7 @@ public class CompositeItemProcessorTests {
 			composite.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class SynchronizedItemStreamWriterTests extends AbstractSynchronizedItemS
 
 	@Test
 	public void testDelegateIsNotNullWhenPropertiesSet() {
-		final Exception expectedException = assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalStateException.class,
 				() -> ((InitializingBean) new SynchronizedItemStreamWriter<>()).afterPropertiesSet());
 		assertEquals("A delegate item writer is required", expectedException.getMessage());
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/SpringValidatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/SpringValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class SpringValidatorTests {
 	/**
 	 * Validator property is not set
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalStateException.class)
 	public void testNullValidator() throws Exception {
 		validator.setValidator(null);
 		validator.afterPropertiesSet();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ public class StaxEventItemReaderTests {
 			source.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 
@@ -129,7 +129,7 @@ public class StaxEventItemReaderTests {
 			source.afterPropertiesSet();
 			fail();
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 
     @Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(dataSource, "A DataSource is required");
+		Assert.state(dataSource != null, "A DataSource is required");
 		initialize();
 	}
 

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemProcessor.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class AsyncItemProcessor<I, O> implements ItemProcessor<I, Future<O>>, In
 	 * @see InitializingBean#afterPropertiesSet()
 	 */
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(delegate, "The delegate must be set.");
+		Assert.state(delegate != null, "The delegate must be set.");
 	}
 
 	/**

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 	private ItemWriter<T> delegate;
 
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(delegate, "A delegate ItemWriter must be provided.");
+		Assert.state(delegate != null, "A delegate ItemWriter must be provided.");
 	}
 
 	/**

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkProcessorChunkHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkProcessorChunkHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class ChunkProcessorChunkHandler<S> implements ChunkHandler<S>, Initializ
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(chunkProcessor, "A ChunkProcessor must be provided");
+		Assert.state(chunkProcessor != null, "A ChunkProcessor must be provided");
 	}
 
 	/**

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ public class MessageChannelPartitionHandler implements PartitionHandler, Initial
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(stepName, "A step name must be provided for the remote workers.");
+		Assert.state(stepName != null, "A step name must be provided for the remote workers.");
 		Assert.state(messagingGateway != null, "The MessagingOperations must be set");
 
 		pollRepositoryForResults = !(dataSource == null && jobExplorer == null);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class AsyncItemProcessorTests {
 		};
 	};
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = IllegalStateException.class)
 	public void testNoDelegate() throws Exception {
 		processor.afterPropertiesSet();
 	}

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemListener.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class StagingItemListener extends StepListenerSupport<Long, Long> impleme
 
 	@Override
 	public final void afterPropertiesSet() throws Exception {
-		Assert.notNull(jdbcTemplate, "You must provide a DataSource.");
+		Assert.state(jdbcTemplate != null, "You must provide a DataSource.");
 	}
 
 	@Override

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemProcessor.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class StagingItemProcessor<T> implements ItemProcessor<ProcessIndicatorIt
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(jdbcTemplate, "Either jdbcTemplate or dataSource must be set");
+		Assert.state(jdbcTemplate != null, "Either jdbcTemplate or dataSource must be set");
 	}
 
 	/**

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemReader.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/common/StagingItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ InitializingBean, DisposableBean {
 
 	@Override
 	public final void afterPropertiesSet() throws Exception {
-		Assert.notNull(jdbcTemplate, "You must provide a DataSource.");
+		Assert.state(jdbcTemplate != null, "You must provide a DataSource.");
 	}
 
 	private List<Long> retrieveKeys() {

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/multiline/AggregateItemFieldSetMapper.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/multiline/AggregateItemFieldSetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class AggregateItemFieldSetMapper<T> implements FieldSetMapper<AggregateI
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(delegate, "A FieldSetMapper delegate must be provided.");
+		Assert.state(delegate != null, "A FieldSetMapper delegate must be provided.");
 	}
 
 	/**

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/HibernateAwareCustomerCreditItemWriter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/domain/trade/internal/HibernateAwareCustomerCreditItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class HibernateAwareCustomerCreditItemWriter implements ItemWriter<Custom
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(sessionFactory != null, "Hibernate SessionFactory is required");
-		Assert.notNull(dao, "Delegate DAO must be set");
+		Assert.state(dao != null, "Delegate DAO must be set");
 	}
 
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/loop/GeneratingTradeResettingListener.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/loop/GeneratingTradeResettingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class GeneratingTradeResettingListener implements StepExecutionListener, 
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.reader, "The 'reader' must be set.");
+		Assert.state(this.reader != null, "The 'reader' must be set.");
 	}
 }

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/multiline/AggregateItemFieldSetMapperTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/multiline/AggregateItemFieldSetMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,9 +56,9 @@ public class AggregateItemFieldSetMapperTests {
 	public void testMandatoryProperties() throws Exception {
 		try {
 			mapper.afterPropertiesSet();
-			fail("Expected IllegalArgumentException");
+			fail("Expected IllegalStateException");
 		}
-		catch (IllegalArgumentException e) {
+		catch (IllegalStateException e) {
 			// expected
 		}
 	}

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 
 	@Override
 	public void afterPropertiesSet() {
-		Assert.notNull(this.dataSource, "A DataSource is required");
+		Assert.state(this.dataSource != null, "A DataSource is required");
 		initialize();
 	}
 

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobRepositoryTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobRepositoryTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,8 +75,8 @@ public class JobRepositoryTestUtils extends AbstractJdbcBatchMetadataDao impleme
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(jobRepository, "JobRepository must be set");
-		Assert.notNull(jdbcTemplate, "DataSource must be set");
+		Assert.state(jobRepository != null, "JobRepository must be set");
+		Assert.state(jdbcTemplate != null, "DataSource must be set");
 	}
 
 	/**

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobRepositoryTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobRepositoryTestUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,13 +67,13 @@ public class JobRepositoryTestUtilsTests {
 		beforeSteps = JdbcTestUtils.countRowsInTable(jdbcTemplate, "BATCH_STEP_EXECUTION");
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testMandatoryProperties() throws Exception {
 		utils = new JobRepositoryTestUtils();
 		utils.afterPropertiesSet();
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=IllegalStateException.class)
 	public void testMandatoryDataSource() throws Exception {
 		utils = new JobRepositoryTestUtils();
 		utils.setJobRepository(jobRepository);


### PR DESCRIPTION
Consistently use Assert.state in the afterPropertiesSet() methods to
throw IllegalStateException instead of IllegalArgumentException when
some properties are missing and/or invalid.

Issue #2244