### PR TITLE
Upgrade next version of Micrometer and fix breaking changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<spring-framework.version>6.0.0-M2</spring-framework.version>
 		<spring-retry.version>1.3.1</spring-retry.version>
 		<spring-integration.version>6.0.0-M1</spring-integration.version>
-		<micrometer.version>2.0.0-M1</micrometer.version>
+		<micrometer.version>2.0.0-SNAPSHOT</micrometer.version>
 		<jackson.version>2.13.1</jackson.version>
 
 		<!-- optional production dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<spring-framework.version>6.0.0-M2</spring-framework.version>
 		<spring-retry.version>1.3.1</spring-retry.version>
 		<spring-integration.version>6.0.0-M1</spring-integration.version>
-		<micrometer.version>2.0.0-SNAPSHOT</micrometer.version>
+		<micrometer.version>2.0.0-M2</micrometer.version>
 		<jackson.version>2.13.1</jackson.version>
 
 		<!-- optional production dependencies -->

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -19,9 +19,9 @@ package org.springframework.batch.core.job;
 import java.util.Collection;
 import java.util.Date;
 
-import io.micrometer.core.instrument.LongTaskTimer;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.api.instrument.LongTaskTimer;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Timer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.core.BatchStatus;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/metrics/BatchMetrics.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/metrics/BatchMetrics.java
@@ -20,10 +20,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import io.micrometer.core.instrument.LongTaskTimer;
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.api.instrument.LongTaskTimer;
+import io.micrometer.api.instrument.Metrics;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Timer;
 
 import org.springframework.lang.Nullable;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
@@ -18,8 +18,8 @@ package org.springframework.batch.core.step;
 import java.time.Duration;
 import java.util.Date;
 
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Timer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.core.BatchStatus;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProcessor.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.api.instrument.Timer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProcessor.java
@@ -18,8 +18,8 @@ package org.springframework.batch.core.step.item;
 
 import java.util.List;
 
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Timer;
 
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProvider.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleChunkProvider.java
@@ -18,9 +18,9 @@ package org.springframework.batch.core.step.item;
 
 import java.util.List;
 
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.api.instrument.Metrics;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Timer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.core.StepContribution;

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/metrics/PrometheusConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/metrics/PrometheusConfiguration.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import jakarta.annotation.PostConstruct;
 
-import io.micrometer.core.instrument.Metrics;
+import io.micrometer.api.instrument.Metrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/metrics/BatchMetricsTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/metrics/BatchMetricsTests.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Metrics;
+import io.micrometer.api.instrument.Meter;
+import io.micrometer.api.instrument.Metrics;
 import org.junit.Test;
 
 import org.springframework.batch.core.ExitStatus;


### PR DESCRIPTION
Micrometer `2.0.0-M2` will contain breaking changes, this PR upgrades it to the latest snapshot and fixes those issues. Once Micrometer `2.0.0-M2` is released, I will modify the Micrometer version in this PR.