### PR TITLE
Change transaction manager type in default batch configuration

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/DefaultBatchConfigurer.java
@@ -25,7 +25,7 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.Assert;
@@ -48,11 +48,11 @@ public class DefaultBatchConfigurer implements BatchConfigurer {
 
 	/**
 	 * Create a new {@link DefaultBatchConfigurer} with the passed datasource. This
-	 * constructor will configure a default {@link DataSourceTransactionManager}.
+	 * constructor will configure a default {@link JdbcTransactionManager}.
 	 * @param dataSource to use for the job repository and job explorer
 	 */
 	public DefaultBatchConfigurer(DataSource dataSource) {
-		this(dataSource, new DataSourceTransactionManager(dataSource));
+		this(dataSource, new JdbcTransactionManager(dataSource));
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.java
@@ -117,7 +117,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * </ul>
  *
  * The transaction manager provided by this annotation will be of type
- * {@link org.springframework.jdbc.datasource.DataSourceTransactionManager} configured
+ * {@link org.springframework.jdbc.support.JdbcTransactionManager} configured
  * with the {@link javax.sql.DataSource} provided within the context.
  *
  * In order to use a custom transaction manager, a custom {@link BatchConfigurer} should

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/DataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
@@ -50,8 +50,8 @@ public class DataSourceConfiguration {
 	}
 
 	@Bean
-	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-		return new DataSourceTransactionManager(dataSource);
+	public JdbcTransactionManager transactionManager(DataSource dataSource) {
+		return new JdbcTransactionManager(dataSource);
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithBatchConfigurerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithBatchConfigurerTests.java
@@ -29,7 +29,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -45,10 +45,10 @@ public class TransactionManagerConfigurationWithBatchConfigurerTests extends Tra
 		BatchConfigurer batchConfigurer = applicationContext.getBean(BatchConfigurer.class);
 
 		PlatformTransactionManager platformTransactionManager = batchConfigurer.getTransactionManager();
-		Assert.assertTrue(platformTransactionManager instanceof DataSourceTransactionManager);
-		DataSourceTransactionManager dataSourceTransactionManager = AopTestUtils
+		Assert.assertTrue(platformTransactionManager instanceof JdbcTransactionManager);
+		JdbcTransactionManager JdbcTransactionManager = AopTestUtils
 				.getTargetObject(platformTransactionManager);
-		Assert.assertEquals(applicationContext.getBean(DataSource.class), dataSourceTransactionManager.getDataSource());
+		Assert.assertEquals(applicationContext.getBean(DataSource.class), JdbcTransactionManager.getDataSource());
 		Assert.assertSame(getTransactionManagerSetOnJobRepository(applicationContext.getBean(JobRepository.class)),
 				platformTransactionManager);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/TransactionManagerConfigurationWithoutBatchConfigurerTests.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -68,9 +68,9 @@ public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends 
 				BatchConfigurationWithDataSourceAndNoTransactionManager.class);
 		PlatformTransactionManager platformTransactionManager = getTransactionManagerSetOnJobRepository(
 				applicationContext.getBean(JobRepository.class));
-		Assert.assertTrue(platformTransactionManager instanceof DataSourceTransactionManager);
-		DataSourceTransactionManager dataSourceTransactionManager = (DataSourceTransactionManager) platformTransactionManager;
-		Assert.assertEquals(applicationContext.getBean(DataSource.class), dataSourceTransactionManager.getDataSource());
+		Assert.assertTrue(platformTransactionManager instanceof JdbcTransactionManager);
+		JdbcTransactionManager JdbcTransactionManager = (JdbcTransactionManager) platformTransactionManager;
+		Assert.assertEquals(applicationContext.getBean(DataSource.class), JdbcTransactionManager.getDataSource());
 	}
 
 	@Test
@@ -81,10 +81,10 @@ public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends 
 				.getBean(PlatformTransactionManager.class);
 		Assert.assertSame(transactionManager, platformTransactionManager);
 		// In this case, the supplied transaction manager won't be used by batch and a
-		// DataSourceTransactionManager will be used instead.
+		// JdbcTransactionManager will be used instead.
 		// The user has to provide a custom BatchConfigurer.
 		Assert.assertTrue(getTransactionManagerSetOnJobRepository(
-				applicationContext.getBean(JobRepository.class)) instanceof DataSourceTransactionManager);
+				applicationContext.getBean(JobRepository.class)) instanceof JdbcTransactionManager);
 	}
 
 	@Test
