### PR TITLE
Migrate Spring Batch Infrastructure to JUnit Jupiter

### DIFF
--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -170,16 +170,16 @@
 
 		<!-- test dependencies -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit-jupiter.version}</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.hamcrest</groupId>
-					<artifactId>hamcrest-core</artifactId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit-jupiter.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
@@ -303,7 +303,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/config/DatasourceTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/config/DatasourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,16 @@
 
 package org.springframework.batch.config;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.annotation.Transactional;
-import org.junit.runner.RunWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 public class DatasourceTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/config/MessagingTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/config/MessagingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,25 @@
 
 package org.springframework.batch.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.core.JmsTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 public class MessagingTests {
 
 	@Autowired
 	private JmsTemplate jmsTemplate;
 
-	@Before
+	@BeforeEach
 	public void onSetUp() throws Exception {
 		Thread.sleep(100L);
 		getMessages(); // drain queue

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.container.jms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -29,11 +29,10 @@ import jakarta.jms.Message;
 import jakarta.jms.MessageListener;
 import jakarta.jms.TextMessage;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.core.JmsTemplate;
@@ -44,16 +43,14 @@ import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.support.DefaultRetryState;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  * 
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 @DirtiesContext
 public class BatchMessageListenerContainerIntegrationTests {
 
@@ -67,8 +64,8 @@ public class BatchMessageListenerContainerIntegrationTests {
 
 	private volatile BlockingQueue<String> processed = new LinkedBlockingQueue<>();
 
-	@After
-	@Before
+	@AfterEach
+	@BeforeEach
 	public void drainQueue() throws Exception {
 		container.stop();
 		while (jmsTemplate.receiveAndConvert("queue") != null) {
@@ -77,7 +74,7 @@ public class BatchMessageListenerContainerIntegrationTests {
 		processed.clear();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void giveContainerTimeToStop() throws Exception {
 		Thread.sleep(1000);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,17 +26,17 @@ import jakarta.jms.MessageListener;
 import jakarta.jms.Session;
 
 import org.aopalliance.aop.Advice;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.repeat.interceptor.RepeatOperationsInterceptor;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.batch.repeat.support.RepeatTemplate;
 import org.springframework.util.ReflectionUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,7 +66,7 @@ public class BatchMessageListenerContainerTests {
 		when(consumer.receive(1000)).thenReturn(message);
 
 		boolean received = doExecute(session, consumer);
-		assertTrue("Message not received", received);
+		assertTrue(received, "Message not received");
 
 	}
 
@@ -86,7 +86,7 @@ public class BatchMessageListenerContainerTests {
 		when(session.getTransacted()).thenReturn(false);
 
 		boolean received = doExecute(session, consumer);
-		assertFalse("Message not received", received);
+		assertFalse(received, "Message not received");
 
 	}
 
@@ -98,7 +98,7 @@ public class BatchMessageListenerContainerTests {
 		container.setSessionTransacted(true);
 		try {
 			boolean received = doTestWithException(new IllegalStateException("No way!"), true, 2);
-			assertFalse("Message received", received);
+			assertFalse(received, "Message received");
 			fail("Expected IllegalStateException");
 		}
 		catch (IllegalStateException e) {
@@ -113,7 +113,7 @@ public class BatchMessageListenerContainerTests {
 		container = getContainer(template);
 		container.setSessionTransacted(false);
 		boolean received = doTestWithException(new IllegalStateException("No way!"), false, 2);
-		assertTrue("Message not received but listener not transactional so this should be true", received);
+		assertTrue(received, "Message not received but listener not transactional so this should be true");
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class BatchMessageListenerContainerTests {
 		container.setSessionTransacted(false);
 		try {
 			boolean received = doTestWithException(new RuntimeException("No way!"), false, 2);
-			assertTrue("Message not received but listener not transactional so this should be true", received);
+			assertTrue(received, "Message not received but listener not transactional so this should be true");
 		}
 		catch (RuntimeException e) {
 			assertEquals("No way!", e.getMessage());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/AbstractItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/AbstractItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2010 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package org.springframework.batch.item;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.sample.Foo;
 
 /**
@@ -35,7 +35,7 @@ public abstract class AbstractItemReaderTests {
 	 */
 	protected abstract ItemReader<Foo> getItemReader() throws Exception;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		tested = getItemReader();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/AbstractItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/AbstractItemStreamItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package org.springframework.batch.item;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.springframework.batch.item.sample.Foo;
-import org.junit.Before;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Common tests for readers implementing both {@link ItemReader} and {@link ItemStream}.
@@ -38,13 +38,13 @@ public abstract class AbstractItemStreamItemReaderTests extends AbstractItemRead
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		testedAsStream().open(executionContext);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		testedAsStream().close();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package org.springframework.batch.item;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.util.SerializationUtils;
 
 /**
@@ -36,7 +36,7 @@ public class ExecutionContextTests {
 
 	private ExecutionContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		context = new ExecutionContext();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ItemRecoveryHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ItemRecoveryHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.springframework.batch.item;
 
+import org.junit.jupiter.api.Test;
 import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class ItemRecoveryHandlerTests extends TestCase {
+public class ItemRecoveryHandlerTests {
 
 	MethodInvocationRecoverer<String> recoverer = new MethodInvocationRecoverer<String>() {
 		@Override
@@ -29,6 +30,7 @@ public class ItemRecoveryHandlerTests extends TestCase {
 		}
 	};
 
+	@Test
 	public void testRecover() throws Exception {
 		try {
 			recoverer.recover(new Object[] { "foo" }, null);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/AbstractDelegatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/AbstractDelegatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,16 @@ package org.springframework.batch.item.adapter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.adapter.AbstractMethodInvokingDelegator.InvocationTargetThrowableWrapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link AbstractMethodInvokingDelegator}
@@ -44,7 +44,7 @@ public class AbstractDelegatorTests {
 
 	private Foo foo = new Foo("foo", 1);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		delegator.setTargetObject(foo);
 		delegator.setArguments(null);
@@ -98,7 +98,7 @@ public class AbstractDelegatorTests {
 	 * Regular use - calling methods directly and via delegator leads to same results
 	 */
 	@Test
-	@Ignore // FIXME
+	@Disabled // FIXME
 	public void testDelegationWithMultipleArguments() throws Exception {
 		FooService fooService = new FooService();
 		delegator.setTargetObject(fooService);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/HippyMethodInvokerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/HippyMethodInvokerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.adapter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HippyMethodInvokerTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/ItemProcessorAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/ItemProcessorAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,19 @@
  */
 package org.springframework.batch.item.adapter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * Tests for {@link ItemProcessorAdapter}.
  *
  * @author Dave Syer
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "delegating-item-processor.xml")
+@SpringJUnitConfig(locations = "delegating-item-processor.xml")
 public class ItemProcessorAdapterTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/ItemReaderAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/ItemReaderAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,23 @@
  */
 package org.springframework.batch.item.adapter;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.batch.item.sample.FooService;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link ItemReaderAdapter}.
  *
  * @author Robert Kasanicky
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "delegating-item-provider.xml")
+@SpringJUnitConfig(locations = "delegating-item-provider.xml")
 public class ItemReaderAdapterTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/ItemWriterAdapterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/ItemWriterAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,26 @@
  */
 package org.springframework.batch.item.adapter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.batch.item.sample.FooService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * Tests for {@link ItemWriterAdapter}.
  *
  * @author Robert Kasanicky
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "delegating-item-writer.xml")
+@SpringJUnitConfig(locations = "delegating-item-writer.xml")
 public class ItemWriterAdapterTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemProcessorIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemProcessorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2018 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,15 @@
  */
 package org.springframework.batch.item.adapter;
 
-import static org.junit.Assert.*;
-import org.junit.runner.RunWith;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.batch.item.sample.FooService;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -34,8 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Robert Kasanicky
  * @author Mahmoud Ben Hassine
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "pe-delegating-item-writer.xml")
+@SpringJUnitConfig(locations = "pe-delegating-item-writer.xml")
 public class PropertyExtractingDelegatingItemProcessorIntegrationTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package org.springframework.batch.item.amqp;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * <p>
@@ -37,9 +38,9 @@ import static org.junit.Assert.fail;
  */
 public class AmqpItemReaderTests {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testNullAmqpTemplate() {
-		new AmqpItemReader<String>(null);
+		assertThrows(IllegalArgumentException.class, () -> new AmqpItemReader<String>(null));
 	}
 
 	@Test
@@ -96,12 +97,12 @@ public class AmqpItemReaderTests {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testNullItemType() {
 		final AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
 
 		final AmqpItemReader<String> amqpItemReader = new AmqpItemReader<>(amqpTemplate);
-		amqpItemReader.setItemType(null);
+		assertThrows(IllegalArgumentException.class, () -> amqpItemReader.setItemType(null));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 package org.springframework.batch.item.amqp;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.AmqpTemplate;
 
 import java.util.Arrays;
@@ -33,9 +34,9 @@ import java.util.Arrays;
  */
 public class AmqpItemWriterTests {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testNullAmqpTemplate() {
-		new AmqpItemWriter<String>(null);
+		assertThrows(IllegalArgumentException.class, () -> new AmqpItemWriter<String>(null));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,27 +16,24 @@
 
 package org.springframework.batch.item.amqp.builder;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 import org.springframework.batch.item.amqp.AmqpItemReader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro
  */
+@ExtendWith(MockitoExtension.class)
 public class AmqpItemReaderBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	AmqpTemplate amqpTemplate;
@@ -79,8 +76,8 @@ public class AmqpItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"amqpTemplate is required.", iae.getMessage());
+			assertEquals("amqpTemplate is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package org.springframework.batch.item.amqp.builder;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 import org.springframework.batch.item.amqp.AmqpItemWriter;
 
 import static org.aspectj.bridge.MessageUtil.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -41,8 +41,8 @@ public class AmqpItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"amqpTemplate is required.", iae.getMessage());
+			assertEquals("amqpTemplate is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/AvroItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/AvroItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 package org.springframework.batch.item.avro;
 
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.avro.example.User;
 import org.springframework.batch.item.avro.support.AvroItemReaderTestSupport;
 import org.springframework.core.io.ClassPathResource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author David Turanski
@@ -68,14 +70,16 @@ public class AvroItemReaderTests extends AvroItemReaderTestSupport {
 		verify(itemReader, plainOldUsers());
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void dataResourceDoesNotExist() {
-		new AvroItemReader<User>(new ClassPathResource("doesnotexist"), schemaResource);
+		assertThrows(IllegalStateException.class,
+				() -> new AvroItemReader<User>(new ClassPathResource("doesnotexist"), schemaResource));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void schemaResourceDoesNotExist() {
-		new AvroItemReader<User>(dataResource, new ClassPathResource("doesnotexist"));
+		assertThrows(IllegalStateException.class,
+				() -> new AvroItemReader<User>(dataResource, new ClassPathResource("doesnotexist")));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/AvroItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/AvroItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package org.springframework.batch.item.avro;
 import java.io.ByteArrayOutputStream;
 
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.avro.example.User;
 import org.springframework.batch.item.avro.support.AvroItemWriterTestSupport;
 import org.springframework.core.io.WritableResource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author David Turanski
@@ -87,15 +89,16 @@ public class AvroItemWriterTests extends AvroItemWriterTestSupport {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWitNoOutput() {
-		new AvroItemWriter<>(null, this.schemaResource, User.class).open(new ExecutionContext());
-
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemWriter<>(null, this.schemaResource, User.class).open(new ExecutionContext()));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWitNoType() {
-		new AvroItemWriter<>(this.output, this.schemaResource, null).open(new ExecutionContext());
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemWriter<>(this.output, this.schemaResource, null).open(new ExecutionContext()));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 package org.springframework.batch.item.avro.builder;
 
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.avro.AvroItemReader;
 import org.springframework.batch.item.avro.example.User;
 import org.springframework.batch.item.avro.support.AvroItemReaderTestSupport;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author David Turanski
@@ -66,20 +68,22 @@ public class AvroItemReaderBuilderTests extends AvroItemReaderTestSupport {
 		verify(avroItemReader, avroGeneratedUsers());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void itemReaderWithNoSchemaStringShouldFail() {
-		new AvroItemReaderBuilder<GenericRecord>().schema("").resource(dataResource).build();
-
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemReaderBuilder<GenericRecord>().schema("").resource(dataResource).build());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void itemReaderWithPartialConfigurationShouldFail() {
-		new AvroItemReaderBuilder<GenericRecord>().resource(dataResource).build();
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemReaderBuilder<GenericRecord>().resource(dataResource).build());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void itemReaderWithNoInputsShouldFail() {
-		new AvroItemReaderBuilder<GenericRecord>().schema(schemaResource).build();
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemReaderBuilder<GenericRecord>().schema(schemaResource).build());
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/builder/AvroItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/builder/AvroItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,15 @@ package org.springframework.batch.item.avro.builder;
 import java.io.ByteArrayOutputStream;
 
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.avro.AvroItemWriter;
 import org.springframework.batch.item.avro.example.User;
 import org.springframework.batch.item.avro.support.AvroItemWriterTestSupport;
 import org.springframework.core.io.WritableResource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author David Turanski
@@ -90,18 +92,16 @@ public class AvroItemWriterBuilderTests extends AvroItemWriterTestSupport {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWitNoOutput() {
-
-		new AvroItemWriterBuilder<GenericRecord>().type(GenericRecord.class).build();
-
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemWriterBuilder<GenericRecord>().type(GenericRecord.class).build());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWitNoType() {
-
-		new AvroItemWriterBuilder<>().resource(output).schema(schemaResource).build();
-
+		assertThrows(IllegalArgumentException.class,
+				() -> new AvroItemWriterBuilder<>().resource(output).schema(schemaResource).build());
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/GemfireItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/GemfireItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,35 +15,31 @@
  */
 package org.springframework.batch.item.data;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.SpELItemKeyMapper;
 import org.springframework.data.gemfire.GemfireTemplate;
 import org.springframework.core.convert.converter.Converter;
 
-@SuppressWarnings("serial")
+@ExtendWith(MockitoExtension.class)
 public class GemfireItemWriterTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	private GemfireItemWriter<String, Foo> writer;
 
 	@Mock
 	private GemfireTemplate template;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		writer = new GemfireItemWriter<>();
 		writer.setTemplate(template);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
@@ -20,13 +20,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
@@ -34,10 +33,10 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -45,10 +44,8 @@ import static org.mockito.Mockito.when;
  * @author Michael Minella
  * @author Parikshit Dutta
  */
+@ExtendWith(MockitoExtension.class)
 public class MongoItemReaderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	private MongoItemReader<String> reader;
 
@@ -57,7 +54,7 @@ public class MongoItemReaderTests {
 
 	private Map<String, Sort.Direction> sortOptions;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		reader = new MongoItemReader<>();
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,12 @@ import java.util.Collections;
 import java.util.List;
 
 import org.bson.Document;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -33,8 +35,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.BulkOperations;
@@ -50,8 +52,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -61,10 +63,8 @@ import static org.mockito.ArgumentMatchers.eq;
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
  */
+@ExtendWith(MockitoExtension.class)
 public class MongoItemWriterTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	private MongoItemWriter<Object> writer;
 
@@ -79,14 +79,14 @@ public class MongoItemWriterTests {
 
 	private PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
-		when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
+		lenient().when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
+		lenient().when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
 
 		MappingContext<MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext = new MongoMappingContext();
 		MappingMongoConverter mongoConverter = spy(new MappingMongoConverter(this.dbRefResolver, mappingContext));
-		when(this.template.getConverter()).thenReturn(mongoConverter);
+		lenient().when(this.template.getConverter()).thenReturn(mongoConverter);
 
 		writer = new MongoItemWriter<>();
 		writer.setTemplate(template);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,24 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class Neo4jItemReaderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private Iterable<String> result;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/Neo4jItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,22 @@ package org.springframework.batch.item.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class Neo4jItemWriterTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	private Neo4jItemWriter<String> writer;
 
@@ -92,7 +90,7 @@ public class Neo4jItemWriterTests {
 		writer.setSessionFactory(this.sessionFactory);
 		writer.afterPropertiesSet();
 
-		when(this.sessionFactory.openSession()).thenReturn(this.session);
+		lenient().when(this.sessionFactory.openSession()).thenReturn(this.session);
 		writer.write(null);
 
 		verifyNoInteractions(this.session);
@@ -105,7 +103,7 @@ public class Neo4jItemWriterTests {
 		writer.setSessionFactory(this.sessionFactory);
 		writer.afterPropertiesSet();
 
-		when(this.sessionFactory.openSession()).thenReturn(this.session);
+		lenient().when(this.sessionFactory.openSession()).thenReturn(this.session);
 		writer.write(new ArrayList<>());
 
 		verifyNoInteractions(this.session);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.adapter.DynamicMethodInvocationException;
 import org.springframework.data.domain.Page;
@@ -39,23 +38,20 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("serial")
+@ExtendWith(MockitoExtension.class)
 public class RepositoryItemReaderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	private RepositoryItemReader<Object> reader;
 
@@ -64,7 +60,7 @@ public class RepositoryItemReaderTests {
 
 	private Map<String, Sort.Direction> sorts;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		sorts = Collections.singletonMap("id", Direction.ASC);
 		reader = new RepositoryItemReader<>();
@@ -202,7 +198,7 @@ public class RepositoryItemReaderTests {
 
 		// the page must only actually be fetched on the next "doRead()" call
 		final Object o = reader.doRead();
-		assertSame("Fetched object should be at index 85 in the current page", o, objectList.get(85));
+		assertSame(o, objectList.get(85), "Fetched object should be at index 85 in the current page");
 
 		Pageable pageRequest = pageRequestContainer.getValue();
 		assertEquals(400, pageRequest.getOffset());
@@ -221,7 +217,7 @@ public class RepositoryItemReaderTests {
 		reader.jumpToItem(150);
 		verify(repository, never()).findAll(any(Pageable.class));
 
-		assertSame("Fetched object should be the first one in the current page", objectList.get(0), reader.doRead());
+		assertSame(objectList.get(0), reader.doRead(), "Fetched object should be the first one in the current page");
 
 		Pageable pageRequest = pageRequestContainer.getValue();
 		assertEquals(150, pageRequest.getOffset());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.item.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -26,25 +26,22 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.repository.CrudRepository;
 
+@ExtendWith(MockitoExtension.class)
 public class RepositoryItemWriterTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private CrudRepository<String, Serializable> repository;
 
 	private RepositoryItemWriter<String> writer;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		writer = new RepositoryItemWriter<>();
 		writer.setMethodName("save");
@@ -73,8 +70,8 @@ public class RepositoryItemWriterTests {
 		}
 		catch (IllegalArgumentException e) {
 			// expected
-			assertEquals("Wrong message for exception: " + e.getMessage(), "methodName must not be empty.",
-					e.getMessage());
+			assertEquals("methodName must not be empty.", e.getMessage(),
+					"Wrong message for exception: " + e.getMessage());
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/GemfireItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/GemfireItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,28 +19,25 @@ package org.springframework.batch.item.data.builder;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.SpELItemKeyMapper;
 import org.springframework.batch.item.data.GemfireItemWriter;
 import org.springframework.data.gemfire.GemfireTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Glenn Renfro
  */
+@ExtendWith(MockitoExtension.class)
 public class GemfireItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private GemfireTemplate template;
@@ -49,7 +46,7 @@ public class GemfireItemWriterBuilderTests {
 
 	private List<GemfireItemWriterBuilderTests.Foo> items;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.items = Arrays.asList(new GemfireItemWriterBuilderTests.Foo(new GemfireItemWriterBuilderTests.Bar("val1")),
 				new GemfireItemWriterBuilderTests.Foo(new GemfireItemWriterBuilderTests.Bar("val2")));
@@ -90,8 +87,8 @@ public class GemfireItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", "template is required.",
-					iae.getMessage());
+			assertEquals("template is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -102,8 +99,8 @@ public class GemfireItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"itemKeyMapper is required.", iae.getMessage());
+			assertEquals("itemKeyMapper is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
@@ -21,21 +21,20 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.data.MongoItemReader;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -47,10 +46,8 @@ import static org.springframework.data.mongodb.core.query.Query.query;
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
  */
+@ExtendWith(MockitoExtension.class)
 public class MongoItemReaderBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private MongoOperations template;
@@ -59,7 +56,7 @@ public class MongoItemReaderBuilderTests {
 
 	private ArgumentCaptor<Query> queryContainer;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.sortOptions = new HashMap<>();
 		this.sortOptions.put("name", Sort.Direction.DESC);
@@ -72,7 +69,7 @@ public class MongoItemReaderBuilderTests {
 
 		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals(50, query.getLimit());
@@ -87,7 +84,7 @@ public class MongoItemReaderBuilderTests {
 
 		when(this.template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals(1, query.getFieldsObject().get("name"));
@@ -101,7 +98,7 @@ public class MongoItemReaderBuilderTests {
 
 		when(this.template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals("{ $natural : 1}", query.getHint());
@@ -117,7 +114,7 @@ public class MongoItemReaderBuilderTests {
 		when(this.template.find(this.queryContainer.capture(), eq(String.class), collectionContainer.capture()))
 				.thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
@@ -135,7 +132,7 @@ public class MongoItemReaderBuilderTests {
 		when(this.template.find(this.queryContainer.capture(), eq(String.class), collectionContainer.capture()))
 				.thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
@@ -151,7 +148,7 @@ public class MongoItemReaderBuilderTests {
 
 		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals(50, query.getLimit());
@@ -164,7 +161,7 @@ public class MongoItemReaderBuilderTests {
 
 		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
 
-		assertNull("reader should not return result", reader.read());
+		assertNull(reader.read(), "reader should not return result");
 
 		Query query = this.queryContainer.getValue();
 		assertEquals(10, query.getLimit());
@@ -215,11 +212,11 @@ public class MongoItemReaderBuilderTests {
 			fail("Exception should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", message,
-					iae.getMessage());
+			assertEquals(message, iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 		catch (IllegalStateException ise) {
-			assertEquals("IllegalStateException message did not match the expected result.", message, ise.getMessage());
+			assertEquals(message, ise.getMessage(), "IllegalStateException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,17 +20,17 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.bson.Document;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.data.MongoItemWriter;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.BulkOperations;
@@ -43,8 +43,8 @@ import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
 import org.springframework.data.mongodb.core.query.Query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -54,10 +54,8 @@ import static org.mockito.ArgumentMatchers.eq;
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
  */
+@ExtendWith(MockitoExtension.class)
 public class MongoItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private MongoOperations template;
@@ -74,14 +72,14 @@ public class MongoItemWriterBuilderTests {
 
 	private List<Item> removeItems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
-		when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
+		lenient().when(this.template.bulkOps(any(), anyString())).thenReturn(this.bulkOperations);
+		lenient().when(this.template.bulkOps(any(), any(Class.class))).thenReturn(this.bulkOperations);
 
 		MappingContext<MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext = new MongoMappingContext();
 		mongoConverter = spy(new MappingMongoConverter(this.dbRefResolver, mappingContext));
-		when(this.template.getConverter()).thenReturn(mongoConverter);
+		lenient().when(this.template.getConverter()).thenReturn(mongoConverter);
 
 		this.saveItems = Arrays.asList(new Item("Foo"), new Item("Bar"));
 		this.removeItems = Arrays.asList(new Item(1), new Item(2));
@@ -130,8 +128,8 @@ public class MongoItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", "template is required.",
-					iae.getMessage());
+			assertEquals("template is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,28 +20,25 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 
 import org.springframework.batch.item.data.Neo4jItemReader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro
  */
+@ExtendWith(MockitoExtension.class)
 public class Neo4jItemReaderBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private Iterable<String> result;
@@ -64,9 +61,9 @@ public class Neo4jItemReaderBuilderTests {
 				.thenReturn(result);
 		when(result.iterator()).thenReturn(Arrays.asList("foo", "bar", "baz").iterator());
 
-		assertEquals("The expected value was not returned by reader.", "foo", itemReader.read());
-		assertEquals("The expected value was not returned by reader.", "bar", itemReader.read());
-		assertEquals("The expected value was not returned by reader.", "baz", itemReader.read());
+		assertEquals("foo", itemReader.read(), "The expected value was not returned by reader.");
+		assertEquals("bar", itemReader.read(), "The expected value was not returned by reader.");
+		assertEquals("baz", itemReader.read(), "The expected value was not returned by reader.");
 	}
 
 	@Test
@@ -80,8 +77,8 @@ public class Neo4jItemReaderBuilderTests {
 				.thenReturn(result);
 		when(result.iterator()).thenReturn(Arrays.asList("foo", "bar", "baz").iterator());
 
-		assertEquals("The expected value was not returned by reader.", "foo", itemReader.read());
-		assertNull("The expected value was not should be null.", itemReader.read());
+		assertEquals("foo", itemReader.read(), "The expected value was not returned by reader.");
+		assertNull(itemReader.read(), "The expected value was not should be null.");
 	}
 
 	@Test
@@ -99,7 +96,7 @@ public class Neo4jItemReaderBuilderTests {
 				.thenReturn(result);
 		when(result.iterator()).thenReturn(Arrays.asList("foo", "bar", "baz").iterator());
 
-		assertEquals("The expected value was not returned by reader.", "foo", itemReader.read());
+		assertEquals("foo", itemReader.read(), "The expected value was not returned by reader.");
 	}
 
 	@Test
@@ -111,8 +108,8 @@ public class Neo4jItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"sessionFactory is required.", iae.getMessage());
+			assertEquals("sessionFactory is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -196,8 +193,8 @@ public class Neo4jItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", message,
-					iae.getMessage());
+			assertEquals(message, iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/Neo4jItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,18 +19,17 @@ package org.springframework.batch.item.data.builder;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 
 import org.springframework.batch.item.data.Neo4jItemWriter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,10 +37,8 @@ import static org.mockito.Mockito.when;
 /**
  * @author Glenn Renfro
  */
+@ExtendWith(MockitoExtension.class)
 public class Neo4jItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private SessionFactory sessionFactory;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,28 +21,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.data.RepositoryItemReader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro
  * @author Drummond Dawson
  */
+@ExtendWith(MockitoExtension.class)
 public class RepositoryItemReaderBuilderTests {
 
 	private static final String ARG1 = "foo";
@@ -52,9 +53,6 @@ public class RepositoryItemReaderBuilderTests {
 	private static final String ARG3 = "baz";
 
 	private static final String TEST_CONTENT = "FOOBAR";
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private TestRepository repository;
@@ -66,7 +64,7 @@ public class RepositoryItemReaderBuilderTests {
 
 	private ArgumentCaptor<PageRequest> pageRequestContainer;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.sorts = new HashMap<>();
 		this.sorts.put("id", Sort.Direction.ASC);
@@ -74,9 +72,9 @@ public class RepositoryItemReaderBuilderTests {
 
 		List<String> testResult = new ArrayList<>();
 		testResult.add(TEST_CONTENT);
-		when(page.getContent()).thenReturn(testResult);
-		when(page.getSize()).thenReturn(5);
-		when(this.repository.foo(this.pageRequestContainer.capture())).thenReturn(this.page);
+		lenient().when(page.getContent()).thenReturn(testResult);
+		lenient().when(page.getSize()).thenReturn(5);
+		lenient().when(this.repository.foo(this.pageRequestContainer.capture())).thenReturn(this.page);
 	}
 
 	@Test
@@ -84,8 +82,8 @@ public class RepositoryItemReaderBuilderTests {
 		RepositoryItemReader<Object> reader = new RepositoryItemReaderBuilder<>().repository(this.repository)
 				.sorts(this.sorts).maxItemCount(5).methodName("foo").name("bar").build();
 		String result = (String) reader.read();
-		assertEquals("Result returned from reader was not expected value.", TEST_CONTENT, result);
-		assertEquals("page size was not expected value.", 10, this.pageRequestContainer.getValue().getPageSize());
+		assertEquals(TEST_CONTENT, result, "Result returned from reader was not expected value.");
+		assertEquals(10, this.pageRequestContainer.getValue().getPageSize(), "page size was not expected value.");
 	}
 
 	@Test
@@ -96,8 +94,8 @@ public class RepositoryItemReaderBuilderTests {
 		RepositoryItemReader<Object> reader = new RepositoryItemReaderBuilder<>().repository(repositoryMethodReference)
 				.sorts(this.sorts).maxItemCount(5).name("bar").build();
 		String result = (String) reader.read();
-		assertEquals("Result returned from reader was not expected value.", TEST_CONTENT, result);
-		assertEquals("page size was not expected value.", 10, this.pageRequestContainer.getValue().getPageSize());
+		assertEquals(TEST_CONTENT, result, "Result returned from reader was not expected value.");
+		assertEquals(10, this.pageRequestContainer.getValue().getPageSize(), "page size was not expected value.");
 	}
 
 	@Test
@@ -114,7 +112,7 @@ public class RepositoryItemReaderBuilderTests {
 				this.pageRequestContainer.capture())).thenReturn(this.page);
 
 		String result = (String) reader.read();
-		assertEquals("Result returned from reader was not expected value.", TEST_CONTENT, result);
+		assertEquals(TEST_CONTENT, result, "Result returned from reader was not expected value.");
 		verifyMultiArgRead(arg1Captor, arg2Captor, arg3Captor, result);
 	}
 
@@ -122,7 +120,7 @@ public class RepositoryItemReaderBuilderTests {
 	public void testCurrentItemCount() throws Exception {
 		RepositoryItemReader<Object> reader = new RepositoryItemReaderBuilder<>().repository(this.repository)
 				.sorts(this.sorts).currentItemCount(6).maxItemCount(5).methodName("foo").name("bar").build();
-		assertNull("Result returned from reader was not null.", reader.read());
+		assertNull(reader.read(), "Result returned from reader was not null.");
 	}
 
 	@Test
@@ -130,7 +128,7 @@ public class RepositoryItemReaderBuilderTests {
 		RepositoryItemReader<Object> reader = new RepositoryItemReaderBuilder<>().repository(this.repository)
 				.sorts(this.sorts).maxItemCount(5).methodName("foo").name("bar").pageSize(2).build();
 		reader.read();
-		assertEquals("page size was not expected value.", 2, this.pageRequestContainer.getValue().getPageSize());
+		assertEquals(2, this.pageRequestContainer.getValue().getPageSize(), "page size was not expected value.");
 	}
 
 	@Test
@@ -141,8 +139,8 @@ public class RepositoryItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"methodName is required.", iae.getMessage());
+			assertEquals("methodName is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 		try {
 			new RepositoryItemReaderBuilder<>().repository(this.repository).sorts(this.sorts).methodName("")
@@ -151,8 +149,8 @@ public class RepositoryItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"methodName is required.", iae.getMessage());
+			assertEquals("methodName is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -165,8 +163,8 @@ public class RepositoryItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalStateException ise) {
-			assertEquals("IllegalStateException name was not set when saveState was true.",
-					"A name is required when saveState is set to true.", ise.getMessage());
+			assertEquals("A name is required when saveState is set to true.", ise.getMessage(),
+					"IllegalStateException name was not set when saveState was true.");
 		}
 		// No IllegalStateException for a name that is not set, should not be thrown since
 		// saveState was false.
@@ -182,8 +180,8 @@ public class RepositoryItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException sorts did not match the expected result.", "sorts map is required.",
-					iae.getMessage());
+			assertEquals("sorts map is required.", iae.getMessage(),
+					"IllegalArgumentException sorts did not match the expected result.");
 		}
 	}
 
@@ -195,8 +193,8 @@ public class RepositoryItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"repository is required.", iae.getMessage());
+			assertEquals("repository is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -244,12 +242,12 @@ public class RepositoryItemReaderBuilderTests {
 
 	private void verifyMultiArgRead(ArgumentCaptor<String> arg1Captor, ArgumentCaptor<String> arg2Captor,
 			ArgumentCaptor<String> arg3Captor, String result) {
-		assertEquals("Result returned from reader was not expected value.", TEST_CONTENT, result);
-		assertEquals("ARG1 for calling method did not match expected result", ARG1, arg1Captor.getValue());
-		assertEquals("ARG2 for calling method did not match expected result", ARG2, arg2Captor.getValue());
-		assertEquals("ARG3 for calling method did not match expected result", ARG3, arg3Captor.getValue());
-		assertEquals("Result Total Pages did not match expected result", 10,
-				this.pageRequestContainer.getValue().getPageSize());
+		assertEquals(TEST_CONTENT, result, "Result returned from reader was not expected value.");
+		assertEquals(ARG1, arg1Captor.getValue(), "ARG1 for calling method did not match expected result");
+		assertEquals(ARG2, arg2Captor.getValue(), "ARG2 for calling method did not match expected result");
+		assertEquals(ARG3, arg3Captor.getValue(), "ARG3 for calling method did not match expected result");
+		assertEquals(10, this.pageRequestContainer.getValue().getPageSize(),
+				"Result Total Pages did not match expected result");
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,26 +20,23 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.data.RepositoryItemWriter;
 import org.springframework.data.repository.CrudRepository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
  */
+@ExtendWith(MockitoExtension.class)
 public class RepositoryItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private TestRepository repository;
@@ -52,8 +49,8 @@ public class RepositoryItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"repository is required.", iae.getMessage());
+			assertEquals("repository is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -65,8 +62,8 @@ public class RepositoryItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"methodName must not be empty.", iae.getMessage());
+			assertEquals("methodName must not be empty.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractDataSourceItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractDataSourceItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.springframework.batch.item.database;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -30,10 +30,10 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Common scenarios for testing {@link ItemReader} implementations which read data from
@@ -62,7 +62,7 @@ public abstract class AbstractDataSourceItemReaderIntegrationTests {
 
 	protected abstract ItemReader<Foo> createItemReader() throws Exception;
 
-	@Before
+	@BeforeEach
 	public void onSetUpInTransaction() throws Exception {
 		reader = createItemReader();
 		executionContext = new ExecutionContext();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractDatabaseItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractDatabaseItemStreamItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package org.springframework.batch.item.database;
 
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
@@ -28,21 +28,21 @@ import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class AbstractDatabaseItemStreamItemReaderTests extends AbstractItemStreamItemReaderTests {
 
 	protected ClassPathXmlApplicationContext ctx;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		initializeContext();
 		super.setUp();
 	}
 
 	@Override
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		super.tearDown();
 		ctx.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractGenericDataSourceItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractGenericDataSourceItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
  */
 package org.springframework.batch.item.database;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * Generic configuration for testing {@link ItemReader} implementations which read data
@@ -26,8 +24,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @author Thomas Risberg
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "data-source-context.xml")
+@SpringJUnitConfig(locations = "data-source-context.xml")
 public abstract class AbstractGenericDataSourceItemReaderIntegrationTests
 		extends AbstractDataSourceItemReaderIntegrationTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractJdbcItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractJdbcItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStream;
@@ -59,14 +59,14 @@ public abstract class AbstractJdbcItemReaderIntegrationTests {
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}
 
-	@Before
+	@BeforeEach
 	public void onSetUp() throws Exception {
 		itemReader = createItemReader();
 		getAsInitializingBean(itemReader).afterPropertiesSet();
 		executionContext = new ExecutionContext();
 	}
 
-	@After
+	@AfterEach
 	public void onTearDown() throws Exception {
 		getAsDisposableBean(itemReader).destroy();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractJdbcPagingItemReaderParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractJdbcPagingItemReaderParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.springframework.batch.item.database;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jimmy Praet

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractPagingItemReaderParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractPagingItemReaderParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package org.springframework.batch.item.database;
 
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.sample.Foo;
@@ -39,12 +39,12 @@ public abstract class AbstractPagingItemReaderParameterTests {
 	@Autowired
 	protected DataSource dataSource;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		tested = getItemReader();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		((ItemStream) tested).close();
 	}
@@ -55,19 +55,19 @@ public abstract class AbstractPagingItemReaderParameterTests {
 		((ItemStream) tested).open(executionContext);
 
 		Foo foo2 = tested.read();
-		Assert.assertEquals(2, foo2.getValue());
+		Assertions.assertEquals(2, foo2.getValue());
 
 		Foo foo3 = tested.read();
-		Assert.assertEquals(3, foo3.getValue());
+		Assertions.assertEquals(3, foo3.getValue());
 
 		Foo foo4 = tested.read();
-		Assert.assertEquals(4, foo4.getValue());
+		Assertions.assertEquals(4, foo4.getValue());
 
 		Foo foo5 = tested.read();
-		Assert.assertEquals(5, foo5.getValue());
+		Assertions.assertEquals(5, foo5.getValue());
 
 		Object o = tested.read();
-		Assert.assertNull(o);
+		Assertions.assertNull(o);
 	}
 
 	@Test
@@ -77,13 +77,13 @@ public abstract class AbstractPagingItemReaderParameterTests {
 		((ItemStream) tested).open(executionContext);
 
 		Foo foo4 = tested.read();
-		Assert.assertEquals(4, foo4.getValue());
+		Assertions.assertEquals(4, foo4.getValue());
 
 		Foo foo5 = tested.read();
-		Assert.assertEquals(5, foo5.getValue());
+		Assertions.assertEquals(5, foo5.getValue());
 
 		Object o = tested.read();
-		Assert.assertNull(o);
+		Assertions.assertNull(o);
 	}
 
 	@Test
@@ -93,10 +93,10 @@ public abstract class AbstractPagingItemReaderParameterTests {
 		((ItemStream) tested).open(executionContext);
 
 		Foo foo5 = tested.read();
-		Assert.assertEquals(5, foo5.getValue());
+		Assertions.assertEquals(5, foo5.getValue());
 
 		Object o = tested.read();
-		Assert.assertNull(o);
+		Assertions.assertNull(o);
 	}
 
 	protected String getName() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,13 @@ package org.springframework.batch.item.database;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.PrintWriter;
 import java.sql.Connection;
@@ -34,7 +35,7 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.DataSourceUtils;
@@ -66,29 +67,29 @@ public class ExtendedConnectionDataSourceProxyTests {
 
 		Connection con1 = csds.getConnection();
 		Connection con2 = csds.getConnection();
-		assertNotSame("shouldn't be the same connection", con1, con2);
+		assertNotSame(con1, con2, "shouldn't be the same connection");
 
-		assertTrue("should be able to close connection", csds.shouldClose(con1));
+		assertTrue(csds.shouldClose(con1), "should be able to close connection");
 		con1.close();
-		assertTrue("should be able to close connection", csds.shouldClose(con2));
+		assertTrue(csds.shouldClose(con2), "should be able to close connection");
 		con2.close();
 
 		Connection con3 = csds.getConnection();
 		csds.startCloseSuppression(con3);
 		Connection con3_1 = csds.getConnection();
-		assertSame("should be same connection", con3_1, con3);
-		assertFalse("should not be able to close connection", csds.shouldClose(con3));
+		assertSame(con3_1, con3, "should be same connection");
+		assertFalse(csds.shouldClose(con3), "should not be able to close connection");
 		con3_1.close(); // no mock call for this - should be suppressed
 		Connection con3_2 = csds.getConnection();
-		assertSame("should be same connection", con3_2, con3);
+		assertSame(con3_2, con3, "should be same connection");
 		Connection con4 = csds.getConnection();
-		assertNotSame("shouldn't be same connection", con4, con3);
+		assertNotSame(con4, con3, "shouldn't be same connection");
 		csds.stopCloseSuppression(con3);
-		assertTrue("should be able to close connection", csds.shouldClose(con3));
+		assertTrue(csds.shouldClose(con3), "should be able to close connection");
 		con3_1 = null;
 		con3_2 = null;
 		con3.close();
-		assertTrue("should be able to close connection", csds.shouldClose(con4));
+		assertTrue(csds.shouldClose(con4), "should be able to close connection");
 		con4.close();
 
 	}
@@ -108,18 +109,18 @@ public class ExtendedConnectionDataSourceProxyTests {
 		Connection con1 = csds.getConnection();
 		csds.startCloseSuppression(con1);
 		Connection con1_1 = csds.getConnection();
-		assertSame("should be same connection", con1_1, con1);
+		assertSame(con1_1, con1, "should be same connection");
 		con1_1.close(); // no mock call for this - should be suppressed
 		Connection con1_2 = csds.getConnection();
-		assertSame("should be same connection", con1_2, con1);
+		assertSame(con1_2, con1, "should be same connection");
 		Connection con2 = csds.getConnection();
-		assertNotSame("shouldn't be same connection", con2, con1);
+		assertNotSame(con2, con1, "shouldn't be same connection");
 		csds.stopCloseSuppression(con1);
-		assertTrue("should be able to close connection", csds.shouldClose(con1));
+		assertTrue(csds.shouldClose(con1), "should be able to close connection");
 		con1_1 = null;
 		con1_2 = null;
 		con1.close();
-		assertTrue("should be able to close connection", csds.shouldClose(con2));
+		assertTrue(csds.shouldClose(con2), "should be able to close connection");
 		con2.close();
 
 	}
@@ -227,11 +228,11 @@ public class ExtendedConnectionDataSourceProxyTests {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void delegateIsRequired() throws Exception {
+	@Test
+	public void delegateIsRequired() {
 
 		ExtendedConnectionDataSourceProxy tested = new ExtendedConnectionDataSourceProxy(null);
-		tested.afterPropertiesSet();
+		assertThrows(IllegalArgumentException.class, tested::afterPropertiesSet);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2010 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hibernate.StatelessSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.sample.Foo;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorItemReaderStatefulIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorItemReaderStatefulIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.batch.item.database;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.sample.Foo;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorProjectionItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorProjectionItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,28 +19,25 @@ import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link HibernateCursorItemReader} using {@link StatelessSession}.
  *
  * @author Robert Kasanicky
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "data-source-context.xml")
+@SpringJUnitConfig(locations = "data-source-context.xml")
 public class HibernateCursorProjectionItemReaderIntegrationTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemReaderHelperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemReaderHelperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2009 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package org.springframework.batch.item.database;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +45,7 @@ public class HibernateItemWriterTests {
 
 	Session currentSession;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		writer = new HibernateItemWriter<>();
 		factory = mock(SessionFactory.class);
@@ -68,7 +68,7 @@ public class HibernateItemWriterTests {
 		}
 		catch (IllegalStateException e) {
 			// expected
-			assertTrue("Wrong message for exception: " + e.getMessage(), e.getMessage().indexOf("SessionFactory") >= 0);
+			assertTrue(e.getMessage().contains("SessionFactory"), "Wrong message for exception: " + e.getMessage());
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterClassicTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterClassicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,8 +25,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.UncategorizedSQLException;
@@ -49,7 +49,7 @@ public class JdbcBatchItemWriterClassicTests {
 
 	private PreparedStatement ps;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		ps = mock(PreparedStatement.class);
 		jdbcTemplate = new JdbcTemplate() {
@@ -91,8 +91,8 @@ public class JdbcBatchItemWriterClassicTests {
 		catch (IllegalArgumentException e) {
 			// expected
 			String message = e.getMessage();
-			assertTrue("Message does not contain ' NamedParameterJdbcTemplate'.",
-					message.indexOf("NamedParameterJdbcTemplate") >= 0);
+			assertTrue(message.contains("NamedParameterJdbcTemplate"),
+					"Message does not contain ' NamedParameterJdbcTemplate'.");
 		}
 		writer.setJdbcTemplate(new NamedParameterJdbcTemplate(jdbcTemplate));
 		try {
@@ -102,7 +102,7 @@ public class JdbcBatchItemWriterClassicTests {
 		catch (IllegalArgumentException e) {
 			// expected
 			String message = e.getMessage().toLowerCase();
-			assertTrue("Message does not contain 'sql'.", message.indexOf("sql") >= 0);
+			assertTrue(message.contains("sql"), "Message does not contain 'sql'.");
 		}
 		writer.setSql("select * from foo where id = ?");
 		try {
@@ -112,8 +112,8 @@ public class JdbcBatchItemWriterClassicTests {
 		catch (IllegalArgumentException e) {
 			// expected
 			String message = e.getMessage();
-			assertTrue("Message does not contain 'ItemPreparedStatementSetter'.",
-					message.indexOf("ItemPreparedStatementSetter") >= 0);
+			assertTrue(message.contains("ItemPreparedStatementSetter"),
+					"Message does not contain 'ItemPreparedStatementSetter'.");
 		}
 		writer.setItemPreparedStatementSetter(new ItemPreparedStatementSetter<String>() {
 			@Override
@@ -144,7 +144,7 @@ public class JdbcBatchItemWriterClassicTests {
 		catch (EmptyResultDataAccessException e) {
 			// expected
 			String message = e.getMessage();
-			assertTrue("Wrong message: " + message, message.indexOf("did not update") >= 0);
+			assertTrue(message.contains("did not update"), "Wrong message: " + message);
 		}
 		assertEquals(2, list.size());
 		assertTrue(list.contains("SQL"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -30,9 +30,9 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -82,7 +82,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		namedParameterJdbcOperations = mock(NamedParameterJdbcOperations.class);
 		writer.setSql(sql);
@@ -106,8 +106,8 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		catch (IllegalArgumentException e) {
 			// expected
 			String message = e.getMessage();
-			assertTrue("Message does not contain 'NamedParameterJdbcTemplate'.",
-					message.contains("NamedParameterJdbcTemplate"));
+			assertTrue(message.contains("NamedParameterJdbcTemplate"),
+					"Message does not contain 'NamedParameterJdbcTemplate'.");
 		}
 		writer.setJdbcTemplate(namedParameterJdbcOperations);
 		try {
@@ -117,7 +117,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		catch (IllegalArgumentException e) {
 			// expected
 			String message = e.getMessage().toLowerCase();
-			assertTrue("Message does not contain 'sql'.", message.contains("sql"));
+			assertTrue(message.contains("sql"), "Message does not contain 'sql'.");
 		}
 		writer.setSql("select * from foo where id = :id");
 
@@ -189,7 +189,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		catch (EmptyResultDataAccessException e) {
 			// expected
 			String message = e.getMessage();
-			assertTrue("Wrong message: " + message, message.contains("did not update"));
+			assertTrue(message.contains("did not update"), "Wrong message: " + message);
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,14 @@
  */
 package org.springframework.batch.item.database;
 
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ReaderNotOpenException;
 import org.springframework.batch.item.sample.Foo;
 
-@RunWith(JUnit4.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class JdbcCursorItemReaderCommonTests extends AbstractDatabaseItemStreamItemReaderTests {
 
 	@Override
@@ -63,10 +62,10 @@ public class JdbcCursorItemReaderCommonTests extends AbstractDatabaseItemStreamI
 		reader.open(new ExecutionContext());
 	}
 
-	@Test(expected = ReaderNotOpenException.class)
+	@Test
 	public void testReadBeforeOpen() throws Exception {
 		tested = getItemReader();
-		tested.read();
+		assertThrows(ReaderNotOpenException.class, tested::read);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import javax.sql.DataSource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.batch.item.ExecutionContext;
@@ -32,14 +30,13 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class JdbcCursorItemReaderConfigTests {
 
 	/*

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,14 @@
  */
 package org.springframework.batch.item.database;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.sample.Foo;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Tests for {@link JdbcCursorItemReader}
  *
  * @author Robert Kasanicky
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 public class JdbcCursorItemReaderIntegrationTests extends AbstractGenericDataSourceItemReaderIntegrationTests {
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderAsyncTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderAsyncTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -36,10 +36,9 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
@@ -47,12 +46,10 @@ import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "JdbcPagingItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "JdbcPagingItemReaderCommonTests-context.xml")
 public class JdbcPagingItemReaderAsyncTests {
 
 	/**
@@ -77,7 +74,7 @@ public class JdbcPagingItemReaderAsyncTests {
 
 	private int maxId;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		Integer maxIdResult = jdbcTemplate.queryForObject("SELECT MAX(ID) from T_FOOS", Integer.class);
@@ -88,7 +85,7 @@ public class JdbcPagingItemReaderAsyncTests {
 		assertEquals(ITEM_COUNT, JdbcTestUtils.countRowsInTable(jdbcTemplate, "T_FOOS"));
 	}
 
-	@After
+	@AfterEach
 	public void destroy() {
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		jdbcTemplate.update("DELETE from T_FOOS where ID>?", maxId);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderClassicParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderClassicParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -37,8 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Michael Minella
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(
+@SpringJUnitConfig(
 		locations = "/org/springframework/batch/item/database/JdbcPagingItemReaderParameterTests-context.xml")
 public class JdbcPagingItemReaderClassicParameterTests extends AbstractJdbcPagingItemReaderParameterTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.junit.runner.RunWith;
-
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -31,16 +29,14 @@ import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Dave Syer
  * @author Thomas Risberg
  * @author Michael Minella
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 public class JdbcPagingItemReaderCommonTests extends AbstractItemStreamItemReaderTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2018 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,18 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.ContextConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import org.springframework.test.util.ReflectionTestUtils;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 public class JdbcPagingItemReaderConfigTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderEmptyResultSetTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderEmptyResultSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,21 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
 
 import javax.sql.DataSource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "JdbcPagingItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "JdbcPagingItemReaderCommonTests-context.xml")
 public class JdbcPagingItemReaderEmptyResultSetTests {
 
 	private static final int PAGE_SIZE = 2;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderNamedParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,13 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -37,12 +35,12 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(
+@SpringJUnitConfig(
 		locations = "/org/springframework/batch/item/database/JdbcPagingItemReaderParameterTests-context.xml")
-@Ignore("This test fails when integration tests are skipped..") // FIXME make this test
-																// independent of other
-																// tests
+@Disabled("This test fails when integration tests are skipped..") // FIXME make this test
+																	// independent of
+																	// other
+																	// tests
 public class JdbcPagingItemReaderNamedParameterTests extends AbstractJdbcPagingItemReaderParameterTests {
 
 	// force jumpToItemQuery in JdbcPagingItemReader.doJumpToPage(int)

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingQueryIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,23 +26,21 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.support.AbstractSqlPagingQueryProvider;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Dave Syer
@@ -50,8 +48,7 @@ import static org.junit.Assert.assertTrue;
  * @author Mahmoud Ben Hassine
  * @since 2.1
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "JdbcPagingItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "JdbcPagingItemReaderCommonTests-context.xml")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class JdbcPagingQueryIntegrationTests {
 
@@ -68,7 +65,7 @@ public class JdbcPagingQueryIntegrationTests {
 
 	private int pageSize = 2;
 
-	@Before
+	@BeforeEach
 	public void testInit() {
 		jdbcTemplate = new JdbcTemplate(dataSource);
 		String[] names = { "Foo", "Bar", "Baz", "Foo", "Bar", "Baz", "Foo", "Bar", "Baz" };
@@ -82,7 +79,7 @@ public class JdbcPagingQueryIntegrationTests {
 		assertEquals(itemCount, JdbcTestUtils.countRowsInTable(jdbcTemplate, "T_FOOS"));
 	}
 
-	@After
+	@AfterEach
 	public void destroy() {
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "T_FOOS");
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingRestartIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingRestartIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -30,11 +30,10 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -44,8 +43,7 @@ import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
 /**
@@ -53,8 +51,7 @@ import org.springframework.test.jdbc.JdbcTestUtils;
  * @author Michael Minella
  * @since 2.1
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "JdbcPagingItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "JdbcPagingItemReaderCommonTests-context.xml")
 public class JdbcPagingRestartIntegrationTests {
 
 	private static Log logger = LogFactory.getLog(JdbcPagingRestartIntegrationTests.class);
@@ -70,7 +67,7 @@ public class JdbcPagingRestartIntegrationTests {
 
 	private int pageSize = 2;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		jdbcTemplate = new JdbcTemplate(dataSource);
 		maxId = jdbcTemplate.queryForObject("SELECT MAX(ID) from T_FOOS", Integer.class);
@@ -81,13 +78,13 @@ public class JdbcPagingRestartIntegrationTests {
 		assertEquals(itemCount, JdbcTestUtils.countRowsInTable(jdbcTemplate, "T_FOOS"));
 	}
 
-	@After
+	@AfterEach
 	public void destroy() {
 		jdbcTemplate.update("DELETE from T_FOOS where ID>?", maxId);
 	}
 
 	@Test
-	@Ignore // FIXME
+	@Disabled // FIXME
 	public void testReaderFromStart() throws Exception {
 
 		ItemReader<Foo> reader = getItemReader();
@@ -110,7 +107,7 @@ public class JdbcPagingRestartIntegrationTests {
 	}
 
 	@Test
-	@Ignore // FIXME
+	@Disabled // FIXME
 	public void testReaderOnRestart() throws Exception {
 
 		ItemReader<Foo> reader = getItemReader();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcParameterUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcParameterUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
-import org.springframework.batch.item.database.JdbcParameterUtils;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.ArrayList;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,9 @@ import java.util.List;
 import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.sample.Person;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,16 +37,14 @@ import org.springframework.orm.jpa.persistenceunit.DefaultPersistenceUnitManager
 import org.springframework.orm.jpa.persistenceunit.PersistenceUnitManager;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = JpaItemWriterIntegrationTests.JpaConfiguration.class)
+@SpringJUnitConfig(classes = JpaItemWriterIntegrationTests.JpaConfiguration.class)
 @Transactional
 @DirtiesContext
 public class JpaItemWriterIntegrationTests {
@@ -58,12 +55,12 @@ public class JpaItemWriterIntegrationTests {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.jdbcTemplate.update("create table person (id int not null primary key, name varchar(32))");
 	}
 
-	@After
+	@AfterEach
 	public void destroy() {
 		JdbcTestUtils.dropTables(this.jdbcTemplate, "person");
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,8 +29,8 @@ import java.util.List;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -46,7 +46,7 @@ public class JpaItemWriterTests {
 
 	JpaItemWriter<Object> writer;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		if (TransactionSynchronizationManager.isSynchronizationActive()) {
 			TransactionSynchronizationManager.clearSynchronization();
@@ -65,8 +65,8 @@ public class JpaItemWriterTests {
 		}
 		catch (IllegalArgumentException e) {
 			// expected
-			assertTrue("Wrong message for exception: " + e.getMessage(),
-					e.getMessage().indexOf("EntityManagerFactory") >= 0);
+			assertTrue(e.getMessage().contains("EntityManagerFactory"),
+					"Wrong message for exception: " + e.getMessage());
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaNativeQueryProviderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaNativeQueryProviderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,13 +24,11 @@ import java.util.List;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.orm.JpaNativeQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -38,8 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "JpaPagingItemReaderCommonTests-context.xml" })
+@SpringJUnitConfig(locations = { "JpaPagingItemReaderCommonTests-context.xml" })
 public class JpaNativeQueryProviderIntegrationTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderAsyncTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderAsyncTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -33,20 +33,17 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "JpaPagingItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "JpaPagingItemReaderCommonTests-context.xml")
 public class JpaPagingItemReaderAsyncTests {
 
 	/**
@@ -69,7 +66,7 @@ public class JpaPagingItemReaderAsyncTests {
 
 	private int maxId;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		maxId = jdbcTemplate.queryForObject("SELECT MAX(ID) from T_FOOS", Integer.class);
@@ -79,7 +76,7 @@ public class JpaPagingItemReaderAsyncTests {
 		assertEquals(ITEM_COUNT, JdbcTestUtils.countRowsInTable(jdbcTemplate, "T_FOOS"));
 	}
 
-	@After
+	@AfterEach
 	public void destroy() {
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		jdbcTemplate.update("DELETE from T_FOOS where ID>?", maxId);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,14 @@ package org.springframework.batch.item.database;
 
 import jakarta.persistence.EntityManagerFactory;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 public class JpaPagingItemReaderCommonTests extends AbstractItemStreamItemReaderTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNamedQueryIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNamedQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,10 @@ package org.springframework.batch.item.database;
 
 import jakarta.persistence.EntityManagerFactory;
 
-import org.junit.runner.RunWith;
-
 import org.springframework.batch.item.database.orm.JpaNamedQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * Integration Test for {@link JpaPagingItemReader} and {@link JpaNamedQueryProvider}.
@@ -31,8 +28,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "JpaPagingItemReaderCommonTests-context.xml" })
+@SpringJUnitConfig(locations = { "JpaPagingItemReaderCommonTests-context.xml" })
 public class JpaPagingItemReaderNamedQueryIntegrationTests extends AbstractPagingItemReaderParameterTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNativeQueryIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderNativeQueryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.Collections;
 import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.database.orm.JpaNativeQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,8 +32,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.persistenceunit.DefaultPersistenceUnitManager;
 import org.springframework.orm.jpa.persistenceunit.PersistenceUnitManager;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -42,8 +40,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = JpaPagingItemReaderNativeQueryIntegrationTests.JpaConfiguration.class)
+@SpringJUnitConfig(classes = JpaPagingItemReaderNativeQueryIntegrationTests.JpaConfiguration.class)
 public class JpaPagingItemReaderNativeQueryIntegrationTests extends AbstractPagingItemReaderParameterTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaPagingItemReaderParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,11 @@ import java.util.Collections;
 
 import jakarta.persistence.EntityManagerFactory;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "JpaPagingItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "JpaPagingItemReaderCommonTests-context.xml")
 public class JpaPagingItemReaderParameterTests extends AbstractPagingItemReaderParameterTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/RepositoryItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/RepositoryItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,23 @@
  */
 package org.springframework.batch.item.database;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.data.RepositoryItemReader;
 import org.springframework.batch.item.sample.books.Author;
 import org.springframework.batch.item.sample.books.Book;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "RepositoryItemReaderCommonTests-context.xml")
+@SpringJUnitConfig(locations = "RepositoryItemReaderCommonTests-context.xml")
 @Transactional
 public class RepositoryItemReaderIntegrationTests {
 
@@ -43,7 +40,7 @@ public class RepositoryItemReaderIntegrationTests {
 	@Autowired
 	private RepositoryItemReader<Author> reader;
 
-	@After
+	@AfterEach
 	public void reinitializeReader() {
 		reader.close();
 	}
@@ -56,9 +53,9 @@ public class RepositoryItemReaderIntegrationTests {
 
 		assertNotNull(author);
 		final List<Book> books = author.getBooks();
-		assertEquals("Books list size must be = 2", 2, books.size());
-		assertEquals("First book must be author 1 - book 1", "author 1 - book 1", books.get(0).getName());
-		assertEquals("Second book must be author 1 - book 2", "author 1 - book 2", books.get(1).getName());
+		assertEquals(2, books.size(), "Books list size must be = 2");
+		assertEquals("author 1 - book 1", books.get(0).getName(), "First book must be author 1 - book 1");
+		assertEquals("author 1 - book 2", books.get(1).getName(), "Second book must be author 1 - book 2");
 	}
 
 	@Test
@@ -70,9 +67,9 @@ public class RepositoryItemReaderIntegrationTests {
 
 		assertNotNull(author);
 		final List<Book> books = author.getBooks();
-		assertEquals("Books list size must be = 2", 2, books.size());
-		assertEquals("First book must be author 2 - book 1", "author 2 - book 1", books.get(0).getName());
-		assertEquals("Second book must be author 2 - book 2", "author 2 - book 2", books.get(1).getName());
+		assertEquals(2, books.size(), "Books list size must be = 2");
+		assertEquals("author 2 - book 1", books.get(0).getName(), "First book must be author 2 - book 1");
+		assertEquals("author 2 - book 2", books.get(1).getName(), "Second book must be author 2 - book 2");
 	}
 
 	@Test
@@ -85,9 +82,9 @@ public class RepositoryItemReaderIntegrationTests {
 
 		assertNotNull(author);
 		final List<Book> books = author.getBooks();
-		assertEquals("Books list size must be = 2", 2, books.size());
-		assertEquals("First book must be author 3 - book 1", "author 3 - book 1", books.get(0).getName());
-		assertEquals("Second book must be author 3 - book 2", "author 3 - book 2", books.get(1).getName());
+		assertEquals(2, books.size(), "Books list size must be = 2");
+		assertEquals("author 3 - book 1", books.get(0).getName(), "First book must be author 3 - book 1");
+		assertEquals("author 3 - book 2", books.get(1).getName(), "Second book must be author 3 - book 2");
 	}
 
 	@Test
@@ -100,9 +97,9 @@ public class RepositoryItemReaderIntegrationTests {
 
 		assertNotNull(author);
 		final List<Book> books = author.getBooks();
-		assertEquals("Books list size must be = 2", 2, books.size());
-		assertEquals("First book must be author 2 - book 1", "author 2 - book 1", books.get(0).getName());
-		assertEquals("Second book must be author 2 - book 2", "author 2 - book 2", books.get(1).getName());
+		assertEquals(2, books.size(), "Books list size must be = 2");
+		assertEquals("author 2 - book 1", books.get(0).getName(), "First book must be author 2 - book 1");
+		assertEquals("author 2 - book 2", books.get(1).getName(), "Second book must be author 2 - book 2");
 	}
 
 	@Test
@@ -116,9 +113,9 @@ public class RepositoryItemReaderIntegrationTests {
 
 		assertNotNull(author);
 		final List<Book> books = author.getBooks();
-		assertEquals("Books list size must be = 2", 2, books.size());
-		assertEquals("First book must be author 3 - book 1", "author 3 - book 1", books.get(0).getName());
-		assertEquals("Second book must be author 3 - book 2", "author 3 - book 2", books.get(1).getName());
+		assertEquals(2, books.size(), "Books list size must be = 2");
+		assertEquals("author 3 - book 1", books.get(0).getName(), "First book must be author 3 - book 1");
+		assertEquals("author 3 - book 2", books.get(1).getName(), "Second book must be author 3 - book 2");
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredProcedureItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredProcedureItemReaderCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import org.hsqldb.types.Types;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ReaderNotOpenException;
@@ -30,7 +28,8 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.SqlParameter;
 
-@RunWith(JUnit4.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class StoredProcedureItemReaderCommonTests extends AbstractDatabaseItemStreamItemReaderTests {
 
 	@Override
@@ -82,11 +81,11 @@ public class StoredProcedureItemReaderCommonTests extends AbstractDatabaseItemSt
 		reader.open(new ExecutionContext());
 	}
 
-	@Test(expected = ReaderNotOpenException.class)
+	@Test
 	public void testReadBeforeOpen() throws Exception {
 		testedAsStream().close();
 		tested = getItemReader();
-		tested.read();
+		assertThrows(ReaderNotOpenException.class, tested::read);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredProcedureItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredProcedureItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,11 @@
  */
 package org.springframework.batch.item.database;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.sample.Foo;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "stored-procedure-context.xml")
+@SpringJUnitConfig(locations = "stored-procedure-context.xml")
 public class StoredProcedureItemReaderIntegrationTests extends AbstractDataSourceItemReaderIntegrationTests {
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredprocedureItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredprocedureItemReaderConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,7 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.hsqldb.types.Types;
-import org.junit.Test;
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.SqlParameter;
@@ -40,7 +38,6 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-@RunWith(JUnit4.class)
 public class StoredprocedureItemReaderConfigTests {
 
 	/*

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateCursorItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.HibernateCursorItemReader;
@@ -39,9 +39,9 @@ import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -52,13 +52,13 @@ public class HibernateCursorItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
 		this.sessionFactory = (SessionFactory) context.getBean("sessionFactory");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernateItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,28 +20,25 @@ import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.database.HibernateItemWriter;
 import org.springframework.batch.item.sample.Foo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Michael Minella
  */
+@ExtendWith(MockitoExtension.class)
 public class HibernateItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private SessionFactory sessionFactory;
@@ -49,9 +46,9 @@ public class HibernateItemWriterBuilderTests {
 	@Mock
 	private Session session;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
-		when(this.sessionFactory.getCurrentSession()).thenReturn(this.session);
+		lenient().when(this.sessionFactory.getCurrentSession()).thenReturn(this.session);
 	}
 
 	@Test
@@ -94,7 +91,7 @@ public class HibernateItemWriterBuilderTests {
 			fail("sessionFactory is required");
 		}
 		catch (IllegalStateException ise) {
-			assertEquals("Incorrect message", "SessionFactory must be provided", ise.getMessage());
+			assertEquals("SessionFactory must be provided", ise.getMessage(), "Incorrect message");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernatePagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/HibernatePagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.HibernateItemReaderHelper;
@@ -41,9 +41,9 @@ import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -55,14 +55,14 @@ public class HibernatePagingItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(
 				HibernatePagingItemReaderBuilderTests.TestDataSourceConfiguration.class);
 		this.sessionFactory = (SessionFactory) context.getBean("sessionFactory");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcBatchItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcBatchItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.JdbcBatchItemWriter;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -43,9 +43,10 @@ import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -56,13 +57,13 @@ public class JdbcBatchItemWriterBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
 		this.dataSource = (DataSource) context.getBean("dataSource");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();
@@ -120,8 +121,8 @@ public class JdbcBatchItemWriterBuilderTests {
 		verifyWrite();
 	}
 
-	@Test(expected = EmptyResultDataAccessException.class)
-	public void testAssertUpdates() throws Exception {
+	@Test
+	public void testAssertUpdates() {
 		JdbcBatchItemWriter<Foo> writer = new JdbcBatchItemWriterBuilder<Foo>().beanMapped().dataSource(this.dataSource)
 				.sql("UPDATE FOO SET second = :second, third = :third WHERE first = :first").assertUpdates(true)
 				.build();
@@ -132,7 +133,7 @@ public class JdbcBatchItemWriterBuilderTests {
 
 		items.add(new Foo(1, "two", "three"));
 
-		writer.write(items);
+		assertThrows(EmptyResultDataAccessException.class, () -> writer.write(items));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.sql.Types;
 import java.util.Arrays;
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.JdbcCursorItemReader;
@@ -39,10 +39,10 @@ import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -56,13 +56,13 @@ public class JdbcCursorItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
 		this.dataSource = (DataSource) context.getBean("dataSource");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.JdbcPagingItemReader;
@@ -39,10 +39,10 @@ import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -54,13 +54,13 @@ public class JdbcPagingItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
 		this.dataSource = (DataSource) context.getBean("dataSource");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaCursorItemReaderBuilderTests.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.JpaCursorItemReader;
@@ -44,9 +44,9 @@ import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -57,14 +57,14 @@ public class JpaCursorItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(
 				JpaCursorItemReaderBuilderTests.TestDataSourceConfiguration.class);
 		this.entityManagerFactory = (EntityManagerFactory) context.getBean("entityManagerFactory");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,28 +20,25 @@ import java.util.List;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Mahmoud Ben Hassine
  */
+@ExtendWith(MockitoExtension.class)
 public class JpaItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private EntityManagerFactory entityManagerFactory;
@@ -49,13 +46,13 @@ public class JpaItemWriterBuilderTests {
 	@Mock
 	private EntityManager entityManager;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		TransactionSynchronizationManager.bindResource(this.entityManagerFactory,
 				new EntityManagerHolder(this.entityManager));
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		TransactionSynchronizationManager.unbindResource(this.entityManagerFactory);
 	}
@@ -82,7 +79,7 @@ public class JpaItemWriterBuilderTests {
 			fail("Should fail if no EntityManagerFactory is provided");
 		}
 		catch (IllegalStateException ise) {
-			assertEquals("Incorrect message", "EntityManagerFactory must be provided", ise.getMessage());
+			assertEquals("EntityManagerFactory must be provided", ise.getMessage(), "Incorrect message");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import java.util.Map;
 import jakarta.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.JpaPagingItemReader;
@@ -44,10 +44,10 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -60,14 +60,14 @@ public class JpaPagingItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(
 				JpaPagingItemReaderBuilderTests.TestDataSourceConfiguration.class);
 		this.entityManagerFactory = (EntityManagerFactory) context.getBean("entityManagerFactory");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package org.springframework.batch.item.database.builder;
 
 import javax.sql.DataSource;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import test.jdbc.datasource.DataSourceInitializer;
 import test.jdbc.datasource.DerbyDataSourceFactoryBean;
 import test.jdbc.datasource.DerbyShutdownBean;
@@ -39,10 +39,10 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -54,13 +54,13 @@ public class StoredProcedureItemReaderBuilderTests {
 
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.context = new AnnotationConfigApplicationContext(TestDataSourceConfiguration.class);
 		this.dataSource = (DataSource) this.context.getBean("dataSource");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		this.context.close();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.batch.item.sample.Foo;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.Order;
 
 /**
@@ -36,7 +36,7 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 
 	protected int pageSize;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		if (pagingQueryProvider == null) {
 			throw new IllegalArgumentException("pagingQueryProvider can't be null");
@@ -55,14 +55,14 @@ public abstract class AbstractSqlPagingQueryProviderTests {
 	@Test
 	public void testQueryContainsSortKey() {
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize).toLowerCase();
-		assertTrue("Wrong query: " + s, s.contains("id asc"));
+		assertTrue(s.contains("id asc"), "Wrong query: " + s);
 	}
 
 	@Test
 	public void testQueryContainsSortKeyDesc() {
 		pagingQueryProvider.getSortKeys().put("id", Order.DESCENDING);
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize).toLowerCase();
-		assertTrue("Wrong query: " + s, s.contains("id desc"));
+		assertTrue(s.contains("id desc"), "Wrong query: " + s);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/ColumnMapExecutionContextRowMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/ColumnMapExecutionContextRowMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,14 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Lucas Ward
  * @author Will Schipp
  */
-public class ColumnMapExecutionContextRowMapperTests extends TestCase {
+public class ColumnMapExecutionContextRowMapperTests {
 
 	private ColumnMapItemPreparedStatementSetter mapper;
 
@@ -35,10 +36,8 @@ public class ColumnMapExecutionContextRowMapperTests extends TestCase {
 
 	private PreparedStatement ps;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
-
 		ps = mock(PreparedStatement.class);
 		mapper = new ColumnMapItemPreparedStatementSetter();
 
@@ -47,11 +46,13 @@ public class ColumnMapExecutionContextRowMapperTests extends TestCase {
 		key.put("2", Integer.valueOf(2));
 	}
 
+	@Test
 	public void testCreateExecutionContextFromEmptyKeys() throws Exception {
 
 		mapper.setValues(new HashMap<>(), ps);
 	}
 
+	@Test
 	public void testCreateSetter() throws Exception {
 
 		ps.setObject(1, Integer.valueOf(1));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/Db2PagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/Db2PagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DefaultDataFieldMaxValueIncrementerFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DefaultDataFieldMaxValueIncrementerFactoryTests.java
@@ -17,10 +17,13 @@ package org.springframework.batch.item.database.support;
 
 import javax.sql.DataSource;
 
-import junit.framework.TestCase;
-
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.support.incrementer.Db2LuwMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.Db2MainframeMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.DerbyMaxValueIncrementer;
@@ -29,7 +32,6 @@ import org.springframework.jdbc.support.incrementer.HsqlMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.MySQLMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.OracleSequenceMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.PostgresSequenceMaxValueIncrementer;
-import org.springframework.jdbc.support.incrementer.SqlServerMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.SybaseMaxValueIncrementer;
 
 /**
@@ -38,23 +40,17 @@ import org.springframework.jdbc.support.incrementer.SybaseMaxValueIncrementer;
  * @author Drummond Dawson
  * @author Mahmoud Ben Hassine
  */
-public class DefaultDataFieldMaxValueIncrementerFactoryTests extends TestCase {
+public class DefaultDataFieldMaxValueIncrementerFactoryTests {
 
 	private DefaultDataFieldMaxValueIncrementerFactory factory;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see junit.framework.TestCase#setUp()
-	 */
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
-
 		DataSource dataSource = mock(DataSource.class);
 		factory = new DefaultDataFieldMaxValueIncrementerFactory(dataSource);
 	}
 
+	@Test
 	public void testSupportedDatabaseType() {
 		assertTrue(factory.isSupportedIncrementerType("db2"));
 		assertTrue(factory.isSupportedIncrementerType("db2zos"));
@@ -69,10 +65,12 @@ public class DefaultDataFieldMaxValueIncrementerFactoryTests extends TestCase {
 		assertTrue(factory.isSupportedIncrementerType("hana"));
 	}
 
+	@Test
 	public void testUnsupportedDatabaseType() {
 		assertFalse(factory.isSupportedIncrementerType("invalidtype"));
 	}
 
+	@Test
 	public void testInvalidDatabaseType() {
 		try {
 			factory.getIncrementer("invalidtype", "NAME");
@@ -83,6 +81,7 @@ public class DefaultDataFieldMaxValueIncrementerFactoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNullIncrementerName() {
 		try {
 			factory.getIncrementer("db2", null);
@@ -93,47 +92,58 @@ public class DefaultDataFieldMaxValueIncrementerFactoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDb2() {
 		assertTrue(factory.getIncrementer("db2", "NAME") instanceof Db2LuwMaxValueIncrementer);
 	}
 
+	@Test
 	public void testDb2zos() {
 		assertTrue(factory.getIncrementer("db2zos", "NAME") instanceof Db2MainframeMaxValueIncrementer);
 	}
 
+	@Test
 	public void testMysql() {
 		assertTrue(factory.getIncrementer("mysql", "NAME") instanceof MySQLMaxValueIncrementer);
 	}
 
+	@Test
 	public void testOracle() {
 		factory.setIncrementerColumnName("ID");
 		assertTrue(factory.getIncrementer("oracle", "NAME") instanceof OracleSequenceMaxValueIncrementer);
 	}
 
+	@Test
 	public void testDerby() {
 		assertTrue(factory.getIncrementer("derby", "NAME") instanceof DerbyMaxValueIncrementer);
 	}
 
+	@Test
 	public void testHsql() {
 		assertTrue(factory.getIncrementer("hsql", "NAME") instanceof HsqlMaxValueIncrementer);
 	}
 
+	@Test
 	public void testPostgres() {
 		assertTrue(factory.getIncrementer("postgres", "NAME") instanceof PostgresSequenceMaxValueIncrementer);
 	}
 
+	@Test
 	public void testMsSqlServer() {
 		assertTrue(factory.getIncrementer("sqlserver", "NAME") instanceof SqlServerSequenceMaxValueIncrementer);
 	}
 
+	@Test
 	public void testSybase() {
 		assertTrue(factory.getIncrementer("sybase", "NAME") instanceof SybaseMaxValueIncrementer);
 	}
 
+	@Test
 	public void testSqlite() {
 		assertTrue(factory.getIncrementer("sqlite", "NAME") instanceof SqliteMaxValueIncrementer);
 	}
 
+	@Test
 	public void testHana() {
 		assertTrue(factory.getIncrementer("hana", "NAME") instanceof HanaSequenceMaxValueIncrementer);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DerbyPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DerbyPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,17 @@ package org.springframework.batch.item.database.support;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 
 import javax.sql.DataSource;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.Order;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 
@@ -86,7 +86,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	public void testGenerateFirstPageQuery() {
 		String sql = "SELECT * FROM ( SELECT TMP_ORDERED.*, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1 ) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		Assert.assertEquals(sql, s);
+		Assertions.assertEquals(sql, s);
 	}
 
 	@Test
@@ -94,7 +94,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	public void testGenerateRemainingPagesQuery() {
 		String sql = "SELECT * FROM ( SELECT TMP_ORDERED.*, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1 ) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100 AND ((id > ?)) ORDER BY id ASC";
 		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		Assert.assertEquals(sql, s);
+		Assertions.assertEquals(sql, s);
 	}
 
 	@Test
@@ -102,7 +102,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	public void testGenerateJumpToItemQuery() {
 		String sql = "SELECT id FROM ( SELECT id, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1 ) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		Assert.assertEquals(sql, s);
+		Assertions.assertEquals(sql, s);
 	}
 
 	@Test
@@ -110,7 +110,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	public void testGenerateJumpToItemQueryForFirstPage() {
 		String sql = "SELECT id FROM ( SELECT id, ROW_NUMBER() OVER () AS ROW_NUMBER FROM (SELECT id, name, age FROM foo WHERE bar = 1 ) AS TMP_ORDERED) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		Assert.assertEquals(sql, s);
+		Assertions.assertEquals(sql, s);
 	}
 
 	/**
@@ -121,7 +121,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	@Override
 	public void testQueryContainsSortKey() {
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize).toLowerCase();
-		assertTrue("Wrong query: " + s, s.contains("id asc"));
+		assertTrue(s.contains("id asc"), "Wrong query: " + s);
 	}
 
 	/**
@@ -133,7 +133,7 @@ public class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProvide
 	public void testQueryContainsSortKeyDesc() {
 		pagingQueryProvider.getSortKeys().put("id", Order.DESCENDING);
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize).toLowerCase();
-		assertTrue("Wrong query: " + s, s.contains("id desc"));
+		assertTrue(s.contains("id desc"), "Wrong query: " + s);
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HanaPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HanaPagingQueryProviderTests.java
@@ -18,11 +18,11 @@ package org.springframework.batch.item.database.support;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.Order;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Jonathan Bregler

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HibernateNativeQueryProviderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HibernateNativeQueryProviderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,25 +25,22 @@ import javax.sql.DataSource;
 
 import org.hibernate.query.Query;
 import org.hibernate.SessionFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.orm.HibernateNativeQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Anatoly Polinsky
  * @author Dave Syer
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "../data-source-context.xml")
+@SpringJUnitConfig(locations = "../data-source-context.xml")
 public class HibernateNativeQueryProviderIntegrationTests {
 
 	protected DataSource dataSource;
@@ -62,7 +59,7 @@ public class HibernateNativeQueryProviderIntegrationTests {
 		hibernateQueryProvider.setEntityClass(Foo.class);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		LocalSessionFactoryBean factoryBean = new LocalSessionFactoryBean();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HibernateNativeQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HibernateNativeQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2008 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ package org.springframework.batch.item.database.support;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.hibernate.query.NativeQuery;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.orm.HibernateNativeQueryProvider;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HsqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HsqlPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/JpaNativeQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/JpaNativeQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.batch.item.database.support;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.orm.JpaNativeQueryProvider;
 import org.springframework.batch.item.sample.Foo;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/MySqlPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/MySqlPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.springframework.batch.item.database.support;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.database.Order;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/OraclePagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/OraclePagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/PostgresPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/PostgresPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg
@@ -50,7 +50,7 @@ public class PostgresPagingQueryProviderTests extends AbstractSqlPagingQueryProv
 	public void testGenerateJumpToItemQuery() {
 		String sql = "SELECT id FROM foo WHERE bar = 1 ORDER BY id ASC LIMIT 1 OFFSET 99";
 		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals("Wrong SQL for jump to", sql, s);
+		assertEquals(sql, s, "Wrong SQL for jump to");
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class PostgresPagingQueryProviderTests extends AbstractSqlPagingQueryProv
 	public void testGenerateJumpToItemQueryForFirstPage() {
 		String sql = "SELECT id FROM foo WHERE bar = 1 ORDER BY id ASC LIMIT 1 OFFSET 0";
 		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals("Wrong SQL for first page", sql, s);
+		assertEquals(sql, s, "Wrong SQL for first page");
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBeanTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,17 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.Order;
 import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.batch.support.DatabaseType;
@@ -66,18 +67,16 @@ public class SqlPagingQueryProviderFactoryBeanTests {
 		assertEquals(true, factory.isSingleton());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testNoDataSource() throws Exception {
+	@Test
+	public void testNoDataSource() {
 		factory.setDataSource(null);
-		PagingQueryProvider provider = factory.getObject();
-		assertNotNull(provider);
+		assertThrows(IllegalArgumentException.class, factory::getObject);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testNoSortKey() throws Exception {
+	@Test
+	public void testNoSortKey() {
 		factory.setSortKeys(null);
-		PagingQueryProvider provider = factory.getObject();
-		assertNotNull(provider);
+		assertThrows(IllegalArgumentException.class, factory::getObject);
 	}
 
 	@Test
@@ -85,28 +84,26 @@ public class SqlPagingQueryProviderFactoryBeanTests {
 		factory.setWhereClause("x=y");
 		PagingQueryProvider provider = factory.getObject();
 		String query = provider.generateFirstPageQuery(100);
-		assertTrue("Wrong query: " + query, query.contains("x=y"));
+		assertTrue(query.contains("x=y"), "Wrong query: " + query);
 	}
 
 	@Test
 	public void testAscending() throws Exception {
 		PagingQueryProvider provider = factory.getObject();
 		String query = provider.generateFirstPageQuery(100);
-		assertTrue("Wrong query: " + query, query.contains("ASC"));
+		assertTrue(query.contains("ASC"), "Wrong query: " + query);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testWrongDatabaseType() throws Exception {
+	@Test
+	public void testWrongDatabaseType() {
 		factory.setDatabaseType("NoSuchDb");
-		PagingQueryProvider provider = factory.getObject();
-		assertNotNull(provider);
+		assertThrows(IllegalArgumentException.class, factory::getObject);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMissingMetaData() throws Exception {
 		factory.setDataSource(DatabaseTypeTestUtils.getMockDataSource(new MetaDataAccessException("foo")));
-		PagingQueryProvider provider = factory.getObject();
-		assertNotNull(provider);
+		assertThrows(IllegalArgumentException.class, factory::getObject);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.Order;
 import org.springframework.util.StringUtils;
 
@@ -37,7 +37,7 @@ public class SqlPagingQueryUtilsTests {
 
 	private Map<String, Order> sortKeys;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		sortKeys = new LinkedHashMap<>();
 		sortKeys.put("ID", Order.ASCENDING);
@@ -151,11 +151,11 @@ public class SqlPagingQueryUtilsTests {
 		sortKeys.put("ID", Order.DESCENDING);
 		AbstractSqlPagingQueryProvider qp = new TestSqlPagingQueryProvider("FOO", "BAR", sortKeys);
 		String query = SqlPagingQueryUtils.generateTopJumpToQuery(qp, "TOP 100, 1");
-		assertTrue("Wrong query: " + query, query.contains("ID DESC"));
-		assertEquals("Wrong query: " + query, 0, StringUtils.countOccurrencesOf(query, "ASC"));
-		assertEquals("Wrong query: " + query, 1, StringUtils.countOccurrencesOf(query, "DESC"));
+		assertTrue(query.contains("ID DESC"), "Wrong query: " + query);
+		assertEquals(0, StringUtils.countOccurrencesOf(query, "ASC"), "Wrong query: " + query);
+		assertEquals(1, StringUtils.countOccurrencesOf(query, "DESC"), "Wrong query: " + query);
 		qp.setWhereClause("BAZ IS NOT NULL");
-		assertTrue("Wrong query: " + query, query.contains("ID DESC"));
+		assertTrue(query.contains("ID DESC"), "Wrong query: " + query);
 	}
 
 	@Test
@@ -163,11 +163,11 @@ public class SqlPagingQueryUtilsTests {
 		sortKeys.put("ID", Order.DESCENDING);
 		AbstractSqlPagingQueryProvider qp = new TestSqlPagingQueryProvider("FOO", "BAR", sortKeys);
 		String query = SqlPagingQueryUtils.generateLimitJumpToQuery(qp, "LIMIT 100, 1");
-		assertTrue("Wrong query: " + query, query.contains("ID DESC"));
-		assertEquals("Wrong query: " + query, 0, StringUtils.countOccurrencesOf(query, "ASC"));
-		assertEquals("Wrong query: " + query, 1, StringUtils.countOccurrencesOf(query, "DESC"));
+		assertTrue(query.contains("ID DESC"), "Wrong query: " + query);
+		assertEquals(0, StringUtils.countOccurrencesOf(query, "ASC"), "Wrong query: " + query);
+		assertEquals(1, StringUtils.countOccurrencesOf(query, "DESC"), "Wrong query: " + query);
 		qp.setWhereClause("BAZ IS NOT NULL");
-		assertTrue("Wrong query: " + query, query.contains("ID DESC"));
+		assertTrue(query.contains("ID DESC"), "Wrong query: " + query);
 	}
 
 	private static class TestSqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlServerSequenceMaxValueIncrementerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlServerSequenceMaxValueIncrementerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,16 @@ package org.springframework.batch.item.database.support;
 
 import javax.sql.DataSource;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.junit.Assert.assertEquals;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SqlServerSequenceMaxValueIncrementerTests {
 
 	@Mock
@@ -45,7 +43,7 @@ public class SqlServerSequenceMaxValueIncrementerTests {
 		String sequenceQuery = this.incrementer.getSequenceQuery();
 
 		// then
-		Assert.assertEquals("select next value for BATCH_JOB_SEQ", sequenceQuery);
+		Assertions.assertEquals("select next value for BATCH_JOB_SEQ", sequenceQuery);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlWindowingPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlWindowingPagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.springframework.batch.item.database.support;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.Order;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Thomas Risberg
@@ -39,7 +39,7 @@ public class SqlWindowingPagingQueryProviderTests extends AbstractSqlPagingQuery
 	public void testGenerateFirstPageQuery() {
 		String sql = "SELECT * FROM ( SELECT *, ROW_NUMBER() OVER ( ORDER BY id ASC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test
@@ -47,7 +47,7 @@ public class SqlWindowingPagingQueryProviderTests extends AbstractSqlPagingQuery
 	public void testGenerateRemainingPagesQuery() {
 		String sql = "SELECT * FROM ( SELECT *, ROW_NUMBER() OVER ( ORDER BY id ASC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER <= 100 AND ((id > ?)) ORDER BY id ASC";
 		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class SqlWindowingPagingQueryProviderTests extends AbstractSqlPagingQuery
 	public void testGenerateJumpToItemQuery() {
 		String sql = "SELECT id FROM ( SELECT id, ROW_NUMBER() OVER ( ORDER BY id ASC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 100 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test
@@ -63,7 +63,7 @@ public class SqlWindowingPagingQueryProviderTests extends AbstractSqlPagingQuery
 	public void testGenerateJumpToItemQueryForFirstPage() {
 		String sql = "SELECT id FROM ( SELECT id, ROW_NUMBER() OVER ( ORDER BY id ASC) AS ROW_NUMBER FROM foo WHERE bar = 1) AS TMP_SUB WHERE TMP_SUB.ROW_NUMBER = 1 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		Assert.assertEquals("", sql, s);
+		Assertions.assertEquals(sql, s);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqliteMaxValueIncrementerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqliteMaxValueIncrementerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.test.jdbc.JdbcTestUtils;
@@ -36,7 +36,7 @@ public class SqliteMaxValueIncrementerTests {
 	static SimpleDriverDataSource dataSource;
 	static JdbcTemplate template;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() {
 		dbFile = System.getProperty("java.io.tmpdir") + File.separator + "batch_sqlite_inc.db";
 		dataSource = new SimpleDriverDataSource();
@@ -46,7 +46,7 @@ public class SqliteMaxValueIncrementerTests {
 		template.execute("create table max_value (id integer primary key autoincrement)");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void removeDbFile() {
 		File db = new File(dbFile);
 		if (db.exists()) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlitePagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlitePagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SybasePagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SybasePagingQueryProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.database.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Risberg
@@ -34,7 +34,7 @@ public class SybasePagingQueryProviderTests extends AbstractSqlPagingQueryProvid
 	public void testGenerateFirstPageQuery() {
 		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE bar = 1 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateFirstPageQuery(pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test
@@ -42,7 +42,7 @@ public class SybasePagingQueryProviderTests extends AbstractSqlPagingQueryProvid
 	public void testGenerateRemainingPagesQuery() {
 		String sql = "SELECT TOP 100 id, name, age FROM foo WHERE (bar = 1) AND ((id > ?)) ORDER BY id ASC";
 		String s = pagingQueryProvider.generateRemainingPagesQuery(pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test
@@ -50,7 +50,7 @@ public class SybasePagingQueryProviderTests extends AbstractSqlPagingQueryProvid
 	public void testGenerateJumpToItemQuery() {
 		String sql = "SELECT id FROM ( SELECT id, ROW_NUMBER() OVER ( ORDER BY id ASC) AS ROW_NUMBER FROM foo WHERE bar = 1) WHERE ROW_NUMBER = 100 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateJumpToItemQuery(145, pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class SybasePagingQueryProviderTests extends AbstractSqlPagingQueryProvid
 	public void testGenerateJumpToItemQueryForFirstPage() {
 		String sql = "SELECT id FROM ( SELECT id, ROW_NUMBER() OVER ( ORDER BY id ASC) AS ROW_NUMBER FROM foo WHERE bar = 1) WHERE ROW_NUMBER = 1 ORDER BY id ASC";
 		String s = pagingQueryProvider.generateJumpToItemQuery(45, pageSize);
-		assertEquals("", sql, s);
+		assertEquals(sql, s);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/DefaultBufferedReaderFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/DefaultBufferedReaderFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 
 /**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,18 @@ package org.springframework.batch.item.file;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemCountAware;
@@ -62,7 +63,7 @@ public class FlatFileItemReaderTests {
 	private Resource inputResource1 = getInputResource(
 			"testLine1\ntestLine2\ntestLine3\ntestLine4\ntestLine5\ntestLine6");
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		reader.setResource(inputResource1);
@@ -433,7 +434,7 @@ public class FlatFileItemReaderTests {
 	/**
 	 * In strict mode, resource must exist at the time reader is opened.
 	 */
-	@Test(expected = ItemStreamException.class)
+	@Test
 	public void testStrictness() throws Exception {
 
 		Resource resource = new NonExistentResource();
@@ -443,7 +444,7 @@ public class FlatFileItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		reader.open(executionContext);
+		assertThrows(ItemStreamException.class, () -> reader.open(executionContext));
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
@@ -28,9 +28,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -46,12 +46,12 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.ClassUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests of regular usage for {@link FlatFileItemWriter} Exception cases will be in
@@ -82,7 +82,7 @@ public class FlatFileItemWriterTests {
 	 * Create temporary output file, define mock behaviour, set dependencies and
 	 * initialize the object under test
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		outputFile = File.createTempFile("flatfile-test-output-", ".tmp");
@@ -99,7 +99,7 @@ public class FlatFileItemWriterTests {
 	/**
 	 * Release resources and delete the temporary output file
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (reader != null) {
 			reader.close();
@@ -531,9 +531,9 @@ public class FlatFileItemWriterTests {
 		writer.setResource(file);
 		new File(file.getFile().getParent()).mkdirs();
 		file.getFile().createNewFile();
-		assertTrue("Test file must exist: " + file, file.exists());
-		assertTrue("Test file set to read-only: " + file, file.getFile().setReadOnly());
-		assertFalse("Should be readonly file: " + file, file.getFile().canWrite());
+		assertTrue(file.exists(), "Test file must exist: " + file);
+		assertTrue(file.getFile().setReadOnly(), "Test file set to read-only: " + file);
+		assertFalse(file.getFile().canWrite(), "Should be readonly file: " + file);
 		writer.afterPropertiesSet();
 		try {
 			writer.open(executionContext);
@@ -541,7 +541,7 @@ public class FlatFileItemWriterTests {
 		}
 		catch (IllegalStateException e) {
 			String message = e.getMessage();
-			assertTrue("Message does not contain 'writable': " + message, message.indexOf("writable") >= 0);
+			assertTrue(message.contains("writable"), "Message does not contain 'writable': " + message);
 		}
 	}
 
@@ -844,13 +844,13 @@ public class FlatFileItemWriterTests {
 		outputFile = toBeCreated.getFile(); // enable easy content reading and auto-delete
 											// the file
 
-		assertFalse("output file does not exist yet", toBeCreated.exists());
+		assertFalse(toBeCreated.exists(), "output file does not exist yet");
 		writer.setResource(toBeCreated);
 		writer.setAppendAllowed(true);
 		writer.afterPropertiesSet();
 
 		writer.open(executionContext);
-		assertTrue("output file was created", toBeCreated.exists());
+		assertTrue(toBeCreated.exists(), "output file was created");
 
 		writer.write(Collections.singletonList("test1"));
 		writer.close();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileParseExceptionTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileParseExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package org.springframework.batch.item.file;
 
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.support.AbstractExceptionTests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FlatFileParseExceptionTests extends AbstractExceptionTests {
 
@@ -30,6 +33,7 @@ public class FlatFileParseExceptionTests extends AbstractExceptionTests {
 		return new FlatFileParseException(msg, t, "bar", 100);
 	}
 
+	@Test
 	public void testMessageInputLineCount() throws Exception {
 		FlatFileParseException exception = new FlatFileParseException("foo", "bar", 100);
 		assertEquals("foo", exception.getMessage());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderFlatFileTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderFlatFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ package org.springframework.batch.item.file;
 
 import java.util.Comparator;
 
-import org.junit.runners.JUnit4;
-import org.junit.runner.RunWith;
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -26,7 +24,6 @@ import org.springframework.batch.item.sample.Foo;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
-@RunWith(JUnit4.class)
 public class MultiResourceItemReaderFlatFileTests extends AbstractItemStreamItemReaderTests {
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Comparator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -62,7 +62,7 @@ public class MultiResourceItemReaderIntegrationTests {
 	/**
 	 * Setup the tested reader to read from the test resources.
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		itemReader.setLineMapper(new PassThroughLineMapper());
@@ -406,12 +406,12 @@ public class MultiResourceItemReaderIntegrationTests {
 	/**
 	 * No resources to read should result in error in strict mode.
 	 */
-	@Test(expected = IllegalStateException.class)
-	public void testStrictModeEnabled() throws Exception {
+	@Test
+	public void testStrictModeEnabled() {
 		tested.setResources(new Resource[] {});
 		tested.setStrict(true);
 
-		tested.open(ctx);
+		assertThrows(IllegalStateException.class, () -> tested.open(ctx));
 	}
 
 	/**
@@ -423,7 +423,7 @@ public class MultiResourceItemReaderIntegrationTests {
 		tested.setStrict(false);
 
 		tested.open(ctx);
-		assertTrue("empty input doesn't cause an error", true);
+		assertTrue(true, "empty input doesn't cause an error");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderResourceAwareTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderResourceAwareTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package org.springframework.batch.item.file;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ResourceAware;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import java.util.Comparator;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests to ensure that the current Resource is correctly being set on items that
@@ -52,7 +52,7 @@ public class MultiResourceItemReaderResourceAwareTests {
 	/**
 	 * Setup the tested reader to read from the test resources.
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		itemReader.setLineMapper(new FooLineMapper());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderXmlTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderXmlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -25,8 +25,6 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.transform.Source;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -38,7 +36,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.oxm.XmlMappingException;
 
-@RunWith(JUnit4.class)
 public class MultiResourceItemReaderXmlTests extends AbstractItemStreamItemReaderTests {
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterFlatFileTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterFlatFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2017 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,8 +24,8 @@ import java.io.Writer;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -65,7 +65,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 
 	private FlatFileItemWriter<String> delegate;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.createFile();
 		delegate = new FlatFileItemWriter<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterXmlTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterXmlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2017 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,8 +26,8 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.transform.Result;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.xml.StaxEventItemWriter;
 import org.springframework.batch.item.xml.StaxTestUtils;
 import org.springframework.oxm.Marshaller;
@@ -45,7 +45,7 @@ public class MultiResourceItemWriterXmlTests extends AbstractMultiResourceItemWr
 
 	private StaxEventItemWriter<String> delegate;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.createFile();
 		delegate = new StaxEventItemWriter<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/ResourcesItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/ResourcesItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2013 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -27,7 +27,7 @@ public class ResourcesItemReaderTests {
 
 	private ResourcesItemReader reader = new ResourcesItemReader();
 
-	@Before
+	@BeforeEach
 	public void init() {
 		reader.setResources(
 				new Resource[] { new ByteArrayResource("foo".getBytes()), new ByteArrayResource("bar".getBytes()) });

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 
 /**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/SimpleResourceSuffixCreatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/SimpleResourceSuffixCreatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.file;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link SimpleResourceSuffixCreator}.

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.io.LineNumberReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.file.FlatFileItemReader;
@@ -40,10 +40,10 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -382,15 +382,17 @@ public class FlatFileItemReaderBuilderTests {
 		catch (IllegalStateException iae) {
 			assertEquals("A name is required when saveState is set to true.", iae.getMessage());
 		}
-		assertNotNull("builder should return new instance of FlatFileItemReader",
+		assertNotNull(
 				new FlatFileItemReaderBuilder<Foo>().resource(getResource("1  2  3")).fixedLength()
 						.columns(new Range(1, 3), new Range(4, 6), new Range(7)).names("first", "second", "third")
-						.targetType(Foo.class).saveState(false).build());
+						.targetType(Foo.class).saveState(false).build(),
+				"builder should return new instance of FlatFileItemReader");
 
-		assertNotNull("builder should return new instance of FlatFileItemReader",
+		assertNotNull(
 				new FlatFileItemReaderBuilder<Foo>().resource(getResource("1  2  3")).fixedLength()
 						.columns(new Range(1, 3), new Range(4, 6), new Range(7)).names("first", "second", "third")
-						.targetType(Foo.class).name("foobar").build());
+						.targetType(Foo.class).name("foobar").build(),
+				"builder should return new instance of FlatFileItemReader");
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
@@ -22,7 +22,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 
@@ -33,9 +33,10 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Michael Minella
@@ -48,17 +49,20 @@ public class FlatFileItemWriterBuilderTests {
 	// reads the output file to check the result
 	private BufferedReader reader;
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMissingLineAggregator() {
-		new FlatFileItemWriterBuilder<Foo>().build();
+		FlatFileItemWriterBuilder<Foo> builder = new FlatFileItemWriterBuilder<>();
+		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testMultipleLineAggregators() throws IOException {
 		WritableResource output = new FileSystemResource(File.createTempFile("foo", "txt"));
 
-		new FlatFileItemWriterBuilder<Foo>().name("itemWriter").resource(output).delimited().delimiter(";")
-				.names("foo", "bar").formatted().format("%2s%2s").names("foo", "bar").build();
+		FlatFileItemWriterBuilder<Foo> builder = new FlatFileItemWriterBuilder<Foo>().name("itemWriter")
+				.resource(output).delimited().delimiter(";").names("foo", "bar").formatted().format("%2s%2s")
+				.names("foo", "bar");
+		assertThrows(IllegalStateException.class, builder::build);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/MultiResourceItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/MultiResourceItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.batch.item.file.builder;
 
 import java.util.Comparator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.AbstractItemStreamItemReaderTests;
 import org.springframework.batch.item.ExecutionContext;
@@ -29,8 +29,8 @@ import org.springframework.batch.item.sample.Foo;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -70,8 +70,8 @@ public class MultiResourceItemReaderBuilderTests extends AbstractItemStreamItemR
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", "delegate is required.",
-					ise.getMessage());
+			assertEquals("delegate is required.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -83,8 +83,8 @@ public class MultiResourceItemReaderBuilderTests extends AbstractItemStreamItemR
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"resources array is required.", ise.getMessage());
+			assertEquals("resources array is required.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/MultiResourceItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/MultiResourceItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.Arrays;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.file.FlatFileItemWriter;
@@ -34,9 +34,9 @@ import org.springframework.batch.item.file.SimpleResourceSuffixCreator;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.core.io.FileSystemResource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Glenn Renfro
@@ -58,7 +58,7 @@ public class MultiResourceItemWriterBuilderTests {
 
 	private FlatFileItemWriter<String> delegate;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.delegate = new FlatFileItemWriter<>();
 		this.delegate.setLineAggregator(new PassThroughLineAggregator<>());
@@ -66,7 +66,7 @@ public class MultiResourceItemWriterBuilderTests {
 		this.writer = null;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (this.writer != null) {
 			this.writer.close();
@@ -212,8 +212,8 @@ public class MultiResourceItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"A name is required when saveState is true.", ise.getMessage());
+			assertEquals("A name is required when saveState is true.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -226,8 +226,8 @@ public class MultiResourceItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", "resource is required.",
-					ise.getMessage());
+			assertEquals("resource is required.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 
@@ -240,8 +240,8 @@ public class MultiResourceItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", "delegate is required.",
-					ise.getMessage());
+			assertEquals("delegate is required.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperConcurrentTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperConcurrentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item.file.mapping;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,8 +25,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
 
 public class BeanWrapperFieldSetMapperConcurrentTests {
@@ -49,7 +49,7 @@ public class BeanWrapperFieldSetMapperConcurrentTests {
 				public Boolean call() throws Exception {
 					for (int i = 0; i < 10; i++) {
 						GreenBean bean = mapper.mapFieldSet(lineTokenizer.tokenize("blue,green"));
-						Assert.assertEquals("green", bean.getGreen());
+						Assertions.assertEquals("green", bean.getGreen());
 					}
 					return true;
 				}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperFuzzyMatchingTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperFuzzyMatchingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,26 @@
 
 package org.springframework.batch.item.file.mapping;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
 import org.springframework.beans.NotWritablePropertyException;
 import org.springframework.validation.BindException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class BeanWrapperFieldSetMapperFuzzyMatchingTests {
 
-	@Test(expected = NotWritablePropertyException.class)
-	public void testFuzzyMatchingWithKeyCandidateCollision() throws BindException {
+	@Test
+	public void testFuzzyMatchingWithKeyCandidateCollision() {
 		BeanWrapperFieldSetMapper<GreenBean> mapper = new BeanWrapperFieldSetMapper<>();
 		mapper.setStrict(true);
 		mapper.setTargetType(GreenBean.class);
 		DelimitedLineTokenizer lineTokenizer = new DelimitedLineTokenizer();
 		String[] names = { "brown", "green", "great", "groin", "braun" };
 		lineTokenizer.setNames(names);
-		GreenBean bean = mapper.mapFieldSet(lineTokenizer.tokenize("brown,green,great,groin,braun"));
-		Assert.assertEquals("green", bean.getGreen());
+		assertThrows(NotWritablePropertyException.class,
+				() -> mapper.mapFieldSet(lineTokenizer.tokenize("brown,green,great,groin,braun")));
 	}
 
 	@Test
@@ -46,7 +48,7 @@ public class BeanWrapperFieldSetMapperFuzzyMatchingTests {
 		String[] names = { "brown", "green", "great", "groin", "braun" };
 		lineTokenizer.setNames(names);
 		GreenBean bean = mapper.mapFieldSet(lineTokenizer.tokenize("brown,green,great,groin,braun"));
-		Assert.assertEquals("green", bean.getGreen());
+		Assertions.assertEquals("green", bean.getGreen());
 	}
 
 	@Test
@@ -59,8 +61,8 @@ public class BeanWrapperFieldSetMapperFuzzyMatchingTests {
 		lineTokenizer.setNames(names);
 		BlueBean bean = mapper.mapFieldSet(lineTokenizer.tokenize("blue"));
 		// An exact match always wins...
-		Assert.assertEquals("blue", bean.getBlue());
-		Assert.assertEquals(null, bean.getBleu());
+		Assertions.assertEquals("blue", bean.getBlue());
+		Assertions.assertEquals(null, bean.getBleu());
 	}
 
 	public static class GreenBean {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.file.transform.FieldSet;
@@ -51,9 +51,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.DataBinder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BeanWrapperFieldSetMapperTests {
 
@@ -61,12 +61,12 @@ public class BeanWrapperFieldSetMapperTests {
 
 	private TimeZone defaultTimeZone = TimeZone.getDefault();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		TimeZone.setDefault(UTC_TIME_ZONE);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		TimeZone.setDefault(defaultTimeZone);
 	}
@@ -466,7 +466,7 @@ public class BeanWrapperFieldSetMapperTests {
 		mapper.afterPropertiesSet();
 		TestObject bean = mapper.mapFieldSet(fieldSet);
 
-		assertEquals("Expecting the conversion to have returned \"CONVERTED\"", bean.getVarString(), "CONVERTED");
+		assertEquals(bean.getVarString(), "CONVERTED", "Expecting the conversion to have returned \"CONVERTED\"");
 	}
 
 	@Test
@@ -491,17 +491,17 @@ public class BeanWrapperFieldSetMapperTests {
 
 		TestObject bean = mapper.mapFieldSet(fieldSet);
 
-		assertEquals("Expected 12 for varInt", bean.getVarInt(), 12);
-		assertEquals("Expected 12345 for varLong", bean.getVarLong(), 12345L);
-		assertEquals("Expected true for varBoolean", bean.isVarBoolean(), true);
-		assertEquals("Expected Z for varChar", bean.getVarChar(), 'Z');
-		assertEquals("Expected A for varByte", bean.getVarByte(), 123);
-		assertEquals("Expected 12345 for varFloat", bean.getVarFloat(), 12345F, 1F);
-		assertEquals("Expected 12345 for varDouble", bean.getVarDouble(), 12345D, 1D);
-		assertEquals("Expected 12 for varShort", bean.getVarShort(), 12);
-		assertEquals("Expected currentDate for varDate", bean.getVarDate().toString(), dateString);
-		assertEquals("Expected 12345 for varBigDecimal", bean.getVarBigDecimal(), bigDecimal);
-		assertEquals("Expected " + sampleString + " for varString", bean.getVarString(), sampleString);
+		assertEquals(bean.getVarInt(), 12, "Expected 12 for varInt");
+		assertEquals(bean.getVarLong(), 12345L, "Expected 12345 for varLong");
+		assertEquals(bean.isVarBoolean(), true, "Expected true for varBoolean");
+		assertEquals(bean.getVarChar(), 'Z', "Expected Z for varChar");
+		assertEquals(bean.getVarByte(), 123, "Expected A for varByte");
+		assertEquals(bean.getVarFloat(), 12345F, 1F, "Expected 12345 for varFloat");
+		assertEquals(bean.getVarDouble(), 12345D, 1D, "Expected 12345 for varDouble");
+		assertEquals(bean.getVarShort(), 12, "Expected 12 for varShort");
+		assertEquals(bean.getVarDate().toString(), dateString, "Expected currentDate for varDate");
+		assertEquals(bean.getVarBigDecimal(), bigDecimal, "Expected 12345 for varBigDecimal");
+		assertEquals(bean.getVarString(), sampleString, "Expected " + sampleString + " for varString");
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/DefaultLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/DefaultLineMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 package org.springframework.batch.item.file.mapping;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
 import org.springframework.batch.item.file.transform.FieldSet;
@@ -32,17 +33,15 @@ public class DefaultLineMapperTests {
 
 	private DefaultLineMapper<String> tested = new DefaultLineMapper<>();
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testMandatoryTokenizer() throws Exception {
-		tested.afterPropertiesSet();
-		tested.mapLine("foo", 1);
+	@Test
+	public void testMandatoryTokenizer() {
+		assertThrows(IllegalArgumentException.class, tested::afterPropertiesSet);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testMandatoryMapper() throws Exception {
+	@Test
+	public void testMandatoryMapper() {
 		tested.setLineTokenizer(new DelimitedLineTokenizer());
-		tested.afterPropertiesSet();
-		tested.mapLine("foo", 1);
+		assertThrows(IllegalArgumentException.class, tested::afterPropertiesSet);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/JsonLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/JsonLineMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2010 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package org.springframework.batch.item.file.mapping;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonLineMapperTests {
 
@@ -40,10 +41,9 @@ public class JsonLineMapperTests {
 		assertEquals(2, ((Map<String, Object>) map.get("bar")).get("foo"));
 	}
 
-	@Test(expected = JsonParseException.class)
-	public void testMappingError() throws Exception {
-		Map<String, Object> map = mapper.mapLine("{\"foo\": 1", 1);
-		assertEquals(1, map.get("foo"));
+	@Test
+	public void testMappingError() {
+		assertThrows(JsonParseException.class, () -> mapper.mapLine("{\"foo\": 1", 1));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PassThroughFieldSetMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PassThroughFieldSetMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,17 @@
  */
 package org.springframework.batch.item.file.mapping;
 
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.file.transform.FieldSet;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Dave Syer
  *
  */
-public class PassThroughFieldSetMapperTests extends TestCase {
+public class PassThroughFieldSetMapperTests {
 
 	private PassThroughFieldSetMapper mapper = new PassThroughFieldSetMapper();
 
@@ -32,6 +33,7 @@ public class PassThroughFieldSetMapperTests extends TestCase {
 	 * Test method for
 	 * {@link org.springframework.batch.item.file.mapping.PassThroughFieldSetMapper#mapFieldSet(org.springframework.batch.item.file.transform.FieldSet)}.
 	 */
+	@Test
 	public void testMapLine() {
 		FieldSet fieldSet = new DefaultFieldSet(new String[] { "foo", "bar" });
 		assertEquals(fieldSet, mapper.mapFieldSet(fieldSet));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PassThroughLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PassThroughLineMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.file.mapping;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PassThroughLineMapper}.

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package org.springframework.batch.item.file.mapping;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
 import org.springframework.batch.item.file.transform.FieldSet;
@@ -39,12 +40,11 @@ public class PatternMatchingCompositeLineMapperTests {
 
 	private PatternMatchingCompositeLineMapper<Name> mapper = new PatternMatchingCompositeLineMapper<>();
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testNoMappers() throws Exception {
+	@Test
+	public void testNoMappers() {
 		mapper.setTokenizers(Collections.singletonMap("", (LineTokenizer) new DelimitedLineTokenizer()));
 		Map<String, FieldSetMapper<Name>> fieldSetMappers = Collections.emptyMap();
-		mapper.setFieldSetMappers(fieldSetMappers);
-		mapper.afterPropertiesSet();
+		assertThrows(IllegalArgumentException.class, () -> mapper.setFieldSetMappers(fieldSetMappers));
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class PatternMatchingCompositeLineMapperTests {
 		assertEquals(new Name("d", "c", 0), name);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testMapperKeyNotFound() throws Exception {
 		Map<String, LineTokenizer> tokenizers = new HashMap<>();
 		tokenizers.put("foo*", new LineTokenizer() {
@@ -109,8 +109,7 @@ public class PatternMatchingCompositeLineMapperTests {
 		});
 		mapper.setFieldSetMappers(fieldSetMappers);
 
-		Name name = mapper.mapLine("bar", 1);
-		assertEquals(new Name("d", "c", 0), name);
+		assertThrows(IllegalStateException.class, () -> mapper.mapLine("bar", 1));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PropertyMatchesTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/PropertyMatchesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,51 +16,70 @@
 
 package org.springframework.batch.item.file.mapping;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class PropertyMatchesTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-	public void setDuckSoup(String duckSoup) {
-	}
+public class PropertyMatchesTests {
 
-	public void setDuckPate(String duckPate) {
-	}
-
-	public void setDuckBreast(String duckBreast) {
-	}
-
-	public void testPropertyMatchesWithMaxDistance() throws Exception {
-		String[] matches = PropertyMatches.forProperty("DUCK_SOUP", getClass(), 2).getPossibleMatches();
+	@Test
+	public void testPropertyMatchesWithMaxDistance() {
+		String[] matches = PropertyMatches.forProperty("DUCK_SOUP", PropertyBean.class, 2).getPossibleMatches();
 		assertEquals(1, matches.length);
 	}
 
-	public void testPropertyMatchesWithDefault() throws Exception {
-		String[] matches = PropertyMatches.forProperty("DUCK_SOUP", getClass()).getPossibleMatches();
+	@Test
+	public void testPropertyMatchesWithDefault() {
+		String[] matches = PropertyMatches.forProperty("DUCK_SOUP", PropertyBean.class).getPossibleMatches();
 		assertEquals(1, matches.length);
 	}
 
-	public void testBuildErrorMessageNoMatches() throws Exception {
-		String msg = PropertyMatches.forProperty("foo", getClass(), 2).buildErrorMessage();
-		assertTrue(msg.indexOf("foo") >= 0);
+	@Test
+	public void testBuildErrorMessageNoMatches() {
+		String msg = PropertyMatches.forProperty("foo", PropertyBean.class, 2).buildErrorMessage();
+		assertTrue(msg.contains("foo"));
 	}
 
-	public void testBuildErrorMessagePossibleMatch() throws Exception {
-		String msg = PropertyMatches.forProperty("DUCKSOUP", getClass(), 1).buildErrorMessage();
+	@Test
+	public void testBuildErrorMessagePossibleMatch() {
+		String msg = PropertyMatches.forProperty("DUCKSOUP", PropertyBean.class, 1).buildErrorMessage();
 		// the message contains the close match
-		assertTrue(msg.indexOf("duckSoup") >= 0);
+		assertTrue(msg.contains("duckSoup"));
 	}
 
-	public void testBuildErrorMessageMultiplePossibleMatches() throws Exception {
-		String msg = PropertyMatches.forProperty("DUCKCRAP", getClass(), 4).buildErrorMessage();
+	@Test
+	public void testBuildErrorMessageMultiplePossibleMatches() {
+		String msg = PropertyMatches.forProperty("DUCKCRAP", PropertyBean.class, 4).buildErrorMessage();
 		// the message contains the close matches
-		assertTrue(msg.indexOf("duckSoup") >= 0);
-		assertTrue(msg.indexOf("duckPate") >= 0);
+		assertTrue(msg.contains("duckSoup"));
+		assertTrue(msg.contains("duckPate"));
 	}
 
-	public void testEmptyString() throws Exception {
-		String[] matches = PropertyMatches.forProperty("", getClass(), 4).getPossibleMatches();
-		// TestCase base class has a name property
+	@Test
+	public void testEmptyString() {
+		String[] matches = PropertyMatches.forProperty("", PropertyBean.class, 4).getPossibleMatches();
 		assertEquals("name", matches[0]);
+	}
+
+	private static class BaseBean {
+
+		public void setName(String name) {
+		}
+
+	}
+
+	private static class PropertyBean extends BaseBean {
+
+		public void setDuckSoup(String duckSoup) {
+		}
+
+		public void setDuckPate(String duckPate) {
+		}
+
+		public void setDuckBreast(String duckBreast) {
+		}
+
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/RecordFieldSetMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/RecordFieldSetMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.file.mapping;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.file.transform.DefaultFieldSet;
 import org.springframework.batch.item.file.transform.FieldSet;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -38,9 +38,9 @@ public class RecordFieldSetMapperTests {
 		Person person = recordFieldSetMapper.mapFieldSet(fieldSet);
 
 		// then
-		Assert.assertNotNull(person);
-		Assert.assertEquals(1, person.id());
-		Assert.assertEquals("foo", person.name());
+		Assertions.assertNotNull(person);
+		Assertions.assertEquals(1, person.id());
+		Assertions.assertEquals("foo", person.name());
 	}
 
 	@Test
@@ -56,7 +56,7 @@ public class RecordFieldSetMapperTests {
 		}
 		catch (IllegalArgumentException e) {
 			// then
-			Assert.assertEquals("Fields count must be equal to record components count", e.getMessage());
+			Assertions.assertEquals("Fields count must be equal to record components count", e.getMessage());
 		}
 	}
 
@@ -73,7 +73,7 @@ public class RecordFieldSetMapperTests {
 		}
 		catch (IllegalArgumentException e) {
 			// then
-			Assert.assertEquals("Field names must specified", e.getMessage());
+			Assertions.assertEquals("Field names must specified", e.getMessage());
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/DefaultRecordSeparatorPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/DefaultRecordSeparatorPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,60 +16,75 @@
 
 package org.springframework.batch.item.file.separator;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class DefaultRecordSeparatorPolicyTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultRecordSeparatorPolicyTests {
 
 	DefaultRecordSeparatorPolicy policy = new DefaultRecordSeparatorPolicy();
 
+	@Test
 	public void testNormalLine() throws Exception {
 		assertTrue(policy.isEndOfRecord("a string"));
 	}
 
+	@Test
 	public void testQuoteUnterminatedLine() throws Exception {
 		assertFalse(policy.isEndOfRecord("a string\"one"));
 	}
 
+	@Test
 	public void testEmptyLine() throws Exception {
 		assertTrue(policy.isEndOfRecord(""));
 	}
 
+	@Test
 	public void testNullLine() throws Exception {
 		assertTrue(policy.isEndOfRecord(null));
 	}
 
+	@Test
 	public void testPostProcess() throws Exception {
 		String line = "foo\nbar";
 		assertEquals(line, policy.postProcess(line));
 	}
 
+	@Test
 	public void testPreProcessWithQuote() throws Exception {
 		String line = "foo\"bar";
 		assertEquals(line + "\n", policy.preProcess(line));
 	}
 
+	@Test
 	public void testPreProcessWithNotDefaultQuote() throws Exception {
 		String line = "foo'bar";
 		policy.setQuoteCharacter("'");
 		assertEquals(line + "\n", policy.preProcess(line));
 	}
 
+	@Test
 	public void testPreProcessWithoutQuote() throws Exception {
 		String line = "foo";
 		assertEquals(line, policy.preProcess(line));
 	}
 
+	@Test
 	public void testContinuationMarkerNotEnd() throws Exception {
 		String line = "foo\\";
 		assertFalse(policy.isEndOfRecord(line));
 	}
 
+	@Test
 	public void testNotDefaultContinuationMarkerNotEnd() throws Exception {
 		String line = "foo bar";
 		policy.setContinuation("bar");
 		assertFalse(policy.isEndOfRecord(line));
 	}
 
+	@Test
 	public void testContinuationMarkerRemoved() throws Exception {
 		String line = "foo\\";
 		assertEquals("foo", policy.preProcess(line));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/JsonRecordSeparatorPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/JsonRecordSeparatorPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.file.separator;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonRecordSeparatorPolicyTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/SimpleRecordSeparatorPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/SimpleRecordSeparatorPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,29 +16,37 @@
 
 package org.springframework.batch.item.file.separator;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class SimpleRecordSeparatorPolicyTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleRecordSeparatorPolicyTests {
 
 	SimpleRecordSeparatorPolicy policy = new SimpleRecordSeparatorPolicy();
 
+	@Test
 	public void testNormalLine() throws Exception {
 		assertTrue(policy.isEndOfRecord("a string"));
 	}
 
+	@Test
 	public void testEmptyLine() throws Exception {
 		assertTrue(policy.isEndOfRecord(""));
 	}
 
+	@Test
 	public void testNullLine() throws Exception {
 		assertTrue(policy.isEndOfRecord(null));
 	}
 
+	@Test
 	public void testPostProcess() throws Exception {
 		String line = "foo\nbar";
 		assertEquals(line, policy.postProcess(line));
 	}
 
+	@Test
 	public void testPreProcess() throws Exception {
 		String line = "foo\nbar";
 		assertEquals(line, policy.preProcess(line));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/SuffixRecordSeparatorPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/separator/SuffixRecordSeparatorPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,50 +16,63 @@
 
 package org.springframework.batch.item.file.separator;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class SuffixRecordSeparatorPolicyTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SuffixRecordSeparatorPolicyTests {
 
 	private static final String LINE = "a string";
 
 	SuffixRecordSeparatorPolicy policy = new SuffixRecordSeparatorPolicy();
 
+	@Test
 	public void testNormalLine() throws Exception {
 		assertFalse(policy.isEndOfRecord(LINE));
 	}
 
+	@Test
 	public void testNormalLineWithDefaultSuffix() throws Exception {
 		assertTrue(policy.isEndOfRecord(LINE + SuffixRecordSeparatorPolicy.DEFAULT_SUFFIX));
 	}
 
+	@Test
 	public void testNormalLineWithNonDefaultSuffix() throws Exception {
 		policy.setSuffix(":foo");
 		assertTrue(policy.isEndOfRecord(LINE + ":foo"));
 	}
 
+	@Test
 	public void testNormalLineWithDefaultSuffixAndWhitespace() throws Exception {
 		assertTrue(policy.isEndOfRecord(LINE + SuffixRecordSeparatorPolicy.DEFAULT_SUFFIX + "  "));
 	}
 
+	@Test
 	public void testNormalLineWithDefaultSuffixWithIgnoreWhitespace() throws Exception {
 		policy.setIgnoreWhitespace(false);
 		assertFalse(policy.isEndOfRecord(LINE + SuffixRecordSeparatorPolicy.DEFAULT_SUFFIX + "  "));
 	}
 
+	@Test
 	public void testEmptyLine() throws Exception {
 		assertFalse(policy.isEndOfRecord(""));
 	}
 
+	@Test
 	public void testNullLineIsEndOfRecord() throws Exception {
 		assertTrue(policy.isEndOfRecord(null));
 	}
 
+	@Test
 	public void testPostProcessSunnyDay() throws Exception {
 		String line = LINE;
 		String record = line + SuffixRecordSeparatorPolicy.DEFAULT_SUFFIX;
 		assertEquals(line, policy.postProcess(record));
 	}
 
+	@Test
 	public void testPostProcessNullLine() throws Exception {
 		String line = null;
 		assertEquals(null, policy.postProcess(line));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.NotReadablePropertyException;
 
 /**
@@ -69,10 +70,9 @@ public class BeanWrapperFieldExtractorTests {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testNamesPropertyMustBeSet() throws Exception {
-		extractor.setNames(null);
-		extractor.afterPropertiesSet();
+	@Test
+	public void testNamesPropertyMustBeSet() {
+		assertThrows(IllegalArgumentException.class, () -> extractor.setNames(null));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/CommonLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/CommonLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package org.springframework.batch.item.file.transform;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link AbstractLineTokenizer}.
@@ -26,12 +29,13 @@ import junit.framework.TestCase;
  * @author Robert Kasanicky
  * @author Dave Syer
  */
-public class CommonLineTokenizerTests extends TestCase {
+public class CommonLineTokenizerTests {
 
 	/**
 	 * Columns names are considered to be specified if they are not <code>null</code> or
 	 * empty.
 	 */
+	@Test
 	public void testHasNames() {
 		AbstractLineTokenizer tokenizer = new AbstractLineTokenizer() {
 			@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DefaultFieldSetFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DefaultFieldSetFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DefaultFieldSetTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DefaultFieldSetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigDecimal;
 import java.text.NumberFormat;
@@ -29,8 +29,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DefaultFieldSetTests {
 
@@ -40,7 +40,7 @@ public class DefaultFieldSetTests {
 
 	String[] names;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		tokens = new String[] { "TestString", "true", "C", "10", "-472", "354224", "543", "124.3", "424.3", "1,3245",
@@ -475,7 +475,7 @@ public class DefaultFieldSetTests {
 		}
 		catch (IllegalArgumentException e) {
 			String message = e.getMessage();
-			assertTrue("Message did not contain: " + message, message.indexOf("dd-MM-yyyy") > 0);
+			assertTrue(message.contains("dd-MM-yyyy"), "Message did not contain: " + message);
 		}
 	}
 
@@ -489,7 +489,7 @@ public class DefaultFieldSetTests {
 		}
 		catch (IllegalArgumentException e) {
 			String message = e.getMessage();
-			assertTrue("Message did not contain: " + message, message.indexOf("yyyyMMdd") > 0);
+			assertTrue(message.contains("yyyyMMdd"), "Message did not contain: " + message);
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineAggregatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer
@@ -35,7 +35,7 @@ public class DelimitedLineAggregatorTests {
 		}
 	};
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		aggregator = new DelimitedLineAggregator<>();
 		aggregator.setFieldExtractor(defaultFieldExtractor);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.springframework.batch.item.file.transform;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DelimitedLineTokenizerTests {
 
@@ -32,29 +33,29 @@ public class DelimitedLineTokenizerTests {
 	public void testTokenizeRegularUse() {
 		FieldSet tokens = tokenizer.tokenize("sfd,\"Well,I have no idea what to do in the afternoon\",sFj, asdf,,as\n");
 		assertEquals(6, tokens.getFieldCount());
-		assertTrue(TOKEN_MATCHES, tokens.readString(0).equals("sfd"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(1).equals("Well,I have no idea what to do in the afternoon"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(2).equals("sFj"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(3).equals("asdf"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(4).equals(""));
-		assertTrue(TOKEN_MATCHES, tokens.readString(5).equals("as"));
+		assertTrue(tokens.readString(0).equals("sfd"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(1).equals("Well,I have no idea what to do in the afternoon"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(2).equals("sFj"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(3).equals("asdf"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(4).equals(""), TOKEN_MATCHES);
+		assertTrue(tokens.readString(5).equals("as"), TOKEN_MATCHES);
 
 		tokens = tokenizer.tokenize("First string,");
 		assertEquals(2, tokens.getFieldCount());
-		assertTrue(TOKEN_MATCHES, tokens.readString(0).equals("First string"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(1).equals(""));
+		assertTrue(tokens.readString(0).equals("First string"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(1).equals(""), TOKEN_MATCHES);
 	}
 
 	@Test
 	public void testBlankString() {
 		FieldSet tokens = tokenizer.tokenize("   ");
-		assertTrue(TOKEN_MATCHES, tokens.readString(0).equals(""));
+		assertTrue(tokens.readString(0).equals(""), TOKEN_MATCHES);
 	}
 
 	@Test
 	public void testEmptyString() {
 		FieldSet tokens = tokenizer.tokenize("\"\"");
-		assertTrue(TOKEN_MATCHES, tokens.readString(0).equals(""));
+		assertTrue(tokens.readString(0).equals(""), TOKEN_MATCHES);
 	}
 
 	@Test
@@ -103,8 +104,8 @@ public class DelimitedLineTokenizerTests {
 
 		FieldSet tokens = tokenizer.tokenize("a,b,c");
 
-		assertTrue(TOKEN_MATCHES, tokens.readString(0).equals("a"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(1).equals("b"));
+		assertTrue(tokens.readString(0).equals("a"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(1).equals("b"), TOKEN_MATCHES);
 	}
 
 	@Test
@@ -128,11 +129,11 @@ public class DelimitedLineTokenizerTests {
 
 		FieldSet tokens = tokenizer.tokenize("a,b,c");
 
-		assertTrue(TOKEN_MATCHES, tokens.readString(0).equals("a"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(1).equals("b"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(2).equals("c"));
-		assertTrue(TOKEN_MATCHES, tokens.readString(3).equals(""));
-		assertTrue(TOKEN_MATCHES, tokens.readString(4).equals(""));
+		assertTrue(tokens.readString(0).equals("a"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(1).equals("b"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(2).equals("c"), TOKEN_MATCHES);
+		assertTrue(tokens.readString(3).equals(""), TOKEN_MATCHES);
+		assertTrue(tokens.readString(4).equals(""), TOKEN_MATCHES);
 	}
 
 	@Test
@@ -142,17 +143,15 @@ public class DelimitedLineTokenizerTests {
 		assertEquals(3, line.getFieldCount());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testDelimitedLineTokenizerNullDelimiter() {
-		AbstractLineTokenizer tokenizer = new DelimitedLineTokenizer(null);
-		tokenizer.tokenize("a b c");
+		assertThrows(IllegalArgumentException.class, () -> new DelimitedLineTokenizer(null));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testDelimitedLineTokenizerEmptyString() throws Exception {
+	@Test
+	public void testDelimitedLineTokenizerEmptyString() {
 		DelimitedLineTokenizer tokenizer = new DelimitedLineTokenizer("");
-		tokenizer.afterPropertiesSet();
-		tokenizer.tokenize("a b c");
+		assertThrows(IllegalArgumentException.class, tokenizer::afterPropertiesSet);
 	}
 
 	@Test
@@ -371,22 +370,18 @@ public class DelimitedLineTokenizerTests {
 		assertEquals("c", line.readString("bar"));
 	}
 
-	@Test(expected = IncorrectTokenCountException.class)
+	@Test
 	public void testTokenizeWithIncludedFieldsAndTooFewNames() {
 		tokenizer.setIncludedFields(new int[] { 1, 2 });
 		tokenizer.setNames(new String[] { "foo" });
-		FieldSet line = tokenizer.tokenize("\"a\",\"b\",\"c\",\"d\"");
-		assertEquals(2, line.getFieldCount());
-		assertEquals("c", line.readString("bar"));
+		assertThrows(IncorrectTokenCountException.class, () -> tokenizer.tokenize("\"a\",\"b\",\"c\",\"d\""));
 	}
 
-	@Test(expected = IncorrectTokenCountException.class)
+	@Test
 	public void testTokenizeWithIncludedFieldsAndTooManyNames() {
 		tokenizer.setIncludedFields(new int[] { 1, 2 });
 		tokenizer.setNames(new String[] { "foo", "bar", "spam" });
-		FieldSet line = tokenizer.tokenize("\"a\",\"b\",\"c\",\"d\"");
-		assertEquals(2, line.getFieldCount());
-		assertEquals("c", line.readString("bar"));
+		assertThrows(IncorrectTokenCountException.class, () -> tokenizer.tokenize("\"a\",\"b\",\"c\",\"d\""));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/FixedLengthTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/FixedLengthTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FixedLengthTokenizerTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/FormatterLineAggregatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/FormatterLineAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link FormatterLineAggregator}
@@ -39,7 +39,7 @@ public class FormatterLineAggregatorTests {
 		}
 	};
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		aggregator = new FormatterLineAggregator<>();
 		aggregator.setFieldExtractor(defaultFieldExtractor);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PassThroughFieldExtractorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PassThroughFieldExtractorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dan Garrette

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PassThroughLineAggregatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PassThroughLineAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,21 @@
  */
 package org.springframework.batch.item.file.transform;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.item.file.transform.LineAggregator;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class PassThroughLineAggregatorTests extends TestCase {
+public class PassThroughLineAggregatorTests {
 
 	private LineAggregator<Object> mapper = new PassThroughLineAggregator<>();
 
+	@Test
 	public void testUnmapItemAsFieldSet() throws Exception {
 		Object item = new Object();
 		assertEquals(item.toString(), mapper.aggregate(item));
 	}
 
+	@Test
 	public void testUnmapItemAsString() throws Exception {
 		assertEquals("foo", mapper.aggregate("foo"));
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 package org.springframework.batch.item.file.transform;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.lang.Nullable;
 
 /**
@@ -35,10 +36,9 @@ public class PatternMatchingCompositeLineTokenizerTests {
 
 	private PatternMatchingCompositeLineTokenizer tokenizer = new PatternMatchingCompositeLineTokenizer();
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testNoTokenizers() throws Exception {
-		tokenizer.afterPropertiesSet();
-		tokenizer.tokenize("a line");
+	@Test
+	public void testNoTokenizers() {
+		assertThrows(IllegalArgumentException.class, tokenizer::afterPropertiesSet);
 	}
 
 	@Test
@@ -74,11 +74,11 @@ public class PatternMatchingCompositeLineTokenizerTests {
 		assertEquals("bar", fields.readString(1));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testNoMatch() throws Exception {
 		tokenizer.setTokenizers(Collections.singletonMap("foo", (LineTokenizer) new DelimitedLineTokenizer()));
 		tokenizer.afterPropertiesSet();
-		tokenizer.tokenize("nomatch");
+		assertThrows(IllegalStateException.class, () -> tokenizer.tokenize("nomatch"));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,20 @@
  */
 package org.springframework.batch.item.file.transform;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class RangeArrayPropertyEditorTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class RangeArrayPropertyEditorTests {
 
 	private Range[] ranges;
 
 	private RangeArrayPropertyEditor pe;
 
-	@Override
+	@BeforeEach
 	public void setUp() {
 
 		ranges = null;
@@ -41,6 +46,7 @@ public class RangeArrayPropertyEditorTests extends TestCase {
 		};
 	}
 
+	@Test
 	public void testSetAsText() {
 		pe.setAsText("15, 32, 1-10, 33");
 
@@ -56,6 +62,7 @@ public class RangeArrayPropertyEditorTests extends TestCase {
 		assertFalse(ranges[3].hasMaxValue());
 	}
 
+	@Test
 	public void testSetAsTextWithNoSpaces() {
 		pe.setAsText("15,32");
 
@@ -67,12 +74,14 @@ public class RangeArrayPropertyEditorTests extends TestCase {
 		assertFalse(ranges[1].hasMaxValue());
 	}
 
+	@Test
 	public void testGetAsText() {
 
 		ranges = new Range[] { new Range(20), new Range(6, 15), new Range(2), new Range(26, 95) };
 		assertEquals("20, 6-15, 2, 26-95", pe.getAsText());
 	}
 
+	@Test
 	public void testValidDisjointRanges() {
 		pe.setForceDisjointRanges(true);
 
@@ -87,6 +96,7 @@ public class RangeArrayPropertyEditorTests extends TestCase {
 
 	}
 
+	@Test
 	public void testInvalidOverlappingRanges() {
 
 		pe.setForceDisjointRanges(true);
@@ -101,6 +111,7 @@ public class RangeArrayPropertyEditorTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testValidOverlappingRanges() {
 
 		// test joint ranges
@@ -113,6 +124,7 @@ public class RangeArrayPropertyEditorTests extends TestCase {
 
 	}
 
+	@Test
 	public void testInvalidInput() {
 
 		try {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/RecursiveCollectionItemTransformerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/RecursiveCollectionItemTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,22 @@ package org.springframework.batch.item.file.transform;
 import java.util.Arrays;
 import java.util.Collections;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.util.StringUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Dave Syer
  *
  */
-public class RecursiveCollectionItemTransformerTests extends TestCase {
+public class RecursiveCollectionItemTransformerTests {
 
 	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
 	private RecursiveCollectionLineAggregator<String> aggregator = new RecursiveCollectionLineAggregator<>();
 
+	@Test
 	public void testSetDelegateAndPassInString() throws Exception {
 		aggregator.setDelegate(new LineAggregator<String>() {
 			@Override
@@ -42,6 +44,7 @@ public class RecursiveCollectionItemTransformerTests extends TestCase {
 		assertEquals("bar", aggregator.aggregate(Collections.singleton("foo")));
 	}
 
+	@Test
 	public void testTransformList() throws Exception {
 		String result = aggregator.aggregate(Arrays.asList(StringUtils.commaDelimitedListToStringArray("foo,bar")));
 		String[] array = StringUtils.delimitedListToStringArray(result, LINE_SEPARATOR);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/RegexLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/RegexLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package org.springframework.batch.item.file.transform;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RegexLineTokenizerTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/function/FunctionItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/function/FunctionItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@ package org.springframework.batch.item.function;
 
 import java.util.function.Function;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemProcessor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Michael Minella
@@ -32,7 +32,7 @@ public class FunctionItemProcessorTests {
 
 	private Function<Object, String> function;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.function = o -> o.toString();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,19 @@
 
 package org.springframework.batch.item.jms;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 
 import jakarta.jms.Message;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.jms.core.JmsOperations;
 import org.springframework.jms.core.JmsTemplate;
 
@@ -98,18 +99,18 @@ public class JmsItemReaderTests {
 		assertEquals(message, itemReader.read());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testTemplateWithNoDefaultDestination() throws Exception {
+	@Test
+	public void testTemplateWithNoDefaultDestination() {
 		JmsTemplate jmsTemplate = new JmsTemplate();
 		jmsTemplate.setReceiveTimeout(100L);
-		itemReader.setJmsTemplate(jmsTemplate);
+		assertThrows(IllegalArgumentException.class, () -> itemReader.setJmsTemplate(jmsTemplate));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testTemplateWithNoTimeout() throws Exception {
+	@Test
+	public void testTemplateWithNoTimeout() {
 		JmsTemplate jmsTemplate = new JmsTemplate();
 		jmsTemplate.setDefaultDestinationName("foo");
-		itemReader.setJmsTemplate(jmsTemplate);
+		assertThrows(IllegalArgumentException.class, () -> itemReader.setJmsTemplate(jmsTemplate));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.springframework.batch.item.jms;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.jms.core.JmsOperations;
 import org.springframework.jms.core.JmsTemplate;
 
@@ -38,10 +39,10 @@ public class JmsItemWriterTests {
 		itemWriter.write(Arrays.asList("foo", "bar"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testTemplateWithNoDefaultDestination() throws Exception {
+	@Test
+	public void testTemplateWithNoDefaultDestination() {
 		JmsTemplate jmsTemplate = new JmsTemplate();
-		itemWriter.setJmsTemplate(jmsTemplate);
+		assertThrows(IllegalArgumentException.class, () -> itemWriter.setJmsTemplate(jmsTemplate));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodArgumentsKeyGeneratorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodArgumentsKeyGeneratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.jms;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import jakarta.jms.Message;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodInvocationRecovererTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodInvocationRecovererTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.springframework.batch.item.jms;
 
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.jms.core.JmsOperations;
 
 /**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsNewMethodArgumentsIdentifierTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsNewMethodArgumentsIdentifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.jms;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import jakarta.jms.Message;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,15 +20,15 @@ import java.util.Date;
 
 import jakarta.jms.Message;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.jms.JmsItemReader;
 import org.springframework.jms.core.JmsOperations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +40,7 @@ public class JmsItemReaderBuilderTests {
 
 	private JmsOperations defaultJmsTemplate;
 
-	@Before
+	@BeforeEach
 	public void setupJmsTemplate() {
 		this.defaultJmsTemplate = mock(JmsOperations.class);
 		when(this.defaultJmsTemplate.receiveAndConvert()).thenReturn("foo");
@@ -97,8 +97,8 @@ public class JmsItemReaderBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"jmsTemplate is required.", ise.getMessage());
+			assertEquals("jmsTemplate is required.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package org.springframework.batch.item.jms.builder;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.batch.item.jms.JmsItemWriter;
 import org.springframework.jms.core.JmsOperations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,8 +43,8 @@ public class JmsItemWriterBuilderTests {
 		ArgumentCaptor<String> argCaptor = ArgumentCaptor.forClass(String.class);
 		itemWriter.write(Arrays.asList("foo", "bar"));
 		verify(jmsTemplate, times(2)).convertAndSend(argCaptor.capture());
-		assertEquals("Expected foo", "foo", argCaptor.getAllValues().get(0));
-		assertEquals("Expected bar", "bar", argCaptor.getAllValues().get(1));
+		assertEquals("foo", argCaptor.getAllValues().get(0), "Expected foo");
+		assertEquals("bar", argCaptor.getAllValues().get(1), "Expected bar");
 	}
 
 	@Test
@@ -54,8 +54,8 @@ public class JmsItemWriterBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException ise) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"jmsTemplate is required.", ise.getMessage());
+			assertEquals("jmsTemplate is required.", ise.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/GsonJsonObjectMarshallerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/GsonJsonObjectMarshallerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.batch.item.json;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -33,7 +33,7 @@ public class GsonJsonObjectMarshallerTests {
 		String foo = jsonObjectMarshaller.marshal(new Foo(1, "foo"));
 
 		// then
-		Assert.assertEquals("{\"id\":1,\"name\":\"foo\"}", foo);
+		Assertions.assertEquals("{\"id\":1,\"name\":\"foo\"}", foo);
 	}
 
 	public static class Foo {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JacksonJsonObjectMarshallerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JacksonJsonObjectMarshallerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.batch.item.json;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -33,7 +33,7 @@ public class JacksonJsonObjectMarshallerTests {
 		String foo = jsonObjectMarshaller.marshal(new Foo(1, "foo"));
 
 		// then
-		Assert.assertEquals("{\"id\":1,\"name\":\"foo\"}", foo);
+		Assertions.assertEquals("{\"id\":1,\"name\":\"foo\"}", foo);
 	}
 
 	public static class Foo {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonFileItemWriterFunctionalTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonFileItemWriterFunctionalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import org.springframework.batch.item.ExecutionContext;
@@ -39,8 +39,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Mahmoud Ben Hassine

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonFileItemWriterTests.java
@@ -20,21 +20,23 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.Arrays;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.WritableResource;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  * @author Mahmoud Ben Hassine
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class JsonFileItemWriterTests {
 
 	private WritableResource resource;
@@ -42,20 +44,20 @@ public class JsonFileItemWriterTests {
 	@Mock
 	private JsonObjectMarshaller<String> jsonObjectMarshaller;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		File file = Files.createTempFile("test", "json").toFile();
 		this.resource = new FileSystemResource(file);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void resourceMustNotBeNull() {
-		new JsonFileItemWriter<>(null, this.jsonObjectMarshaller);
+		assertThrows(IllegalArgumentException.class, () -> new JsonFileItemWriter<>(null, this.jsonObjectMarshaller));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void jsonObjectMarshallerMustNotBeNull() {
-		new JsonFileItemWriter<>(this.resource, null);
+		assertThrows(IllegalArgumentException.class, () -> new JsonFileItemWriter<>(this.resource, null));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderFunctionalTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderFunctionalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package org.springframework.batch.item.json;
 
 import java.math.BigDecimal;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -51,35 +51,35 @@ public abstract class JsonItemReaderFunctionalTests {
 		itemReader.open(new ExecutionContext());
 
 		Trade trade = itemReader.read();
-		Assert.assertNotNull(trade);
-		Assert.assertEquals("123", trade.getIsin());
-		Assert.assertEquals("foo", trade.getCustomer());
-		Assert.assertEquals(new BigDecimal("1.2"), trade.getPrice());
-		Assert.assertEquals(1, trade.getQuantity());
+		Assertions.assertNotNull(trade);
+		Assertions.assertEquals("123", trade.getIsin());
+		Assertions.assertEquals("foo", trade.getCustomer());
+		Assertions.assertEquals(new BigDecimal("1.2"), trade.getPrice());
+		Assertions.assertEquals(1, trade.getQuantity());
 
 		trade = itemReader.read();
-		Assert.assertNotNull(trade);
-		Assert.assertEquals("456", trade.getIsin());
-		Assert.assertEquals("bar", trade.getCustomer());
-		Assert.assertEquals(new BigDecimal("1.4"), trade.getPrice());
-		Assert.assertEquals(2, trade.getQuantity());
+		Assertions.assertNotNull(trade);
+		Assertions.assertEquals("456", trade.getIsin());
+		Assertions.assertEquals("bar", trade.getCustomer());
+		Assertions.assertEquals(new BigDecimal("1.4"), trade.getPrice());
+		Assertions.assertEquals(2, trade.getQuantity());
 
 		trade = itemReader.read();
-		Assert.assertNotNull(trade);
-		Assert.assertEquals("789", trade.getIsin());
-		Assert.assertEquals("foobar", trade.getCustomer());
-		Assert.assertEquals(new BigDecimal("1.6"), trade.getPrice());
-		Assert.assertEquals(3, trade.getQuantity());
+		Assertions.assertNotNull(trade);
+		Assertions.assertEquals("789", trade.getIsin());
+		Assertions.assertEquals("foobar", trade.getCustomer());
+		Assertions.assertEquals(new BigDecimal("1.6"), trade.getPrice());
+		Assertions.assertEquals(3, trade.getQuantity());
 
 		trade = itemReader.read();
-		Assert.assertNotNull(trade);
-		Assert.assertEquals("100", trade.getIsin());
-		Assert.assertEquals("barfoo", trade.getCustomer());
-		Assert.assertEquals(new BigDecimal("1.8"), trade.getPrice());
-		Assert.assertEquals(4, trade.getQuantity());
+		Assertions.assertNotNull(trade);
+		Assertions.assertEquals("100", trade.getIsin());
+		Assertions.assertEquals("barfoo", trade.getCustomer());
+		Assertions.assertEquals(new BigDecimal("1.8"), trade.getPrice());
+		Assertions.assertEquals(4, trade.getQuantity());
 
 		trade = itemReader.read();
-		Assert.assertNull(trade);
+		Assertions.assertNull(trade);
 	}
 
 	@Test
@@ -90,7 +90,7 @@ public abstract class JsonItemReaderFunctionalTests {
 		itemReader.open(new ExecutionContext());
 
 		Trade trade = itemReader.read();
-		Assert.assertNull(trade);
+		Assertions.assertNull(trade);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package org.springframework.batch.item.json;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -31,14 +31,14 @@ import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class JsonItemReaderTests {
 
 	@Mock
@@ -71,7 +71,7 @@ public class JsonItemReaderTests {
 		this.itemReader = new JsonItemReader<>(new NonExistentResource(), this.jsonObjectReader);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(ItemStreamException.class,
+		final Exception expectedException = Assertions.assertThrows(ItemStreamException.class,
 				() -> this.itemReader.open(new ExecutionContext()));
 
 		// then
@@ -85,7 +85,7 @@ public class JsonItemReaderTests {
 		this.itemReader = new JsonItemReader<>(new NonReadableResource(), this.jsonObjectReader);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(ItemStreamException.class,
+		final Exception expectedException = Assertions.assertThrows(ItemStreamException.class,
 				() -> this.itemReader.open(new ExecutionContext()));
 
 		// then

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonFileItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonFileItemWriterBuilderTests.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.batch.item.file.FlatFileFooterCallback;
@@ -32,8 +32,9 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -45,27 +46,30 @@ public class JsonFileItemWriterBuilderTests {
 
 	private JsonObjectMarshaller<String> jsonObjectMarshaller;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		File file = Files.createTempFile("test", "json").toFile();
 		this.resource = new FileSystemResource(file);
 		this.jsonObjectMarshaller = object -> object;
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMissingResource() {
-		new JsonFileItemWriterBuilder<String>().jsonObjectMarshaller(this.jsonObjectMarshaller).build();
+		var builder = new JsonFileItemWriterBuilder<String>().jsonObjectMarshaller(this.jsonObjectMarshaller);
+		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMissingJsonObjectMarshaller() {
-		new JsonFileItemWriterBuilder<String>().resource(this.resource).build();
+		var builder = new JsonFileItemWriterBuilder<String>().resource(this.resource);
+		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMandatoryNameWhenSaveStateIsSet() {
-		new JsonFileItemWriterBuilder<String>().resource(this.resource).jsonObjectMarshaller(this.jsonObjectMarshaller)
-				.build();
+		var builder = new JsonFileItemWriterBuilder<String>().resource(this.resource)
+				.jsonObjectMarshaller(this.jsonObjectMarshaller);
+		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,27 +16,24 @@
 
 package org.springframework.batch.item.json.builder;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.json.JsonItemReader;
 import org.springframework.batch.item.json.JsonObjectReader;
 import org.springframework.core.io.Resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 /**
  * @author Mahmoud Ben Hassine
  */
+@ExtendWith(MockitoExtension.class)
 public class JsonItemReaderBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private Resource resource;
@@ -69,14 +66,14 @@ public class JsonItemReaderBuilderTests {
 				.resource(this.resource).saveState(true).strict(true).name("jsonItemReader").maxItemCount(100)
 				.currentItemCount(50).build();
 
-		Assert.assertEquals(this.jsonObjectReader, getField(itemReader, "jsonObjectReader"));
-		Assert.assertEquals(this.resource, getField(itemReader, "resource"));
-		Assert.assertEquals(100, getField(itemReader, "maxItemCount"));
-		Assert.assertEquals(50, getField(itemReader, "currentItemCount"));
-		Assert.assertTrue((Boolean) getField(itemReader, "saveState"));
-		Assert.assertTrue((Boolean) getField(itemReader, "strict"));
+		Assertions.assertEquals(this.jsonObjectReader, getField(itemReader, "jsonObjectReader"));
+		Assertions.assertEquals(this.resource, getField(itemReader, "resource"));
+		Assertions.assertEquals(100, getField(itemReader, "maxItemCount"));
+		Assertions.assertEquals(50, getField(itemReader, "currentItemCount"));
+		Assertions.assertTrue((Boolean) getField(itemReader, "saveState"));
+		Assertions.assertTrue((Boolean) getField(itemReader, "strict"));
 		Object executionContext = getField(itemReader, "executionContextUserSupport");
-		Assert.assertEquals("jsonItemReader", getField(executionContext, "name"));
+		Assertions.assertEquals("jsonItemReader", getField(executionContext, "name"));
 	}
 
 	@Test
@@ -84,13 +81,13 @@ public class JsonItemReaderBuilderTests {
 		JsonItemReader<String> itemReader = new JsonItemReaderBuilder<String>().jsonObjectReader(this.jsonObjectReader)
 				.saveState(true).strict(true).name("jsonItemReader").maxItemCount(100).currentItemCount(50).build();
 
-		Assert.assertEquals(this.jsonObjectReader, getField(itemReader, "jsonObjectReader"));
-		Assert.assertEquals(100, getField(itemReader, "maxItemCount"));
-		Assert.assertEquals(50, getField(itemReader, "currentItemCount"));
-		Assert.assertTrue((Boolean) getField(itemReader, "saveState"));
-		Assert.assertTrue((Boolean) getField(itemReader, "strict"));
+		Assertions.assertEquals(this.jsonObjectReader, getField(itemReader, "jsonObjectReader"));
+		Assertions.assertEquals(100, getField(itemReader, "maxItemCount"));
+		Assertions.assertEquals(50, getField(itemReader, "currentItemCount"));
+		Assertions.assertTrue((Boolean) getField(itemReader, "saveState"));
+		Assertions.assertTrue((Boolean) getField(itemReader, "strict"));
 		Object executionContext = getField(itemReader, "executionContextUserSupport");
-		Assert.assertEquals("jsonItemReader", getField(executionContext, "name"));
+		Assertions.assertEquals("jsonItemReader", getField(executionContext, "name"));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,28 +19,26 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.util.concurrent.ListenableFuture;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 
+@ExtendWith(MockitoExtension.class)
 public class KafkaItemWriterTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private KafkaTemplate<String, String> kafkaTemplate;
@@ -52,10 +50,10 @@ public class KafkaItemWriterTests {
 
 	private KafkaItemWriter<String, String> writer;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		when(this.kafkaTemplate.getDefaultTopic()).thenReturn("defaultTopic");
-		when(this.kafkaTemplate.sendDefault(any(), any())).thenReturn(this.future);
+		lenient().when(this.kafkaTemplate.sendDefault(any(), any())).thenReturn(this.future);
 		this.itemKeyMapper = new KafkaItemKeyMapper();
 		this.writer = new KafkaItemWriter<>();
 		this.writer.setKafkaTemplate(this.kafkaTemplate);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,18 +26,18 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.kafka.KafkaItemReader;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Mathieu Ouellet
@@ -47,7 +47,7 @@ public class KafkaItemReaderBuilderTests {
 
 	private Properties consumerProperties;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.consumerProperties = new Properties();
 		this.consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
@@ -65,7 +65,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(null);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("Consumer properties must not be null");
@@ -126,7 +126,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(this.consumerProperties).topic(null);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("Topic name must not be null or empty");
@@ -139,7 +139,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(this.consumerProperties).topic("");
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("Topic name must not be null or empty");
@@ -152,7 +152,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(this.consumerProperties).topic("test").pollTimeout(null);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("pollTimeout must not be null");
@@ -165,7 +165,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(this.consumerProperties).topic("test").pollTimeout(Duration.ofSeconds(-1));
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("pollTimeout must not be negative");
@@ -178,7 +178,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(this.consumerProperties).topic("test").pollTimeout(Duration.ZERO);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("pollTimeout must not be zero");
@@ -191,7 +191,7 @@ public class KafkaItemReaderBuilderTests {
 				.consumerProperties(this.consumerProperties).topic("test").pollTimeout(Duration.ofSeconds(10));
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("At least one partition must be provided");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,37 +16,34 @@
 
 package org.springframework.batch.item.kafka.builder;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.kafka.KafkaItemWriter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
  */
+@ExtendWith(MockitoExtension.class)
 public class KafkaItemWriterBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private KafkaTemplate<String, String> kafkaTemplate;
 
 	private KafkaItemKeyMapper itemKeyMapper;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		this.itemKeyMapper = new KafkaItemKeyMapper();
 	}
@@ -58,7 +55,7 @@ public class KafkaItemWriterBuilderTests {
 				.itemKeyMapper(this.itemKeyMapper);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("kafkaTemplate is required.");
@@ -71,7 +68,7 @@ public class KafkaItemWriterBuilderTests {
 				.kafkaTemplate(this.kafkaTemplate);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class, builder::build);
+		final Exception expectedException = Assertions.assertThrows(IllegalArgumentException.class, builder::build);
 
 		// then
 		assertThat(expectedException).hasMessage("itemKeyMapper is required.");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/DefaultMailErrorHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/DefaultMailErrorHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package org.springframework.batch.item.mail;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.mail.MessagingException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailMessage;
 import org.springframework.mail.MailSendException;
@@ -48,16 +48,16 @@ public class DefaultMailErrorHandlerTests {
 		}
 		catch (MailException e) {
 			String msg = e.getMessage();
-			assertTrue("Wrong message: " + msg, msg.matches(".*SimpleMailMessage: f;.*"));
+			assertTrue(msg.matches(".*SimpleMailMessage: f;.*"), "Wrong message: " + msg);
 		}
 	}
 
 	/**
 	 * Test method for {@link DefaultMailErrorHandler#handle(MailMessage, Exception)}.
 	 */
-	@Test(expected = MailSendException.class)
+	@Test
 	public void testHandle() {
-		handler.handle(new SimpleMailMessage(), new MessagingException());
+		assertThrows(MailSendException.class, () -> handler.handle(new SimpleMailMessage(), new MessagingException()));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/SimpleMailMessageItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/SimpleMailMessageItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package org.springframework.batch.item.mail;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,12 +24,13 @@ import static org.mockito.AdditionalMatchers.aryEq;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.mail.MessagingException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailMessage;
@@ -50,7 +52,7 @@ public class SimpleMailMessageItemWriterTests {
 
 	private MailSender mailSender = mock(MailSender.class);
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		writer.setMailSender(mailSender);
 	}
@@ -73,7 +75,7 @@ public class SimpleMailMessageItemWriterTests {
 		}
 	}
 
-	@Test(expected = MailSendException.class)
+	@Test
 	public void testDefaultErrorHandler() throws Exception {
 
 		SimpleMailMessage foo = new SimpleMailMessage();
@@ -91,7 +93,7 @@ public class SimpleMailMessageItemWriterTests {
 		when(mailSender).thenThrow(new MailSendException(
 				Collections.singletonMap((Object) foo, (Exception) new MessagingException("FOO"))));
 
-		writer.write(Arrays.asList(items));
+		assertThrows(MailSendException.class, () -> writer.write(List.of(items)));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/builder/SimpleMailMessageItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/builder/SimpleMailMessageItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ package org.springframework.batch.item.mail.builder;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.mail.MessagingException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.mail.MailErrorHandler;
 import org.springframework.batch.item.mail.SimpleMailMessageItemWriter;
@@ -33,8 +34,9 @@ import org.springframework.mail.MailSendException;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,7 +55,7 @@ public class SimpleMailMessageItemWriterBuilderTests {
 
 	private SimpleMailMessage[] items;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		mailSender = mock(MailSender.class);
 		this.foo = new SimpleMailMessage();
@@ -81,15 +83,15 @@ public class SimpleMailMessageItemWriterBuilderTests {
 		}
 	}
 
-	@Test(expected = MailSendException.class)
-	public void testErrorHandler() throws Exception {
+	@Test
+	public void testErrorHandler() {
 		SimpleMailMessageItemWriter writer = new SimpleMailMessageItemWriterBuilder().mailSender(this.mailSender)
 				.build();
 
 		this.mailSender.send(this.foo, this.bar);
 		when(this.mailSender)
 				.thenThrow(new MailSendException(Collections.singletonMap(this.foo, new MessagingException("FOO"))));
-		writer.write(Arrays.asList(this.items));
+		assertThrows(MailSendException.class, () -> writer.write(List.of(this.items)));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/javamail/MimeMessageItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/javamail/MimeMessageItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,15 @@
  */
 package org.springframework.batch.item.mail.javamail;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.AdditionalMatchers.aryEq;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,8 +31,8 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.mail.MailErrorHandler;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailMessage;
@@ -54,7 +56,7 @@ public class MimeMessageItemWriterTests {
 
 	private Session session = Session.getDefaultInstance(new Properties());
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		writer.setJavaMailSender(mailSender);
 	}
@@ -72,8 +74,8 @@ public class MimeMessageItemWriterTests {
 
 	}
 
-	@Test(expected = MailSendException.class)
-	public void testDefaultErrorHandler() throws Exception {
+	@Test
+	public void testDefaultErrorHandler() {
 
 		MimeMessage foo = new MimeMessage(session);
 		MimeMessage bar = new MimeMessage(session);
@@ -90,7 +92,7 @@ public class MimeMessageItemWriterTests {
 		when(mailSender).thenThrow(new MailSendException(
 				Collections.singletonMap((Object) foo, (Exception) new MessagingException("FOO"))));
 
-		writer.write(Arrays.asList(items));
+		assertThrows(MailSendException.class, () -> writer.write(List.of(items)));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractSynchronizedItemStreamWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamWriter;
 
@@ -37,10 +36,8 @@ import org.springframework.batch.item.ItemStreamWriter;
  * @author Dimitrios Liapis
  *
  */
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractSynchronizedItemStreamWriterTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	protected ItemStreamWriter<Object> delegate;
@@ -53,7 +50,7 @@ public abstract class AbstractSynchronizedItemStreamWriterTests {
 
 	abstract protected SynchronizedItemStreamWriter<Object> createNewSynchronizedItemStreamWriter();
 
-	@Before
+	@BeforeEach
 	public void init() {
 		synchronizedItemStreamWriter = createNewSynchronizedItemStreamWriter();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ClassifierCompositeItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ClassifierCompositeItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package org.springframework.batch.item.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.classify.PatternMatchingClassifier;
 import org.springframework.classify.SubclassClassifier;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ClassifierCompositeItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ClassifierCompositeItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.classify.PatternMatchingClassifier;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Dave Syer
@@ -73,8 +73,8 @@ public class ClassifierCompositeItemWriterTests {
 			fail("A classifier is required.");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("Message returned from exception did not match expected result.", "A classifier is required.",
-					iae.getMessage());
+			assertEquals("A classifier is required.", iae.getMessage(),
+					"Message returned from exception did not match expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,18 @@
  */
 package org.springframework.batch.item.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemProcessor;
 
 /**
@@ -44,7 +44,7 @@ public class CompositeItemProcessorTests {
 	private ItemProcessor<Object, Object> processor2;
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		processor1 = mock(ItemProcessor.class);
 		processor2 = mock(ItemProcessor.class);
@@ -128,7 +128,7 @@ public class CompositeItemProcessorTests {
 
 		Object item = new Object();
 		when(processor1.process(item)).thenReturn(null);
-		Assert.assertEquals(null, composite.process(item));
+		Assertions.assertEquals(null, composite.process(item));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemStreamTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemStreamTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,23 +18,24 @@ package org.springframework.batch.item.support;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.ItemStreamSupport;
-import org.springframework.batch.item.support.CompositeItemStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Dave Syer
  *
  */
-public class CompositeItemStreamTests extends TestCase {
+public class CompositeItemStreamTests {
 
 	private CompositeItemStream manager = new CompositeItemStream();
 
 	private List<String> list = new ArrayList<>();
 
+	@Test
 	public void testRegisterAndOpen() {
 		ItemStreamSupport stream = new ItemStreamSupport() {
 			@Override
@@ -48,6 +49,7 @@ public class CompositeItemStreamTests extends TestCase {
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testRegisterTwice() {
 		ItemStreamSupport stream = new ItemStreamSupport() {
 			@Override
@@ -62,6 +64,7 @@ public class CompositeItemStreamTests extends TestCase {
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testMark() {
 		manager.register(new ItemStreamSupport() {
 			@Override
@@ -74,6 +77,7 @@ public class CompositeItemStreamTests extends TestCase {
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testClose() {
 		manager.register(new ItemStreamSupport() {
 			@Override
@@ -86,6 +90,7 @@ public class CompositeItemStreamTests extends TestCase {
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testCloseDoesNotUnregister() {
 		manager.setStreams(new ItemStream[] { new ItemStreamSupport() {
 			@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.batch.item.ItemWriter;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package org.springframework.batch.item.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Iterator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.Nullable;
 
@@ -36,7 +36,7 @@ public class ItemCountingItemStreamItemReaderTests {
 
 	private ItemCountingItemStreamItemReader reader = new ItemCountingItemStreamItemReader();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		reader.setName("foo");
 	}
@@ -62,11 +62,10 @@ public class ItemCountingItemStreamItemReaderTests {
 		assertTrue(reader.closeCalled);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testOpenWithoutName() {
 		reader = new ItemCountingItemStreamItemReader();
-		reader.open(new ExecutionContext());
-		assertFalse(reader.openCalled);
+		assertThrows(IllegalArgumentException.class, () -> reader.open(new ExecutionContext()));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/IteratorItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/IteratorItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,13 @@ package org.springframework.batch.item.support;
 
 import java.util.Arrays;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class IteratorItemReaderTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+public class IteratorItemReaderTests {
+
+	@Test
 	public void testIterable() throws Exception {
 		IteratorItemReader<String> reader = new IteratorItemReader<>(Arrays.asList(new String[] { "a", "b", "c" }));
 		assertEquals("a", reader.read());
@@ -30,6 +33,7 @@ public class IteratorItemReaderTests extends TestCase {
 		assertEquals(null, reader.read());
 	}
 
+	@Test
 	public void testIterator() throws Exception {
 		IteratorItemReader<String> reader = new IteratorItemReader<>(
 				Arrays.asList(new String[] { "a", "b", "c" }).iterator());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ListItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ListItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.batch.item.support.ListItemReader;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ListItemReaderTests extends TestCase {
+public class ListItemReaderTests {
 
 	ListItemReader<String> reader = new ListItemReader<>(Arrays.asList(new String[] { "a", "b", "c" }));
 
+	@Test
 	public void testNext() throws Exception {
 		assertEquals("a", reader.read());
 		assertEquals("b", reader.read());
@@ -35,6 +36,7 @@ public class ListItemReaderTests extends TestCase {
 		assertEquals(null, reader.read());
 	}
 
+	@Test
 	public void testChangeList() throws Exception {
 		List<String> list = new ArrayList<>(Arrays.asList(new String[] { "a", "b", "c" }));
 		reader = new ListItemReader<>(list);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ScriptItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ScriptItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.item.support;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.scripting.bsh.BshScriptEvaluator;
@@ -28,8 +28,9 @@ import javax.script.ScriptEngineManager;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * <p>
@@ -43,7 +44,7 @@ public class ScriptItemProcessorTests {
 
 	private static List<String> availableLanguages = new ArrayList<>();
 
-	@BeforeClass
+	@BeforeAll
 	public static void populateAvailableEngines() {
 		List<ScriptEngineFactory> scriptEngineFactories = new ScriptEngineManager().getEngineFactories();
 
@@ -60,7 +61,7 @@ public class ScriptItemProcessorTests {
 		scriptItemProcessor.setScriptSource("item.toUpperCase();", "javascript");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -72,7 +73,7 @@ public class ScriptItemProcessorTests {
 				"javascript");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -83,7 +84,7 @@ public class ScriptItemProcessorTests {
 		scriptItemProcessor.setScriptSource("$item.upcase", "jruby");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -94,7 +95,7 @@ public class ScriptItemProcessorTests {
 		scriptItemProcessor.setScriptSource("def process(item) $item.upcase end \n process($item)", "jruby");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -105,7 +106,7 @@ public class ScriptItemProcessorTests {
 		scriptItemProcessor.setScriptSource("item.toUpperCase();", "bsh");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -117,7 +118,7 @@ public class ScriptItemProcessorTests {
 				"bsh");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -128,7 +129,7 @@ public class ScriptItemProcessorTests {
 		scriptItemProcessor.setScriptSource("item.toUpperCase();", "groovy");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -140,7 +141,7 @@ public class ScriptItemProcessorTests {
 				"groovy");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -153,7 +154,7 @@ public class ScriptItemProcessorTests {
 		scriptItemProcessor.setScript(resource);
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -166,35 +167,34 @@ public class ScriptItemProcessorTests {
 
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", true, scriptItemProcessor.process("Hello World"));
+		assertEquals(true, scriptItemProcessor.process("Hello World"), "Incorrect transformed value");
 	}
 
-	@Test(expected = IllegalStateException.class)
-	public void testNoScriptSet() throws Exception {
+	@Test
+	public void testNoScriptSet() {
 		ScriptItemProcessor<String, Object> scriptItemProcessor = new ScriptItemProcessor<>();
-		scriptItemProcessor.afterPropertiesSet();
+		assertThrows(IllegalStateException.class, scriptItemProcessor::afterPropertiesSet);
 	}
 
-	@Test(expected = IllegalStateException.class)
-	public void testScriptSourceAndScriptResourceSet() throws Exception {
+	@Test
+	public void testScriptSourceAndScriptResourceSet() {
 		ScriptItemProcessor<String, Object> scriptItemProcessor = new ScriptItemProcessor<>();
 		scriptItemProcessor.setScriptSource("blah", "blah");
 		scriptItemProcessor.setScript(new ClassPathResource("blah"));
-		scriptItemProcessor.afterPropertiesSet();
+		assertThrows(IllegalStateException.class, scriptItemProcessor::afterPropertiesSet);
 	}
 
-	@Test(expected = IllegalStateException.class)
-	public void testNoScriptSetWithoutInitBean() throws Exception {
+	@Test
+	public void testNoScriptSetWithoutInitBean() {
 		ScriptItemProcessor<String, Object> scriptItemProcessor = new ScriptItemProcessor<>();
-		scriptItemProcessor.process("blah");
+		assertThrows(IllegalStateException.class, () -> scriptItemProcessor.process("blah"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testScriptSourceWithNoLanguage() throws Exception {
+	@Test
+	public void testScriptSourceWithNoLanguage() {
 		ScriptItemProcessor<String, Object> scriptItemProcessor = new ScriptItemProcessor<>();
-		scriptItemProcessor.setScriptSource("function process(item) { return item.toUpperCase(); } process(item);",
-				null);
-		scriptItemProcessor.afterPropertiesSet();
+		assertThrows(IllegalArgumentException.class, () -> scriptItemProcessor
+				.setScriptSource("function process(item) { return item.toUpperCase(); } process(item);", null));
 	}
 
 	@Test
@@ -207,7 +207,7 @@ public class ScriptItemProcessorTests {
 				"function process(param) { return param.toUpperCase(); } process(someOtherVarName);", "javascript");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -220,7 +220,7 @@ public class ScriptItemProcessorTests {
 				"bsh");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -233,7 +233,7 @@ public class ScriptItemProcessorTests {
 				"groovy");
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "SS", scriptItemProcessor.process("ss"));
+		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
 	}
 
 	private boolean languageExists(String engineName) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SingleItemPeekableItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SingleItemPeekableItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package org.springframework.batch.item.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.lang.Nullable;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.springframework.batch.item.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamReader;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SynchronizedItemStreamWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.InitializingBean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/TransactionAwareListItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/TransactionAwareListItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -30,17 +30,22 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-public class TransactionAwareListItemReaderTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TransactionAwareListItemReaderTests {
 
 	private ListItemReader<String> reader;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
 		reader = new ListItemReader<>(
 				TransactionAwareProxyFactory.createTransactionalList(Arrays.asList("a", "b", "c")));
 	}
 
+	@Test
 	public void testNext() throws Exception {
 		assertEquals("a", reader.read());
 		assertEquals("b", reader.read());
@@ -48,6 +53,7 @@ public class TransactionAwareListItemReaderTests extends TestCase {
 		assertEquals(null, reader.read());
 	}
 
+	@Test
 	public void testCommit() throws Exception {
 		PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 		final List<Object> taken = new ArrayList<>();
@@ -76,6 +82,7 @@ public class TransactionAwareListItemReaderTests extends TestCase {
 		assertFalse(taken.contains("a"));
 	}
 
+	@Test
 	public void testTransactionalExhausted() throws Exception {
 		PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 		final List<Object> taken = new ArrayList<>();
@@ -94,6 +101,7 @@ public class TransactionAwareListItemReaderTests extends TestCase {
 		assertEquals("a", taken.get(0));
 	}
 
+	@Test
 	public void testRollback() throws Exception {
 		PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 		final List<Object> taken = new ArrayList<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemProcessorBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemProcessorBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ package org.springframework.batch.item.support.builder;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.support.ClassifierCompositeItemProcessor;
 import org.springframework.classify.PatternMatchingClassifier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Glenn Renfro
@@ -57,8 +57,8 @@ public class ClassifierCompositeItemProcessorBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.",
-					"A classifier is required.", iae.getMessage());
+			assertEquals("A classifier is required.", iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,14 +22,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.ClassifierCompositeItemWriter;
 import org.springframework.classify.PatternMatchingClassifier;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Glenn Renfro
@@ -62,8 +62,8 @@ public class ClassifierCompositeItemWriterBuilderTests {
 			fail("A classifier is required.");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("Message returned from exception did not match expected result.", "A classifier is required.",
-					iae.getMessage());
+			assertEquals("A classifier is required.", iae.getMessage(),
+					"Message returned from exception did not match expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemProcessorBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemProcessorBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,28 +19,25 @@ package org.springframework.batch.item.support.builder;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.support.CompositeItemProcessor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 /**
  * @author Glenn Renfro
  * @author Drummond Dawson
  */
+@ExtendWith(MockitoExtension.class)
 public class CompositeItemProcessorBuilderTests {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private ItemProcessor<Object, Object> processor1;
@@ -50,7 +47,7 @@ public class CompositeItemProcessorBuilderTests {
 
 	private List<ItemProcessor<Object, Object>> processors;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		this.processors = new ArrayList<>();
 		this.processors.add(processor1);
@@ -100,8 +97,8 @@ public class CompositeItemProcessorBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", message,
-					iae.getMessage());
+			assertEquals(message, iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamWriter;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/ScriptItemProcessorBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/ScriptItemProcessorBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,17 +22,17 @@ import java.util.List;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.support.ScriptItemProcessor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * @author Glenn Renfro
@@ -41,7 +41,7 @@ public class ScriptItemProcessorBuilderTests {
 
 	private static List<String> availableLanguages = new ArrayList<>();
 
-	@BeforeClass
+	@BeforeAll
 	public static void populateAvailableEngines() {
 		List<ScriptEngineFactory> scriptEngineFactories = new ScriptEngineManager().getEngineFactories();
 
@@ -50,7 +50,7 @@ public class ScriptItemProcessorBuilderTests {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		assumeTrue(availableLanguages.contains("javascript"));
 	}
@@ -61,7 +61,7 @@ public class ScriptItemProcessorBuilderTests {
 				.scriptSource("item.toUpperCase();").language("javascript").build();
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "AA", scriptItemProcessor.process("aa"));
+		assertEquals("AA", scriptItemProcessor.process("aa"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class ScriptItemProcessorBuilderTests {
 				.scriptSource("foo.contains('World');").language("javascript").itemBindingVariableName("foo").build();
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", true, scriptItemProcessor.process("Hello World"));
+		assertEquals(true, scriptItemProcessor.process("Hello World"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -80,7 +80,7 @@ public class ScriptItemProcessorBuilderTests {
 				.scriptResource(resource).build();
 		scriptItemProcessor.afterPropertiesSet();
 
-		assertEquals("Incorrect transformed value", "BB", scriptItemProcessor.process("bb"));
+		assertEquals("BB", scriptItemProcessor.process("bb"), "Incorrect transformed value");
 	}
 
 	@Test
@@ -102,8 +102,8 @@ public class ScriptItemProcessorBuilderTests {
 			fail("IllegalArgumentException should have been thrown");
 		}
 		catch (IllegalArgumentException iae) {
-			assertEquals("IllegalArgumentException message did not match the expected result.", message,
-					iae.getMessage());
+			assertEquals(message, iae.getMessage(),
+					"IllegalArgumentException message did not match the expected result.");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SingleItemPeekableItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SingleItemPeekableItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package org.springframework.batch.item.support.builder;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.batch.item.support.SingleItemPeekableItemReader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Glenn Renfro

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.batch.item.support.builder;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamReader;
@@ -29,9 +29,9 @@ import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.batch.item.support.SynchronizedItemStreamReader;
 import org.springframework.lang.Nullable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Glenn Renfro

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.support.builder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.support.AbstractSynchronizedItemStreamWriterTests;
 import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/ExecutionContextUserSupportTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/ExecutionContextUserSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,22 @@
  */
 package org.springframework.batch.item.util;
 
-import org.springframework.batch.item.util.ExecutionContextUserSupport;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link ExecutionContextUserSupport}.
  */
-public class ExecutionContextUserSupportTests extends TestCase {
+public class ExecutionContextUserSupportTests {
 
 	ExecutionContextUserSupport tested = new ExecutionContextUserSupport();
 
 	/**
 	 * Regular usage scenario - prepends the name (supposed to be unique) to argument.
 	 */
+	@Test
 	public void testGetKey() {
 		tested.setName("uniqueName");
 		assertEquals("uniqueName.key", tested.getKey("key"));
@@ -37,6 +39,7 @@ public class ExecutionContextUserSupportTests extends TestCase {
 	/**
 	 * Exception scenario - name must not be empty.
 	 */
+	@Test
 	public void testGetKeyWithNoNameSet() {
 		tested.setName("");
 		try {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/FileUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/FileUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,16 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.util.Assert;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link FileUtils}
@@ -191,20 +191,20 @@ public class FileUtilsTests {
 		}
 		catch (ItemStreamException ex) {
 			String message = ex.getMessage();
-			assertTrue("Wrong message: " + message, message.startsWith("Output file was not created"));
+			assertTrue(message.startsWith("Output file was not created"), "Wrong message: " + message);
 		}
 		finally {
 			file.delete();
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		file.delete();
 		Assert.state(!file.exists(), "File delete failed");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		file.delete();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/BeanValidatingItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/BeanValidatingItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package org.springframework.batch.item.validator;
 
 import jakarta.validation.constraints.NotEmpty;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -37,10 +39,10 @@ public class BeanValidatingItemProcessorTests {
 		Foo processed = validatingItemProcessor.process(foo);
 
 		// then
-		Assert.assertNotNull(processed);
+		Assertions.assertNotNull(processed);
 	}
 
-	@Test(expected = ValidationException.class)
+	@Test
 	public void testInvalidObjectValidation() throws Exception {
 		// given
 		BeanValidatingItemProcessor<Foo> validatingItemProcessor = new BeanValidatingItemProcessor<>();
@@ -48,7 +50,7 @@ public class BeanValidatingItemProcessorTests {
 		Foo foo = new Foo("");
 
 		// when
-		validatingItemProcessor.process(foo);
+		assertThrows(ValidationException.class, () -> validatingItemProcessor.process(foo));
 
 		// then
 		// expected exception

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/SpringValidatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/SpringValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.springframework.batch.item.validator;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -34,7 +35,7 @@ public class SpringValidatorTests {
 
 	private Validator mockValidator;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		mockValidator = new MockSpringValidator();
 		validator.setValidator(mockValidator);
@@ -43,18 +44,19 @@ public class SpringValidatorTests {
 	/**
 	 * Validator property is not set
 	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testNullValidator() throws Exception {
+	@Test
+	public void testNullValidator() {
 		validator.setValidator(null);
-		validator.afterPropertiesSet();
+		assertThrows(IllegalArgumentException.class, validator::afterPropertiesSet);
 	}
 
 	/**
 	 * Validator does not know how to validate object of the given class
 	 */
-	@Test(expected = ValidationException.class)
+	@Test
 	public void testValidateUnsupportedType() {
-		validator.validate(Integer.valueOf(1)); // only strings are supported
+		assertThrows(ValidationException.class, () -> validator.validate(1));
+		// only strings are supported
 	}
 
 	/**
@@ -68,22 +70,19 @@ public class SpringValidatorTests {
 	/**
 	 * Typical failed validation - {@link ValidationException} is thrown
 	 */
-	@Test(expected = ValidationException.class)
+	@Test
 	public void testValidateFailure() {
-		validator.validate(MockSpringValidator.REJECT_VALUE);
+		assertThrows(ValidationException.class, () -> validator.validate(MockSpringValidator.REJECT_VALUE));
 	}
 
 	/**
 	 * Typical failed validation - {@link ValidationException} is thrown
 	 */
-	@Test(expected = BindException.class)
-	public void testValidateFailureWithErrors() throws Exception {
-		try {
-			validator.validate(MockSpringValidator.REJECT_VALUE);
-		}
-		catch (ValidationException e) {
-			throw (BindException) e.getCause();
-		}
+	@Test
+	public void testValidateFailureWithErrors() {
+		ValidationException e = assertThrows(ValidationException.class,
+				() -> validator.validate(MockSpringValidator.REJECT_VALUE));
+		assertTrue(e.getCause() instanceof BindException);
 	}
 
 	/**
@@ -96,10 +95,10 @@ public class SpringValidatorTests {
 			fail("exception should have been thrown on invalid value");
 		}
 		catch (ValidationException expected) {
-			assertTrue("message should contain the item#toString() value",
-					expected.getMessage().contains("TestBeanToString"));
-			assertTrue("message should contain names of the invalid fields", expected.getMessage().contains("foo"));
-			assertTrue("message should contain names of the invalid fields", expected.getMessage().contains("bar"));
+			assertTrue(expected.getMessage().contains("TestBeanToString"),
+					"message should contain the item#toString() value");
+			assertTrue(expected.getMessage().contains("foo"), "message should contain names of the invalid fields");
+			assertTrue(expected.getMessage().contains("bar"), "message should contain names of the invalid fields");
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/ValidatingItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/ValidatingItemProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  */
 package org.springframework.batch.item.validator;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link ValidatingItemProcessor}.
@@ -42,12 +43,12 @@ public class ValidatingItemProcessorTests {
 		assertSame(ITEM, tested.process(ITEM));
 	}
 
-	@Test(expected = ValidationException.class)
-	public void testFailedValidation() throws Exception {
+	@Test
+	public void testFailedValidation() {
 
 		ValidatingItemProcessor<String> tested = new ValidatingItemProcessor<>(validator);
 
-		processFailedValidation(tested);
+		assertThrows(ValidationException.class, () -> processFailedValidation(tested));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/AbstractStaxEventReaderItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/AbstractStaxEventReaderItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package org.springframework.batch.item.xml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.xml.domain.Trade;
 import org.springframework.core.io.ClassPathResource;
@@ -35,7 +35,7 @@ public abstract class AbstractStaxEventReaderItemReaderTests {
 
 	protected StaxEventItemReader<Trade> reader = new StaxEventItemReader<>();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		reader.setFragmentRootElementName("trade");
 		reader.setUnmarshaller(getUnmarshaller());
@@ -79,25 +79,25 @@ public abstract class AbstractStaxEventReaderItemReaderTests {
 		assertEquals(3, results.size());
 
 		Trade trade1 = results.get(0);
-		Assert.assertEquals("XYZ0001", trade1.getIsin());
-		Assert.assertEquals(5, trade1.getQuantity());
-		Assert.assertEquals(new BigDecimal("11.39"), trade1.getPrice());
-		Assert.assertEquals("Customer1", trade1.getCustomer());
+		Assertions.assertEquals("XYZ0001", trade1.getIsin());
+		Assertions.assertEquals(5, trade1.getQuantity());
+		Assertions.assertEquals(new BigDecimal("11.39"), trade1.getPrice());
+		Assertions.assertEquals("Customer1", trade1.getCustomer());
 
 		Trade trade2 = results.get(1);
-		Assert.assertEquals("XYZ0002", trade2.getIsin());
-		Assert.assertEquals(2, trade2.getQuantity());
-		Assert.assertEquals(new BigDecimal("72.99"), trade2.getPrice());
-		Assert.assertEquals("Customer2", trade2.getCustomer());
+		Assertions.assertEquals("XYZ0002", trade2.getIsin());
+		Assertions.assertEquals(2, trade2.getQuantity());
+		Assertions.assertEquals(new BigDecimal("72.99"), trade2.getPrice());
+		Assertions.assertEquals("Customer2", trade2.getCustomer());
 
 		Trade trade3 = results.get(2);
-		Assert.assertEquals("XYZ0003", trade3.getIsin());
-		Assert.assertEquals(9, trade3.getQuantity());
-		Assert.assertEquals(new BigDecimal("99.99"), trade3.getPrice());
-		Assert.assertEquals("Customer3", trade3.getCustomer());
+		Assertions.assertEquals("XYZ0003", trade3.getIsin());
+		Assertions.assertEquals(9, trade3.getQuantity());
+		Assertions.assertEquals(new BigDecimal("99.99"), trade3.getPrice());
+		Assertions.assertEquals("Customer3", trade3.getCustomer());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		reader.close();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/AbstractStaxEventWriterItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/AbstractStaxEventWriterItemWriterTests.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
@@ -102,7 +102,7 @@ public abstract class AbstractStaxEventWriterItemWriterTests {
 				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		File directory = new File("target/data");
@@ -118,7 +118,7 @@ public abstract class AbstractStaxEventWriterItemWriterTests {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		outputFile.delete();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/Jaxb2MarshallingTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/Jaxb2MarshallingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.xml;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringWriter;
 import java.math.BigDecimal;
@@ -43,7 +43,7 @@ public class Jaxb2MarshallingTests extends AbstractStaxEventWriterItemWriterTest
 		StringWriter string = new StringWriter();
 		marshaller.marshal(new Trade("FOO", 100, BigDecimal.valueOf(10.), "bar"), new StreamResult(string));
 		String content = string.toString();
-		assertTrue("Wrong content: " + content, content.contains("<customer>bar</customer>"));
+		assertTrue(content.contains("<customer>bar</customer>"), "Wrong content: " + content);
 		return marshaller;
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/Jaxb2NamespaceMarshallingTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/Jaxb2NamespaceMarshallingTests.java
@@ -24,9 +24,9 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xmlunit.builder.Input;
 import org.xmlunit.matchers.CompareMatcher;
 
@@ -46,7 +46,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StopWatch;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Jaxb2NamespaceMarshallingTests {
 
@@ -104,7 +104,7 @@ public class Jaxb2NamespaceMarshallingTests {
 				CompareMatcher.isSimilarTo(Input.from(resource.getFile())).normalizeWhitespace());
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		File directory = new File("target/data");
@@ -123,7 +123,7 @@ public class Jaxb2NamespaceMarshallingTests {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		outputFile.delete();
 	}
@@ -137,7 +137,7 @@ public class Jaxb2NamespaceMarshallingTests {
 		StringWriter string = new StringWriter();
 		marshaller.marshal(new QualifiedTrade("FOO", 100, BigDecimal.valueOf(10.), "bar"), new StreamResult(string));
 		String content = string.toString();
-		assertTrue("Wrong content: " + content, content.contains("<customer>bar</customer>"));
+		assertTrue(content.contains("<customer>bar</customer>"), "Wrong content: " + content);
 		return marshaller;
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/Jaxb2NamespaceUnmarshallingTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/Jaxb2NamespaceUnmarshallingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.xml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 import java.math.BigDecimal;
@@ -24,12 +24,11 @@ import java.util.List;
 
 import javax.xml.transform.stream.StreamSource;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.xml.StaxEventItemReader;
 import org.springframework.batch.item.xml.domain.QualifiedTrade;
 import org.springframework.batch.item.xml.domain.Trade;
 import org.springframework.core.io.ClassPathResource;
@@ -45,7 +44,7 @@ public class Jaxb2NamespaceUnmarshallingTests {
 	private Resource resource = new ClassPathResource(
 			ClassUtils.addResourcePathToPackagePath(getClass(), "domain/trades.xml"));
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		reader.setResource(resource);
 		reader.setFragmentRootElementName("{urn:org.springframework.batch.io.oxm.domain}trade");
@@ -58,10 +57,10 @@ public class Jaxb2NamespaceUnmarshallingTests {
 	public void testUnmarshal() throws Exception {
 		QualifiedTrade trade = (QualifiedTrade) getUnmarshaller()
 				.unmarshal(new StreamSource(new StringReader(TRADE_XML)));
-		Assert.assertEquals("XYZ0001", trade.getIsin());
-		Assert.assertEquals(5, trade.getQuantity());
-		Assert.assertEquals(new BigDecimal("11.39"), trade.getPrice());
-		Assert.assertEquals("Customer1", trade.getCustomer());
+		Assertions.assertEquals("XYZ0001", trade.getIsin());
+		Assertions.assertEquals(5, trade.getQuantity());
+		Assertions.assertEquals(new BigDecimal("11.39"), trade.getPrice());
+		Assertions.assertEquals("Customer1", trade.getCustomer());
 	}
 
 	@Test
@@ -92,25 +91,25 @@ public class Jaxb2NamespaceUnmarshallingTests {
 		assertEquals(3, results.size());
 
 		QualifiedTrade trade1 = results.get(0);
-		Assert.assertEquals("XYZ0001", trade1.getIsin());
-		Assert.assertEquals(5, trade1.getQuantity());
-		Assert.assertEquals(new BigDecimal("11.39"), trade1.getPrice());
-		Assert.assertEquals("Customer1", trade1.getCustomer());
+		Assertions.assertEquals("XYZ0001", trade1.getIsin());
+		Assertions.assertEquals(5, trade1.getQuantity());
+		Assertions.assertEquals(new BigDecimal("11.39"), trade1.getPrice());
+		Assertions.assertEquals("Customer1", trade1.getCustomer());
 
 		QualifiedTrade trade2 = results.get(1);
-		Assert.assertEquals("XYZ0002", trade2.getIsin());
-		Assert.assertEquals(2, trade2.getQuantity());
-		Assert.assertEquals(new BigDecimal("72.99"), trade2.getPrice());
-		Assert.assertEquals("Customer2", trade2.getCustomer());
+		Assertions.assertEquals("XYZ0002", trade2.getIsin());
+		Assertions.assertEquals(2, trade2.getQuantity());
+		Assertions.assertEquals(new BigDecimal("72.99"), trade2.getPrice());
+		Assertions.assertEquals("Customer2", trade2.getCustomer());
 
 		QualifiedTrade trade3 = results.get(2);
-		Assert.assertEquals("XYZ0003", trade3.getIsin());
-		Assert.assertEquals(9, trade3.getQuantity());
-		Assert.assertEquals(new BigDecimal("99.99"), trade3.getPrice());
-		Assert.assertEquals("Customer3", trade3.getCustomer());
+		Assertions.assertEquals("XYZ0003", trade3.getIsin());
+		Assertions.assertEquals(9, trade3.getQuantity());
+		Assertions.assertEquals(new BigDecimal("99.99"), trade3.getPrice());
+		Assertions.assertEquals("Customer3", trade3.getCustomer());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		reader.close();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.oxm.XmlMappingException;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StaxEventItemReaderCommonTests extends AbstractItemStreamItemReaderTests {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.springframework.batch.item.xml;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemCountAware;
 import org.springframework.batch.item.ItemStreamException;
@@ -51,12 +51,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link StaxEventItemReader}.
@@ -99,7 +100,7 @@ public class StaxEventItemReaderTests {
 
 	private ExecutionContext executionContext;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.executionContext = new ExecutionContext();
 		source = createNewInputSource();
@@ -569,14 +570,14 @@ public class StaxEventItemReaderTests {
 		source.read();
 	}
 
-	@Test(expected = ItemStreamException.class)
+	@Test
 	public void testStrictness() throws Exception {
 
 		source.setResource(new NonExistentResource());
 		source.setStrict(true);
 		source.afterPropertiesSet();
 
-		source.open(executionContext);
+		assertThrows(ItemStreamException.class, () -> source.open(executionContext));
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
@@ -26,8 +26,8 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Result;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.UnexpectedInputException;
@@ -46,10 +46,11 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -109,7 +110,7 @@ public class StaxEventItemWriterTests {
 
 	private Jaxb2Marshaller jaxbMarshaller;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		File directory = new File("target/data");
 		directory.mkdirs();
@@ -130,15 +131,15 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.update(executionContext);
 		writer.close();
-		assertTrue("execution context keys should be prefixed with writer name",
-				executionContext.containsKey("test.position"));
+		assertTrue(executionContext.containsKey("test.position"),
+				"execution context keys should be prefixed with writer name");
 	}
 
-	@Test(expected = WriterNotOpenException.class)
-	public void testAssertWriterIsInitialized() throws Exception {
+	@Test
+	public void testAssertWriterIsInitialized() {
 		StaxEventItemWriter<String> writer = new StaxEventItemWriter<>();
 
-		writer.write(Collections.singletonList("foo"));
+		assertThrows(WriterNotOpenException.class, () -> writer.write(List.of("foo")));
 	}
 
 	@Test
@@ -179,7 +180,7 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	@Test
@@ -189,7 +190,7 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -407,8 +408,8 @@ public class StaxEventItemWriterTests {
 		writer.open(executionContext);
 		writer.write(items);
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(("<header/>")));
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(("<header/>")), "Wrong content: " + content);
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -506,7 +507,7 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -518,7 +519,7 @@ public class StaxEventItemWriterTests {
 		writer.setShouldDeleteIfEmpty(true);
 		writer.open(executionContext);
 		writer.close();
-		assertFalse("file should be deleted" + resource, resource.getFile().exists());
+		assertFalse(resource.getFile().exists(), "file should be deleted" + resource);
 	}
 
 	/**
@@ -562,7 +563,7 @@ public class StaxEventItemWriterTests {
 		});
 		writer.open(executionContext);
 		writer.close();
-		assertFalse("file should be deleted" + resource, resource.getFile().exists());
+		assertFalse(resource.getFile().exists(), "file should be deleted" + resource);
 	}
 
 	/**
@@ -582,7 +583,7 @@ public class StaxEventItemWriterTests {
 		writer.open(executionContext);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -602,7 +603,7 @@ public class StaxEventItemWriterTests {
 		writer.update(executionContext);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -647,13 +648,13 @@ public class StaxEventItemWriterTests {
 		writer.open(executionContext);
 		writer.update(executionContext);
 		writer.close();
-		assertFalse("file should be deleted" + resource, resource.getFile().exists());
+		assertFalse(resource.getFile().exists(), "file should be deleted" + resource);
 		writer.open(executionContext);
 		writer.write(items);
 		writer.update(executionContext);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -667,10 +668,10 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content,
-				content.contains(("<root xmlns=\"https://www.springframework.org/test\">")));
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
-		assertTrue("Wrong content: " + content, content.contains(("</root>")));
+		assertTrue(content.contains(("<root xmlns=\"https://www.springframework.org/test\">")),
+				"Wrong content: " + content);
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
+		assertTrue(content.contains(("</root>")), "Wrong content: " + content);
 	}
 
 	/**
@@ -686,11 +687,11 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content,
-				content.contains(("<ns:root xmlns:ns=\"https://www.springframework.org/test\">")));
-		assertTrue("Wrong content: " + content, content.contains(NS_TEST_STRING));
-		assertTrue("Wrong content: " + content, content.contains(("</ns:root>")));
-		assertTrue("Wrong content: " + content, content.contains(("<ns:root")));
+		assertTrue(content.contains(("<ns:root xmlns:ns=\"https://www.springframework.org/test\">")),
+				"Wrong content: " + content);
+		assertTrue(content.contains(NS_TEST_STRING), "Wrong content: " + content);
+		assertTrue(content.contains(("</ns:root>")), "Wrong content: " + content);
+		assertTrue(content.contains(("<ns:root")), "Wrong content: " + content);
 	}
 
 	/**
@@ -707,11 +708,12 @@ public class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(
-				("<ns:root xmlns:ns=\"https://www.springframework.org/test\" " + "xmlns:foo=\"urn:org.test.foo\">")));
-		assertTrue("Wrong content: " + content, content.contains(FOO_TEST_STRING));
-		assertTrue("Wrong content: " + content, content.contains(("</ns:root>")));
-		assertTrue("Wrong content: " + content, content.contains(("<ns:root")));
+		assertTrue(content.contains(
+				("<ns:root xmlns:ns=\"https://www.springframework.org/test\" " + "xmlns:foo=\"urn:org.test.foo\">")),
+				"Wrong content: " + content);
+		assertTrue(content.contains(FOO_TEST_STRING), "Wrong content: " + content);
+		assertTrue(content.contains(("</ns:root>")), "Wrong content: " + content);
+		assertTrue(content.contains(("<ns:root")), "Wrong content: " + content);
 	}
 
 	/**
@@ -737,8 +739,8 @@ public class StaxEventItemWriterTests {
 		writer.close();
 
 		String content = getOutputFileContent();
-		assertEquals("Wrong content: " + content,
-				"<root xmlns=\"https://www.springframework.org/test\"><item/><item/></root>", content);
+		assertEquals("<root xmlns=\"https://www.springframework.org/test\"><item/><item/></root>", content,
+				"Wrong content: " + content);
 	}
 
 	/**
@@ -764,8 +766,8 @@ public class StaxEventItemWriterTests {
 		writer.close();
 
 		String content = getOutputFileContent();
-		assertEquals("Wrong content: " + content,
-				"<ns:root xmlns:ns=\"https://www.springframework.org/test\"><ns:item/><ns:item/></ns:root>", content);
+		assertEquals("<ns:root xmlns:ns=\"https://www.springframework.org/test\"><ns:item/><ns:item/></ns:root>",
+				content, "Wrong content: " + content);
 	}
 
 	/**
@@ -793,9 +795,9 @@ public class StaxEventItemWriterTests {
 		writer.close();
 
 		String content = getOutputFileContent();
-		assertEquals("Wrong content: " + content,
+		assertEquals(
 				"<foo:root xmlns:foo=\"urn:org.test.foo\" xmlns:ns=\"https://www.springframework.org/test\"><ns:item/><ns:item/></foo:root>",
-				content);
+				content, "Wrong content: " + content);
 	}
 
 	/**
@@ -836,9 +838,9 @@ public class StaxEventItemWriterTests {
 		writer.close();
 		String content = getOutputFileContent();
 
-		assertEquals("Wrong content: " + content,
+		assertEquals(
 				"<ns:testroot xmlns:ns=\"https://www.springframework.org/test\"><ns:group><StaxEventItemWriter-testString/></ns:group></ns:testroot>",
-				content);
+				content, "Wrong content: " + content);
 	}
 
 	/**
@@ -859,9 +861,9 @@ public class StaxEventItemWriterTests {
 		writer.close();
 		String content = getOutputFileContent();
 
-		assertEquals("Wrong content: " + content, "<ns:testroot xmlns:ns=\"https://www.springframework.org/test\">"
+		assertEquals("<ns:testroot xmlns:ns=\"https://www.springframework.org/test\">"
 				+ "<ns:group><StaxEventItemWriter-testString/><StaxEventItemWriter-testString/></ns:group></ns:testroot>",
-				content);
+				content, "Wrong content: " + content);
 	}
 
 	/**
@@ -882,13 +884,11 @@ public class StaxEventItemWriterTests {
 		writer.close();
 		String content = getOutputFileContent();
 
-		assertEquals("Wrong content: " + content,
-				"<ns:testroot xmlns:ns=\"https://www.springframework.org/test\">"
-						+ "<preHeader>PRE-HEADER</preHeader><ns:group><subGroup><postHeader>POST-HEADER</postHeader>"
-						+ "<StaxEventItemWriter-testString/><StaxEventItemWriter-testString/>"
-						+ "<preFooter>PRE-FOOTER</preFooter></subGroup></ns:group><postFooter>POST-FOOTER</postFooter>"
-						+ "</ns:testroot>",
-				content);
+		assertEquals("<ns:testroot xmlns:ns=\"https://www.springframework.org/test\">"
+				+ "<preHeader>PRE-HEADER</preHeader><ns:group><subGroup><postHeader>POST-HEADER</postHeader>"
+				+ "<StaxEventItemWriter-testString/><StaxEventItemWriter-testString/>"
+				+ "<preFooter>PRE-FOOTER</preFooter></subGroup></ns:group><postFooter>POST-FOOTER</postFooter>"
+				+ "</ns:testroot>", content, "Wrong content: " + content);
 	}
 
 	private void initWriterForSimpleCallbackTests() throws Exception {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/TransactionalStaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/TransactionalStaxEventItemWriterTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.batch.item.xml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,8 +30,8 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Result;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.core.io.FileSystemResource;
@@ -73,7 +73,7 @@ public class TransactionalStaxEventItemWriterTests {
 	private static final String TEST_STRING = "<!--" + ClassUtils.getShortName(StaxEventItemWriter.class)
 			+ "-testString-->";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		resource = new FileSystemResource(File.createTempFile("StaxEventWriterOutputSourceTests", ".xml"));
 		writer = createItemWriter();
@@ -100,7 +100,7 @@ public class TransactionalStaxEventItemWriterTests {
 		});
 		writer.close();
 		String content = outputFileContent();
-		assertTrue("Wrong content: " + content, content.contains(TEST_STRING));
+		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -159,8 +159,8 @@ public class TransactionalStaxEventItemWriterTests {
 		});
 		writer.close();
 		String content = outputFileContent();
-		assertEquals("Wrong content: " + content, 1, StringUtils.countOccurrencesOf(content, ("<header/>")));
-		assertEquals("Wrong content: " + content, 1, StringUtils.countOccurrencesOf(content, TEST_STRING));
+		assertEquals(1, StringUtils.countOccurrencesOf(content, ("<header/>")), "Wrong content: " + content);
+		assertEquals(1, StringUtils.countOccurrencesOf(content, TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**
@@ -220,8 +220,8 @@ public class TransactionalStaxEventItemWriterTests {
 		}
 		writer.close();
 		String content = outputFileContent();
-		assertEquals("Wrong content: " + content, 1, StringUtils.countOccurrencesOf(content, ("<header/>")));
-		assertEquals("Wrong content: " + content, 1, StringUtils.countOccurrencesOf(content, TEST_STRING));
+		assertEquals(1, StringUtils.countOccurrencesOf(content, ("<header/>")), "Wrong content: " + content);
+		assertEquals(1, StringUtils.countOccurrencesOf(content, TEST_STRING), "Wrong content: " + content);
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,10 @@ import java.nio.charset.StandardCharsets;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import javax.xml.stream.XMLInputFactory;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.xml.StaxEventItemReader;
@@ -33,10 +32,11 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 /**
@@ -44,15 +44,13 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
  */
+@ExtendWith(MockitoExtension.class)
 public class StaxEventItemReaderBuilderTests {
 
 	private static final String SIMPLE_XML = "<foos><foo><first>1</first>"
 			+ "<second>two</second><third>three</third></foo><foo><first>4</first>"
 			+ "<second>five</second><third>six</third></foo><foo><first>7</first>"
 			+ "<second>eight</second><third>nine</third></foo></foos>";
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule().silent();
 
 	@Mock
 	private Resource resource;
@@ -141,7 +139,7 @@ public class StaxEventItemReaderBuilderTests {
 		assertEquals(2, executionContext.size());
 	}
 
-	@Test(expected = ItemStreamException.class)
+	@Test
 	public void testStrict() throws Exception {
 		Jaxb2Marshaller unmarshaller = new Jaxb2Marshaller();
 		unmarshaller.setClassesToBeBound(Foo.class);
@@ -152,7 +150,7 @@ public class StaxEventItemReaderBuilderTests {
 		reader.afterPropertiesSet();
 
 		ExecutionContext executionContext = new ExecutionContext();
-		reader.open(executionContext);
+		assertThrows(ItemStreamException.class, () -> reader.open(executionContext));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/builder/StaxEventItemWriterBuilderTests.java
@@ -27,8 +27,8 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -40,9 +40,10 @@ import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Michael Minella
@@ -65,7 +66,7 @@ public class StaxEventItemWriterBuilderTests {
 			+ "<ns2:item xmlns:ns2=\"https://www.springframework.org/test\"><first>7</first>"
 			+ "<second>eight</second><third>nine</third></ns2:item>\uFEFF</ns:group>\uFEFF" + "</foobarred>";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws IOException {
 		File directory = new File("target/data");
 		directory.mkdirs();
@@ -81,27 +82,12 @@ public class StaxEventItemWriterBuilderTests {
 		((Jaxb2Marshaller) marshaller).setClassesToBeBound(Foo.class);
 	}
 
-	@Test(expected = ItemStreamException.class)
+	@Test
 	public void testOverwriteOutput() throws Exception {
 		StaxEventItemWriter<Foo> staxEventItemWriter = new StaxEventItemWriterBuilder<Foo>().name("fooWriter")
 				.marshaller(marshaller).resource(this.resource).overwriteOutput(false).build();
-
 		staxEventItemWriter.afterPropertiesSet();
-
-		ExecutionContext executionContext = new ExecutionContext();
-		staxEventItemWriter.open(executionContext);
-
-		staxEventItemWriter.write(this.items);
-
-		staxEventItemWriter.update(executionContext);
-		staxEventItemWriter.close();
-
-		File output = this.resource.getFile();
-
-		assertTrue(output.exists());
-
-		executionContext = new ExecutionContext();
-		staxEventItemWriter.open(executionContext);
+		assertThrows(ItemStreamException.class, () -> staxEventItemWriter.open(new ExecutionContext()));
 	}
 
 	@Test
@@ -178,14 +164,16 @@ public class StaxEventItemWriterBuilderTests {
 		assertEquals(0, executionContext.size());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMissingMarshallerValidation() {
-		new StaxEventItemWriterBuilder<Foo>().name("fooWriter").build();
+		var builder = new StaxEventItemWriterBuilder<Foo>().name("fooWriter");
+		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMissingNameValidation() {
-		new StaxEventItemWriterBuilder<Foo>().marshaller(new Jaxb2Marshaller()).build();
+		var builder = new StaxEventItemWriterBuilder<Foo>().marshaller(new Jaxb2Marshaller());
+		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventReaderWrapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventReaderWrapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.item.xml.stax;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,31 +24,32 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Lucas Ward
  * @author Will Schipp
  */
-public class AbstractEventReaderWrapperTests extends TestCase {
+public class AbstractEventReaderWrapperTests {
 
 	AbstractEventReaderWrapper eventReaderWrapper;
 
 	XMLEventReader xmlEventReader;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
-
 		xmlEventReader = mock(XMLEventReader.class);
 		eventReaderWrapper = new StubEventReader(xmlEventReader);
 	}
 
+	@Test
 	public void testClose() throws XMLStreamException {
 		xmlEventReader.close();
 		eventReaderWrapper.close();
 	}
 
+	@Test
 	public void testGetElementText() throws XMLStreamException {
 
 		String text = "text";
@@ -54,6 +57,7 @@ public class AbstractEventReaderWrapperTests extends TestCase {
 		assertEquals(eventReaderWrapper.getElementText(), text);
 	}
 
+	@Test
 	public void testGetProperty() throws IllegalArgumentException {
 
 		String text = "text";
@@ -61,12 +65,14 @@ public class AbstractEventReaderWrapperTests extends TestCase {
 		assertEquals(eventReaderWrapper.getProperty("name"), text);
 	}
 
+	@Test
 	public void testHasNext() {
 
 		when(xmlEventReader.hasNext()).thenReturn(true);
 		assertTrue(eventReaderWrapper.hasNext());
 	}
 
+	@Test
 	public void testNext() {
 
 		String text = "text";
@@ -74,6 +80,7 @@ public class AbstractEventReaderWrapperTests extends TestCase {
 		assertEquals(eventReaderWrapper.next(), text);
 	}
 
+	@Test
 	public void testNextEvent() throws XMLStreamException {
 
 		XMLEvent event = mock(XMLEvent.class);
@@ -81,6 +88,7 @@ public class AbstractEventReaderWrapperTests extends TestCase {
 		assertEquals(eventReaderWrapper.nextEvent(), event);
 	}
 
+	@Test
 	public void testNextTag() throws XMLStreamException {
 
 		XMLEvent event = mock(XMLEvent.class);
@@ -88,6 +96,7 @@ public class AbstractEventReaderWrapperTests extends TestCase {
 		assertEquals(eventReaderWrapper.nextTag(), event);
 	}
 
+	@Test
 	public void testPeek() throws XMLStreamException {
 
 		XMLEvent event = mock(XMLEvent.class);
@@ -95,6 +104,7 @@ public class AbstractEventReaderWrapperTests extends TestCase {
 		assertEquals(eventReaderWrapper.peek(), event);
 	}
 
+	@Test
 	public void testRemove() {
 
 		xmlEventReader.remove();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventWriterWrapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventWriterWrapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.xml.stax;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,27 +25,27 @@ import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Lucas Ward
  * @author Will Schipp
  *
  */
-public class AbstractEventWriterWrapperTests extends TestCase {
+public class AbstractEventWriterWrapperTests {
 
 	AbstractEventWriterWrapper eventWriterWrapper;
 
 	XMLEventWriter xmlEventWriter;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
-
 		xmlEventWriter = mock(XMLEventWriter.class);
 		eventWriterWrapper = new StubEventWriter(xmlEventWriter);
 	}
 
+	@Test
 	public void testAdd() throws XMLStreamException {
 
 		XMLEvent event = mock(XMLEvent.class);
@@ -53,6 +54,7 @@ public class AbstractEventWriterWrapperTests extends TestCase {
 
 	}
 
+	@Test
 	public void testAddReader() throws XMLStreamException {
 
 		XMLEventReader reader = mock(XMLEventReader.class);
@@ -60,34 +62,40 @@ public class AbstractEventWriterWrapperTests extends TestCase {
 		eventWriterWrapper.add(reader);
 	}
 
+	@Test
 	public void testClose() throws XMLStreamException {
 		xmlEventWriter.close();
 		eventWriterWrapper.close();
 	}
 
+	@Test
 	public void testFlush() throws XMLStreamException {
 		xmlEventWriter.flush();
 		eventWriterWrapper.flush();
 	}
 
+	@Test
 	public void testGetNamespaceContext() {
 		NamespaceContext context = mock(NamespaceContext.class);
 		when(xmlEventWriter.getNamespaceContext()).thenReturn(context);
 		assertEquals(eventWriterWrapper.getNamespaceContext(), context);
 	}
 
+	@Test
 	public void testGetPrefix() throws XMLStreamException {
 		String uri = "uri";
 		when(xmlEventWriter.getPrefix(uri)).thenReturn(uri);
 		assertEquals(eventWriterWrapper.getPrefix(uri), uri);
 	}
 
+	@Test
 	public void testSetDefaultNamespace() throws XMLStreamException {
 		String uri = "uri";
 		xmlEventWriter.setDefaultNamespace(uri);
 		eventWriterWrapper.setDefaultNamespace(uri);
 	}
 
+	@Test
 	public void testSetNamespaceContext() throws XMLStreamException {
 
 		NamespaceContext context = mock(NamespaceContext.class);
@@ -95,6 +103,7 @@ public class AbstractEventWriterWrapperTests extends TestCase {
 		eventWriterWrapper.setNamespaceContext(context);
 	}
 
+	@Test
 	public void testSetPrefix() throws XMLStreamException {
 
 		String uri = "uri";

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/DefaultFragmentEventReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/DefaultFragmentEventReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2020 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,16 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.xml.EventHelper;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.xml.StaxUtils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link DefaultFragmentEventReader}.
@@ -34,7 +38,7 @@ import org.springframework.util.xml.StaxUtils;
  * @author Robert Kasanicky
  * @author Mahmoud Ben Hassine
  */
-public class DefaultFragmentEventReaderTests extends TestCase {
+public class DefaultFragmentEventReaderTests {
 
 	// object under test
 	private FragmentEventReader fragmentReader;
@@ -48,7 +52,7 @@ public class DefaultFragmentEventReaderTests extends TestCase {
 	/**
 	 * Setup the fragmentReader to read the test input.
 	 */
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
 		Resource input = new ByteArrayResource(xml.getBytes());
 		eventReader = StaxUtils.createDefensiveInputFactory().createXMLEventReader(input.getInputStream());
@@ -60,6 +64,7 @@ public class DefaultFragmentEventReaderTests extends TestCase {
 	 * uses redundant peek() calls before nextEvent() in important moments to assure
 	 * peek() has no side effects on the inner state of reader.
 	 */
+	@Test
 	public void testFragmentWrapping() throws XMLStreamException {
 
 		assertTrue(fragmentReader.hasNext());
@@ -104,6 +109,7 @@ public class DefaultFragmentEventReaderTests extends TestCase {
 	 * When fragment is marked as processed the cursor is moved after the end of the
 	 * fragment.
 	 */
+	@Test
 	public void testMarkFragmentProcessed() throws XMLStreamException {
 		moveCursorBeforeFragmentStart();
 
@@ -124,6 +130,7 @@ public class DefaultFragmentEventReaderTests extends TestCase {
 	 * Cursor is moved to the end of the fragment as usually even if nothing was read from
 	 * the event reader after beginning of fragment was marked.
 	 */
+	@Test
 	public void testMarkFragmentProcessedImmediatelyAfterMarkFragmentStart() throws Exception {
 		moveCursorBeforeFragmentStart();
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2013 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.events.XMLEvent;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.times;
  * @author Robert Kasanicky
  * @author Will Schipp
  */
-public class NoStartEndDocumentWriterTests extends TestCase {
+public class NoStartEndDocumentWriterTests {
 
 	// object under test
 	private NoStartEndDocumentStreamWriter writer;
@@ -41,7 +42,7 @@ public class NoStartEndDocumentWriterTests extends TestCase {
 
 	private XMLEventFactory eventFactory = XMLEventFactory.newInstance();
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
 		wrappedWriter = mock(XMLEventWriter.class);
 		writer = new NoStartEndDocumentStreamWriter(wrappedWriter);
@@ -50,6 +51,7 @@ public class NoStartEndDocumentWriterTests extends TestCase {
 	/**
 	 * StartDocument and EndDocument events are not passed to the wrapped writer.
 	 */
+	@Test
 	public void testNoStartEnd() throws Exception {
 		XMLEvent event = eventFactory.createComment("testEvent");
 
@@ -66,6 +68,7 @@ public class NoStartEndDocumentWriterTests extends TestCase {
 	 * Close is not delegated to the wrapped writer. Instead, the wrapped writer is
 	 * flushed.
 	 */
+	@Test
 	public void testClose() throws Exception {
 		writer.close();
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnclosedElementCollectingEventWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnclosedElementCollectingEventWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item.xml.stax;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -24,8 +24,8 @@ import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.events.XMLEvent;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -47,7 +47,7 @@ public class UnclosedElementCollectingEventWriterTests {
 
 	private QName elementC = new QName("elementC");
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		wrappedWriter = mock(XMLEventWriter.class);
 		writer = new UnclosedElementCollectingEventWriter(wrappedWriter);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package org.springframework.batch.item.xml.stax;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -31,8 +32,8 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.dao.DataAccessResourceFailureException;
 
@@ -59,7 +60,7 @@ public class UnopenedElementClosingEventWriterTests {
 
 	private QName other = new QName("http://test", "other", "t");
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		wrappedWriter = mock(XMLEventWriter.class);
 		ioWriter = mock(Writer.class);
@@ -122,11 +123,11 @@ public class UnopenedElementClosingEventWriterTests {
 		verify(wrappedWriter).add(event);
 	}
 
-	@Test(expected = DataAccessResourceFailureException.class)
+	@Test
 	public void testIOException() throws Exception {
 		EndElement endElementB = eventFactory.createEndElement(unopenedB, null);
 		Mockito.doThrow(new IOException("Simulated IOException")).when(ioWriter).write("</unopened-b>");
-		writer.add(endElementB);
+		assertThrows(DataAccessResourceFailureException.class, () -> writer.add(endElementB));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jms/ExternalRetryInBatchTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jms/ExternalRetryInBatchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 
 package org.springframework.batch.jms;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
@@ -37,8 +36,7 @@ import org.springframework.retry.RetryContext;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.DefaultRetryState;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -49,10 +47,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 public class ExternalRetryInBatchTests {
 
 	@Autowired
@@ -71,7 +68,7 @@ public class ExternalRetryInBatchTests {
 	@Autowired
 	private PlatformTransactionManager transactionManager;
 
-	@Before
+	@BeforeEach
 	public void onSetUp() throws Exception {
 		getMessages(); // drain queue
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "T_BARS");
@@ -89,7 +86,7 @@ public class ExternalRetryInBatchTests {
 		retryTemplate = new RetryTemplate();
 	}
 
-	@After
+	@AfterEach
 	public void onTearDown() throws Exception {
 		getMessages(); // drain queue
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "T_BARS");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/poller/DirectPollerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/poller/DirectPollerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.batch.poller;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -25,7 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/AbstractExceptionTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/AbstractExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,19 @@
 
 package org.springframework.batch.repeat;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public abstract class AbstractExceptionTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+public abstract class AbstractExceptionTests {
+
+	@Test
 	public void testExceptionString() throws Exception {
 		Exception exception = getException("foo");
 		assertEquals("foo", exception.getMessage());
 	}
 
+	@Test
 	public void testExceptionStringThrowable() throws Exception {
 		Exception exception = getException("foo", new IllegalStateException());
 		assertEquals("foo", exception.getMessage().substring(0, 3));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/callback/NestedRepeatCallbackTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/callback/NestedRepeatCallbackTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,20 @@
 
 package org.springframework.batch.repeat.callback;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.support.RepeatTemplate;
 
-public class NestedRepeatCallbackTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class NestedRepeatCallbackTests {
 
 	int count = 0;
 
+	@Test
 	public void testExecute() throws Exception {
 		NestedRepeatCallback callback = new NestedRepeatCallback(new RepeatTemplate(), new RepeatCallback() {
 			@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/context/RepeatContextCounterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/context/RepeatContextCounterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,32 @@
 
 package org.springframework.batch.repeat.context;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 
-public class RepeatContextCounterTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RepeatContextCounterTests {
 
 	RepeatContext parent = new RepeatContextSupport(null);
 
 	RepeatContext context = new RepeatContextSupport(parent);
 
+	@Test
 	public void testAttributeCreated() {
 		new RepeatContextCounter(context, "FOO");
 		assertTrue(context.hasAttribute("FOO"));
 	}
 
+	@Test
 	public void testAttributeCreatedWithNullParent() {
 		new RepeatContextCounter(parent, "FOO", true);
 		assertTrue(parent.hasAttribute("FOO"));
 	}
 
+	@Test
 	public void testVanillaIncrement() throws Exception {
 		RepeatContextCounter counter = new RepeatContextCounter(context, "FOO");
 		assertEquals(0, counter.getCount());
@@ -45,12 +51,14 @@ public class RepeatContextCounterTests extends TestCase {
 		assertEquals(3, counter.getCount());
 	}
 
+	@Test
 	public void testAttributeCreatedInParent() throws Exception {
 		new RepeatContextCounter(context, "FOO", true);
 		assertFalse(context.hasAttribute("FOO"));
 		assertTrue(parent.hasAttribute("FOO"));
 	}
 
+	@Test
 	public void testParentIncrement() throws Exception {
 		RepeatContextCounter counter = new RepeatContextCounter(context, "FOO", true);
 		assertEquals(0, counter.getCount());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/context/RepeatContextSupportTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/context/RepeatContextSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,17 @@ package org.springframework.batch.repeat.context;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author dsyer
  *
  */
-public class RepeatContextSupportTests extends TestCase {
+public class RepeatContextSupportTests {
 
 	private List<String> list = new ArrayList<>();
 
@@ -32,6 +36,7 @@ public class RepeatContextSupportTests extends TestCase {
 	 * Test method for
 	 * {@link org.springframework.batch.repeat.context.RepeatContextSupport#registerDestructionCallback(java.lang.String, java.lang.Runnable)}.
 	 */
+	@Test
 	public void testDestructionCallbackSunnyDay() throws Exception {
 		RepeatContextSupport context = new RepeatContextSupport(null);
 		context.setAttribute("foo", "FOO");
@@ -50,6 +55,7 @@ public class RepeatContextSupportTests extends TestCase {
 	 * Test method for
 	 * {@link org.springframework.batch.repeat.context.RepeatContextSupport#registerDestructionCallback(java.lang.String, java.lang.Runnable)}.
 	 */
+	@Test
 	public void testDestructionCallbackMissingAttribute() throws Exception {
 		RepeatContextSupport context = new RepeatContextSupport(null);
 		context.registerDestructionCallback("foo", new Runnable() {
@@ -67,6 +73,7 @@ public class RepeatContextSupportTests extends TestCase {
 	 * Test method for
 	 * {@link org.springframework.batch.repeat.context.RepeatContextSupport#registerDestructionCallback(java.lang.String, java.lang.Runnable)}.
 	 */
+	@Test
 	public void testDestructionCallbackWithException() throws Exception {
 		RepeatContextSupport context = new RepeatContextSupport(null);
 		context.setAttribute("foo", "FOO");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,32 +21,40 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.core.AttributeAccessorSupport;
 
-public class SynchronizedAttributeAccessorTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SynchronizedAttributeAccessorTests {
 
 	SynchronizedAttributeAccessor accessor = new SynchronizedAttributeAccessor();
 
+	@Test
 	public void testHashCode() {
 		SynchronizedAttributeAccessor another = new SynchronizedAttributeAccessor();
 		accessor.setAttribute("foo", "bar");
 		another.setAttribute("foo", "bar");
 		assertEquals(accessor, another);
-		assertEquals("Object.hashCode() contract broken", accessor.hashCode(), another.hashCode());
+		assertEquals(accessor.hashCode(), another.hashCode(), "Object.hashCode() contract broken");
 	}
 
+	@Test
 	public void testToStringWithNoAttributes() throws Exception {
 		assertNotNull(accessor.toString());
 	}
 
+	@Test
 	public void testToStringWithAttributes() throws Exception {
 		accessor.setAttribute("foo", "bar");
 		accessor.setAttribute("spam", "bucket");
 		assertNotNull(accessor.toString());
 	}
 
+	@Test
 	public void testAttributeNames() {
 		accessor.setAttribute("foo", "bar");
 		accessor.setAttribute("spam", "bucket");
@@ -55,6 +63,7 @@ public class SynchronizedAttributeAccessorTests extends TestCase {
 		assertTrue(list.contains("foo"));
 	}
 
+	@Test
 	public void testEqualsSameType() {
 		SynchronizedAttributeAccessor another = new SynchronizedAttributeAccessor();
 		accessor.setAttribute("foo", "bar");
@@ -62,11 +71,13 @@ public class SynchronizedAttributeAccessorTests extends TestCase {
 		assertEquals(accessor, another);
 	}
 
+	@Test
 	public void testEqualsSelf() {
 		accessor.setAttribute("foo", "bar");
 		assertEquals(accessor, accessor);
 	}
 
+	@Test
 	public void testEqualsWrongType() {
 		accessor.setAttribute("foo", "bar");
 		Map<String, String> another = Collections.singletonMap("foo", "bar");
@@ -75,6 +86,7 @@ public class SynchronizedAttributeAccessorTests extends TestCase {
 		assertFalse(accessor.equals(another));
 	}
 
+	@Test
 	public void testEqualsSupport() {
 		@SuppressWarnings("serial")
 		AttributeAccessorSupport another = new AttributeAccessorSupport() {
@@ -84,26 +96,31 @@ public class SynchronizedAttributeAccessorTests extends TestCase {
 		assertEquals(accessor, another);
 	}
 
+	@Test
 	public void testGetAttribute() {
 		accessor.setAttribute("foo", "bar");
 		assertEquals("bar", accessor.getAttribute("foo"));
 	}
 
+	@Test
 	public void testSetAttributeIfAbsentWhenAlreadyPresent() {
 		accessor.setAttribute("foo", "bar");
 		assertEquals("bar", accessor.setAttributeIfAbsent("foo", "spam"));
 	}
 
+	@Test
 	public void testSetAttributeIfAbsentWhenNotAlreadyPresent() {
 		assertEquals(null, accessor.setAttributeIfAbsent("foo", "bar"));
 		assertEquals("bar", accessor.getAttribute("foo"));
 	}
 
+	@Test
 	public void testHasAttribute() {
 		accessor.setAttribute("foo", "bar");
 		assertEquals(true, accessor.hasAttribute("foo"));
 	}
 
+	@Test
 	public void testRemoveAttribute() {
 		accessor.setAttribute("foo", "bar");
 		assertEquals("bar", accessor.getAttribute("foo"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/CompositeExceptionHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/CompositeExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,17 @@ package org.springframework.batch.repeat.exception;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
-import org.springframework.batch.repeat.exception.CompositeExceptionHandler;
-import org.springframework.batch.repeat.exception.ExceptionHandler;
 
-public class CompositeExceptionHandlerTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class CompositeExceptionHandlerTests {
 
 	private CompositeExceptionHandler handler = new CompositeExceptionHandler();
 
+	@Test
 	public void testNewHandler() throws Throwable {
 		try {
 			handler.handleException(null, new RuntimeException());
@@ -38,6 +39,7 @@ public class CompositeExceptionHandlerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDelegation() throws Throwable {
 		final List<String> list = new ArrayList<>();
 		handler.setHandlers(new ExceptionHandler[] { new ExceptionHandler() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/DefaultExceptionHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/DefaultExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,19 @@
 
 package org.springframework.batch.repeat.exception;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 
-public class DefaultExceptionHandlerTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class DefaultExceptionHandlerTests {
 
 	private DefaultExceptionHandler handler = new DefaultExceptionHandler();
 
 	private RepeatContext context = null;
 
+	@Test
 	public void testRuntimeException() throws Throwable {
 		try {
 			handler.handleException(context, new RuntimeException("Foo"));
@@ -36,6 +39,7 @@ public class DefaultExceptionHandlerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testError() throws Throwable {
 		try {
 			handler.handleException(context, new Error("Foo"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/LogOrRethrowExceptionHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/LogOrRethrowExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package org.springframework.batch.repeat.exception;
 
 import java.io.StringWriter;
 
-import junit.framework.TestCase;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -27,6 +25,8 @@ import org.apache.logging.log4j.core.appender.WriterAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,11 @@ import org.springframework.classify.ClassifierSupport;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.exception.LogOrRethrowExceptionHandler.Level;
 
-public class LogOrRethrowExceptionHandlerTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class LogOrRethrowExceptionHandlerTests {
 
 	private LogOrRethrowExceptionHandler handler = new LogOrRethrowExceptionHandler();
 
@@ -42,9 +46,8 @@ public class LogOrRethrowExceptionHandlerTests extends TestCase {
 
 	private RepeatContext context = null;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
 		Logger logger = LoggerFactory.getLogger(LogOrRethrowExceptionHandler.class);
 		writer = new StringWriter();
 		LoggerContext loggerContext = (LoggerContext) LogManager.getContext();
@@ -59,6 +62,7 @@ public class LogOrRethrowExceptionHandlerTests extends TestCase {
 		rootLoggerConfig.addAppender(appender, org.apache.logging.log4j.Level.DEBUG, null);
 	}
 
+	@Test
 	public void testRuntimeException() throws Throwable {
 		try {
 			handler.handleException(context, new RuntimeException("Foo"));
@@ -69,6 +73,7 @@ public class LogOrRethrowExceptionHandlerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testError() throws Throwable {
 		try {
 			handler.handleException(context, new Error("Foo"));
@@ -79,7 +84,7 @@ public class LogOrRethrowExceptionHandlerTests extends TestCase {
 		}
 	}
 
-	@SuppressWarnings("serial")
+	@Test
 	public void testNotRethrownErrorLevel() throws Throwable {
 		handler.setExceptionClassifier(new ClassifierSupport<Throwable, Level>(Level.RETHROW) {
 			@Override
@@ -92,7 +97,7 @@ public class LogOrRethrowExceptionHandlerTests extends TestCase {
 		assertNotNull(writer.toString());
 	}
 
-	@SuppressWarnings("serial")
+	@Test
 	public void testNotRethrownWarnLevel() throws Throwable {
 		handler.setExceptionClassifier(new ClassifierSupport<Throwable, Level>(Level.RETHROW) {
 			@Override
@@ -105,7 +110,7 @@ public class LogOrRethrowExceptionHandlerTests extends TestCase {
 		assertNotNull(writer.toString());
 	}
 
-	@SuppressWarnings("serial")
+	@Test
 	public void testNotRethrownDebugLevel() throws Throwable {
 		handler.setExceptionClassifier(new ClassifierSupport<Throwable, Level>(Level.RETHROW) {
 			@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/RethrowOnThresholdExceptionHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/RethrowOnThresholdExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 package org.springframework.batch.repeat.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.context.RepeatContextSupport;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,17 @@
 
 package org.springframework.batch.repeat.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.context.RepeatContextSupport;
 
 /**
@@ -40,7 +40,7 @@ public class SimpleLimitExceptionHandlerTests {
 	// object under test
 	private SimpleLimitExceptionHandler handler = new SimpleLimitExceptionHandler();
 
-	@Before
+	@BeforeEach
 	public void initializeHandler() throws Exception {
 		handler.afterPropertiesSet();
 	}
@@ -74,7 +74,7 @@ public class SimpleLimitExceptionHandlerTests {
 			fail("Exception was swallowed.");
 		}
 		catch (RuntimeException expected) {
-			assertTrue("Exception is rethrown, ignoring the exception limit", true);
+			assertTrue(true, "Exception is rethrown, ignoring the exception limit");
 			assertSame(expected, throwable);
 		}
 	}
@@ -98,7 +98,7 @@ public class SimpleLimitExceptionHandlerTests {
 			fail("Exception was swallowed.");
 		}
 		catch (RuntimeException expected) {
-			assertTrue("Exception is rethrown, ignoring the exception limit", true);
+			assertTrue(true, "Exception is rethrown, ignoring the exception limit");
 			assertSame(expected, throwable);
 		}
 	}
@@ -202,7 +202,7 @@ public class SimpleLimitExceptionHandlerTests {
 			for (Throwable throwable : throwables) {
 
 				handler.handleException(context, throwable);
-				assertTrue("exceptions up to limit are swallowed", true);
+				assertTrue(true, "exceptions up to limit are swallowed");
 
 			}
 		}
@@ -240,7 +240,7 @@ public class SimpleLimitExceptionHandlerTests {
 			for (Throwable throwable : throwables) {
 
 				handler.handleException(context, throwable);
-				assertTrue("exceptions up to limit are swallowed", true);
+				assertTrue(true, "exceptions up to limit are swallowed");
 
 			}
 		}
@@ -251,7 +251,7 @@ public class SimpleLimitExceptionHandlerTests {
 		// after reaching the limit, behaviour should be idempotent
 		try {
 			handler.handleException(context, new RuntimeException("foo"));
-			assertTrue("exceptions up to limit are swallowed", true);
+			assertTrue(true, "exceptions up to limit are swallowed");
 
 		}
 		catch (RuntimeException expected) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/AsynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/AsynchronousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,9 @@ import jakarta.jms.Message;
 import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.container.jms.BatchMessageListenerContainer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,16 +33,14 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 @DirtiesContext
 public class AsynchronousTests {
 
@@ -56,7 +53,7 @@ public class AsynchronousTests {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
-	@Before
+	@BeforeEach
 	public void onSetUp() throws Exception {
 		String foo = "";
 		int count = 0;
@@ -75,7 +72,7 @@ public class AsynchronousTests {
 
 	}
 
-	@After
+	@AfterEach
 	public void onTearDown() throws Exception {
 		container.stop();
 		// Need to give the container time to shutdown
@@ -173,7 +170,7 @@ public class AsynchronousTests {
 		int count = JdbcTestUtils.countRowsInTable(jdbcTemplate, "T_BARS");
 		assertEquals(0, count);
 
-		assertTrue("Foo not on queue", msgs.contains("foo"));
+		assertTrue(msgs.contains("foo"), "Foo not on queue");
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/SynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/jms/SynchronousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.batch.repeat.jms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,8 +26,7 @@ import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Session;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
@@ -42,8 +41,7 @@ import org.springframework.jms.connection.SessionProxy;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.SessionCallback;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.transaction.BeforeTransaction;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -51,8 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 @DirtiesContext
 public class SynchronousTests implements ApplicationContextAware {
 
@@ -161,7 +158,7 @@ public class SynchronousTests implements ApplicationContextAware {
 
 		// ... and so did the message session. The rollback should have restored
 		// the queue, so this should now be non-null
-		assertTrue("Foo not on queue", msgs.contains("foo"));
+		assertTrue(msgs.contains("foo"), "Foo not on queue");
 	}
 
 	@Transactional
@@ -198,7 +195,7 @@ public class SynchronousTests implements ApplicationContextAware {
 					@Override
 					public Void doInJms(Session session) throws JMSException {
 						try {
-							assertTrue("Not a SessionProxy - wrong spring version?", session instanceof SessionProxy);
+							assertTrue(session instanceof SessionProxy, "Not a SessionProxy - wrong spring version?");
 							((SessionProxy) session).getTargetSession().rollback();
 						}
 						catch (JMSException e) {
@@ -228,8 +225,8 @@ public class SynchronousTests implements ApplicationContextAware {
 		assertEquals(2, count);
 
 		// ...but the JMS session rolled back, so the message is still there
-		assertTrue("Foo not on queue", msgs.contains("foo"));
-		assertTrue("Bar not on queue", msgs.contains("bar"));
+		assertTrue(msgs.contains("foo"), "Foo not on queue");
+		assertTrue(msgs.contains("bar"), "Bar not on queue");
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/listener/CompositeRepeatListenerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/listener/CompositeRepeatListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package org.springframework.batch.repeat.listener;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatListener;
 import org.springframework.batch.repeat.context.RepeatContextSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  *
  */
-public class CompositeRepeatListenerTests extends TestCase {
+public class CompositeRepeatListenerTests {
 
 	private CompositeRepeatListener listener = new CompositeRepeatListener();
 
@@ -40,6 +41,7 @@ public class CompositeRepeatListenerTests extends TestCase {
 	/**
 	 * Test method for {@link CompositeRepeatListener#setListeners(RepeatListener[])}.
 	 */
+	@Test
 	public void testSetListeners() {
 		listener.setListeners(new RepeatListener[] { new RepeatListener() {
 			@Override
@@ -59,6 +61,7 @@ public class CompositeRepeatListenerTests extends TestCase {
 	/**
 	 * Test method for {@link CompositeRepeatListener#register(RepeatListener)}.
 	 */
+	@Test
 	public void testSetListener() {
 		listener.register(new RepeatListener() {
 			@Override
@@ -70,6 +73,7 @@ public class CompositeRepeatListenerTests extends TestCase {
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testClose() {
 		listener.register(new RepeatListener() {
 			@Override
@@ -81,6 +85,7 @@ public class CompositeRepeatListenerTests extends TestCase {
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testOnError() {
 		listener.register(new RepeatListener() {
 			@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/listener/RepeatListenerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/listener/RepeatListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package org.springframework.batch.repeat.listener;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
@@ -29,10 +28,15 @@ import org.springframework.batch.repeat.support.RepeatTemplate;
 import org.springframework.batch.repeat.support.TaskExecutorRepeatTemplate;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 
-public class RepeatListenerTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class RepeatListenerTests {
 
 	int count = 0;
 
+	@Test
 	public void testBeforeInterceptors() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -62,6 +66,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[1, 2, 1, 2]", calls.toString());
 	}
 
+	@Test
 	public void testBeforeInterceptorCanVeto() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -84,6 +89,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[1]", calls.toString());
 	}
 
+	@Test
 	public void testAfterInterceptors() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -111,6 +117,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[2, 1]", calls.toString());
 	}
 
+	@Test
 	public void testOpenInterceptors() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -137,6 +144,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[1, 2]", calls.toString());
 	}
 
+	@Test
 	public void testSingleOpenInterceptor() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -158,6 +166,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[1]", calls.toString());
 	}
 
+	@Test
 	public void testCloseInterceptors() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -185,6 +194,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[2, 1]", calls.toString());
 	}
 
+	@Test
 	public void testOnErrorInterceptors() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -215,6 +225,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[2, 1]", calls.toString());
 	}
 
+	@Test
 	public void testOnErrorInterceptorsPrecedence() throws Exception {
 		RepeatTemplate template = new RepeatTemplate();
 		final List<Object> calls = new ArrayList<>();
@@ -246,6 +257,7 @@ public class RepeatListenerTests extends TestCase {
 		assertEquals("[2]", calls.toString());
 	}
 
+	@Test
 	public void testAsynchronousOnErrorInterceptorsPrecedence() throws Exception {
 		TaskExecutorRepeatTemplate template = new TaskExecutorRepeatTemplate();
 		template.setTaskExecutor(new SimpleAsyncTaskExecutor());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/CompositeCompletionPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/CompositeCompletionPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,19 @@
 
 package org.springframework.batch.repeat.policy;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.CompletionPolicy;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatContext;
 
-public class CompositeCompletionPolicyTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+public class CompositeCompletionPolicyTests {
+
+	@Test
 	public void testEmptyPolicies() throws Exception {
 		CompositeCompletionPolicy policy = new CompositeCompletionPolicy();
 		RepeatContext context = policy.start(null);
@@ -31,6 +36,7 @@ public class CompositeCompletionPolicyTests extends TestCase {
 		assertFalse(policy.isComplete(context));
 	}
 
+	@Test
 	public void testTrivialPolicies() throws Exception {
 		CompositeCompletionPolicy policy = new CompositeCompletionPolicy();
 		policy.setPolicies(
@@ -43,6 +49,7 @@ public class CompositeCompletionPolicyTests extends TestCase {
 		assertEquals(1, context.getStartedCount());
 	}
 
+	@Test
 	public void testNonTrivialPolicies() throws Exception {
 		CompositeCompletionPolicy policy = new CompositeCompletionPolicy();
 		policy.setPolicies(
@@ -56,6 +63,7 @@ public class CompositeCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context));
 	}
 
+	@Test
 	public void testNonTrivialPoliciesWithResult() throws Exception {
 		CompositeCompletionPolicy policy = new CompositeCompletionPolicy();
 		policy.setPolicies(

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/CountingCompletionPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/CountingCompletionPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,17 @@
 
 package org.springframework.batch.repeat.policy;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.context.RepeatContextSupport;
 
-public class CountingCompletionPolicyTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+public class CountingCompletionPolicyTests {
+
+	@Test
 	public void testDefaultBehaviour() throws Exception {
 		CountingCompletionPolicy policy = new CountingCompletionPolicy() {
 			@Override
@@ -35,6 +38,7 @@ public class CountingCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context));
 	}
 
+	@Test
 	public void testNullResult() throws Exception {
 		CountingCompletionPolicy policy = new CountingCompletionPolicy() {
 			@Override
@@ -47,6 +51,7 @@ public class CountingCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context, null));
 	}
 
+	@Test
 	public void testFinishedResult() throws Exception {
 		CountingCompletionPolicy policy = new CountingCompletionPolicy() {
 			@Override
@@ -59,6 +64,7 @@ public class CountingCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context, RepeatStatus.FINISHED));
 	}
 
+	@Test
 	public void testDefaultBehaviourWithUpdate() throws Exception {
 		CountingCompletionPolicy policy = new CountingCompletionPolicy() {
 			int count = 0;
@@ -82,6 +88,7 @@ public class CountingCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context));
 	}
 
+	@Test
 	public void testUpdateNotSavedAcrossSession() throws Exception {
 		CountingCompletionPolicy policy = new CountingCompletionPolicy() {
 			int count = 0;
@@ -114,6 +121,7 @@ public class CountingCompletionPolicyTests extends TestCase {
 		assertFalse(policy.isComplete(context));
 	}
 
+	@Test
 	public void testUpdateSavedAcrossSession() throws Exception {
 		CountingCompletionPolicy policy = new CountingCompletionPolicy() {
 			int count = 0;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/SimpleCompletionPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/SimpleCompletionPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 
 package org.springframework.batch.repeat.policy;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatContext;
 
-public class SimpleCompletionPolicyTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleCompletionPolicyTests {
 
 	SimpleCompletionPolicy policy = new SimpleCompletionPolicy();
 
@@ -29,12 +32,12 @@ public class SimpleCompletionPolicyTests extends TestCase {
 
 	RepeatStatus dummy = RepeatStatus.CONTINUABLE;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
-		super.setUp();
 		context = policy.start(null);
 	}
 
+	@Test
 	public void testTerminationAfterDefaultSize() throws Exception {
 		for (int i = 0; i < SimpleCompletionPolicy.DEFAULT_CHUNK_SIZE - 1; i++) {
 			policy.update(context);
@@ -44,6 +47,7 @@ public class SimpleCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context, dummy));
 	}
 
+	@Test
 	public void testTerminationAfterExplicitChunkSize() throws Exception {
 		int chunkSize = 2;
 		policy.setChunkSize(chunkSize);
@@ -55,6 +59,7 @@ public class SimpleCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context, dummy));
 	}
 
+	@Test
 	public void testTerminationAfterNullResult() throws Exception {
 		policy.update(context);
 		assertFalse(policy.isComplete(context, dummy));
@@ -62,6 +67,7 @@ public class SimpleCompletionPolicyTests extends TestCase {
 		assertTrue(policy.isComplete(context, null));
 	}
 
+	@Test
 	public void testReset() throws Exception {
 		policy.setChunkSize(2);
 		policy.update(context);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/TimeoutCompletionPolicyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/policy/TimeoutCompletionPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.batch.repeat.policy;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatContext;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/AbstractTradeBatchTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/AbstractTradeBatchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.batch.repeat.support;
 
 import java.util.List;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.file.FlatFileItemReader;
@@ -45,7 +45,7 @@ public abstract class AbstractTradeBatchTests {
 
 	protected TradeItemReader provider;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		provider = new TradeItemReader(resource);
 		provider.open(new ExecutionContext());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ChunkedRepeatTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ChunkedRepeatTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.repeat.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.repeat.RepeatCallback;
@@ -27,9 +27,9 @@ import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.lang.Nullable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test various approaches to chunking of a batch. Not really a unit test, but it should
@@ -104,7 +104,7 @@ public class ChunkedRepeatTests extends AbstractTradeBatchTests {
 
 		assertEquals(NUMBER_OF_ITEMS, processor.count);
 		assertFalse(result.isContinuable());
-		assertTrue("Expected at least 3 chunks but found: " + count, count >= 3);
+		assertTrue(count >= 3, "Expected at least 3 chunks but found: " + count);
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/RepeatSynchronizationManagerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/RepeatSynchronizationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,38 @@
 
 package org.springframework.batch.repeat.support;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.context.RepeatContextSupport;
 
-public class RepeatSynchronizationManagerTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RepeatSynchronizationManagerTests {
 
 	private RepeatContext context = new RepeatContextSupport(null);
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
 		RepeatSynchronizationManager.clear();
 	}
 
-	@Override
+	@AfterEach
 	protected void tearDown() throws Exception {
 		RepeatSynchronizationManager.clear();
 	}
 
+	@Test
 	public void testGetContext() {
 		RepeatSynchronizationManager.register(context);
 		assertEquals(context, RepeatSynchronizationManager.getContext());
 	}
 
+	@Test
 	public void testSetSessionCompleteOnly() {
 		assertNull(RepeatSynchronizationManager.getContext());
 		RepeatSynchronizationManager.register(context);
@@ -48,6 +56,7 @@ public class RepeatSynchronizationManagerTests extends TestCase {
 		assertTrue(RepeatSynchronizationManager.getContext().isCompleteOnly());
 	}
 
+	@Test
 	public void testSetSessionCompleteOnlyWithParent() {
 		assertNull(RepeatSynchronizationManager.getContext());
 		RepeatContext child = new RepeatContextSupport(context);
@@ -58,6 +67,7 @@ public class RepeatSynchronizationManagerTests extends TestCase {
 		assertTrue(context.isCompleteOnly());
 	}
 
+	@Test
 	public void testClear() {
 		RepeatSynchronizationManager.register(context);
 		assertEquals(context, RepeatSynchronizationManager.getContext());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ResultHolderResultQueueTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ResultHolderResultQueueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2012 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package org.springframework.batch.repeat.support;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatStatus;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/SimpleRepeatTemplateTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/SimpleRepeatTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,18 @@
 
 package org.springframework.batch.repeat.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatException;
@@ -99,7 +99,7 @@ public class SimpleRepeatTemplateTests extends AbstractTradeBatchTests {
 		}
 
 		assertEquals(1, count);
-		assertTrue("Too many attempts: " + count, count <= 10);
+		assertTrue(count <= 10, "Too many attempts: " + count);
 
 	}
 
@@ -281,7 +281,7 @@ public class SimpleRepeatTemplateTests extends AbstractTradeBatchTests {
 			public RepeatStatus doInIteration(RepeatContext context) throws Exception {
 				count++;
 				assertNotNull(context);
-				assertNotSame("Nested batch should have new session", context, context.getParent());
+				assertNotSame(context, context.getParent(), "Nested batch should have new session");
 				assertSame(context, RepeatSynchronizationManager.getContext());
 				return RepeatStatus.FINISHED;
 			}
@@ -329,7 +329,7 @@ public class SimpleRepeatTemplateTests extends AbstractTradeBatchTests {
 			public RepeatStatus doInIteration(RepeatContext context) throws Exception {
 				count++;
 				assertNotNull(context);
-				assertNotSame("Nested batch should have new session", context, context.getParent());
+				assertNotSame(context, context.getParent(), "Nested batch should have new session");
 				assertSame(context, RepeatSynchronizationManager.getContext());
 				return RepeatStatus.FINISHED;
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateAsynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateAsynchronousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package org.springframework.batch.repeat.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
@@ -76,8 +76,8 @@ public class TaskExecutorRepeatTemplateAsynchronousTests extends AbstractTradeBa
 			assertEquals("foo!", e.getMessage());
 		}
 
-		assertTrue("Too few attempts: " + count, count >= 1);
-		assertTrue("Too many attempts: " + count, count <= 10);
+		assertTrue(count >= 1, "Too few attempts: " + count);
+		assertTrue(count <= 10, "Too many attempts: " + count);
 
 	}
 
@@ -103,8 +103,8 @@ public class TaskExecutorRepeatTemplateAsynchronousTests extends AbstractTradeBa
 			}
 		});
 
-		assertTrue("Too few attempts: " + count, count >= 1);
-		assertTrue("Too many attempts: " + count, count <= 10);
+		assertTrue(count >= 1, "Too few attempts: " + count);
+		assertTrue(count <= 10, "Too many attempts: " + count);
 
 	}
 
@@ -119,7 +119,7 @@ public class TaskExecutorRepeatTemplateAsynchronousTests extends AbstractTradeBa
 			public RepeatStatus doInIteration(RepeatContext context) throws Exception {
 				count++;
 				assertNotNull(context);
-				assertNotSame("Nested batch should have new session", context, context.getParent());
+				assertNotSame(context, context.getParent(), "Nested batch should have new session");
 				assertSame(context, RepeatSynchronizationManager.getContext());
 				return RepeatStatus.FINISHED;
 			}
@@ -133,8 +133,8 @@ public class TaskExecutorRepeatTemplateAsynchronousTests extends AbstractTradeBa
 			}
 		});
 
-		assertTrue("Too few attempts: " + count, count >= 1);
-		assertTrue("Too many attempts: " + count, count <= 10);
+		assertTrue(count >= 1, "Too few attempts: " + count);
+		assertTrue(count <= 10, "Too many attempts: " + count);
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateBulkAsynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateBulkAsynchronousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.batch.repeat.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,9 +28,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatStatus;
@@ -68,7 +68,7 @@ public class TaskExecutorRepeatTemplateBulkAsynchronousTests {
 
 	private ThreadPoolTaskExecutor threadPool = new ThreadPoolTaskExecutor();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		template = new TaskExecutorRepeatTemplate();
@@ -114,7 +114,7 @@ public class TaskExecutorRepeatTemplateBulkAsynchronousTests {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		threadPool.destroy();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.batch.repeat.support;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueueTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 package org.springframework.batch.repeat.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer
@@ -88,8 +88,8 @@ public class ThrottleLimitResultQueueTests {
 		long t1 = System.currentTimeMillis();
 		assertEquals("foo", queue.take());
 		assertTrue(queue.isExpecting());
-		assertTrue("Did not block on expect (throttle limit should have been hit): time taken=" + (t1 - t0),
-				t1 - t0 > 50);
+		assertTrue(t1 - t0 > 50,
+				"Did not block on expect (throttle limit should have been hit): time taken=" + (t1 - t0));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/ExternalRetryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/ExternalRetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.springframework.batch.retry.jms;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,8 +29,7 @@ import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.support.DefaultRetryState;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -42,11 +40,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 public class ExternalRetryTests {
 
 	@Autowired
@@ -62,7 +59,7 @@ public class ExternalRetryTests {
 	@Autowired
 	private PlatformTransactionManager transactionManager;
 
-	@Before
+	@BeforeEach
 	public void onSetUp() throws Exception {
 		getMessages(); // drain queue
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "T_BARS");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/SynchronousTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/SynchronousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.springframework.batch.retry.jms;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.jms.JmsItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -26,8 +25,7 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.test.context.transaction.BeforeTransaction;
 import org.springframework.test.jdbc.JdbcTestUtils;
@@ -40,13 +38,12 @@ import org.springframework.transaction.support.TransactionTemplate;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/org/springframework/batch/jms/jms-context.xml")
+@SpringJUnitConfig(locations = "/org/springframework/batch/jms/jms-context.xml")
 public class SynchronousTests {
 
 	@Autowired
@@ -69,7 +66,7 @@ public class SynchronousTests {
 		assertNotNull(text);
 	}
 
-	@Before
+	@BeforeEach
 	public void onSetUpInTransaction() throws Exception {
 		retryTemplate = new RetryTemplate();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/AbstractExceptionTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/AbstractExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,19 @@
 
 package org.springframework.batch.support;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public abstract class AbstractExceptionTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+public abstract class AbstractExceptionTests {
+
+	@Test
 	public void testExceptionString() throws Exception {
 		Exception exception = getException("foo");
 		assertEquals("foo", exception.getMessage());
 	}
 
+	@Test
 	public void testExceptionStringThrowable() throws Exception {
 		Exception exception = getException("foo", new IllegalStateException());
 		assertEquals("foo", exception.getMessage().substring(0, 3));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/AnnotationMethodResolverTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/AnnotationMethodResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 package org.springframework.batch.support;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -25,8 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
-import org.junit.Test;
-import org.springframework.batch.support.AnnotationMethodResolver;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Mark Fisher
@@ -40,10 +40,10 @@ public class AnnotationMethodResolverTests {
 		assertNotNull(method);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void multipleAnnotations() {
 		AnnotationMethodResolver resolver = new AnnotationMethodResolver(TestAnnotation.class);
-		resolver.findMethod(MultipleAnnotationTestBean.class);
+		assertThrows(IllegalArgumentException.class, () -> resolver.findMethod(MultipleAnnotationTestBean.class));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.batch.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Dave Syer

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTests.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.batch.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.support.MetaDataAccessException;
 
 import javax.sql.DataSource;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.batch.support.DatabaseType.DB2;
 import static org.springframework.batch.support.DatabaseType.DB2VSE;
 import static org.springframework.batch.support.DatabaseType.DB2ZOS;
@@ -60,10 +61,9 @@ public class DatabaseTypeTests {
 		assertEquals(HANA, fromProductName("HDB"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidProductName() {
-
-		fromProductName("bad product name");
+		assertThrows(IllegalArgumentException.class, () -> fromProductName("bad product name"));
 	}
 
 	@Test
@@ -150,10 +150,10 @@ public class DatabaseTypeTests {
 		assertEquals(HANA, DatabaseType.fromMetaData(ds));
 	}
 
-	@Test(expected = MetaDataAccessException.class)
+	@Test
 	public void testBadMetaData() throws Exception {
 		DataSource ds = DatabaseTypeTestUtils.getMockDataSource(new MetaDataAccessException("Bad!"));
-		assertEquals(SYBASE, DatabaseType.fromMetaData(ds));
+		assertThrows(MetaDataAccessException.class, () -> DatabaseType.fromMetaData(ds));
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DefaultPropertyEditorRegistrarTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DefaultPropertyEditorRegistrarTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package org.springframework.batch.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
@@ -43,11 +45,11 @@ public class DefaultPropertyEditorRegistrarTests {
 		assertEquals(4, result.numbers[3]);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testSetCustomEditorsWithInvalidTypeName() throws Exception {
-
 		DefaultPropertyEditorRegistrar mapper = new DefaultPropertyEditorRegistrar();
-		mapper.setCustomEditors(Collections.singletonMap("FOO", new CustomNumberEditor(Long.class, true)));
+		var customEditors = Map.of("FOO", new CustomNumberEditor(Long.class, true));
+		assertThrows(IllegalArgumentException.class, () -> mapper.setCustomEditors(customEditors));
 	}
 
 	@Test
@@ -63,11 +65,11 @@ public class DefaultPropertyEditorRegistrarTests {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testSetCustomEditorsWithInvalidType() throws Exception {
-
 		DefaultPropertyEditorRegistrar mapper = new DefaultPropertyEditorRegistrar();
-		mapper.setCustomEditors(Collections.singletonMap(new Object(), new CustomNumberEditor(Long.class, true)));
+		var customEditors = Map.of(new Object(), new CustomNumberEditor(Long.class, true));
+		assertThrows(IllegalArgumentException.class, () -> mapper.setCustomEditors(customEditors));
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/LastModifiedResourceComparatorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/LastModifiedResourceComparatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,15 @@
  */
 package org.springframework.batch.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResource;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Dave Syer
@@ -35,14 +36,18 @@ public class LastModifiedResourceComparatorTests {
 
 	private LastModifiedResourceComparator comparator = new LastModifiedResourceComparator();
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testCompareTwoNonExistent() {
-		comparator.compare(new FileSystemResource("garbage"), new FileSystemResource("crap"));
+		FileSystemResource garbage = new FileSystemResource("garbage");
+		FileSystemResource crap = new FileSystemResource("crap");
+		assertThrows(IllegalArgumentException.class, () -> comparator.compare(garbage, crap));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testCompareOneNonExistent() {
-		comparator.compare(new FileSystemResource(FILE_PATH), new FileSystemResource("crap"));
+		FileSystemResource exists = new FileSystemResource(FILE_PATH);
+		FileSystemResource crap = new FileSystemResource("crap");
+		assertThrows(IllegalArgumentException.class, () -> comparator.compare(exists, crap));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PatternMatcherTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PatternMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,15 @@
  */
 package org.springframework.batch.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dan Garrette
@@ -116,9 +117,10 @@ public class PatternMatcherTests {
 		assertEquals(4, new PatternMatcher<>(map).match("biggest").intValue());
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testMatchPrefixNoMatch() {
-		new PatternMatcher<>(map).match("bat");
+		PatternMatcher<Integer> matcher = new PatternMatcher<>(map);
+		assertThrows(IllegalStateException.class, () -> matcher.match("bat"));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PropertiesConverterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PropertiesConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.batch.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.util.StringUtils;
 
 /**
@@ -94,8 +94,8 @@ public class PropertiesConverterTests {
 
 		String value = PropertiesConverter.propertiesToString(storedProps);
 
-		assertTrue("Wrong value: " + value, value.contains("key1=value1"));
-		assertTrue("Wrong value: " + value, value.contains("key2=value2"));
+		assertTrue(value.contains("key1=value1"), "Wrong value: " + value);
+		assertTrue(value.contains("key2=value2"), "Wrong value: " + value);
 		assertEquals(1, StringUtils.countOccurrencesOf(value, ","));
 	}
 
@@ -121,7 +121,7 @@ public class PropertiesConverterTests {
 	public void testStringToPropertiesNull() {
 		props = PropertiesConverter.stringToProperties(null);
 		assertNotNull(props);
-		assertEquals("properties are empty", 0, props.size());
+		assertEquals(0, props.size(), "properties are empty");
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/ReflectionUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/ReflectionUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,8 +23,8 @@ import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Michael Minella

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SimpleMethodInvokerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SimpleMethodInvokerTests.java
@@ -1,21 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,14 +17,15 @@ package org.springframework.batch.support;
 
 import java.lang.reflect.Method;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.util.Assert;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Lucas Ward
@@ -52,7 +37,7 @@ public class SimpleMethodInvokerTests {
 
 	String value = "foo";
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		testClass = new TestClass();
 	}
@@ -89,19 +74,18 @@ public class SimpleMethodInvokerTests {
 		assertTrue(testClass.beforeCalled);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testMethodWithTooManyArguments() throws Exception {
 		Method method = TestClass.class.getMethod("beforeWithTooManyArguments", String.class, int.class);
 		MethodInvoker methodInvoker = new SimpleMethodInvoker(testClass, method);
-		methodInvoker.invokeMethod(value);
+		assertThrows(IllegalArgumentException.class, () -> methodInvoker.invokeMethod(value));
 		assertFalse(testClass.beforeCalled);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testMethodByNameWithTooManyArguments() throws Exception {
-		MethodInvoker methodInvoker = new SimpleMethodInvoker(testClass, "beforeWithTooManyArguments", String.class);
-		methodInvoker.invokeMethod(value);
-		assertFalse(testClass.beforeCalled);
+	@Test
+	public void testMethodByNameWithTooManyArguments() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new SimpleMethodInvoker(testClass, "beforeWithTooManyArguments", String.class));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SystemPropertyInitializerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/SystemPropertyInitializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 package org.springframework.batch.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dave Syer
@@ -31,8 +32,8 @@ public class SystemPropertyInitializerTests {
 
 	private SystemPropertyInitializer initializer = new SystemPropertyInitializer();
 
-	@Before
-	@After
+	@BeforeEach
+	@AfterEach
 	public void initializeProperty() {
 		System.clearProperty(SystemPropertyInitializer.ENVIRONMENT);
 		System.clearProperty(SIMPLE_NAME);
@@ -53,9 +54,9 @@ public class SystemPropertyInitializerTests {
 		assertEquals("foo", System.getProperty(SystemPropertyInitializer.ENVIRONMENT));
 	}
 
-	@Test(expected = IllegalStateException.class)
-	public void testNoDefaultValue() throws Exception {
-		initializer.afterPropertiesSet();
+	@Test
+	public void testNoDefaultValue() {
+		assertThrows(IllegalStateException.class, initializer::afterPropertiesSet);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ConcurrentTransactionAwareProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ConcurrentTransactionAwareProxyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 package org.springframework.batch.support.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,10 +34,10 @@ import java.util.concurrent.Executors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
@@ -48,7 +49,7 @@ import org.springframework.util.Assert;
  * @author Mahmoud Ben Hassine
  *
  */
-@Ignore // FIXME https://github.com/spring-projects/spring-batch/issues/3847
+@Disabled // FIXME https://github.com/spring-projects/spring-batch/issues/3847
 public class ConcurrentTransactionAwareProxyTests {
 
 	private static Log logger = LogFactory.getLog(ConcurrentTransactionAwareProxyTests.class);
@@ -63,21 +64,21 @@ public class ConcurrentTransactionAwareProxyTests {
 
 	private CompletionService<List<String>> completionService;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		executor = Executors.newFixedThreadPool(outerMax);
 		completionService = new ExecutorCompletionService<>(executor);
 	}
 
-	@After
+	@AfterEach
 	public void close() {
 		executor.shutdown();
 	}
 
-	@Test(expected = Throwable.class)
-	public void testConcurrentTransactionalSet() throws Exception {
+	@Test
+	public void testConcurrentTransactionalSet() {
 		Set<String> set = TransactionAwareProxyFactory.createTransactionalSet();
-		testSet(set);
+		assertThrows(Throwable.class, () -> testSet(set));
 	}
 
 	@Test
@@ -98,10 +99,10 @@ public class ConcurrentTransactionAwareProxyTests {
 		testMap(map);
 	}
 
-	@Test(expected = ExecutionException.class)
-	public void testConcurrentTransactionalMap() throws Exception {
+	@Test
+	public void testConcurrentTransactionalMap() {
 		Map<Long, Map<String, String>> map = TransactionAwareProxyFactory.createTransactionalMap();
-		testMap(map);
+		assertThrows(ExecutionException.class, () -> testMap(map));
 	}
 
 	@Test
@@ -173,10 +174,10 @@ public class ConcurrentTransactionAwareProxyTests {
 
 		for (int i = 0; i < outerMax; i++) {
 			List<String> result = completionService.take().get();
-			assertEquals("Wrong number of results in inner task", innerMax, result.size());
+			assertEquals(innerMax, result.size(), "Wrong number of results in inner task");
 		}
 
-		assertEquals("Wrong number of results in aggregate", innerMax * outerMax, list.size());
+		assertEquals(innerMax * outerMax, list.size(), "Wrong number of results in aggregate");
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ResourcelessTransactionManagerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ResourcelessTransactionManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.batch.support.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -49,7 +49,7 @@ public class TransactionAwareBufferedWriterTests {
 
 	private TransactionAwareBufferedWriter writer;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		fileChannel = mock(FileChannel.class);
 
@@ -266,7 +266,7 @@ public class TransactionAwareBufferedWriterTests {
 		catch (RuntimeException e) {
 			// expected
 			String message = e.getMessage();
-			assertEquals("Wrong message:  " + message, "Planned failure", message);
+			assertEquals("Planned failure", message, "Wrong message:  " + message);
 		}
 		assertEquals(0, writer.getBufferSize());
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareListFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareListFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 package org.springframework.batch.support.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -36,7 +36,7 @@ public class TransactionAwareListFactoryTests {
 
 	private List<String> list;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		list = TransactionAwareProxyFactory.createTransactionalList(Arrays.asList("foo", "bar", "spam"));
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareMapFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareMapFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,24 @@ package org.springframework.batch.support.transaction;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-public class TransactionAwareMapFactoryTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TransactionAwareMapFactoryTests {
 
 	TransactionTemplate transactionTemplate = new TransactionTemplate(new ResourcelessTransactionManager());
 
 	Map<String, String> map;
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
 		Map<String, String> seed = new HashMap<>();
 		seed.put("foo", "oof");
@@ -40,24 +45,28 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		map = TransactionAwareProxyFactory.createTransactionalMap(seed);
 	}
 
+	@Test
 	public void testAdd() {
 		assertEquals(3, map.size());
 		map.put("bucket", "crap");
 		assertTrue(map.keySet().contains("bucket"));
 	}
 
+	@Test
 	public void testEmpty() {
 		assertEquals(3, map.size());
 		map.put("bucket", "crap");
 		assertFalse(map.isEmpty());
 	}
 
+	@Test
 	public void testValues() {
 		assertEquals(3, map.size());
 		map.put("bucket", "crap");
 		assertEquals(4, map.keySet().size());
 	}
 
+	@Test
 	public void testRemove() {
 		assertEquals(3, map.size());
 		assertTrue(map.keySet().contains("spam"));
@@ -65,12 +74,14 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertFalse(map.keySet().contains("spam"));
 	}
 
+	@Test
 	public void testClear() {
 		assertEquals(3, map.size());
 		map.clear();
 		assertEquals(0, map.size());
 	}
 
+	@Test
 	public void testTransactionalAdd() throws Exception {
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 			@Override
@@ -82,6 +93,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(4, map.size());
 	}
 
+	@Test
 	public void testTransactionalEmpty() throws Exception {
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 			@Override
@@ -93,6 +105,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(4, map.size());
 	}
 
+	@Test
 	public void testTransactionalValues() throws Exception {
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 			@Override
@@ -104,6 +117,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(4, map.size());
 	}
 
+	@Test
 	public void testTransactionalRemove() throws Exception {
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 			@Override
@@ -115,6 +129,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(2, map.size());
 	}
 
+	@Test
 	public void testTransactionalClear() throws Exception {
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 			@Override
@@ -126,6 +141,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(0, map.size());
 	}
 
+	@Test
 	public void testTransactionalAddWithRollback() throws Exception {
 		try {
 			transactionTemplate.execute(new TransactionCallback<Void>() {
@@ -143,6 +159,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(3, map.size());
 	}
 
+	@Test
 	public void testTransactionalRemoveWithRollback() throws Exception {
 		try {
 			transactionTemplate.execute(new TransactionCallback<Void>() {
@@ -160,6 +177,7 @@ public class TransactionAwareMapFactoryTests extends TestCase {
 		assertEquals(3, map.size());
 	}
 
+	@Test
 	public void testTransactionalClearWithRollback() throws Exception {
 		try {
 			transactionTemplate.execute(new TransactionCallback<Void>() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,38 +21,46 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class TransactionAwareProxyFactoryTests extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+public class TransactionAwareProxyFactoryTests {
+
+	@Test
 	public void testCreateList() throws Exception {
 		List<String> list = TransactionAwareProxyFactory.createTransactionalList();
 		list.add("foo");
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testCreateListWithValues() throws Exception {
 		List<String> list = TransactionAwareProxyFactory.createTransactionalList(Collections.singletonList("foo"));
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testCreateSet() throws Exception {
 		Set<String> set = TransactionAwareProxyFactory.createTransactionalSet();
 		set.add("foo");
 		assertEquals(1, set.size());
 	}
 
+	@Test
 	public void testCreateSetWithValues() throws Exception {
 		Set<String> list = TransactionAwareProxyFactory.createTransactionalSet(Collections.singleton("foo"));
 		assertEquals(1, list.size());
 	}
 
+	@Test
 	public void testCreateMap() throws Exception {
 		Map<String, String> map = TransactionAwareProxyFactory.createTransactionalMap();
 		map.put("foo", "bar");
 		assertEquals(1, map.size());
 	}
 
+	@Test
 	public void testCreateMapWithValues() throws Exception {
 		Map<String, String> map = TransactionAwareProxyFactory
 				.createTransactionalMap(Collections.singletonMap("foo", "bar"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareSetFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareSetFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,17 @@
 
 package org.springframework.batch.support.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -37,7 +37,7 @@ public class TransactionAwareSetFactoryTests {
 
 	private Set<String> set;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		set = TransactionAwareProxyFactory.createTransactionalSet(new HashSet<>(Arrays.asList("foo", "bar", "spam")));
 	}


### PR DESCRIPTION
This is a follow-up on #4124. It's quite a high number of touched files but I don't think there is a single change that's in itself interesting. If it helps, I can also split this up e.g. in tests from JUnit 3 and from JUnit 4 or something similar.

JUnit 4 is no longer on the classpath of the module.

Together with #4124 and #4112, it feels like the biggest part of migrating all tests to JUnit 5 is already done. The biggest open part is Spring Batch Core which shouldn't take long either. So far this migration is not on any roadmap but I think it would be nice to do it. With the release of Spring Batch 5, there will also be 5 years of JUnit 5. Perfect moment! 🥳 