### PR TITLE
Add package-info.java to integration

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/package-info.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Provides integration with Spring Integration.
+ */
+@NonNullApi
+package org.springframework.batch.integration;
+
+import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
It looks no `package-info.java` in integration root package. Comment may be changed.