@@ -95,10 +95,10 @@ public class TransactionManagerConfigurationWithoutBatchConfigurerTests extends 
 				.getBean(PlatformTransactionManager.class);
 		Assert.assertSame(transactionManager2, platformTransactionManager);
 		// In this case, the supplied primary transaction manager won't be used by batch
-		// and a DataSourceTransactionManager will be used instead.
+		// and a JdbcTransactionManager will be used instead.
 		// The user has to provide a custom BatchConfigurer.
 		Assert.assertTrue(getTransactionManagerSetOnJobRepository(
-				applicationContext.getBean(JobRepository.class)) instanceof DataSourceTransactionManager);
+				applicationContext.getBean(JobRepository.class)) instanceof JdbcTransactionManager);
 	}
 
 	@Configuration

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.dao.DeadlockLoserDataAccessException;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.retry.RetryListener;
 import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -297,7 +297,7 @@ public class StepParserTests {
 	public void testTransactionManagerDefaults() throws Exception {
 		ApplicationContext ctx = stepParserParentAttributeTestsCtx;
 
-		assertTrue(getTransactionManager("defaultTxMgrStep", ctx) instanceof DataSourceTransactionManager);
+		assertTrue(getTransactionManager("defaultTxMgrStep", ctx) instanceof JdbcTransactionManager);
 
 		assertDummyTransactionManager("specifiedTxMgrStep", "dummyTxMgr", ctx);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -61,7 +61,7 @@ public class ExtendedAbstractJobTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		jobRepository = factory.getObject();
 		job = new StubJob("job", jobRepository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobFailureTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobFailureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.batch.core.UnexpectedJobExecutionException;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -56,7 +56,7 @@ public class SimpleJobFailureTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		JobRepository jobRepository = factory.getObject();
 		job.setJobRepository(jobRepository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -49,7 +49,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -97,7 +97,7 @@ public class SimpleJobTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").generateUniqueName(true).build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 		repositoryFactoryBean.setDataSource(embeddedDatabase);
 		repositoryFactoryBean.setTransactionManager(transactionManager);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleStepHandlerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleStepHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -53,7 +53,7 @@ public class SimpleStepHandlerTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		jobRepository = factory.getObject();
 		jobExecution = jobRepository.createJobExecution("job", new JobParameters());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -114,7 +114,7 @@ public class FlowJobBuilderTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		jobRepository = factory.getObject();
 		execution = jobRepository.createJobExecution("flow", new JobParameters());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowJobFailureTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowJobFailureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.springframework.batch.core.job.flow.support.state.StepState;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -61,7 +61,7 @@ public class FlowJobFailureTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		JobRepository jobRepository = factory.getObject();
 		job.setJobRepository(jobRepository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.springframework.batch.core.job.flow.support.state.StepState;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -78,7 +78,7 @@ public class FlowJobTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		this.jobRepository = factory.getObject();
 		job.setJobRepository(this.jobRepository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowStepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.springframework.batch.core.job.flow.support.state.StepState;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -59,7 +59,7 @@ public class FlowStepTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean jobRepositoryFactoryBean = new JobRepositoryFactoryBean();
 		jobRepositoryFactoryBean.setDataSource(embeddedDatabase);
-		jobRepositoryFactoryBean.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		jobRepositoryFactoryBean.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		jobRepositoryFactoryBean.afterPropertiesSet();
 		jobRepository = jobRepositoryFactoryBean.getObject();
 		jobExecution = jobRepository.createJobExecution("job", new JobParameters());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/PartitionStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/PartitionStepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.batch.core.partition.PartitionHandler;
 import org.springframework.batch.core.partition.StepExecutionSplitter;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -57,7 +57,7 @@ public class PartitionStepTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		jobRepository = factory.getObject();
 		step.setJobRepository(jobRepository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/RemoteStepExecutionAggregatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/RemoteStepExecutionAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2021 the original author or authors.
+ * Copyright 2011-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -53,7 +53,7 @@ public class RemoteStepExecutionAggregatorTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		JobRepository jobRepository = factory.getObject();
 		JobExplorerFactoryBean explorerFactoryBean = new JobExplorerFactoryBean();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -60,7 +60,7 @@ public class SimpleStepExecutionSplitterTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		jobRepository = factory.getObject();
 		stepExecution = jobRepository.createJobExecution("job", new JobParameters()).createStepExecution("bar");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
@@ -47,7 +47,7 @@ import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.batch.item.support.ListItemWriter;
 import org.springframework.batch.item.support.PassThroughItemProcessor;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -71,7 +71,7 @@ public class StepBuilderTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
 		factory.setTransactionManager(transactionManager);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ import org.springframework.batch.item.support.AbstractItemCountingItemStreamItem
 import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -103,7 +103,7 @@ public class FaultTolerantStepFactoryBeanRetryTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").generateUniqueName(true).build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 		repositoryFactoryBean.setDataSource(embeddedDatabase);
 		repositoryFactoryBean.setTransactionManager(transactionManager);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRollbackTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRollbackTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2021 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.batch.support.transaction.TransactionAwareProxyFactory;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.transaction.interceptor.RollbackRuleAttribute;
@@ -114,7 +114,7 @@ public class FaultTolerantStepFactoryBeanRollbackTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean repositoryFactory = new JobRepositoryFactoryBean();
 		repositoryFactory.setDataSource(embeddedDatabase);
-		repositoryFactory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		repositoryFactory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		repositoryFactory.afterPropertiesSet();
 		repository = repositoryFactory.getObject();
 		factory.setJobRepository(repository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ import org.springframework.batch.item.WriteFailedException;
 import org.springframework.batch.item.WriterNotOpenException;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -113,7 +113,7 @@ public class FaultTolerantStepFactoryBeanTests {
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb-extended.sql").generateUniqueName(true)
 				.build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 
 		factory = new FaultTolerantStepFactoryBean<>();
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanUnexpectedRollbackTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanUnexpectedRollbackTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2020 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.batch.core.step.factory.FaultTolerantStepFactoryBean;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.TransactionException;
@@ -62,7 +62,7 @@ public class FaultTolerantStepFactoryBeanUnexpectedRollbackTests {
 		factory.setItemWriter(writer);
 
 		@SuppressWarnings("serial")
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(dataSource) {
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(dataSource) {
 			private boolean failed = false;
 
 			@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import org.springframework.batch.repeat.exception.SimpleLimitExceptionHandler;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -87,7 +87,7 @@ public class SimpleStepFactoryBeanTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").generateUniqueName(true).build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 		repositoryFactoryBean.setDataSource(embeddedDatabase);
 		repositoryFactoryBean.setTransactionManager(transactionManager);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/job/JobStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/job/JobStepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -59,7 +59,7 @@ public class JobStepTests {
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
 		factory.setDataSource(embeddedDatabase);
-		factory.setTransactionManager(new DataSourceTransactionManager(embeddedDatabase));
+		factory.setTransactionManager(new JdbcTransactionManager(embeddedDatabase));
 		factory.afterPropertiesSet();
 		jobRepository = factory.getObject();
 		step.setJobRepository(jobRepository);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/StepExecutorInterruptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/StepExecutorInterruptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.batch.repeat.support.RepeatTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -68,7 +68,7 @@ public class StepExecutorInterruptionTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").generateUniqueName(true).build();
-		this.transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		this.transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 		repositoryFactoryBean.setDataSource(embeddedDatabase);
 		repositoryFactoryBean.setTransactionManager(this.transactionManager);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletStepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.batch.repeat.support.RepeatTemplate;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
@@ -231,7 +231,7 @@ public class TaskletStepTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 		repositoryFactoryBean.setDataSource(embeddedDatabase);
 		repositoryFactoryBean.setTransactionManager(transactionManager);

--- a/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-core/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -49,6 +49,7 @@ import org.springframework.util.StringUtils;
  * Java Application. Do the same any time you want to wipe the database and start again.
  *
  * @author Dave Syer
+ * @author Mahmoud Ben Hassine
  *
  */
 public class DataSourceInitializer implements InitializingBean {
@@ -97,7 +98,7 @@ public class DataSourceInitializer implements InitializingBean {
 			throw new IllegalArgumentException("Script resource is null or does not exist");
 		}
 
-		TransactionTemplate transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+		TransactionTemplate transactionTemplate = new TransactionTemplate(new JdbcTransactionManager(dataSource));
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 
 			@Override

--- a/spring-batch-core/src/test/resources/applicationContext-test2.xml
+++ b/spring-batch-core/src/test/resources/applicationContext-test2.xml
@@ -58,7 +58,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/data-source-context.xml
+++ b/spring-batch-core/src/test/resources/data-source-context.xml
@@ -24,7 +24,7 @@
 		<property name="validationQuery" value="${batch.jdbc.validationQuery}"/>
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager" lazy-init="true">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager" lazy-init="true">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/annotation/JobScopeConfigurationTestsXmlImportUsingNamespace-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/annotation/JobScopeConfigurationTestsXmlImportUsingNamespace-context.xml
@@ -3,7 +3,7 @@
 	   xmlns:batch="http://www.springframework.org/schema/batch"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd">
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/JobRegistryIntegrationTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/JobRegistryIntegrationTests-context.xml
@@ -22,7 +22,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/BeanDefinitionOverrideTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/BeanDefinitionOverrideTests-context.xml
@@ -23,7 +23,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/InlineItemHandlerWithStepScopeParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/InlineItemHandlerWithStepScopeParserTests-context.xml
@@ -13,7 +13,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRegistryJobParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRegistryJobParserTests-context.xml
@@ -12,7 +12,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRepositoryDefaultParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRepositoryDefaultParserTests-context.xml
@@ -7,7 +7,7 @@
 		<property name="driverClassName" value="org.hsqldb.jdbcDriver" />
 		<property name="url" value="jdbc:hsqldb:mem:testdb;sql.enforce_strict_size=true;hsqldb.tx=mvcc" />
 	</bean>
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRepositoryParserReferenceTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRepositoryParserReferenceTests-context.xml
@@ -8,7 +8,7 @@
 		<beans:property name="driverClassName" value="org.hsqldb.jdbcDriver" />
 		<beans:property name="url" value="jdbc:hsqldb:mem:testdb;sql.enforce_strict_size=true;hsqldb.tx=mvcc" />
 	</beans:bean>
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRepositoryParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/JobRepositoryParserTests-context.xml
@@ -11,7 +11,7 @@
 	<beans:bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
 	    <beans:property name="dataSource" ref="dataSource" />
 	</beans:bean>
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 	<beans:bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler"/>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/PartitionStepWithNonDefaultTransactionManagerParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/PartitionStepWithNonDefaultTransactionManagerParserTests-context.xml
@@ -24,7 +24,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/RepositoryJobParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/RepositoryJobParserTests-context.xml
@@ -13,7 +13,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserTaskletAttributesTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserTaskletAttributesTests-context.xml
@@ -55,7 +55,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/TaskletParserAdapterTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/TaskletParserAdapterTests-context.xml
@@ -30,7 +30,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/TaskletParserBeanPropertiesTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/TaskletParserBeanPropertiesTests-context.xml
@@ -44,7 +44,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/TaskletStepAllowStartIfCompleteTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/TaskletStepAllowStartIfCompleteTests-context.xml
@@ -12,7 +12,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/common-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/common-context.xml
@@ -12,7 +12,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/JobLauncherIntegrationTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/JobLauncherIntegrationTests-context.xml
@@ -31,7 +31,7 @@
 		<property name="url" value="jdbc:hsqldb:mem:testdb;sql.enforce_strict_size=true;hsqldb.tx=mvcc" />
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/repository/dao/OptimisticLockingFailureTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/repository/dao/OptimisticLockingFailureTests-context.xml
@@ -44,7 +44,7 @@
 		</property>
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/repository/dao/TablePrefixTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/repository/dao/TablePrefixTests-context.xml
@@ -35,7 +35,7 @@
 		<property name="password" value="" />
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/repository/dao/data-source-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/repository/dao/data-source-context.xml
@@ -17,7 +17,7 @@
 		<property name="username" value="sa" />
 		<property name="password" value="" />
 	</bean>
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 	<bean id="incrementerParent" class="org.springframework.jdbc.support.incrementer.HsqlMaxValueIncrementer"

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/scope/context/CommitIntervalJobParameter-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/scope/context/CommitIntervalJobParameter-context.xml
@@ -13,7 +13,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/step/RestartInPriorStepTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/step/RestartInPriorStepTests-context.xml
@@ -81,7 +81,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/step/RestartLoopTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/step/RestartLoopTests-context.xml
@@ -30,7 +30,7 @@
         <jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
     </jdbc:initialize-database>
 
-    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
         <property name="dataSource" ref="dataSource"/>
     </bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/step/item/FaultTolerantExceptionClassesTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/step/item/FaultTolerantExceptionClassesTests-context.xml
@@ -152,7 +152,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/step/item/ScriptItemProcessorTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/step/item/ScriptItemProcessorTests-context.xml
@@ -22,7 +22,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<beans:bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<beans:bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<beans:property name="dataSource" ref="dataSource"/>
 	</beans:bean>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/step/skip/ReprocessExceptionTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/step/skip/ReprocessExceptionTests-context.xml
@@ -51,7 +51,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.jdbc.datasource.SmartDataSource;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -183,7 +183,7 @@ public class ExtendedConnectionDataSourceProxyTests {
 
 		final ExtendedConnectionDataSourceProxy csds = new ExtendedConnectionDataSourceProxy();
 		csds.setDataSource(ds);
-		PlatformTransactionManager tm = new DataSourceTransactionManager(csds);
+		PlatformTransactionManager tm = new JdbcTransactionManager(csds);
 		TransactionTemplate tt = new TransactionTemplate(tm);
 		final TransactionTemplate tt2 = new TransactionTemplate(tm);
 		tt2.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2014 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
@@ -56,7 +56,7 @@ public class JdbcCursorItemReaderConfigTests {
 		when(ds.getConnection()).thenReturn(con);
 		when(ds.getConnection()).thenReturn(con);
 		con.commit();
-		PlatformTransactionManager tm = new DataSourceTransactionManager(ds);
+		PlatformTransactionManager tm = new JdbcTransactionManager(ds);
 		TransactionTemplate tt = new TransactionTemplate(tm);
 		final JdbcCursorItemReader<String> reader = new JdbcCursorItemReader<>();
 		reader.setDataSource(new ExtendedConnectionDataSourceProxy(ds));
@@ -88,7 +88,7 @@ public class JdbcCursorItemReaderConfigTests {
 		when(ds.getConnection()).thenReturn(con);
 		when(ds.getConnection()).thenReturn(con);
 		con.commit();
-		PlatformTransactionManager tm = new DataSourceTransactionManager(ds);
+		PlatformTransactionManager tm = new JdbcTransactionManager(ds);
 		TransactionTemplate tt = new TransactionTemplate(tm);
 		final JdbcCursorItemReader<String> reader = new JdbcCursorItemReader<>();
 		reader.setDataSource(ds);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredprocedureItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredprocedureItemReaderConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.SqlParameter;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
@@ -61,7 +61,7 @@ public class StoredprocedureItemReaderConfigTests {
 		when(ds.getConnection()).thenReturn(con);
 		when(ds.getConnection()).thenReturn(con);
 		con.commit();
-		PlatformTransactionManager tm = new DataSourceTransactionManager(ds);
+		PlatformTransactionManager tm = new JdbcTransactionManager(ds);
 		TransactionTemplate tt = new TransactionTemplate(tm);
 		final StoredProcedureItemReader<String> reader = new StoredProcedureItemReader<>();
 		reader.setDataSource(new ExtendedConnectionDataSourceProxy(ds));
@@ -97,7 +97,7 @@ public class StoredprocedureItemReaderConfigTests {
 		when(ds.getConnection()).thenReturn(con);
 		when(ds.getConnection()).thenReturn(con);
 		con.commit();
-		PlatformTransactionManager tm = new DataSourceTransactionManager(ds);
+		PlatformTransactionManager tm = new JdbcTransactionManager(ds);
 		TransactionTemplate tt = new TransactionTemplate(tm);
 		final StoredProcedureItemReader<String> reader = new StoredProcedureItemReader<>();
 		reader.setDataSource(ds);
@@ -132,7 +132,7 @@ public class StoredprocedureItemReaderConfigTests {
 		when(ds.getConnection()).thenReturn(con);
 		when(ds.getConnection()).thenReturn(con);
 		con.commit();
-		PlatformTransactionManager tm = new DataSourceTransactionManager(ds);
+		PlatformTransactionManager tm = new JdbcTransactionManager(ds);
 		TransactionTemplate tt = new TransactionTemplate(tm);
 		final StoredProcedureItemReader<String> reader = new StoredProcedureItemReader<>();
 		reader.setDataSource(ds);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
 import org.springframework.jdbc.core.SqlParameter;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -190,7 +190,7 @@ public class StoredProcedureItemReaderBuilderTests {
 
 		@Bean
 		public PlatformTransactionManager transactionManager(DataSource dataSource) {
-			DataSourceTransactionManager transactionManager = new DataSourceTransactionManager();
+			JdbcTransactionManager transactionManager = new JdbcTransactionManager();
 
 			transactionManager.setDataSource(dataSource);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/H2PagingQueryProviderIntegrationTests.java
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import org.springframework.batch.item.database.Order;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author Henning Pöttker
+ * @author Mahmoud Ben Hassine
  */
 @RunWith(Parameterized.class)
 public class H2PagingQueryProviderIntegrationTests {
@@ -56,7 +57,7 @@ public class H2PagingQueryProviderIntegrationTests {
 		String connectionUrl = String.format("jdbc:h2:mem:%s;MODE=%s", UUID.randomUUID(), compatibilityMode);
 		DataSource dataSource = new SimpleDriverDataSource(new org.h2.Driver(), connectionUrl, "sa", "");
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		PlatformTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+		PlatformTransactionManager transactionManager = new JdbcTransactionManager(dataSource);
 		TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
 
 		transactionTemplate.executeWithoutResult(status -> {

--- a/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
+++ b/spring-batch-infrastructure/src/test/java/test/jdbc/datasource/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -50,6 +50,7 @@ import org.springframework.util.StringUtils;
  * Java Application. Do the same any time you want to wipe the database and start again.
  *
  * @author Dave Syer
+ *@author Mahmoud Ben Hassine
  *
  */
 public class DataSourceInitializer implements InitializingBean, DisposableBean {
@@ -136,7 +137,7 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 			return;
 		final JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 
-		TransactionTemplate transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+		TransactionTemplate transactionTemplate = new TransactionTemplate(new JdbcTransactionManager(dataSource));
 		transactionTemplate.execute(new TransactionCallback<Void>() {
 
 			@Override

--- a/spring-batch-infrastructure/src/test/resources/data-source-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/data-source-context.xml
@@ -19,7 +19,7 @@
 		<property name="password" value="${batch.jdbc.password}" />
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager" lazy-init="true">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager" lazy-init="true">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests-context.xml
@@ -8,7 +8,7 @@
 		<jdbc:script location="org/springframework/batch/item/database/init-foo-schema-hsqldb.sql"/>
 	</jdbc:embedded-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderConfigTests-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderConfigTests-context.xml
@@ -9,7 +9,7 @@
 		<property name="url" value="jdbc:hsqldb:mem:testdb" />
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 	

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderParameterTests-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/JdbcPagingItemReaderParameterTests-context.xml
@@ -13,7 +13,7 @@
 		<property name="url" value="jdbc:hsqldb:mem:testdb" />
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/data-source-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/data-source-context.xml
@@ -13,7 +13,7 @@
 
  	<tx:annotation-driven/>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 	<bean id="incrementerParent" class="org.springframework.jdbc.support.incrementer.HsqlMaxValueIncrementer"

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/stored-procedure-context.xml
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/database/stored-procedure-context.xml
@@ -17,7 +17,7 @@
 		<property name="dataDirectory" value="target/derby-home"/>
 	</bean>
 	
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkMessageItemWriterIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkMessageItemWriterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.core.MessagingTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.messaging.Message;
@@ -82,7 +82,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
-		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);
+		JdbcTransactionManager transactionManager = new JdbcTransactionManager(embeddedDatabase);
 		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 		repositoryFactoryBean.setDataSource(embeddedDatabase);
 		repositoryFactoryBean.setTransactionManager(transactionManager);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessagingTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.PollableChannel;
@@ -325,8 +325,8 @@ public class RemoteChunkingManagerStepBuilderTests {
 		}
 
 		@Bean
-		public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-			return new DataSourceTransactionManager(dataSource);
+		public JdbcTransactionManager transactionManager(DataSource dataSource) {
+			return new JdbcTransactionManager(dataSource);
 		}
 
 	}

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepIntegrationTests-context.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepIntegrationTests-context.xml
@@ -83,7 +83,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJdbcIntegrationTests-context.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJdbcIntegrationTests-context.xml
@@ -110,7 +110,7 @@
 		<property name="validationQuery" value="${batch.jdbc.validationQuery}" />
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJmsIntegrationTests-context.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkFaultTolerantStepJmsIntegrationTests-context.xml
@@ -112,7 +112,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkStepIntegrationTests-context.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/chunk/RemoteChunkStepIntegrationTests-context.xml
@@ -68,7 +68,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserTests.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/config/xml/RemoteChunkingManagerParserTests.xml
@@ -52,6 +52,6 @@
 		  p:driverClassName="${batch.jdbc.driver}" p:url="${batch.jdbc.url}"
 		  p:username="${batch.jdbc.user}" p:password="${batch.jdbc.password}"/>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager"
 		  p:dataSource-ref="dataSource"/>
 </beans>

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/config/xml/RemoteChunkingMasterParserTests.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/config/xml/RemoteChunkingMasterParserTests.xml
@@ -52,6 +52,6 @@
 		  p:driverClassName="${batch.jdbc.driver}" p:url="${batch.jdbc.url}"
 		  p:username="${batch.jdbc.user}" p:password="${batch.jdbc.password}"/>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager"
 		  p:dataSource-ref="dataSource"/>
 </beans>

--- a/spring-batch-integration/src/test/resources/org/springframework/batch/integration/config/xml/batch-setup-context.xml
+++ b/spring-batch-integration/src/test/resources/org/springframework/batch/integration/config/xml/batch-setup-context.xml
@@ -14,7 +14,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-integration/src/test/resources/simple-job-launcher-context.xml
+++ b/spring-batch-integration/src/test/resources/simple-job-launcher-context.xml
@@ -15,7 +15,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/DataSourceConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/DataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import javax.sql.DataSource;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
 /**
@@ -36,8 +36,8 @@ public class DataSourceConfiguration {
 	}
 
 	@Bean
-	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-		return new DataSourceTransactionManager(dataSource);
+	public JdbcTransactionManager transactionManager(DataSource dataSource) {
+		return new JdbcTransactionManager(dataSource);
 	}
 
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/DataSourceConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/DataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -52,8 +52,8 @@ public class DataSourceConfiguration {
 	}
 
 	@Bean
-	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-		return new DataSourceTransactionManager(dataSource);
+	public JdbcTransactionManager transactionManager(DataSource dataSource) {
+		return new JdbcTransactionManager(dataSource);
 	}
 
 }

--- a/spring-batch-samples/src/main/resources/data-source-context.xml
+++ b/spring-batch-samples/src/main/resources/data-source-context.xml
@@ -21,7 +21,7 @@
 		<property name="testWhileIdle" value="${batch.jdbc.testWhileIdle}"/>
 	</bean>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager" lazy-init="true">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager" lazy-init="true">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
 

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/DataSourceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
@@ -125,7 +125,7 @@ public class DataSourceInitializer implements InitializingBean, DisposableBean {
 			return;
 		}
 		TransactionTemplate transactionTemplate = new TransactionTemplate(
-				new DataSourceTransactionManager(this.dataSource));
+				new JdbcTransactionManager(this.dataSource));
 		transactionTemplate.execute((TransactionCallback<Void>) status -> {
 			JdbcTemplate jdbcTemplate = new JdbcTemplate(this.dataSource);
 			String[] scripts;

--- a/spring-batch-test/src/test/resources/data-source-context.xml
+++ b/spring-batch-test/src/test/resources/data-source-context.xml
@@ -24,7 +24,7 @@
 	</bean>
 
 	<bean id="transactionManager"
-		class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
+		class="org.springframework.jdbc.support.JdbcTransactionManager"
 		lazy-init="true">
 		<property name="dataSource" ref="dataSource" />
 	</bean>

--- a/spring-batch-test/src/test/resources/org/springframework/batch/test/StepScopeTestExecutionListenerIntegrationTests-context.xml
+++ b/spring-batch-test/src/test/resources/org/springframework/batch/test/StepScopeTestExecutionListenerIntegrationTests-context.xml
@@ -14,7 +14,7 @@
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-hsqldb.sql"/>
 	</jdbc:initialize-database>
 
-	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.support.JdbcTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 


### PR DESCRIPTION
This commits changes the type of the transaction manager from `DataSourceTransactionManager` to `JdbcTransactionManager` in the default configuration of `@EnableBatchProcessing`.

The `JdbcTransactionManager` adds common JDBC exception translation which is beneficial for Spring Batch to improve exception handling and error reporting.

Issue #4126