### PR TITLE
Fix tests catching nested exceptions

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/JobScopeConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/JobScopeConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.support.ScopeNotActiveException;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -117,7 +118,9 @@ public class JobScopeConfigurationTests {
 			SimpleHolder value = context.getBean(SimpleHolder.class);
 			assertEquals("JOB", value.call());
 		});
-		assertTrue(expectedException.getMessage().contains("job scope"));
+		assertTrue(expectedException instanceof ScopeNotActiveException);
+		String message = expectedException.getCause().getMessage();
+		assertTrue(message.contains("job scope"));
 	}
 
 	@Test
@@ -128,7 +131,9 @@ public class JobScopeConfigurationTests {
 			SimpleHolder value = context.getBean(SimpleHolder.class);
 			assertEquals("JOB", value.call());
 		});
-		assertTrue(expectedException.getMessage().contains("job scope"));
+		assertTrue(expectedException instanceof ScopeNotActiveException);
+		String message = expectedException.getCause().getMessage();
+		assertTrue(message.contains("job scope"));
 	}
 
 	@Test
@@ -148,7 +153,9 @@ public class JobScopeConfigurationTests {
 			Callable<String> value = context.getBean(Callable.class);
 			assertEquals("JOB", value.call());
 		});
-		assertTrue(expectedException.getMessage().contains("job scope"));
+		assertTrue(expectedException instanceof ScopeNotActiveException);
+		String message = expectedException.getCause().getMessage();
+		assertTrue(message.contains("job scope"));
 	}
 
 	public void init(Class<?>... config) throws Exception {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/StepScopeConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/StepScopeConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.support.ScopeNotActiveException;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -116,7 +117,9 @@ public class StepScopeConfigurationTests {
 			SimpleHolder value = context.getBean(SimpleHolder.class);
 			assertEquals("STEP", value.call());
 		});
-		assertTrue(expectedException.getMessage().contains("step scope"));
+		assertTrue(expectedException instanceof ScopeNotActiveException);
+		String message = expectedException.getCause().getMessage();
+		assertTrue(message.contains("step scope"));
 	}
 
 	@Test
@@ -127,7 +130,9 @@ public class StepScopeConfigurationTests {
 			SimpleHolder value = context.getBean(SimpleHolder.class);
 			assertEquals("STEP", value.call());
 		});
-		assertTrue(expectedException.getMessage().contains("step scope"));
+		assertTrue(expectedException instanceof ScopeNotActiveException);
+		String message = expectedException.getCause().getMessage();
+		assertTrue(message.contains("step scope"));
 	}
 
 	@Test
@@ -148,7 +153,9 @@ public class StepScopeConfigurationTests {
 			Callable<String> value = context.getBean(Callable.class);
 			assertEquals("STEP", value.call());
 		});
-		assertTrue(expectedException.getMessage().contains("step scope"));
+		assertTrue(expectedException instanceof ScopeNotActiveException);
+		String message = expectedException.getCause().getMessage();
+		assertTrue(message.contains("step scope"));
 	}
 
 	public void init(Class<?>... config) throws Exception {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/ChunkElementParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/ChunkElementParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ public class ChunkElementParserTests {
 			fail("Expected BeanCreationException");
 		}
 		catch (BeanCreationException e) {
-			String msg = e.getMessage();
+			String msg = e.getRootCause().getMessage();
 			assertTrue("Wrong message: " + msg,
 					msg.contains("The field 'processor-transactional' cannot be false if 'reader-transactional"));
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/JobParserExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/JobParserExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2014 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class JobParserExceptionTests {
 			fail("Error expected");
 		}
 		catch (BeanCreationException e) {
-			String message = e.getMessage();
+			String message = e.getRootCause().getMessage();
 			assertTrue("Wrong message: " + message, message
 					.matches(".*Missing state for \\[StateTransition: \\[state=.*s2, pattern=\\*, next=.*s3\\]\\]"));
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -622,8 +622,8 @@ public class FaultTolerantStepFactoryBeanRetryTests {
 		StepExecution stepExecution = new StepExecution(step.getName(), jobExecution);
 		repository.add(stepExecution);
 		step.execute(stepExecution);
-		String message = stepExecution.getFailureExceptions().get(0).getMessage();
-		assertTrue("Wrong message: " + message, message.contains("Write error - planned but not skippable."));
+		String message = stepExecution.getFailureExceptions().get(0).getCause().getMessage();
+		assertEquals("Wrong message: " + message, "Write error - planned but not skippable.", message);
 
 		List<String> expectedOutput = Arrays.asList(StringUtils.commaDelimitedListToStringArray(""));
 		assertEquals(expectedOutput, written);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkMessageItemWriterIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkMessageItemWriterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public class ChunkMessageItemWriterIntegrationTests {
 
 	@Before
 	public void setUp() throws Exception {
-		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
+		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder().generateUniqueName(true)
 				.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
 				.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
 		DataSourceTransactionManager transactionManager = new DataSourceTransactionManager(embeddedDatabase);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingGatewayIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingGatewayIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class JobLaunchingGatewayIntegrationTests {
 			fail();
 		}
 		catch (MessagingException e) {
-			String message = e.getMessage();
+			String message = e.getCause().getMessage();
 			assertTrue("Wrong message: " + message, message.contains("replyChannel"));
 		}
 		Message<JobExecution> executionMessage = (Message<JobExecution>) responseChannel.receive(1000);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandlerIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandlerIntegrationTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.launch;
 
 import static org.junit.Assert.assertNotNull;
@@ -57,7 +72,7 @@ public class JobLaunchingMessageHandlerIntegrationTests {
 			requestChannel.send(trigger);
 		}
 		catch (MessagingException e) {
-			String message = e.getMessage();
+			String message = e.getCause().getMessage();
 			assertTrue("Wrong message: " + message, message.contains("replyChannel"));
 		}
 		Message<JobExecution> executionMessage = (Message<JobExecution>) responseChannel.receive(1000);


### PR DESCRIPTION
This PR adjusts some tests that are currently failing due to the upstream change spring-projects/spring-framework#25162.

I also added a `generateUniqueName(true)` in `ChunkMessageItemWriterIntegrationTests` as without it `RemoteChunkFaultTolerantStepJdbcIntegrationTests` stalls on my machine when running subsequently.