### PR TITLE
MongoItemWriter - Add protected getters for "delete" and "collection" properties. Fixes #3973

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
@@ -85,6 +85,16 @@ public class MongoItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	}
 
 	/**
+	 * Indicates if the items being passed to the writer are to be saved or removed from
+	 * the data store. If is false (default), the items will be saved. If is true, the
+	 * items will be removed.
+	 * @return removal indicator
+	 */
+	protected boolean isDelete() {
+		return delete;
+	}
+
+	/**
 	 * Set the {@link MongoOperations} to be used to save items to be written.
 	 * @param template the template implementation to be used.
 	 */
@@ -107,6 +117,14 @@ public class MongoItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 */
 	public void setCollection(String collection) {
 		this.collection = collection;
+	}
+
+	/**
+	 * Get the name of the Mongo collection to be written to.
+	 * @return the name of the collection.
+	 */
+	protected String getCollection() {
+		return collection;
 	}
 
 	/**


### PR DESCRIPTION
This PR provides protected getter methods for MongoItemWriter's `delete` and `collection` properties. Thus, any custom implementation of `MongoItemWriter` will be able to extend it's `doWrite` logic regards to these two properties.

Properties itself are still have private access modifier, but they become accessible from subclass via getters as previously did for `template` in cae2cabdce41ae9a67d4e469fb8b82ff4945a7d9

This PR is related to #3973.

Without this change, developers are not be able to write custom implementation something like

```java
public class CustomMongoItemWriter<T> extends MongoItemWriter<T> {

    @Override
    protected void doWrite(List<? extends T> items) {
        if (isDelete()) {
            super.doWrite(items);
        } else {
            if(getCollection().contains("archive")) {
                // Batch insert without checking existence
            } else {
              super.doWrite(items);  
            }
        }
    }
}
```