### PR TITLE
Remove datasource autowiring in AbstractBatchConfiguration

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/AbstractBatchConfiguration.java
@@ -159,9 +159,14 @@ public abstract class AbstractBatchConfiguration implements ImportAware, Initial
 			DataSource dataSource;
 			try {
 				dataSource = this.context.getBean(DataSource.class);
+			}  catch (NoUniqueBeanDefinitionException exception) {
+				throw new IllegalStateException(
+						"Multiple data sources are defined in the application context and no primary candidate was found." +
+						"To use the default BatchConfigurer, one of the data sources should be annotated with '@Primary'.",
+						exception);
 			} catch (NoSuchBeanDefinitionException exception) {
 				throw new IllegalStateException(
-						"To use the default BatchConfigurer the context must contain precisely one DataSource",
+						"To use the default BatchConfigurer, the context must contain at least one datasource bean.",
 						exception);
 			}
 			DefaultBatchConfigurer configurer = new DefaultBatchConfigurer(dataSource);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
@@ -62,7 +62,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * }
  * </pre>
  *
- * The user should to provide a {@link DataSource} as a bean in the context, or else implement {@link BatchConfigurer} in
+ * The user should provide a {@link DataSource} as a bean in the context, or else implement {@link BatchConfigurer} in
  * the configuration class itself, e.g.
  *
  * <pre class="code">
@@ -85,11 +85,8 @@ import org.springframework.transaction.PlatformTransactionManager;
  * }
  * </pre>
  *
