### PR TITLE
BATCH-4087 Return null by ResultSet#getLong or ResultSet#getDouble wh…

### DIFF
--- a/spring-batch-core-tests/src/test/java/org/springframework/batch/core/test/repository/MySQLJdbcJobRepositoryTests.java
+++ b/spring-batch-core-tests/src/test/java/org/springframework/batch/core/test/repository/MySQLJdbcJobRepositoryTests.java
@@ -110,6 +110,37 @@ public class MySQLJdbcJobRepositoryTests {
 		Assert.assertEquals(2, jobExecutions.size());
 	}
 
+	/*
+	 * This test is for issue https://github.com/spring-projects/spring-batch/issues/4087:
+	 * A round trip from a `java.lang.Long` or `java.lang.Double` JobParameter that value is null to the database and back
+	 * again should preserve nullable value which original, otherwise a different
+	 * job instance is created while the existing one should be used.
+	 *
+	 * This test ensures that round trip to the database with a `java.lang.Long` or `java.lang.Double`
+	 * parameter that value is null ends up with a single job instance (with two job executions)
+	 * being created and not two distinct job instances (with a job execution for
+	 * each one).
+	 *
+	 */
+	@Test
+	public void testLongOrDoubleNullable() throws Exception {
+		// given
+		Date date = new Date();
+		JobParameters jobParameters = new JobParametersBuilder()
+				.addLong("attribute", null) // as same as Double type
+				.toJobParameters();
+
+		// when
+		JobExecution jobExecution = this.jobLauncher.run(this.job, jobParameters);
+		this.jobOperator.restart(jobExecution.getId()); // should load the date parameter with fractional seconds precision here
+
+		// then
+		List<Long> jobInstances = this.jobOperator.getJobInstances("job", 0, 100);
+		Assert.assertEquals(1, jobInstances.size());
+		List<Long> jobExecutions = this.jobOperator.getExecutions(jobInstances.get(0));
+		Assert.assertEquals(2, jobExecutions.size());
+	}
+
 	@Configuration
 	@EnableBatchProcessing
 	static class TestConfiguration {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
@@ -374,9 +374,11 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 				if (type == ParameterType.STRING) {
 					value = new JobParameter(rs.getString(4), rs.getString(8).equalsIgnoreCase("Y"));
 				} else if (type == ParameterType.LONG) {
-					value = new JobParameter(rs.getLong(6), rs.getString(8).equalsIgnoreCase("Y"));
+					long longVal = rs.getLong(6);
+					value = new JobParameter(rs.wasNull() ? null : longVal, rs.getString(8).equalsIgnoreCase("Y"));
 				} else if (type == ParameterType.DOUBLE) {
-					value = new JobParameter(rs.getDouble(7), rs.getString(8).equalsIgnoreCase("Y"));
+					double doubleVal = rs.getDouble(7);
+					value = new JobParameter(rs.wasNull() ? null : doubleVal, rs.getString(8).equalsIgnoreCase("Y"));
 				} else if (type == ParameterType.DATE) {
 					value = new JobParameter(rs.getTimestamp(5), rs.getString(8).equalsIgnoreCase("Y"));
 				}


### PR DESCRIPTION
 Return null by ResultSet#getLong or ResultSet#getDouble when the actual value that is null save in database.

Issue #4087

I think it should be merge into 4.x at least, while 5.x is not supported null value in JobParameter at all.