### PR TITLE
Migrate Spring Batch Integration to JUnit Jupiter

### DIFF
--- a/spring-batch-integration/pom.xml
+++ b/spring-batch-integration/pom.xml
@@ -111,16 +111,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit-jupiter.version}</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.hamcrest</groupId>
-					<artifactId>hamcrest-core</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/SmokeTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/SmokeTests.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2008-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -12,12 +26,10 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class SmokeTests {
+@SpringJUnitConfig
+class SmokeTests {
 
 	@Autowired
 	private MessageChannel smokein;
@@ -26,12 +38,12 @@ public class SmokeTests {
 	private PollableChannel smokeout;
 
 	@Test
-	public void testDummyWithSimpleAssert() throws Exception {
+	void testDummyWithSimpleAssert() {
 		assertTrue(true);
 	}
 
 	@Test
-	public void testVanillaSendAndReceive() throws Exception {
+	void testVanillaSendAndReceive() {
 		smokein.send(new GenericMessage<>("foo"));
 		@SuppressWarnings("unchecked")
 		Message<String> message = (Message<String>) smokeout.receive(100);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorMessagingGatewayTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorMessagingGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,73 +15,43 @@
  */
 package org.springframework.batch.integration.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.MethodRule;
-import org.junit.runner.RunWith;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.test.MetaDataInstanceFactory;
-import org.springframework.batch.test.StepScopeTestUtils;
+import org.springframework.batch.test.StepScopeTestExecutionListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
-public class AsyncItemProcessorMessagingGatewayTests {
+@SpringJUnitConfig
+@TestExecutionListeners(listeners = StepScopeTestExecutionListener.class, mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
+class AsyncItemProcessorMessagingGatewayTests {
 
 	private final AsyncItemProcessor<String, String> processor = new AsyncItemProcessor<>();
-
-	private final StepExecution stepExecution = MetaDataInstanceFactory
-			.createStepExecution(new JobParametersBuilder().addLong("factor", 2L).toJobParameters());
-
-	;
-
-	@Rule
-	public MethodRule rule = new MethodRule() {
-		public Statement apply(final Statement base, FrameworkMethod method, Object target) {
-			return new Statement() {
-				@Override
-				public void evaluate() throws Throwable {
-					StepScopeTestUtils.doInStepScope(stepExecution, new Callable<Void>() {
-						public Void call() throws Exception {
-							try {
-								base.evaluate();
-							}
-							catch (Exception e) {
-								throw e;
-							}
-							catch (Throwable e) {
-								throw new Error(e);
-							}
-							return null;
-						}
-					});
-				};
-			};
-		}
-	};
 
 	@Autowired
 	private ItemProcessor<String, String> delegate;
 
+	StepExecution getStepExecution() {
+		return MetaDataInstanceFactory
+				.createStepExecution(new JobParametersBuilder().addLong("factor", 2L).toJobParameters());
+	}
+
 	@Test
-	public void testMultiExecution() throws Exception {
+	void testMultiExecution() throws Exception {
 		processor.setDelegate(delegate);
 		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
 		List<Future<String>> list = new ArrayList<>();
@@ -102,7 +72,7 @@ public class AsyncItemProcessorMessagingGatewayTests {
 	}
 
 	@MessageEndpoint
-	public static class Doubler {
+	static class Doubler {
 
 		private int factor = 1;
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,16 @@
  */
 package org.springframework.batch.integration.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.scope.context.StepContext;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.item.ItemProcessor;
@@ -32,38 +33,38 @@ import org.springframework.batch.test.StepScopeTestUtils;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.lang.Nullable;
 
-public class AsyncItemProcessorTests {
+class AsyncItemProcessorTests {
 
-	private AsyncItemProcessor<String, String> processor = new AsyncItemProcessor<>();
+	private final AsyncItemProcessor<String, String> processor = new AsyncItemProcessor<>();
 
 	private ItemProcessor<String, String> delegate = new ItemProcessor<String, String>() {
 		@Nullable
 		public String process(String item) throws Exception {
 			return item + item;
-		};
+		}
 	};
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testNoDelegate() throws Exception {
-		processor.afterPropertiesSet();
+	@Test
+	void testNoDelegate() {
+		assertThrows(IllegalArgumentException.class, processor::afterPropertiesSet);
 	}
 
 	@Test
-	public void testExecution() throws Exception {
+	void testExecution() throws Exception {
 		processor.setDelegate(delegate);
 		Future<String> result = processor.process("foo");
 		assertEquals("foofoo", result.get());
 	}
 
 	@Test
-	public void testExecutionInStepScope() throws Exception {
+	void testExecutionInStepScope() throws Exception {
 		delegate = new ItemProcessor<String, String>() {
 			@Nullable
 			public String process(String item) throws Exception {
 				StepContext context = StepSynchronizationManager.getContext();
 				assertTrue(context != null && context.getStepExecution() != null);
 				return item + item;
-			};
+			}
 		};
 		processor.setDelegate(delegate);
 		Future<String> result = StepScopeTestUtils.doInStepScope(MetaDataInstanceFactory.createStepExecution(),
@@ -76,7 +77,7 @@ public class AsyncItemProcessorTests {
 	}
 
 	@Test
-	public void testMultiExecution() throws Exception {
+	void testMultiExecution() throws Exception {
 		processor.setDelegate(delegate);
 		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
 		List<Future<String>> list = new ArrayList<>();

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemWriterTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -34,14 +34,15 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author mminella
  */
-public class AsyncItemWriterTests {
+class AsyncItemWriterTests {
 
 	private AsyncItemWriter<String> writer;
 
@@ -49,15 +50,15 @@ public class AsyncItemWriterTests {
 
 	private TaskExecutor taskExecutor;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		taskExecutor = new SimpleAsyncTaskExecutor();
 		writtenItems = new ArrayList<>();
 		writer = new AsyncItemWriter<>();
 	}
 
 	@Test
-	public void testRoseyScenario() throws Exception {
+	void testRoseyScenario() throws Exception {
 		writer.setDelegate(new ListItemWriter(writtenItems));
 		List<FutureTask<String>> processedItems = new ArrayList<>();
 
@@ -87,7 +88,7 @@ public class AsyncItemWriterTests {
 	}
 
 	@Test
-	public void testFilteredItem() throws Exception {
+	void testFilteredItem() throws Exception {
 		writer.setDelegate(new ListItemWriter(writtenItems));
 		List<FutureTask<String>> processedItems = new ArrayList<>();
 
@@ -116,7 +117,7 @@ public class AsyncItemWriterTests {
 	}
 
 	@Test
-	public void testException() throws Exception {
+	void testException() {
 		writer.setDelegate(new ListItemWriter(writtenItems));
 		List<FutureTask<String>> processedItems = new ArrayList<>();
 
@@ -138,17 +139,12 @@ public class AsyncItemWriterTests {
 			taskExecutor.execute(processedItem);
 		}
 
-		try {
-			writer.write(processedItems);
-		}
-		catch (Exception e) {
-			assertTrue(e instanceof RuntimeException);
-			assertEquals("This was expected", e.getMessage());
-		}
+		Exception exception = assertThrows(RuntimeException.class, () -> writer.write(processedItems));
+		assertEquals("This was expected", exception.getMessage());
 	}
 
 	@Test
-	public void testExecutionException() {
+	void testExecutionException() {
 		ListItemWriter delegate = new ListItemWriter(writtenItems);
 		writer.setDelegate(delegate);
 		List<Future<String>> processedItems = new ArrayList<>();
@@ -182,18 +178,14 @@ public class AsyncItemWriterTests {
 			}
 		});
 
-		try {
-			writer.write(processedItems);
-		}
-		catch (Exception e) {
-			assertFalse(e instanceof ExecutionException);
-		}
+		Exception exception = assertThrows(Exception.class, () -> writer.write(processedItems));
+		assertFalse(exception instanceof ExecutionException);
 
 		assertEquals(0, writtenItems.size());
 	}
 
 	@Test
-	public void testStreamDelegate() throws Exception {
+	void testStreamDelegate() throws Exception {
 		ListItemStreamWriter itemWriter = new ListItemStreamWriter(writtenItems);
 		writer.setDelegate(itemWriter);
 
@@ -211,7 +203,7 @@ public class AsyncItemWriterTests {
 	}
 
 	@Test
-	public void testNonStreamDelegate() throws Exception {
+	void testNonStreamDelegate() throws Exception {
 		ListItemWriter itemWriter = new ListItemWriter(writtenItems);
 		writer.setDelegate(itemWriter);
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkMessageItemWriterIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkMessageItemWriterIntegrationTests.java
@@ -17,10 +17,9 @@ package org.springframework.batch.integration.chunk;
 
 import java.util.Arrays;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
@@ -50,16 +49,14 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.StringUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class ChunkMessageItemWriterIntegrationTests {
+@SpringJUnitConfig
+class ChunkMessageItemWriterIntegrationTests {
 
 	private final ChunkMessageChannelItemWriter<Object> writer = new ChunkMessageChannelItemWriter<>();
 
@@ -77,8 +74,8 @@ public class ChunkMessageItemWriterIntegrationTests {
 
 	private static long jobCounter;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder().generateUniqueName(true)
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
@@ -112,19 +109,19 @@ public class ChunkMessageItemWriterIntegrationTests {
 
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		while (replies.receive(10L) != null) {
 		}
 	}
 
 	@Test
-	public void testOpenWithNoState() throws Exception {
+	void testOpenWithNoState() {
 		writer.open(new ExecutionContext());
 	}
 
 	@Test
-	public void testUpdateAndOpenWithState() throws Exception {
+	void testUpdateAndOpenWithState() {
 		ExecutionContext executionContext = new ExecutionContext();
 		writer.update(executionContext);
 		writer.open(executionContext);
@@ -133,7 +130,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 	}
 
 	@Test
-	public void testVanillaIteration() throws Exception {
+	void testVanillaIteration() throws Exception {
 
 		factory.setItemReader(
 				new ListItemReader<>(Arrays.asList(StringUtils.commaDelimitedListToStringArray("1,2,3,4,5,6"))));
@@ -151,7 +148,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 	}
 
 	@Test
-	public void testSimulatedRestart() throws Exception {
+	void testSimulatedRestart() throws Exception {
 
 		factory.setItemReader(
 				new ListItemReader<>(Arrays.asList(StringUtils.commaDelimitedListToStringArray("1,2,3,4,5,6"))));
@@ -176,7 +173,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 	}
 
 	@Test
-	public void testSimulatedRestartWithBadMessagesFromAnotherJob() throws Exception {
+	void testSimulatedRestartWithBadMessagesFromAnotherJob() throws Exception {
 
 		factory.setItemReader(
 				new ListItemReader<>(Arrays.asList(StringUtils.commaDelimitedListToStringArray("1,2,3,4,5,6"))));
@@ -198,7 +195,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 		assertEquals(BatchStatus.FAILED, stepExecution.getStatus());
 		assertEquals(ExitStatus.FAILED.getExitCode(), stepExecution.getExitStatus().getExitCode());
 		String message = stepExecution.getExitStatus().getExitDescription();
-		assertTrue("Message does not contain 'wrong job': " + message, message.contains("wrong job"));
+		assertTrue(message.contains("wrong job"), "Message does not contain 'wrong job': " + message);
 
 		waitForResults(1, 10);
 
@@ -217,7 +214,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 	}
 
 	@Test
-	public void testEarlyCompletionSignalledInHandler() throws Exception {
+	void testEarlyCompletionSignalledInHandler() throws Exception {
 
 		factory.setItemReader(
 				new ListItemReader<>(Arrays.asList(StringUtils.commaDelimitedListToStringArray("1,fail,3,4,5,6"))));
@@ -230,7 +227,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 		assertEquals(BatchStatus.FAILED, stepExecution.getStatus());
 		assertEquals(ExitStatus.FAILED.getExitCode(), stepExecution.getExitStatus().getExitCode());
 		String message = stepExecution.getExitStatus().getExitDescription();
-		assertTrue("Message does not contain 'fail': " + message, message.contains("fail"));
+		assertTrue(message.contains("fail"), "Message does not contain 'fail': " + message);
 
 		waitForResults(2, 10);
 
@@ -244,7 +241,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 	}
 
 	@Test
-	public void testSimulatedRestartWithNoBacklog() throws Exception {
+	void testSimulatedRestartWithNoBacklog() throws Exception {
 
 		factory.setItemReader(
 				new ListItemReader<>(Arrays.asList(StringUtils.commaDelimitedListToStringArray("1,2,3,4,5,6"))));
@@ -268,7 +265,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 		assertEquals(BatchStatus.FAILED, stepExecution.getStatus());
 		assertEquals(ExitStatus.FAILED.getExitCode(), stepExecution.getExitStatus().getExitCode());
 		String message = stepExecution.getExitStatus().getExitDescription();
-		assertTrue("Message did not contain 'timed out': " + message, message.toLowerCase().contains("timed out"));
+		assertTrue(message.toLowerCase().contains("timed out"), "Message did not contain 'timed out': " + message);
 
 		assertEquals(0, TestItemWriter.count);
 		assertEquals(0, stepExecution.getReadCount());
@@ -280,7 +277,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 	 * processing just by waiting for long enough.
 	 */
 	@Test
-	public void testFailureInStepListener() throws Exception {
+	void testFailureInStepListener() throws Exception {
 
 		factory.setItemReader(
 				new ListItemReader<>(Arrays.asList(StringUtils.commaDelimitedListToStringArray("wait,fail,3,4,5,6"))));
@@ -301,8 +298,8 @@ public class ChunkMessageItemWriterIntegrationTests {
 		assertEquals(ExitStatus.FAILED.getExitCode(), stepExecution.getExitStatus().getExitCode());
 
 		String exitDescription = stepExecution.getExitStatus().getExitDescription();
-		assertTrue("Exit description does not contain exception type name: " + exitDescription,
-				exitDescription.contains(AsynchronousFailureException.class.getName()));
+		assertTrue(exitDescription.contains(AsynchronousFailureException.class.getName()),
+				"Exit description does not contain exception type name: " + exitDescription);
 
 	}
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkProcessorChunkHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkProcessorChunkHandlerTests.java
@@ -1,23 +1,38 @@
+/*
+ * Copyright 2008-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.step.item.Chunk;
 import org.springframework.batch.core.step.item.ChunkProcessor;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.util.StringUtils;
 
-public class ChunkProcessorChunkHandlerTests {
+class ChunkProcessorChunkHandlerTests {
 
-	private ChunkProcessorChunkHandler<Object> handler = new ChunkProcessorChunkHandler<>();
+	private final ChunkProcessorChunkHandler<Object> handler = new ChunkProcessorChunkHandler<>();
 
 	protected int count = 0;
 
 	@Test
-	public void testVanillaHandleChunk() throws Exception {
+	void testVanillaHandleChunk() throws Exception {
 		handler.setChunkProcessor(new ChunkProcessor<Object>() {
 			public void process(StepContribution contribution, Chunk<Object> chunk) throws Exception {
 				count += chunk.size();

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkRequestTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkRequestTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.util.SerializationUtils;
 
@@ -28,33 +28,33 @@ import org.springframework.util.SerializationUtils;
  * @author Dave Syer
  *
  */
-public class ChunkRequestTests {
+class ChunkRequestTests {
 
-	private ChunkRequest<String> request = new ChunkRequest<>(0, Arrays.asList("foo", "bar"), 111L,
+	private final ChunkRequest<String> request = new ChunkRequest<>(0, Arrays.asList("foo", "bar"), 111L,
 			MetaDataInstanceFactory.createStepExecution().createStepContribution());
 
 	@Test
-	public void testGetJobId() {
+	void testGetJobId() {
 		assertEquals(111L, request.getJobId());
 	}
 
 	@Test
-	public void testGetItems() {
+	void testGetItems() {
 		assertEquals(2, request.getItems().size());
 	}
 
 	@Test
-	public void testGetStepContribution() {
+	void testGetStepContribution() {
 		assertNotNull(request.getStepContribution());
 	}
 
 	@Test
-	public void testToString() {
+	void testToString() {
 		System.err.println(request.toString());
 	}
 
 	@Test
-	public void testSerializable() {
+	void testSerializable() {
 		ChunkRequest<String> result = SerializationUtils.clone(request);
 		assertNotNull(result.getStepContribution());
 		assertEquals(111L, result.getJobId());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkResponseTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkResponseTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.util.SerializationUtils;
 
@@ -26,28 +26,28 @@ import org.springframework.util.SerializationUtils;
  * @author Dave Syer
  *
  */
-public class ChunkResponseTests {
+class ChunkResponseTests {
 
-	private ChunkResponse response = new ChunkResponse(0, 111L,
+	private final ChunkResponse response = new ChunkResponse(0, 111L,
 			MetaDataInstanceFactory.createStepExecution().createStepContribution());
 
 	@Test
-	public void testGetJobId() {
+	void testGetJobId() {
 		assertEquals(Long.valueOf(111L), response.getJobId());
 	}
 
 	@Test
-	public void testGetStepContribution() {
+	void testGetStepContribution() {
 		assertNotNull(response.getStepContribution());
 	}
 
 	@Test
-	public void testToString() {
+	void testToString() {
 		System.err.println(response.toString());
 	}
 
 	@Test
-	public void testSerializable() {
+	void testSerializable() {
 		ChunkResponse result = SerializationUtils.clone(response);
 		assertNotNull(result.getStepContribution());
 		assertEquals(Long.valueOf(111L), result.getJobId());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/MessageSourcePollerInterceptorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/MessageSourcePollerInterceptorTests.java
@@ -1,37 +1,53 @@
+/*
+ * Copyright 2010-2022 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 
-public class MessageSourcePollerInterceptorTests {
+class MessageSourcePollerInterceptorTests {
 
-	@Test(expected = IllegalStateException.class)
-	public void testMandatoryPropertiesUnset() throws Exception {
+	@Test
+	void testMandatoryPropertiesUnset() {
 		MessageSourcePollerInterceptor interceptor = new MessageSourcePollerInterceptor();
-		interceptor.afterPropertiesSet();
+		assertThrows(IllegalStateException.class, interceptor::afterPropertiesSet);
 	}
 
 	@Test
-	public void testMandatoryPropertiesSetViaConstructor() throws Exception {
+	void testMandatoryPropertiesSetViaConstructor() throws Exception {
 		MessageSourcePollerInterceptor interceptor = new MessageSourcePollerInterceptor(new TestMessageSource("foo"));
 		interceptor.afterPropertiesSet();
 	}
 
 	@Test
-	public void testMandatoryPropertiesSet() throws Exception {
+	void testMandatoryPropertiesSet() throws Exception {
 		MessageSourcePollerInterceptor interceptor = new MessageSourcePollerInterceptor();
 		interceptor.setMessageSource(new TestMessageSource("foo"));
 		interceptor.afterPropertiesSet();
 	}
 
 	@Test
-	public void testPreReceive() throws Exception {
+	void testPreReceive() {
 		MessageSourcePollerInterceptor interceptor = new MessageSourcePollerInterceptor(new TestMessageSource("foo"));
 		QueueChannel channel = new QueueChannel();
 		assertTrue(interceptor.preReceive(channel));

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepIntegrationTests.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright 2010-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -18,12 +32,10 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class RemoteChunkFaultTolerantStepIntegrationTests {
+@SpringJUnitConfig
+class RemoteChunkFaultTolerantStepIntegrationTests {
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -34,8 +46,8 @@ public class RemoteChunkFaultTolerantStepIntegrationTests {
 	@Autowired
 	private PollableChannel replies;
 
-	@Before
-	public void drain() {
+	@BeforeEach
+	void drain() {
 		Message<?> message = replies.receive(100L);
 		while (message != null) {
 			// System.err.println(message);
@@ -44,7 +56,7 @@ public class RemoteChunkFaultTolerantStepIntegrationTests {
 	}
 
 	@Test
-	public void testFailedStep() throws Exception {
+	void testFailedStep() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("unsupported"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
@@ -55,7 +67,7 @@ public class RemoteChunkFaultTolerantStepIntegrationTests {
 	}
 
 	@Test
-	public void testFailedStepOnError() throws Exception {
+	void testFailedStepOnError() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("error"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
@@ -66,7 +78,7 @@ public class RemoteChunkFaultTolerantStepIntegrationTests {
 	}
 
 	@Test
-	public void testSunnyDayFaultTolerant() throws Exception {
+	void testSunnyDayFaultTolerant() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("3"))));
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
@@ -76,7 +88,7 @@ public class RemoteChunkFaultTolerantStepIntegrationTests {
 	}
 
 	@Test
-	public void testSkipsInWriter() throws Exception {
+	void testSkipsInWriter() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParametersBuilder().addString("item.three", "fail").addLong("run.id", 1L).toJobParameters());
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJdbcIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJdbcIntegrationTests.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright 2010-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -19,12 +33,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
+@SpringJUnitConfig
+class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -35,8 +47,8 @@ public class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
 	@Autowired
 	private PollableChannel replies;
 
-	@Before
-	public void drain() {
+	@BeforeEach
+	void drain() {
 		Message<?> message = replies.receive(100L);
 		while (message != null) {
 			message = replies.receive(100L);
@@ -45,7 +57,7 @@ public class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
 
 	@Test
 	@DirtiesContext
-	public void testFailedStep() throws Exception {
+	void testFailedStep() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("unsupported"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
@@ -57,7 +69,7 @@ public class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
 
 	@Test
 	@DirtiesContext
-	public void testFailedStepOnError() throws Exception {
+	void testFailedStepOnError() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("error"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
@@ -69,7 +81,7 @@ public class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
 
 	@Test
 	@DirtiesContext
-	public void testSunnyDayFaultTolerant() throws Exception {
+	void testSunnyDayFaultTolerant() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("3"))));
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
@@ -80,7 +92,7 @@ public class RemoteChunkFaultTolerantStepJdbcIntegrationTests {
 
 	@Test
 	@DirtiesContext
-	public void testSkipsInWriter() throws Exception {
+	void testSkipsInWriter() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParametersBuilder().addString("item.three", "fail").addLong("run.id", 1L).toJobParameters());
 		// System.err.println(new SimpleJdbcTemplate(dataSource).queryForList("SELECT *

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJmsIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJmsIntegrationTests.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright 2010-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.Collections;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -18,17 +32,15 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.FileSystemUtils;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
-public class RemoteChunkFaultTolerantStepJmsIntegrationTests {
+class RemoteChunkFaultTolerantStepJmsIntegrationTests {
 
-	@BeforeClass
-	public static void clear() {
+	@BeforeAll
+	static void clear() {
 		FileSystemUtils.deleteRecursively(new File("activemq-data"));
 	}
 
@@ -39,7 +51,7 @@ public class RemoteChunkFaultTolerantStepJmsIntegrationTests {
 	private Job job;
 
 	@Test
-	public void testFailedStep() throws Exception {
+	void testFailedStep() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("unsupported"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
@@ -50,7 +62,7 @@ public class RemoteChunkFaultTolerantStepJmsIntegrationTests {
 	}
 
 	@Test
-	public void testFailedStepOnError() throws Exception {
+	void testFailedStepOnError() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("error"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
@@ -61,7 +73,7 @@ public class RemoteChunkFaultTolerantStepJmsIntegrationTests {
 	}
 
 	@Test
-	public void testSunnyDayFaultTolerant() throws Exception {
+	void testSunnyDayFaultTolerant() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("3"))));
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
@@ -71,7 +83,7 @@ public class RemoteChunkFaultTolerantStepJmsIntegrationTests {
 	}
 
 	@Test
-	public void testSkipsInWriter() throws Exception {
+	void testSkipsInWriter() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParametersBuilder().addString("item.three", "fail").addLong("run.id", 1L).toJobParameters());
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkStepIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkStepIntegrationTests.java
@@ -1,11 +1,25 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -14,12 +28,10 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class RemoteChunkStepIntegrationTests {
+@SpringJUnitConfig
+class RemoteChunkStepIntegrationTests {
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -28,7 +40,7 @@ public class RemoteChunkStepIntegrationTests {
 	private Job job;
 
 	@Test
-	public void testSunnyDaySimpleStep() throws Exception {
+	void testSunnyDaySimpleStep() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("3"))));
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
@@ -38,7 +50,7 @@ public class RemoteChunkStepIntegrationTests {
 	}
 
 	@Test
-	public void testFailedStep() throws Exception {
+	void testFailedStep() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParameters(Collections.singletonMap("item.three", new JobParameter("fail"))));
 		assertEquals(BatchStatus.FAILED, jobExecution.getStatus());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
@@ -21,9 +21,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ItemReadListener;
@@ -59,13 +57,17 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.retry.RetryListener;
 import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.MapRetryContextCache;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -75,9 +77,8 @@ import static org.mockito.Mockito.when;
 /**
  * @author Mahmoud Ben Hassine
  */
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = { RemoteChunkingManagerStepBuilderTests.BatchConfiguration.class })
-public class RemoteChunkingManagerStepBuilderTests {
+@SpringJUnitConfig(classes = { RemoteChunkingManagerStepBuilderTests.BatchConfiguration.class })
+class RemoteChunkingManagerStepBuilderTests {
 
 	@Autowired
 	private JobRepository jobRepository;
@@ -85,16 +86,16 @@ public class RemoteChunkingManagerStepBuilderTests {
 	@Autowired
 	private PlatformTransactionManager transactionManager;
 
-	private PollableChannel inputChannel = new QueueChannel();
+	private final PollableChannel inputChannel = new QueueChannel();
 
-	private DirectChannel outputChannel = new DirectChannel();
+	private final DirectChannel outputChannel = new DirectChannel();
 
-	private ItemReader<String> itemReader = new ListItemReader<>(Arrays.asList("a", "b", "c"));
+	private final ItemReader<String> itemReader = new ListItemReader<>(Arrays.asList("a", "b", "c"));
 
 	@Test
-	public void inputChannelMustNotBeNull() {
+	void inputChannelMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingManagerStepBuilder<String, String>("step").inputChannel(null).build());
 
 		// then
@@ -102,9 +103,9 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void outputChannelMustNotBeNull() {
+	void outputChannelMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingManagerStepBuilder<String, String>("step").outputChannel(null).build());
 
 		// then
@@ -112,9 +113,9 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void messagingTemplateMustNotBeNull() {
+	void messagingTemplateMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingManagerStepBuilder<String, String>("step").messagingTemplate(null).build());
 
 		// then
@@ -122,9 +123,9 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void maxWaitTimeoutsMustBeGreaterThanZero() {
+	void maxWaitTimeoutsMustBeGreaterThanZero() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingManagerStepBuilder<String, String>("step").maxWaitTimeouts(-1).build());
 
 		// then
@@ -132,9 +133,9 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void throttleLimitMustNotBeGreaterThanZero() {
+	void throttleLimitMustNotBeGreaterThanZero() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingManagerStepBuilder<String, String>("step").throttleLimit(-1L).build());
 
 		// then
@@ -142,26 +143,26 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void testMandatoryInputChannel() {
+	void testMandatoryInputChannel() {
 		// given
 		RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<>("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("An InputChannel must be provided");
 	}
 
 	@Test
-	public void eitherOutputChannelOrMessagingTemplateMustBeProvided() {
+	void eitherOutputChannelOrMessagingTemplateMustBeProvided() {
 		// given
 		RemoteChunkingManagerStepBuilder<String, String> builder = new RemoteChunkingManagerStepBuilder<String, String>(
 				"step").inputChannel(this.inputChannel).outputChannel(new DirectChannel())
 				.messagingTemplate(new MessagingTemplate());
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, builder::build);
+		final Exception expectedException = assertThrows(IllegalStateException.class, builder::build);
 
 		// then
 		assertThat(expectedException)
@@ -169,9 +170,9 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void testUnsupportedOperationExceptionWhenSpecifyingAnItemWriter() {
+	void testUnsupportedOperationExceptionWhenSpecifyingAnItemWriter() {
 		// when
-		final Exception expectedException = Assert.assertThrows(UnsupportedOperationException.class,
+		final Exception expectedException = assertThrows(UnsupportedOperationException.class,
 				() -> new RemoteChunkingManagerStepBuilder<String, String>("step").reader(this.itemReader)
 						.writer(items -> {
 						}).repository(this.jobRepository).transactionManager(this.transactionManager)
@@ -185,14 +186,14 @@ public class RemoteChunkingManagerStepBuilderTests {
 	}
 
 	@Test
-	public void testManagerStepCreation() {
+	void testManagerStepCreation() {
 		// when
 		TaskletStep taskletStep = new RemoteChunkingManagerStepBuilder<String, String>("step").reader(this.itemReader)
 				.repository(this.jobRepository).transactionManager(this.transactionManager)
 				.inputChannel(this.inputChannel).outputChannel(this.outputChannel).build();
 
 		// then
-		Assert.assertNotNull(taskletStep);
+		assertNotNull(taskletStep);
 	}
 
 	/*
@@ -200,7 +201,7 @@ public class RemoteChunkingManagerStepBuilderTests {
 	 */
 	@Test
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void testSetters() throws Exception {
+	void testSetters() throws Exception {
 		// when
 		DefaultTransactionAttribute transactionAttribute = new DefaultTransactionAttribute();
 
@@ -276,7 +277,7 @@ public class RemoteChunkingManagerStepBuilderTests {
 		taskletStep.execute(stepExecution);
 
 		// then
-		Assert.assertNotNull(taskletStep);
+		assertNotNull(taskletStep);
 		ChunkOrientedTasklet tasklet = (ChunkOrientedTasklet) ReflectionTestUtils.getField(taskletStep, "tasklet");
 		SimpleChunkProvider provider = (SimpleChunkProvider) ReflectionTestUtils.getField(tasklet, "chunkProvider");
 		SimpleChunkProcessor processor = (SimpleChunkProcessor) ReflectionTestUtils.getField(tasklet, "chunkProcessor");
@@ -286,22 +287,22 @@ public class RemoteChunkingManagerStepBuilderTests {
 		CompositeItemStream compositeItemStream = (CompositeItemStream) ReflectionTestUtils.getField(taskletStep,
 				"stream");
 
-		Assert.assertEquals(ReflectionTestUtils.getField(provider, "itemReader"), itemReader);
-		Assert.assertFalse((Boolean) ReflectionTestUtils.getField(tasklet, "buffering"));
-		Assert.assertEquals(ReflectionTestUtils.getField(taskletStep, "jobRepository"), this.jobRepository);
-		Assert.assertEquals(ReflectionTestUtils.getField(taskletStep, "transactionManager"), this.transactionManager);
-		Assert.assertEquals(ReflectionTestUtils.getField(taskletStep, "transactionAttribute"), transactionAttribute);
-		Assert.assertEquals(ReflectionTestUtils.getField(itemWriter, "replyChannel"), this.inputChannel);
-		Assert.assertEquals(ReflectionTestUtils.getField(messagingTemplate, "defaultDestination"), this.outputChannel);
-		Assert.assertEquals(ReflectionTestUtils.getField(processor, "itemProcessor"), itemProcessor);
+		assertEquals(ReflectionTestUtils.getField(provider, "itemReader"), itemReader);
+		assertFalse((Boolean) ReflectionTestUtils.getField(tasklet, "buffering"));
+		assertEquals(ReflectionTestUtils.getField(taskletStep, "jobRepository"), this.jobRepository);
+		assertEquals(ReflectionTestUtils.getField(taskletStep, "transactionManager"), this.transactionManager);
+		assertEquals(ReflectionTestUtils.getField(taskletStep, "transactionAttribute"), transactionAttribute);
+		assertEquals(ReflectionTestUtils.getField(itemWriter, "replyChannel"), this.inputChannel);
+		assertEquals(ReflectionTestUtils.getField(messagingTemplate, "defaultDestination"), this.outputChannel);
+		assertEquals(ReflectionTestUtils.getField(processor, "itemProcessor"), itemProcessor);
 
-		Assert.assertEquals((int) ReflectionTestUtils.getField(taskletStep, "startLimit"), 3);
-		Assert.assertTrue((Boolean) ReflectionTestUtils.getField(taskletStep, "allowStartIfComplete"));
+		assertEquals((int) ReflectionTestUtils.getField(taskletStep, "startLimit"), 3);
+		assertTrue((Boolean) ReflectionTestUtils.getField(taskletStep, "allowStartIfComplete"));
 		Object stepOperationsUsed = ReflectionTestUtils.getField(taskletStep, "stepOperations");
-		Assert.assertEquals(stepOperationsUsed, stepOperations);
+		assertEquals(stepOperationsUsed, stepOperations);
 
-		Assert.assertEquals(((List) ReflectionTestUtils.getField(compositeItemStream, "streams")).size(), 2);
-		Assert.assertNotNull(ReflectionTestUtils.getField(processor, "keyGenerator"));
+		assertEquals(((List) ReflectionTestUtils.getField(compositeItemStream, "streams")).size(), 2);
+		assertNotNull(ReflectionTestUtils.getField(processor, "keyGenerator"));
 
 		verify(skipListener, atLeastOnce()).onSkipInProcess(any(), any());
 		verify(retryListener, atLeastOnce()).open(any(), any());
@@ -310,22 +311,22 @@ public class RemoteChunkingManagerStepBuilderTests {
 		verify(itemReadListener, atLeastOnce()).beforeRead();
 		verify(itemWriteListener, atLeastOnce()).beforeWrite(any());
 
-		Assert.assertEquals(stepExecution.getSkipCount(), 2);
-		Assert.assertEquals(stepExecution.getRollbackCount(), 3);
+		assertEquals(stepExecution.getSkipCount(), 2);
+		assertEquals(stepExecution.getRollbackCount(), 3);
 	}
 
 	@Configuration
 	@EnableBatchProcessing
-	public static class BatchConfiguration {
+	static class BatchConfiguration {
 
 		@Bean
-		public DataSource dataSource() {
+		DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 					.addScript("/org/springframework/batch/core/schema-hsqldb.sql").generateUniqueName(true).build();
 		}
 
 		@Bean
-		public JdbcTransactionManager transactionManager(DataSource dataSource) {
+		JdbcTransactionManager transactionManager(DataSource dataSource) {
 			return new JdbcTransactionManager(dataSource);
 		}
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package org.springframework.batch.integration.chunk;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
@@ -25,21 +24,23 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-public class RemoteChunkingWorkerBuilderTests {
+class RemoteChunkingWorkerBuilderTests {
 
-	private ItemProcessor<String, String> itemProcessor = new PassThroughItemProcessor<>();
+	private final ItemProcessor<String, String> itemProcessor = new PassThroughItemProcessor<>();
 
-	private ItemWriter<String> itemWriter = items -> {
+	private final ItemWriter<String> itemWriter = items -> {
 	};
 
 	@Test
-	public void itemProcessorMustNotBeNull() {
+	void itemProcessorMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingWorkerBuilder<String, String>().itemProcessor(null).build());
 
 		// then
@@ -47,9 +48,9 @@ public class RemoteChunkingWorkerBuilderTests {
 	}
 
 	@Test
-	public void itemWriterMustNotBeNull() {
+	void itemWriterMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingWorkerBuilder<String, String>().itemWriter(null).build());
 
 		// then
@@ -57,9 +58,9 @@ public class RemoteChunkingWorkerBuilderTests {
 	}
 
 	@Test
-	public void inputChannelMustNotBeNull() {
+	void inputChannelMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingWorkerBuilder<String, String>().inputChannel(null).build());
 
 		// then
@@ -67,9 +68,9 @@ public class RemoteChunkingWorkerBuilderTests {
 	}
 
 	@Test
-	public void outputChannelMustNotBeNull() {
+	void outputChannelMustNotBeNull() {
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> new RemoteChunkingWorkerBuilder<String, String>().outputChannel(null).build());
 
 		// then
@@ -77,47 +78,47 @@ public class RemoteChunkingWorkerBuilderTests {
 	}
 
 	@Test
-	public void testMandatoryItemWriter() {
+	void testMandatoryItemWriter() {
 		// given
 		RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<>();
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("An ItemWriter must be provided");
 	}
 
 	@Test
-	public void testMandatoryInputChannel() {
+	void testMandatoryInputChannel() {
 		// given
 		RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
 				.itemWriter(items -> {
 				});
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("An InputChannel must be provided");
 	}
 
 	@Test
-	public void testMandatoryOutputChannel() {
+	void testMandatoryOutputChannel() {
 		// given
 		RemoteChunkingWorkerBuilder<String, String> builder = new RemoteChunkingWorkerBuilder<String, String>()
 				.itemWriter(items -> {
 				}).inputChannel(new DirectChannel());
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("An OutputChannel must be provided");
 	}
 
 	@Test
-	public void testIntegrationFlowCreation() {
+	void testIntegrationFlowCreation() {
 		// given
 		DirectChannel inputChannel = new DirectChannel();
 		DirectChannel outputChannel = new DirectChannel();
@@ -129,7 +130,7 @@ public class RemoteChunkingWorkerBuilderTests {
 		IntegrationFlow integrationFlow = builder.build();
 
 		// then
-		Assert.assertNotNull(integrationFlow);
+		assertNotNull(integrationFlow);
 	}
 
 }

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/config/xml/JobLaunchingGatewayParserTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/config/xml/JobLaunchingGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,8 +12,8 @@
  */
 package org.springframework.batch.integration.config.xml;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.integration.launch.JobLaunchingMessageHandler;
@@ -25,25 +25,25 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.test.util.TestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gunnar Hillert
  * @since 1.3
  *
  */
-public class JobLaunchingGatewayParserTests {
+class JobLaunchingGatewayParserTests {
 
 	private ConfigurableApplicationContext context;
 
 	private EventDrivenConsumer consumer;
 
 	@Test
-	public void testGatewayParser() throws Exception {
+	void testGatewayParser() {
 		setUp("JobLaunchingGatewayParserTests-context.xml", getClass());
 
 		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(this.consumer, "inputChannel",
@@ -59,12 +59,12 @@ public class JobLaunchingGatewayParserTests {
 				"handler.messagingTemplate", MessagingTemplate.class);
 		final Long sendTimeout = TestUtils.getPropertyValue(messagingTemplate, "sendTimeout", Long.class);
 
-		assertEquals("Wrong sendTimeout", Long.valueOf(123L), sendTimeout);
+		assertEquals(123L, sendTimeout, "Wrong sendTimeout");
 		assertFalse(this.consumer.isRunning());
 	}
 
 	@Test
-	public void testJobLaunchingGatewayIsRunning() throws Exception {
+	void testJobLaunchingGatewayIsRunning() {
 		setUp("JobLaunchingGatewayParserTestsRunning-context.xml", getClass());
 		assertTrue(this.consumer.isRunning());
 
@@ -72,23 +72,18 @@ public class JobLaunchingGatewayParserTests {
 				"handler.messagingTemplate", MessagingTemplate.class);
 		final Long sendTimeout = TestUtils.getPropertyValue(messagingTemplate, "sendTimeout", Long.class);
 
-		assertEquals("Wrong sendTimeout", Long.valueOf(-1L), sendTimeout);
+		assertEquals(-1L, sendTimeout, "Wrong sendTimeout");
 	}
 
 	@Test
-	public void testJobLaunchingGatewayNoJobLauncher() throws Exception {
-		try {
-			setUp("JobLaunchingGatewayParserTestsNoJobLauncher-context.xml", getClass());
-		}
-		catch (BeanCreationException e) {
-			assertEquals("No bean named 'jobLauncher' available", e.getCause().getMessage());
-			return;
-		}
-		fail("Expected a NoSuchBeanDefinitionException to be thrown.");
+	void testJobLaunchingGatewayNoJobLauncher() {
+		Exception exception = assertThrows(BeanCreationException.class,
+				() -> setUp("JobLaunchingGatewayParserTestsNoJobLauncher-context.xml", getClass()));
+		assertEquals("No bean named 'jobLauncher' available", exception.getCause().getMessage());
 	}
 
 	@Test
-	public void testJobLaunchingGatewayWithEnableBatchProcessing() throws Exception {
+	void testJobLaunchingGatewayWithEnableBatchProcessing() {
 
 		setUp("JobLaunchingGatewayParserTestsWithEnableBatchProcessing-context.xml", getClass());
 		final JobLaunchingMessageHandler jobLaunchingMessageHandler = TestUtils.getPropertyValue(this.consumer,
@@ -101,14 +96,14 @@ public class JobLaunchingGatewayParserTests {
 
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		if (context != null) {
 			context.close();
 		}
 	}
 
-	public void setUp(String name, Class<?> cls) {
+	private void setUp(String name, Class<?> cls) {
 		context = new ClassPathXmlApplicationContext(name, cls);
 		consumer = this.context.getBean("batchjobExecutor", EventDrivenConsumer.class);
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/config/xml/RemoteChunkingParserTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/config/xml/RemoteChunkingParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.springframework.batch.integration.config.xml;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.step.item.ChunkProcessor;
 import org.springframework.batch.core.step.item.SimpleChunkProcessor;
@@ -37,9 +37,10 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * <p>
@@ -52,257 +53,199 @@ import static org.junit.Assert.fail;
  * @since 3.1
  */
 @SuppressWarnings("unchecked")
-public class RemoteChunkingParserTests {
+class RemoteChunkingParserTests {
 
 	@SuppressWarnings("rawtypes")
 	@Test
-	public void testRemoteChunkingWorkerParserWithProcessorDefined() {
+	void testRemoteChunkingWorkerParserWithProcessorDefined() {
 		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingWorkerParserTests.xml");
 
 		ChunkHandler chunkHandler = applicationContext.getBean(ChunkProcessorChunkHandler.class);
 		ChunkProcessor chunkProcessor = (SimpleChunkProcessor) TestUtils.getPropertyValue(chunkHandler,
 				"chunkProcessor");
-		assertNotNull("ChunkProcessor must not be null", chunkProcessor);
+		assertNotNull(chunkProcessor, "ChunkProcessor must not be null");
 
 		ItemWriter<String> itemWriter = (ItemWriter<String>) TestUtils.getPropertyValue(chunkProcessor, "itemWriter");
-		assertNotNull("ChunkProcessor ItemWriter must not be null", itemWriter);
-		assertTrue("Got wrong instance of ItemWriter", itemWriter instanceof Writer);
+		assertNotNull(itemWriter, "ChunkProcessor ItemWriter must not be null");
+		assertTrue(itemWriter instanceof Writer, "Got wrong instance of ItemWriter");
 
 		ItemProcessor<String, String> itemProcessor = (ItemProcessor<String, String>) TestUtils
 				.getPropertyValue(chunkProcessor, "itemProcessor");
-		assertNotNull("ChunkProcessor ItemWriter must not be null", itemProcessor);
-		assertTrue("Got wrong instance of ItemProcessor", itemProcessor instanceof Processor);
+		assertNotNull(itemProcessor, "ChunkProcessor ItemWriter must not be null");
+		assertTrue(itemProcessor instanceof Processor, "Got wrong instance of ItemProcessor");
 
 		FactoryBean serviceActivatorFactoryBean = applicationContext.getBean(ServiceActivatorFactoryBean.class);
-		assertNotNull("ServiceActivatorFactoryBean must not be null", serviceActivatorFactoryBean);
-		assertNotNull("Output channel name must not be null",
-				TestUtils.getPropertyValue(serviceActivatorFactoryBean, "outputChannelName"));
+		assertNotNull(serviceActivatorFactoryBean, "ServiceActivatorFactoryBean must not be null");
+		assertNotNull(TestUtils.getPropertyValue(serviceActivatorFactoryBean, "outputChannelName"),
+				"Output channel name must not be null");
 
 		MessageChannel inputChannel = applicationContext.getBean("requests", MessageChannel.class);
-		assertNotNull("Input channel must not be null", inputChannel);
+		assertNotNull(inputChannel, "Input channel must not be null");
 
 		String targetMethodName = (String) TestUtils.getPropertyValue(serviceActivatorFactoryBean, "targetMethodName");
-		assertNotNull("Target method name must not be null", targetMethodName);
-		assertTrue("Target method name must be handleChunk, got: " + targetMethodName,
-				"handleChunk".equals(targetMethodName));
+		assertNotNull(targetMethodName, "Target method name must not be null");
+		assertEquals("handleChunk", targetMethodName,
+				"Target method name must be handleChunk, got: " + targetMethodName);
 
 		ChunkHandler targetObject = (ChunkHandler) TestUtils.getPropertyValue(serviceActivatorFactoryBean,
 				"targetObject");
-		assertNotNull("Target object must not be null", targetObject);
+		assertNotNull(targetObject, "Target object must not be null");
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Test
-	public void testRemoteChunkingWorkerParserWithProcessorNotDefined() {
+	void testRemoteChunkingWorkerParserWithProcessorNotDefined() {
 		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingWorkerParserNoProcessorTests.xml");
 
 		ChunkHandler chunkHandler = applicationContext.getBean(ChunkProcessorChunkHandler.class);
 		ChunkProcessor chunkProcessor = (SimpleChunkProcessor) TestUtils.getPropertyValue(chunkHandler,
 				"chunkProcessor");
-		assertNotNull("ChunkProcessor must not be null", chunkProcessor);
+		assertNotNull(chunkProcessor, "ChunkProcessor must not be null");
 
 		ItemProcessor<String, String> itemProcessor = (ItemProcessor<String, String>) TestUtils
 				.getPropertyValue(chunkProcessor, "itemProcessor");
-		assertNotNull("ChunkProcessor ItemWriter must not be null", itemProcessor);
-		assertTrue("Got wrong instance of ItemProcessor", itemProcessor instanceof PassThroughItemProcessor);
+		assertNotNull(itemProcessor, "ChunkProcessor ItemWriter must not be null");
+		assertTrue(itemProcessor instanceof PassThroughItemProcessor, "Got wrong instance of ItemProcessor");
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Test
-	public void testRemoteChunkingManagerParser() {
+	void testRemoteChunkingManagerParser() {
 		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserTests.xml");
 
 		ItemWriter itemWriter = applicationContext.getBean("itemWriter", ChunkMessageChannelItemWriter.class);
-		assertNotNull("Messaging template must not be null",
-				TestUtils.getPropertyValue(itemWriter, "messagingGateway"));
-		assertNotNull("Reply channel must not be null", TestUtils.getPropertyValue(itemWriter, "replyChannel"));
+		assertNotNull(TestUtils.getPropertyValue(itemWriter, "messagingGateway"),
+				"Messaging template must not be null");
+		assertNotNull(TestUtils.getPropertyValue(itemWriter, "replyChannel"), "Reply channel must not be null");
 
 		FactoryBean<ChunkHandler> remoteChunkingHandlerFactoryBean = applicationContext
 				.getBean(RemoteChunkHandlerFactoryBean.class);
-		assertNotNull("Chunk writer must not be null",
-				TestUtils.getPropertyValue(remoteChunkingHandlerFactoryBean, "chunkWriter"));
-		assertNotNull("Step must not be null", TestUtils.getPropertyValue(remoteChunkingHandlerFactoryBean, "step"));
+		assertNotNull(TestUtils.getPropertyValue(remoteChunkingHandlerFactoryBean, "chunkWriter"),
+				"Chunk writer must not be null");
+		assertNotNull(TestUtils.getPropertyValue(remoteChunkingHandlerFactoryBean, "step"), "Step must not be null");
 	}
 
 	@Test
-	public void testRemoteChunkingManagerIdAttrAssert() throws Exception {
+	void testRemoteChunkingManagerIdAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserMissingIdAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue("Expected: " + "The id attribute must be specified" + " but got: " + iae.getMessage(),
-					"The id attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The id attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingManagerMessageTemplateAttrAssert() throws Exception {
+	void testRemoteChunkingManagerMessageTemplateAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserMissingMessageTemplateAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue(
-					"Expected: " + "The message-template attribute must be specified" + " but got: " + iae.getMessage(),
-					"The message-template attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The message-template attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingManagerStepAttrAssert() throws Exception {
+	void testRemoteChunkingManagerStepAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserMissingStepAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue("Expected: " + "The step attribute must be specified" + " but got: " + iae.getMessage(),
-					"The step attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The step attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingManagerReplyChannelAttrAssert() throws Exception {
+	void testRemoteChunkingManagerReplyChannelAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserMissingReplyChannelAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue("Expected: " + "The reply-channel attribute must be specified" + " but got: " + iae.getMessage(),
-					"The reply-channel attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The reply-channel attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingWorkerIdAttrAssert() throws Exception {
+	void testRemoteChunkingWorkerIdAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingWorkerParserMissingIdAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue("Expected: " + "The id attribute must be specified" + " but got: " + iae.getMessage(),
-					"The id attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The id attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingWorkerInputChannelAttrAssert() throws Exception {
+	void testRemoteChunkingWorkerInputChannelAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingWorkerParserMissingInputChannelAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue("Expected: " + "The input-channel attribute must be specified" + " but got: " + iae.getMessage(),
-					"The input-channel attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The input-channel attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingWorkerItemWriterAttrAssert() throws Exception {
+	void testRemoteChunkingWorkerItemWriterAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingWorkerParserMissingItemWriterAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue("Expected: " + "The item-writer attribute must be specified" + " but got: " + iae.getMessage(),
-					"The item-writer attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The item-writer attribute must be specified", iae.getMessage());
 	}
 
 	@Test
-	public void testRemoteChunkingWorkerOutputChannelAttrAssert() throws Exception {
+	void testRemoteChunkingWorkerOutputChannelAttrAssert() {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
 		applicationContext.setValidating(false);
 		applicationContext.setConfigLocation(
 				"/org/springframework/batch/integration/config/xml/RemoteChunkingWorkerParserMissingOutputChannelAttrTests.xml");
 
-		try {
-			applicationContext.refresh();
-			fail();
-		}
-		catch (BeanDefinitionStoreException e) {
-			assertTrue("Nested exception must be of type IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+		Exception exception = assertThrows(BeanDefinitionStoreException.class, applicationContext::refresh);
+		assertTrue(exception.getCause() instanceof IllegalArgumentException,
+				"Nested exception must be of type IllegalArgumentException");
 
-			IllegalArgumentException iae = (IllegalArgumentException) e.getCause();
-
-			assertTrue(
-					"Expected: " + "The output-channel attribute must be specified" + " but got: " + iae.getMessage(),
-					"The output-channel attribute must be specified".equals(iae.getMessage()));
-		}
+		IllegalArgumentException iae = (IllegalArgumentException) exception.getCause();
+		assertEquals("The output-channel attribute must be specified", iae.getMessage());
 	}
 
 	private static class Writer implements ItemWriter<String> {

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/file/FileToMessagesJobIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/file/FileToMessagesJobIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package org.springframework.batch.integration.file;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -30,16 +29,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  *
  */
-@ContextConfiguration()
-@RunWith(SpringJUnit4ClassRunner.class)
-public class FileToMessagesJobIntegrationTests implements MessageHandler {
+@SpringJUnitConfig
+class FileToMessagesJobIntegrationTests implements MessageHandler {
 
 	@Autowired
 	@Qualifier("requests")
@@ -53,17 +50,18 @@ public class FileToMessagesJobIntegrationTests implements MessageHandler {
 
 	int count = 0;
 
+	@Override
 	public void handleMessage(Message<?> message) {
 		count++;
 	}
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		requests.subscribe(this);
 	}
 
 	@Test
-	public void testFileSent() throws Exception {
+	void testFileSent() throws Exception {
 
 		JobExecution execution = jobLauncher.run(job,
 				new JobParametersBuilder().addLong("time.stamp", System.currentTimeMillis()).toJobParameters());

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/file/ResourceSplitterIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/file/ResourceSplitterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  */
 package org.springframework.batch.integration.file;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
@@ -32,17 +31,15 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  *
  */
-@ContextConfiguration()
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @MessageEndpoint
-public class ResourceSplitterIntegrationTests {
+class ResourceSplitterIntegrationTests {
 
 	@Autowired
 	@Qualifier("resources")
@@ -67,9 +64,9 @@ public class ResourceSplitterIntegrationTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	@Ignore // FIXME
+	@Disabled // FIXME
 	// This broke with Integration 2.0 in a milestone, so watch out when upgrading...
-	public void testVanillaConversion() throws Exception {
+	void testVanillaConversion() {
 		resources.send(new GenericMessage<>("classpath:*-context.xml"));
 		Message<Resource> message = (Message<Resource>) requests.receive(200L);
 		assertNotNull(message);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/item/MessagingGatewayIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/item/MessagingGatewayIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,20 @@
  */
 package org.springframework.batch.integration.item;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * Test case showing the use of a MessagingGateway to provide an ItemWriter or
@@ -41,9 +39,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mahmoud Ben Hassine
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class MessagingGatewayIntegrationTests {
+@SpringJUnitConfig
+class MessagingGatewayIntegrationTests {
 
 	@Autowired
 	private ItemProcessor<String, String> processor;
@@ -64,14 +61,14 @@ public class MessagingGatewayIntegrationTests {
 	private SplitService splitter;
 
 	@Test
-	public void testProcessor() throws Exception {
+	void testProcessor() throws Exception {
 		String result = processor.process("foo");
 		assertEquals("foo: 0: 1", result);
 		assertNull(processor.process("filter"));
 	}
 
 	@Test
-	public void testWriter() throws Exception {
+	void testWriter() throws Exception {
 		writer.write(Arrays.asList("foo", "bar", "spam"));
 		assertEquals(3, splitter.count);
 		assertEquals(3, service.count);
@@ -87,7 +84,7 @@ public class MessagingGatewayIntegrationTests {
 	 *
 	 */
 	@MessageEndpoint
-	public static class Activator {
+	static class Activator {
 
 		private int count;
 
@@ -110,7 +107,7 @@ public class MessagingGatewayIntegrationTests {
 	 *
 	 */
 	@MessageEndpoint
-	public static class SplitService {
+	static class SplitService {
 
 		// Just for assertions in the test case
 		private int count;
@@ -132,7 +129,7 @@ public class MessagingGatewayIntegrationTests {
 	 *
 	 */
 	@MessageEndpoint
-	public static class EndService {
+	static class EndService {
 
 		private int count;
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingGatewayTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.integration.launch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersInvalidException;
@@ -25,8 +25,8 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,10 +36,10 @@ import static org.mockito.Mockito.when;
  * @since 1.3
  *
  */
-public class JobLaunchingGatewayTests {
+class JobLaunchingGatewayTests {
 
 	@Test
-	public void testExceptionRaised() throws Exception {
+	void testExceptionRaised() throws Exception {
 
 		final Message<JobLaunchRequest> message = MessageBuilder
 				.withPayload(new JobLaunchRequest(new JobSupport("testJob"), new JobParameters())).build();
@@ -49,17 +49,9 @@ public class JobLaunchingGatewayTests {
 				.thenThrow(new JobParametersInvalidException("This is a JobExecutionException."));
 
 		JobLaunchingGateway jobLaunchingGateway = new JobLaunchingGateway(jobLauncher);
-
-		try {
-			jobLaunchingGateway.handleMessage(message);
-		}
-		catch (MessageHandlingException e) {
-			assertEquals("This is a JobExecutionException.", e.getCause().getMessage());
-			return;
-		}
-
-		fail("Expecting a MessageHandlingException to be thrown.");
-
+		Exception exception = assertThrows(MessageHandlingException.class,
+				() -> jobLaunchingGateway.handleMessage(message));
+		assertEquals("This is a JobExecutionException.", exception.getCause().getMessage());
 	}
 
 }

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandlerTests.java
@@ -1,41 +1,55 @@
+/*
+ * Copyright 2008-2022 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.springframework.batch.integration.launch;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.integration.JobSupport;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ContextConfiguration(locations = { "/job-execution-context.xml" })
-public class JobLaunchingMessageHandlerTests extends AbstractJUnit4SpringContextTests {
+@SpringJUnitConfig(locations = { "/job-execution-context.xml" })
+class JobLaunchingMessageHandlerTests {
 
 	JobLaunchRequestHandler messageHandler;
 
 	StubJobLauncher jobLauncher;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		jobLauncher = new StubJobLauncher();
 		messageHandler = new JobLaunchingMessageHandler(jobLauncher);
 	}
 
 	@Test
-	public void testSimpleDelivery() throws Exception {
+	void testSimpleDelivery() throws Exception {
 		messageHandler.launch(new JobLaunchRequest(new JobSupport("testjob"), null));
 
-		assertEquals("Wrong job count", 1, jobLauncher.jobs.size());
-		assertEquals("Wrong job name", jobLauncher.jobs.get(0).getName(), "testjob");
+		assertEquals(1, jobLauncher.jobs.size(), "Wrong job count");
+		assertEquals("testjob", jobLauncher.jobs.get(0).getName(), "Wrong job name");
 
 	}
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/BeanFactoryStepLocatorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/BeanFactoryStepLocatorTests.java
@@ -1,29 +1,44 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.partition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobInterruptedException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
-public class BeanFactoryStepLocatorTests {
+class BeanFactoryStepLocatorTests {
 
-	private BeanFactoryStepLocator stepLocator = new BeanFactoryStepLocator();
+	private final BeanFactoryStepLocator stepLocator = new BeanFactoryStepLocator();
 
-	private DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+	private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 
 	@Test
-	public void testGetStep() throws Exception {
+	void testGetStep() {
 		beanFactory.registerSingleton("foo", new StubStep("foo"));
 		stepLocator.setBeanFactory(beanFactory);
 		assertNotNull(stepLocator.getStep("foo"));
 	}
 
 	@Test
-	public void testGetStepNames() throws Exception {
+	void testGetStepNames() {
 		beanFactory.registerSingleton("foo", new StubStep("foo"));
 		beanFactory.registerSingleton("bar", new StubStep("bar"));
 		stepLocator.setBeanFactory(beanFactory);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/ExampleItemReaderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/ExampleItemReaderTests.java
@@ -1,24 +1,39 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.partition;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 
-public class ExampleItemReaderTests {
+class ExampleItemReaderTests {
 
-	private ExampleItemReader reader = new ExampleItemReader();
+	private final ExampleItemReader reader = new ExampleItemReader();
 
-	@Before
-	@After
-	public void ensureFailFlagUnset() {
+	@BeforeEach
+	@AfterEach
+	void ensureFailFlagUnset() {
 		ExampleItemReader.fail = false;
 	}
 
 	@Test
-	public void testRead() throws Exception {
+	void testRead() throws Exception {
 		int count = 0;
 		while (reader.read() != null) {
 			count++;
@@ -27,7 +42,7 @@ public class ExampleItemReaderTests {
 	}
 
 	@Test
-	public void testOpen() throws Exception {
+	void testOpen() throws Exception {
 		ExecutionContext context = new ExecutionContext();
 		for (int i = 0; i < 4; i++) {
 			reader.read();
@@ -42,22 +57,15 @@ public class ExampleItemReaderTests {
 	}
 
 	@Test
-	public void testFailAndRestart() throws Exception {
+	void testFailAndRestart() throws Exception {
 		ExecutionContext context = new ExecutionContext();
 		ExampleItemReader.fail = true;
 		for (int i = 0; i < 4; i++) {
 			reader.read();
 			reader.update(context);
 		}
-		try {
-			reader.read();
-			reader.update(context);
-			fail("Expected Exception");
-		}
-		catch (Exception e) {
-			// expected
-			assertEquals("Planned failure", e.getMessage());
-		}
+		Exception exception = assertThrows(Exception.class, reader::read);
+		assertEquals("Planned failure", exception.getMessage());
 		assertFalse(ExampleItemReader.fail);
 		reader.open(context);
 		int count = 0;

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/JmsIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/JmsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,8 +16,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -29,22 +28,20 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Dave Syer
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
-public class JmsIntegrationTests {
+class JmsIntegrationTests {
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -56,20 +53,20 @@ public class JmsIntegrationTests {
 	private JobExplorer jobExplorer;
 
 	@Test
-	public void testSimpleProperties() throws Exception {
+	void testSimpleProperties() {
 		assertNotNull(jobLauncher);
 	}
 
 	@Test
-	public void testLaunchJob() throws Exception {
+	void testLaunchJob() throws Exception {
 		int before = jobExplorer.getJobInstances(job.getName(), 0, 100).size();
 		assertNotNull(jobLauncher.run(job, new JobParameters()));
 		List<JobInstance> jobInstances = jobExplorer.getJobInstances(job.getName(), 0, 100);
 		int after = jobInstances.size();
 		assertEquals(1, after - before);
 		JobExecution jobExecution = jobExplorer.getJobExecutions(jobInstances.get(jobInstances.size() - 1)).get(0);
-		assertEquals(jobExecution.getExitStatus().getExitDescription(), BatchStatus.COMPLETED,
-				jobExecution.getStatus());
+		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus(),
+				jobExecution.getExitStatus().getExitDescription());
 		assertEquals(3, jobExecution.getStepExecutions().size());
 		for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
 			// BATCH-1703: we are using a map dao so the step executions in the job

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -34,9 +34,10 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -50,12 +51,12 @@ import static org.mockito.Mockito.when;
  * @author Mahmoud Ben Hassine
  *
  */
-public class MessageChannelPartitionHandlerTests {
+class MessageChannelPartitionHandlerTests {
 
 	private MessageChannelPartitionHandler messageChannelPartitionHandler;
 
 	@Test
-	public void testNoPartitions() throws Exception {
+	void testNoPartitions() throws Exception {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
@@ -71,7 +72,7 @@ public class MessageChannelPartitionHandlerTests {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
-	public void testHandleNoReply() throws Exception {
+	void testHandleNoReply() throws Exception {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
@@ -98,7 +99,7 @@ public class MessageChannelPartitionHandlerTests {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
-	public void testHandleWithReplyChannel() throws Exception {
+	void testHandleWithReplyChannel() throws Exception {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
@@ -127,8 +128,8 @@ public class MessageChannelPartitionHandlerTests {
 	}
 
 	@SuppressWarnings("rawtypes")
-	@Test(expected = MessageTimeoutException.class)
-	public void messageReceiveTimeout() throws Exception {
+	@Test
+	void messageReceiveTimeout() throws Exception {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
@@ -145,11 +146,12 @@ public class MessageChannelPartitionHandlerTests {
 		messageChannelPartitionHandler.setMessagingOperations(operations);
 
 		// execute
-		messageChannelPartitionHandler.handle(stepExecutionSplitter, managerStepExecution);
+		assertThrows(MessageTimeoutException.class,
+				() -> messageChannelPartitionHandler.handle(stepExecutionSplitter, managerStepExecution));
 	}
 
 	@Test
-	public void testHandleWithJobRepositoryPolling() throws Exception {
+	void testHandleWithJobRepositoryPolling() throws Exception {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
@@ -196,8 +198,8 @@ public class MessageChannelPartitionHandlerTests {
 		verify(operations, times(3)).send(any(Message.class));
 	}
 
-	@Test(expected = TimeoutException.class)
-	public void testHandleWithJobRepositoryPollingTimeout() throws Exception {
+	@Test
+	void testHandleWithJobRepositoryPollingTimeout() throws Exception {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
@@ -228,7 +230,8 @@ public class MessageChannelPartitionHandlerTests {
 		messageChannelPartitionHandler.afterPropertiesSet();
 
 		// execute
-		messageChannelPartitionHandler.handle(stepExecutionSplitter, managerStepExecution);
+		assertThrows(TimeoutException.class,
+				() -> messageChannelPartitionHandler.handle(stepExecutionSplitter, managerStepExecution));
 	}
 
 }

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/PollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/PollingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  */
 package org.springframework.batch.integration.partition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -31,16 +30,14 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class PollingIntegrationTests {
+@SpringJUnitConfig
+class PollingIntegrationTests {
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -52,12 +49,12 @@ public class PollingIntegrationTests {
 	private JobExplorer jobExplorer;
 
 	@Test
-	public void testSimpleProperties() throws Exception {
+	void testSimpleProperties() {
 		assertNotNull(jobLauncher);
 	}
 
 	@Test
-	public void testLaunchJob() throws Exception {
+	void testLaunchJob() throws Exception {
 		int before = jobExplorer.getJobInstances(job.getName(), 0, 100).size();
 		assertNotNull(jobLauncher.run(job, new JobParameters()));
 		List<JobInstance> jobInstances = jobExplorer.getJobInstances(job.getName(), 0, 100);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package org.springframework.batch.integration.partition;
 
 import javax.sql.DataSource;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.batch.core.Step;
@@ -36,29 +34,31 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = { RemotePartitioningManagerStepBuilderTests.BatchConfiguration.class })
-public class RemotePartitioningManagerStepBuilderTests {
+@SpringJUnitConfig(classes = { RemotePartitioningManagerStepBuilderTests.BatchConfiguration.class })
+class RemotePartitioningManagerStepBuilderTests {
 
 	@Autowired
 	private JobRepository jobRepository;
 
 	@Test
-	public void inputChannelMustNotBeNull() {
+	void inputChannelMustNotBeNull() {
 		// given
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.inputChannel(null));
 
 		// then
@@ -66,12 +66,12 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void outputChannelMustNotBeNull() {
+	void outputChannelMustNotBeNull() {
 		// given
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.outputChannel(null));
 
 		// then
@@ -79,12 +79,12 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void messagingTemplateMustNotBeNull() {
+	void messagingTemplateMustNotBeNull() {
 		// given
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.messagingTemplate(null));
 
 		// then
@@ -92,12 +92,12 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void jobExplorerMustNotBeNull() {
+	void jobExplorerMustNotBeNull() {
 		// given
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.jobExplorer(null));
 
 		// then
@@ -105,12 +105,12 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void pollIntervalMustBeGreaterThanZero() {
+	void pollIntervalMustBeGreaterThanZero() {
 		// given
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.pollInterval(-1));
 
 		// then
@@ -118,13 +118,13 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void eitherOutputChannelOrMessagingTemplateMustBeProvided() {
+	void eitherOutputChannelOrMessagingTemplateMustBeProvided() {
 		// given
 		RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step")
 				.outputChannel(new DirectChannel()).messagingTemplate(new MessagingTemplate());
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalStateException.class, builder::build);
+		final Exception expectedException = assertThrows(IllegalStateException.class, builder::build);
 
 		// then
 		assertThat(expectedException)
@@ -132,13 +132,13 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void testUnsupportedOperationExceptionWhenSpecifyingPartitionHandler() {
+	void testUnsupportedOperationExceptionWhenSpecifyingPartitionHandler() {
 		// given
 		PartitionHandler partitionHandler = Mockito.mock(PartitionHandler.class);
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(UnsupportedOperationException.class,
+		final Exception expectedException = assertThrows(UnsupportedOperationException.class,
 				() -> builder.partitionHandler(partitionHandler));
 
 		// then
@@ -149,7 +149,7 @@ public class RemotePartitioningManagerStepBuilderTests {
 	}
 
 	@Test
-	public void testManagerStepCreationWhenPollingRepository() {
+	void testManagerStepCreationWhenPollingRepository() {
 		// given
 		int gridSize = 5;
 		int startLimit = 3;
@@ -167,28 +167,28 @@ public class RemotePartitioningManagerStepBuilderTests {
 				.allowStartIfComplete(true).build();
 
 		// then
-		Assert.assertNotNull(step);
-		Assert.assertEquals(getField(step, "startLimit"), startLimit);
-		Assert.assertEquals(getField(step, "jobRepository"), this.jobRepository);
-		Assert.assertEquals(getField(step, "stepExecutionAggregator"), stepExecutionAggregator);
-		Assert.assertTrue((Boolean) getField(step, "allowStartIfComplete"));
+		assertNotNull(step);
+		assertEquals(getField(step, "startLimit"), startLimit);
+		assertEquals(getField(step, "jobRepository"), this.jobRepository);
+		assertEquals(getField(step, "stepExecutionAggregator"), stepExecutionAggregator);
+		assertTrue((Boolean) getField(step, "allowStartIfComplete"));
 
 		Object partitionHandler = getField(step, "partitionHandler");
-		Assert.assertNotNull(partitionHandler);
-		Assert.assertTrue(partitionHandler instanceof MessageChannelPartitionHandler);
+		assertNotNull(partitionHandler);
+		assertTrue(partitionHandler instanceof MessageChannelPartitionHandler);
 		MessageChannelPartitionHandler messageChannelPartitionHandler = (MessageChannelPartitionHandler) partitionHandler;
-		Assert.assertEquals(getField(messageChannelPartitionHandler, "gridSize"), gridSize);
-		Assert.assertEquals(getField(messageChannelPartitionHandler, "pollInterval"), pollInterval);
-		Assert.assertEquals(getField(messageChannelPartitionHandler, "timeout"), timeout);
+		assertEquals(getField(messageChannelPartitionHandler, "gridSize"), gridSize);
+		assertEquals(getField(messageChannelPartitionHandler, "pollInterval"), pollInterval);
+		assertEquals(getField(messageChannelPartitionHandler, "timeout"), timeout);
 
 		Object messagingGateway = getField(messageChannelPartitionHandler, "messagingGateway");
-		Assert.assertNotNull(messagingGateway);
+		assertNotNull(messagingGateway);
 		MessagingTemplate messagingTemplate = (MessagingTemplate) messagingGateway;
-		Assert.assertEquals(getField(messagingTemplate, "defaultDestination"), outputChannel);
+		assertEquals(getField(messagingTemplate, "defaultDestination"), outputChannel);
 	}
 
 	@Test
-	public void testManagerStepCreationWhenAggregatingReplies() {
+	void testManagerStepCreationWhenAggregatingReplies() {
 		// given
 		int gridSize = 5;
 		int startLimit = 3;
@@ -203,34 +203,34 @@ public class RemotePartitioningManagerStepBuilderTests {
 				.startLimit(startLimit).aggregator(stepExecutionAggregator).allowStartIfComplete(true).build();
 
 		// then
-		Assert.assertNotNull(step);
-		Assert.assertEquals(getField(step, "startLimit"), startLimit);
-		Assert.assertEquals(getField(step, "jobRepository"), this.jobRepository);
-		Assert.assertEquals(getField(step, "stepExecutionAggregator"), stepExecutionAggregator);
-		Assert.assertTrue((Boolean) getField(step, "allowStartIfComplete"));
+		assertNotNull(step);
+		assertEquals(getField(step, "startLimit"), startLimit);
+		assertEquals(getField(step, "jobRepository"), this.jobRepository);
+		assertEquals(getField(step, "stepExecutionAggregator"), stepExecutionAggregator);
+		assertTrue((Boolean) getField(step, "allowStartIfComplete"));
 
 		Object partitionHandler = getField(step, "partitionHandler");
-		Assert.assertNotNull(partitionHandler);
-		Assert.assertTrue(partitionHandler instanceof MessageChannelPartitionHandler);
+		assertNotNull(partitionHandler);
+		assertTrue(partitionHandler instanceof MessageChannelPartitionHandler);
 		MessageChannelPartitionHandler messageChannelPartitionHandler = (MessageChannelPartitionHandler) partitionHandler;
-		Assert.assertEquals(getField(messageChannelPartitionHandler, "gridSize"), gridSize);
+		assertEquals(getField(messageChannelPartitionHandler, "gridSize"), gridSize);
 
 		Object replyChannel = getField(messageChannelPartitionHandler, "replyChannel");
-		Assert.assertNotNull(replyChannel);
-		Assert.assertTrue(replyChannel instanceof QueueChannel);
+		assertNotNull(replyChannel);
+		assertTrue(replyChannel instanceof QueueChannel);
 
 		Object messagingGateway = getField(messageChannelPartitionHandler, "messagingGateway");
-		Assert.assertNotNull(messagingGateway);
+		assertNotNull(messagingGateway);
 		MessagingTemplate messagingTemplate = (MessagingTemplate) messagingGateway;
-		Assert.assertEquals(getField(messagingTemplate, "defaultDestination"), outputChannel);
+		assertEquals(getField(messagingTemplate, "defaultDestination"), outputChannel);
 	}
 
 	@Configuration
 	@EnableBatchProcessing
-	public static class BatchConfiguration {
+	static class BatchConfiguration {
 
 		@Bean
-		public DataSource dataSource() {
+		DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 					.addScript("/org/springframework/batch/core/schema-hsqldb.sql").generateUniqueName(true).build();
 		}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,30 @@
 
 package org.springframework.batch.integration.partition;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.integration.channel.DirectChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-public class RemotePartitioningWorkerStepBuilderTests {
+class RemotePartitioningWorkerStepBuilderTests {
 
 	@Mock
 	private Tasklet tasklet;
 
 	@Test
-	public void inputChannelMustNotBeNull() {
+	void inputChannelMustNotBeNull() {
 		// given
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.inputChannel(null));
 
 		// then
@@ -47,12 +47,12 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	}
 
 	@Test
-	public void outputChannelMustNotBeNull() {
+	void outputChannelMustNotBeNull() {
 		// given
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.outputChannel(null));
 
 		// then
@@ -60,12 +60,12 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	}
 
 	@Test
-	public void jobExplorerMustNotBeNull() {
+	void jobExplorerMustNotBeNull() {
 		// given
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.jobExplorer(null));
 
 		// then
@@ -73,12 +73,12 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	}
 
 	@Test
-	public void stepLocatorMustNotBeNull() {
+	void stepLocatorMustNotBeNull() {
 		// given
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.stepLocator(null));
 
 		// then
@@ -86,12 +86,12 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	}
 
 	@Test
-	public void beanFactoryMustNotBeNull() {
+	void beanFactoryMustNotBeNull() {
 		// given
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.beanFactory(null));
 
 		// then
@@ -99,12 +99,12 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	}
 
 	@Test
-	public void testMandatoryInputChannel() {
+	void testMandatoryInputChannel() {
 		// given
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.tasklet(this.tasklet));
 
 		// then
@@ -112,14 +112,14 @@ public class RemotePartitioningWorkerStepBuilderTests {
 	}
 
 	@Test
-	public void testMandatoryJobExplorer() {
+	void testMandatoryJobExplorer() {
 		// given
 		DirectChannel inputChannel = new DirectChannel();
 		final RemotePartitioningWorkerStepBuilder builder = new RemotePartitioningWorkerStepBuilder("step")
 				.inputChannel(inputChannel);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> builder.tasklet(this.tasklet));
 
 		// then

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/StepExecutionRequestTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/StepExecutionRequestTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,22 @@ package org.springframework.batch.integration.partition;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-public class StepExecutionRequestTests {
+class StepExecutionRequestTests {
 
 	private static final String SERIALIZED_REQUEST = "{\"stepExecutionId\":1,\"stepName\":\"step\",\"jobExecutionId\":1}";
 
-	private ObjectMapper objectMapper = new ObjectMapper();
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Test
-	public void stepExecutionRequestShouldBeSerializableWithJackson() throws IOException {
+	void stepExecutionRequestShouldBeSerializableWithJackson() throws IOException {
 		// given
 		StepExecutionRequest request = new StepExecutionRequest("step", 1L, 1L);
 
@@ -40,20 +42,20 @@ public class StepExecutionRequestTests {
 		String serializedRequest = this.objectMapper.writeValueAsString(request);
 
 		// then
-		Assert.assertEquals(SERIALIZED_REQUEST, serializedRequest);
+		assertEquals(SERIALIZED_REQUEST, serializedRequest);
 	}
 
 	@Test
-	public void stepExecutionRequestShouldBeDeserializableWithJackson() throws IOException {
+	void stepExecutionRequestShouldBeDeserializableWithJackson() throws IOException {
 		// when
 		StepExecutionRequest deserializedRequest = this.objectMapper.readValue(SERIALIZED_REQUEST,
 				StepExecutionRequest.class);
 
 		// then
-		Assert.assertNotNull(deserializedRequest);
-		Assert.assertEquals("step", deserializedRequest.getStepName());
-		Assert.assertEquals(1L, deserializedRequest.getJobExecutionId().longValue());
-		Assert.assertEquals(1L, deserializedRequest.getStepExecutionId().longValue());
+		assertNotNull(deserializedRequest);
+		assertEquals("step", deserializedRequest.getStepName());
+		assertEquals(1L, deserializedRequest.getJobExecutionId().longValue());
+		assertEquals(1L, deserializedRequest.getStepExecutionId().longValue());
 	}
 
 }

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/VanillaIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/VanillaIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  */
 package org.springframework.batch.integration.partition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -30,16 +29,14 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class VanillaIntegrationTests {
+@SpringJUnitConfig
+class VanillaIntegrationTests {
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -51,12 +48,12 @@ public class VanillaIntegrationTests {
 	private JobExplorer jobExplorer;
 
 	@Test
-	public void testSimpleProperties() throws Exception {
+	void testSimpleProperties() {
 		assertNotNull(jobLauncher);
 	}
 
 	@Test
-	public void testLaunchJob() throws Exception {
+	void testLaunchJob() throws Exception {
 		int before = jobExplorer.getJobInstances(job.getName(), 0, 100).size();
 		assertNotNull(jobLauncher.run(job, new JobParameters()));
 		List<JobInstance> jobInstances = jobExplorer.getJobInstances(job.getName(), 0, 100);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RepeatTransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RepeatTransactionalPollingIntegrationTests.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2008-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.retry;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -8,9 +23,8 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -18,22 +32,20 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.StringUtils;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @MessageEndpoint
-public class RepeatTransactionalPollingIntegrationTests implements ApplicationContextAware {
+class RepeatTransactionalPollingIntegrationTests implements ApplicationContextAware {
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
-	private static List<String> processed = new ArrayList<>();
+	private static final List<String> processed = new ArrayList<>();
 
 	private static List<String> expected;
 
-	private static List<String> handled = new ArrayList<>();
+	private static final List<String> handled = new ArrayList<>();
 
 	private static List<String> list = new ArrayList<>();
 
@@ -71,8 +83,8 @@ public class RepeatTransactionalPollingIntegrationTests implements ApplicationCo
 		logger.debug("Handled: " + message);
 	}
 
-	@Before
-	public void clearLists() {
+	@BeforeEach
+	void clearLists() {
 		list.clear();
 		handled.clear();
 		processed.clear();
@@ -81,7 +93,7 @@ public class RepeatTransactionalPollingIntegrationTests implements ApplicationCo
 
 	@Test
 	@DirtiesContext
-	public void testSunnyDay() throws Exception {
+	void testSunnyDay() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d,e,f,g,h,j,k")));
 		expected = Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d"));
@@ -91,7 +103,7 @@ public class RepeatTransactionalPollingIntegrationTests implements ApplicationCo
 
 	@Test
 	@DirtiesContext
-	public void testRollback() throws Exception {
+	void testRollback() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,d,e,f,g,h,j,k")));
 		expected = Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,fail"));

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryRepeatTransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryRepeatTransactionalPollingIntegrationTests.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2010-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.retry;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -8,9 +23,8 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,16 +33,14 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.StringUtils;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @MessageEndpoint
-public class RetryRepeatTransactionalPollingIntegrationTests implements ApplicationContextAware {
+class RetryRepeatTransactionalPollingIntegrationTests implements ApplicationContextAware {
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
 	private volatile static List<String> list = new ArrayList<>();
 
@@ -46,8 +58,8 @@ public class RetryRepeatTransactionalPollingIntegrationTests implements Applicat
 
 	private static volatile int count = 0;
 
-	@Before
-	public void clearLists() {
+	@BeforeEach
+	void clearLists() {
 		list.clear();
 		count = 0;
 	}
@@ -67,7 +79,7 @@ public class RetryRepeatTransactionalPollingIntegrationTests implements Applicat
 
 	@Test
 	@DirtiesContext
-	public void testSunnyDay() throws Exception {
+	void testSunnyDay() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d,e,f,g,h,j,k")));
 		List<String> expected = Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d"));
@@ -79,7 +91,7 @@ public class RetryRepeatTransactionalPollingIntegrationTests implements Applicat
 
 	@Test
 	@DirtiesContext
-	public void testRollback() throws Exception {
+	void testRollback() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,d,e,f,g,h,j,k")));
 		List<String> expected = Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,fail,d,e,f"));

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryTransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryTransactionalPollingIntegrationTests.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2010-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.retry;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,9 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,15 +33,13 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.StringUtils;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 public class RetryTransactionalPollingIntegrationTests implements ApplicationContextAware {
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
 	private static List<String> list = new ArrayList<>();
 
@@ -43,10 +55,10 @@ public class RetryTransactionalPollingIntegrationTests implements ApplicationCon
 		bus = (Lifecycle) applicationContext;
 	}
 
-	private static AtomicInteger count = new AtomicInteger(0);
+	private static final AtomicInteger count = new AtomicInteger(0);
 
-	@Before
-	public void clearLists() {
+	@BeforeEach
+	void clearLists() {
 		list.clear();
 		count.set(0);
 	}
@@ -69,7 +81,7 @@ public class RetryTransactionalPollingIntegrationTests implements ApplicationCon
 
 	@Test
 	@DirtiesContext
-	public void testSunnyDay() throws Exception {
+	void testSunnyDay() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d,e,f,g,h,j,k")));
 		List<String> expected = Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d"));
@@ -81,7 +93,7 @@ public class RetryTransactionalPollingIntegrationTests implements ApplicationCon
 
 	@Test
 	@DirtiesContext
-	public void testRollback() throws Exception {
+	void testRollback() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,d,e,f,g,h,j,k")));
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/TransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/TransactionalPollingIntegrationTests.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2008-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.retry;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -8,9 +23,8 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -19,20 +33,18 @@ import org.springframework.context.Lifecycle;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.StringUtils;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @MessageEndpoint
-public class TransactionalPollingIntegrationTests implements ApplicationContextAware {
+class TransactionalPollingIntegrationTests implements ApplicationContextAware {
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
-	private static List<String> processed = new ArrayList<>();
+	private static final List<String> processed = new ArrayList<>();
 
-	private static List<String> handled = new ArrayList<>();
+	private static final List<String> handled = new ArrayList<>();
 
 	private static List<String> expected = new ArrayList<>();
 
@@ -75,8 +87,8 @@ public class TransactionalPollingIntegrationTests implements ApplicationContextA
 		logger.debug("Handled: " + message);
 	}
 
-	@Before
-	public void clearLists() {
+	@BeforeEach
+	void clearLists() {
 		list.clear();
 		handled.clear();
 		processed.clear();
@@ -85,7 +97,7 @@ public class TransactionalPollingIntegrationTests implements ApplicationContextA
 
 	@Test
 	@DirtiesContext
-	public void testSunnyDay() throws Exception {
+	void testSunnyDay() {
 		try {
 			list = TransactionAwareProxyFactory.createTransactionalList(
 					Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,c,d,e,f,g,h,j,k")));
@@ -101,7 +113,7 @@ public class TransactionalPollingIntegrationTests implements ApplicationContextA
 
 	@Test
 	@DirtiesContext
-	public void testRollback() throws Exception {
+	void testRollback() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(
 				Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,d,e,f,g,h,j,k")));
 		expected = Arrays.asList(StringUtils.commaDelimitedListToStringArray("a,b,fail,fail"));

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/step/StepGatewayIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/step/StepGatewayIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package org.springframework.batch.integration.step;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
@@ -29,16 +28,14 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  *
  */
-@ContextConfiguration()
-@RunWith(SpringJUnit4ClassRunner.class)
-public class StepGatewayIntegrationTests {
+@SpringJUnitConfig
+class StepGatewayIntegrationTests {
 
 	@Autowired
 	private JobLauncher jobLauncher;
@@ -50,20 +47,20 @@ public class StepGatewayIntegrationTests {
 	@Autowired
 	private TestTasklet tasklet;
 
-	@After
-	public void clear() {
+	@AfterEach
+	void clear() {
 		tasklet.setFail(false);
 	}
 
 	@Test
-	public void testLaunchJob() throws Exception {
+	void testLaunchJob() throws Exception {
 		JobExecution jobExecution = jobLauncher.run(job, new JobParameters());
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 		assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
 	}
 
 	@Test
-	public void testLaunchFailedJob() throws Exception {
+	void testLaunchFailedJob() throws Exception {
 		tasklet.setFail(true);
 		JobExecution jobExecution = jobLauncher.run(job,
 				new JobParametersBuilder().addLong("run.id", 2L).toJobParameters());


### PR DESCRIPTION
As of now, most of Spring Batch's tests are written with JUnit 4 which works mostly fine but lacks some niceties (e.g. parameterized tests are a bit cumbersome), and can lead to issues when integrating with test frameworks of other projects. 😉 

This PR migrates the tests of Spring Batch Integration fully to JUnit 5 such that JUnit 4 is no longer on the classpath of the module.

The changes are optimized for reviewability in the sense that I tried to keep them minimal. E.g. all the `public` modifiers are still there as their removal would be very noisy.

The most part of the PR has been done by automation. Only `AsyncItemProcessorMessagingGatewayTests` and `PollingAsyncItemProcessorMessagingGatewayTests` were migrated manually for the most part.

Please let me know if you're interested in the same for the other modules.