- * If multiple {@link javax.sql.DataSource}s are defined in the context, the one annotated with
- * {@link org.springframework.context.annotation.Primary} will be used (Note that if none
- * of them is annotated with {@link org.springframework.context.annotation.Primary}, the one
- * named <code>dataSource</code> will be used if any, otherwise a {@link UnsatisfiedDependencyException}
- * will be thrown).
+ * If multiple {@link javax.sql.DataSource}s are defined in the context, the primary autowire candidate
+ * will be used, otherwise an exception will be thrown.
  *
  * Note that only one of your configuration classes needs to have the <code>&#064;EnableBatchProcessing</code>
  * annotation. Once you have an <code>&#064;EnableBatchProcessing</code> class in your configuration you will have an

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/SimpleBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/SimpleBatchConfiguration.java
@@ -92,6 +92,12 @@ public class SimpleBatchConfiguration extends AbstractBatchConfiguration {
 		return createLazyProxy(transactionManager, PlatformTransactionManager.class);
 	}
 
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		super.afterPropertiesSet();
+		this.initialize();
+	}
+
 	private <T> T createLazyProxy(AtomicReference<T> reference, Class<T> type) {
 		ProxyFactory factory = new ProxyFactory();
 		factory.setTargetSource(new ReferenceTargetSource<>(reference));

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/InlineDataSourceDefinitionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/InlineDataSourceDefinitionTests.java
@@ -38,7 +38,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
-// https://github.com/spring-projects/spring-batch/issues/3991
 public class InlineDataSourceDefinitionTests {
 
     @Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/InlineDataSourceDefinitionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/InlineDataSourceDefinitionTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.configuration.annotation;
+
+import javax.sql.DataSource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+// https://github.com/spring-projects/spring-batch/issues/3991
+public class InlineDataSourceDefinitionTests {
+
+    @Test
+    public void testInlineDataSourceDefinition() throws Exception {
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(MyJobConfiguration.class);
+        Job job = applicationContext.getBean(Job.class);
+        JobLauncher jobLauncher = applicationContext.getBean(JobLauncher.class);
+        JobExecution jobExecution = jobLauncher.run(job, new JobParameters());
+        Assert.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+    }
+
+    @Configuration
+    @EnableBatchProcessing
+    static class MyJobConfiguration {
+
+        private JobBuilderFactory jobs;
+        private StepBuilderFactory steps;
+
+        public MyJobConfiguration(JobBuilderFactory jobs, StepBuilderFactory steps) {
+            this.jobs = jobs;
+            this.steps = steps;
+        }
+
+        @Bean
+        public Job job() {
+            return jobs.get("job")
+                    .start(steps.get("step")
+                            .tasklet((contribution, chunkContext) -> {
+                                System.out.println("hello world");
+                                return RepeatStatus.FINISHED;
+                            })
+                            .build())
+                    .build();
+        }
+
+        @Bean
+        public DataSource dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                    .setType(EmbeddedDatabaseType.H2)
+                    .addScript("/org/springframework/batch/core/schema-drop-h2.sql")
+                    .addScript("/org/springframework/batch/core/schema-h2.sql")
+                    .generateUniqueName(true)
+                    .build();
+        }
+    }
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithBatchConfigurerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithBatchConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import javax.sql.DataSource;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -34,11 +36,6 @@ import org.springframework.transaction.PlatformTransactionManager;
  * @author Mahmoud Ben Hassine
  */
 public class TransactionManagerConfigurationWithBatchConfigurerTests extends TransactionManagerConfigurationTests {
-
-	@Test(expected = UnsatisfiedDependencyException.class)
-	public void testConfigurationWithNoDataSourceAndNoTransactionManager() {
-		new AnnotationConfigApplicationContext(BatchConfigurationWithNoDataSourceAndNoTransactionManager.class);
-	}
 
 	@Test
 	public void testConfigurationWithDataSourceAndNoTransactionManager() throws Exception {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -35,6 +36,16 @@ import org.springframework.transaction.PlatformTransactionManager;
  * @author Mahmoud Ben Hassine
  */
 public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends TransactionManagerConfigurationTests {
+
+	@Test(expected = BeanCreationException.class)
+	public void testConfigurationWithNoDataSourceAndNoTransactionManager() {
+		new AnnotationConfigApplicationContext(BatchConfigurationWithNoDataSourceAndNoTransactionManager.class);
+	}
+
+	@Test(expected = BeanCreationException.class)
+	public void testConfigurationWithNoDataSourceAndTransactionManager() {
+		new AnnotationConfigApplicationContext(BatchConfigurationWithNoDataSourceAndTransactionManager.class);
+	}
 
 	@Test
 	public void testConfigurationWithDataSourceAndNoTransactionManager() throws Exception {
@@ -63,6 +74,11 @@ public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends 
 		// In this case, the supplied primary transaction manager won't be used by batch and a DataSourceTransactionManager will be used instead.
 		// The user has to provide a custom BatchConfigurer.
 		Assert.assertTrue(getTransactionManagerSetOnJobRepository(applicationContext.getBean(JobRepository.class)) instanceof DataSourceTransactionManager);
+	}
+
+	@EnableBatchProcessing
+	public static class BatchConfigurationWithNoDataSourceAndNoTransactionManager {
+
 	}
 
 	@EnableBatchProcessing

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,16 +36,6 @@ import org.springframework.transaction.PlatformTransactionManager;
  */
 public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends TransactionManagerConfigurationTests {
 
-	@Test(expected = UnsatisfiedDependencyException.class)
-	public void testConfigurationWithNoDataSourceAndNoTransactionManager() {
-		new AnnotationConfigApplicationContext(BatchConfigurationWithNoDataSourceAndNoTransactionManager.class);
-	}
-
-	@Test(expected = UnsatisfiedDependencyException.class)
-	public void testConfigurationWithNoDataSourceAndTransactionManager() {
-		new AnnotationConfigApplicationContext(BatchConfigurationWithNoDataSourceAndTransactionManager.class);
-	}
-
 	@Test
 	public void testConfigurationWithDataSourceAndNoTransactionManager() throws Exception {
 		ApplicationContext applicationContext = new AnnotationConfigApplicationContext(BatchConfigurationWithDataSourceAndNoTransactionManager.class);
@@ -73,12 +63,6 @@ public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends 
 		// In this case, the supplied primary transaction manager won't be used by batch and a DataSourceTransactionManager will be used instead.
 		// The user has to provide a custom BatchConfigurer.
 		Assert.assertTrue(getTransactionManagerSetOnJobRepository(applicationContext.getBean(JobRepository.class)) instanceof DataSourceTransactionManager);
-
-	}
-
-	@EnableBatchProcessing
-	public static class BatchConfigurationWithNoDataSourceAndNoTransactionManager {
-
 	}
 
 	@EnableBatchProcessing


### PR DESCRIPTION
Before this commit, the datasource was autowired in
AbstractBatchConfiguration. This was causing context
startup failures when no datasource or more than one
datasource is present in the context.

This commit fixes these failures by looking for the
datasource in the application context. This also
prevents cyclic configuration dependencies when
the datasource bean is defined in the same class where
other batch artifacts are autowired.

Issue #3991