### PR TITLE
Reduce use of deprecated APIs

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/ExitStatusTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/ExitStatusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,13 +226,10 @@ public class ExitStatusTests {
 	}
 
 	@Test
-	public void testSerializable() throws Exception {
+	public void testSerializable() {
 		ExitStatus status = ExitStatus.EXECUTING.replaceExitCode("FOO");
-		byte[] bytes = SerializationUtils.serialize(status);
-		Object object = SerializationUtils.deserialize(bytes);
-		assertTrue(object instanceof ExitStatus);
-		ExitStatus restored = (ExitStatus) object;
-		assertEquals(status.getExitCode(), restored.getExitCode());
+		ExitStatus clone = SerializationUtils.clone(status);
+		assertEquals(status.getExitCode(), clone.getExitCode());
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobExecutionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobExecutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,13 +193,13 @@ public class JobExecutionTests {
 
 	@Test
 	public void testSerialization() {
-		byte[] serialized = SerializationUtils.serialize(execution);
-		JobExecution deserialize = (JobExecution) SerializationUtils.deserialize(serialized);
-		assertEquals(execution, deserialize);
-		assertNotNull(deserialize.createStepExecution("foo"));
-		assertNotNull(deserialize.getFailureExceptions());
+		JobExecution clone = SerializationUtils.clone(execution);
+		assertEquals(execution, clone);
+		assertNotNull(clone.createStepExecution("foo"));
+		assertNotNull(clone.getFailureExceptions());
 	}
 
+	@Test
 	public void testFailureExceptions() {
 
 		RuntimeException exception = new RuntimeException();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobInstanceTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobInstanceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,7 @@ public class JobInstanceTests {
 	@Test
 	public void testSerialization() {
 		instance = new JobInstance(1L, "jobName");
-
-		byte[] serialized = SerializationUtils.serialize(instance);
-
-		assertEquals(instance, SerializationUtils.deserialize(serialized));
+		assertEquals(instance, SerializationUtils.clone(instance));
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -184,10 +183,7 @@ public class JobParametersTests {
 	@Test
 	public void testSerialization() {
 		JobParameters params = getNewParameters();
-
-		byte[] serialized = SerializationUtils.serialize(params);
-
-		assertEquals(params, SerializationUtils.deserialize(serialized));
+		assertEquals(params, SerializationUtils.clone(params));
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/StepExecutionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/StepExecutionTests.java
@@ -259,18 +259,17 @@ public class StepExecutionTests {
 	}
 
 	@Test
-	public void testSerialization() throws Exception {
+	public void testSerialization() {
 
 		ExitStatus status = ExitStatus.NOOP;
 		execution.setExitStatus(status);
 		execution.setExecutionContext(foobarEc);
 
-		byte[] serialized = SerializationUtils.serialize(execution);
-		StepExecution deserialized = (StepExecution) SerializationUtils.deserialize(serialized);
+		StepExecution clone = SerializationUtils.clone(execution);
 
-		assertEquals(execution, deserialized);
-		assertEquals(status, deserialized.getExitStatus());
-		assertNotNull(deserialized.getFailureExceptions());
+		assertEquals(execution, clone);
+		assertEquals(status, clone.getExitStatus());
+		assertNotNull(clone.getFailureExceptions());
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/Db2JobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/Db2JobRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class Db2JobRepositoryIntegrationTests {
 			dataSource.setUser(db2.getUsername());
 			dataSource.setPassword(db2.getPassword());
 			dataSource.setDriverType(4);
-			dataSource.setServerName(db2.getContainerIpAddress());
+			dataSource.setServerName(db2.getHost());
 			dataSource.setPortNumber(db2.getMappedPort(Db2Container.DB2_PORT));
 			dataSource.setSslConnection(false);
 			return dataSource;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/HANAJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/HANAJobRepositoryIntegrationTests.java
@@ -48,7 +48,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.EnabledIf;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -228,7 +227,7 @@ public class HANAJobRepositoryIntegrationTests {
 
 		@Override
 		public String getJdbcUrl() {
-			return "jdbc:sap://" + getContainerIpAddress() + ":" + getMappedPort(PORT) + "/";
+			return "jdbc:sap://" + getHost() + ":" + getMappedPort(PORT) + "/";
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/OracleJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/OracleJobRepositoryIntegrationTests.java
@@ -103,7 +103,7 @@ public class OracleJobRepositoryIntegrationTests {
 			oracleDataSource.setUser(oracle.getUsername());
 			oracleDataSource.setPassword(oracle.getPassword());
 			oracleDataSource.setDatabaseName(oracle.getDatabaseName());
-			oracleDataSource.setServerName(oracle.getContainerIpAddress());
+			oracleDataSource.setServerName(oracle.getHost());
 			oracleDataSource.setPortNumber(oracle.getOraclePort());
 			return oracleDataSource;
 		}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,12 +153,10 @@ public class ExecutionContextTests {
 		context.put("5", s);
 		context.putInt("6", 6);
 
-		byte[] serialized = SerializationUtils.serialize(context);
+		ExecutionContext clone = SerializationUtils.clone(context);
 
-		ExecutionContext deserialized = (ExecutionContext) SerializationUtils.deserialize(serialized);
-
-		assertEquals(context, deserialized);
-		assertEquals(7, ((TestSerializable) deserialized.get("5")).value);
+		assertEquals(context, clone);
+		assertEquals(7, ((TestSerializable) clone.get("5")).value);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,17 +74,6 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 	public static void main(String... args) {
 		new ClassPathXmlApplicationContext(ClassUtils.addResourcePathToPackagePath(DataSourceInitializer.class,
 				DataSourceInitializer.class.getSimpleName() + "-context.xml"));
-	}
-
-	/**
-	 * @throws Throwable
-	 * @see java.lang.Object#finalize()
-	 */
-	@Override
-	protected void finalize() throws Throwable {
-		logger.debug("finalize called for " + dataSource);
-		super.finalize();
-		initialized = false;
 	}
 
 	@Override

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkRequestTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkRequestTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,10 +54,8 @@ public class ChunkRequestTests {
 	}
 
 	@Test
-	public void testSerializable() throws Exception {
-		@SuppressWarnings("unchecked")
-		ChunkRequest<String> result = (ChunkRequest<String>) SerializationUtils
-				.deserialize(SerializationUtils.serialize(request));
+	public void testSerializable() {
+		ChunkRequest<String> result = SerializationUtils.clone(request);
 		assertNotNull(result.getStepContribution());
 		assertEquals(111L, result.getJobId());
 		assertEquals(2, result.getItems().size());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkResponseTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkResponseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,8 @@ public class ChunkResponseTests {
 	}
 
 	@Test
-	public void testSerializable() throws Exception {
-		ChunkResponse result = (ChunkResponse) SerializationUtils.deserialize(SerializationUtils.serialize(response));
+	public void testSerializable() {
+		ChunkResponse result = SerializationUtils.clone(response);
 		assertNotNull(result.getStepContribution());
 		assertEquals(Long.valueOf(111L), result.getJobId());
 	}


### PR DESCRIPTION
This PR reduces the use of the following deprecated APIs:

1. `ContainerState#getContainerIpAddress`
2. `Object#finalize`
3. `SerializationUtils#deserialize`.

The first two are completely replaced or removed. For the third, there is one use left in `StagingItemReader`.