### PR TITLE
Remove SQLLite Batch database tables before starting tests

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/SQLiteJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/SQLiteJobRepositoryIntegrationTests.java
@@ -74,6 +74,7 @@ public class SQLiteJobRepositoryIntegrationTests {
 			SQLiteDataSource dataSource = new SQLiteDataSource();
 			dataSource.setUrl("jdbc:sqlite:target/spring-batch.sqlite");
 			ResourceDatabasePopulator databasePopulator = new ResourceDatabasePopulator();
+			databasePopulator.addScript(new ClassPathResource("/org/springframework/batch/core/schema-drop-sqlite.sql"));
 			databasePopulator.addScript(new ClassPathResource("/org/springframework/batch/core/schema-sqlite.sql"));
 			databasePopulator.execute(dataSource);
 			return dataSource;


### PR DESCRIPTION
SQL Lite integration tests sporadically fails because tables already exist.   This removes those tables before starting.