### PR TITLE
Add missing initialized flag set to FlowJob

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
@@ -35,6 +35,7 @@ import org.springframework.batch.core.step.StepLocator;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  * @since 2.0
  */
 public class FlowJob extends AbstractJob {
@@ -84,6 +85,7 @@ public class FlowJob extends AbstractJob {
 	 */
 	private void init() {
 		findSteps(flow, stepMap);
+		initialized = true;
 	}
 
 	/**


### PR DESCRIPTION
`initialized` flag isn't set to true.