### PR TITLE
Remove benign [WARNINGS] from batch build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-		<maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+		<maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
 		<flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
@@ -204,6 +204,8 @@
 					</excludePackageNames>
 					<overview>${project.basedir}/spring-batch-docs/src/main/javadoc/overview.html</overview>
 					<detectJavaApiLink>false</detectJavaApiLink>
+					<doclint>all,-missing</doclint>
+					<quiet>true</quiet>
 				</configuration>
 				<executions>
 					<execution>

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -45,7 +45,7 @@ import java.util.List;
  * <p>
  * Implementation of {@link JobRepository} that stores JobInstances,
  * JobExecutions, and StepExecutions using the injected DAOs.
- * <p>
+ * </p>
  *
  * @author Lucas Ward
  * @author Dave Syer


### PR DESCRIPTION
This is done by:
1) Enabling quiet for doc build so that it, "Shuts off non-error and non-warning messages," so that builders can focus on warnings.
2) Disable missing javadoc warnings.   We will handle missing javadoc warnings in subsequent PRs.
3) Fix existing warnings that are in the batch code base.

This reduces the number of [WARNING]s from 7171 down to 52
