### PR TITLE
Replace deprecated `IntegrationFlows`

### DIFF
--- a/spring-batch-docs/src/main/asciidoc/spring-batch-integration.adoc
+++ b/spring-batch-docs/src/main/asciidoc/spring-batch-integration.adoc
@@ -285,7 +285,7 @@ public JobLaunchingGateway jobLaunchingGateway() {
 
 @Bean
 public IntegrationFlow integrationFlow(JobLaunchingGateway jobLaunchingGateway) {
-    return IntegrationFlows.from(Files.inboundAdapter(new File("/tmp/myfiles")).
+    return IntegrationFlow.from(Files.inboundAdapter(new File("/tmp/myfiles")).
                     filter(new SimplePatternFileListFilter("*.csv")),
             c -> c.poller(Pollers.fixedRate(1000).maxMessagesPerPoll(1))).
             transform(fileMessageToJobRequest()).
@@ -748,7 +748,7 @@ public DirectChannel requests() {
 
 @Bean
 public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-    return IntegrationFlows
+    return IntegrationFlow
             .from(requests())
             .handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
             .get();
@@ -764,7 +764,7 @@ public QueueChannel replies() {
 
 @Bean
 public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-    return IntegrationFlows
+    return IntegrationFlow
             .from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("replies"))
             .channel(replies())
             .get();
@@ -862,7 +862,7 @@ public DirectChannel requests() {
 
 @Bean
 public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-    return IntegrationFlows
+    return IntegrationFlow
             .from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
             .channel(requests())
             .get();
@@ -878,7 +878,7 @@ public DirectChannel replies() {
 
 @Bean
 public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-    return IntegrationFlows
+    return IntegrationFlow
             .from(replies())
             .handle(Jms.outboundAdapter(connectionFactory).destination("replies"))
             .get();
@@ -1129,7 +1129,7 @@ public DirectChannel outboundRequests() {
 
 @Bean
 public IntegrationFlow outboundJmsRequests() {
-    return IntegrationFlows.from("outboundRequests")
+    return IntegrationFlow.from("outboundRequests")
             .handle(Jms.outboundGateway(connectionFactory())
                     .requestDestination("requestsQueue"))
             .get();
@@ -1152,7 +1152,7 @@ public DirectChannel inboundStaging() {
 
 @Bean
 public IntegrationFlow inboundJmsStaging() {
-    return IntegrationFlows
+    return IntegrationFlow
             .from(Jms.messageDrivenChannelAdapter(connectionFactory())
                     .configureListenerContainer(c -> c.subscriptionDurable(false))
                     .destination("stagingQueue"))
@@ -1183,7 +1183,7 @@ public DirectChannel inboundRequests() {
 }
 
 public IntegrationFlow inboundJmsRequests() {
-    return IntegrationFlows
+    return IntegrationFlow
             .from(Jms.messageDrivenChannelAdapter(connectionFactory())
                     .configureListenerContainer(c -> c.subscriptionDurable(false))
                     .destination("requestsQueue"))
@@ -1198,7 +1198,7 @@ public DirectChannel outboundStaging() {
 
 @Bean
 public IntegrationFlow outboundJmsStaging() {
-    return IntegrationFlows.from("outboundStaging")
+    return IntegrationFlow.from("outboundStaging")
             .handle(Jms.outboundGateway(connectionFactory())
                     .requestDestination("stagingQueue"))
             .get();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingWorkerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.PassThroughItemProcessor;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
@@ -117,8 +116,8 @@ public class RemoteChunkingWorkerBuilder<I, O> {
 		ChunkProcessorChunkHandler<I> chunkProcessorChunkHandler = new ChunkProcessorChunkHandler<>();
 		chunkProcessorChunkHandler.setChunkProcessor(chunkProcessor);
 
-		return IntegrationFlows.from(this.inputChannel)
-				.handle(chunkProcessorChunkHandler, SERVICE_ACTIVATOR_METHOD_NAME).channel(this.outputChannel).get();
+		return IntegrationFlow.from(this.inputChannel).handle(chunkProcessorChunkHandler, SERVICE_ACTIVATOR_METHOD_NAME)
+				.channel(this.outputChannel).get();
 	}
 
 }

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessagingTemplate;
-import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.StandardIntegrationFlow;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.messaging.MessageChannel;
@@ -207,7 +207,7 @@ public class RemotePartitioningManagerStepBuilder extends PartitionStepBuilder {
 		else {
 			PollableChannel replies = new QueueChannel();
 			partitionHandler.setReplyChannel(replies);
-			StandardIntegrationFlow standardIntegrationFlow = IntegrationFlows.from(this.inputChannel)
+			StandardIntegrationFlow standardIntegrationFlow = IntegrationFlow.from(this.inputChannel)
 					.aggregate(aggregatorSpec -> aggregatorSpec.processor(partitionHandler)).channel(replies).get();
 			IntegrationFlowContext integrationFlowContext = this.beanFactory.getBean(IntegrationFlowContext.class);
 			integrationFlowContext.registration(standardIntegrationFlow).autoStartup(false).register();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import org.springframework.batch.repeat.CompletionPolicy;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.StandardIntegrationFlow;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.messaging.MessageChannel;
@@ -249,7 +248,7 @@ public class RemotePartitioningWorkerStepBuilder extends StepBuilder {
 		stepExecutionRequestHandler.setJobExplorer(this.jobExplorer);
 		stepExecutionRequestHandler.setStepLocator(this.stepLocator);
 
-		StandardIntegrationFlow standardIntegrationFlow = IntegrationFlows.from(this.inputChannel)
+		StandardIntegrationFlow standardIntegrationFlow = IntegrationFlow.from(this.inputChannel)
 				.handle(stepExecutionRequestHandler, SERVICE_ACTIVATOR_METHOD_NAME).channel(this.outputChannel).get();
 		IntegrationFlowContext integrationFlowContext = this.beanFactory.getBean(IntegrationFlowContext.class);
 		integrationFlowContext.registration(standardIntegrationFlow).autoStartup(false).register();

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/ManagerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/ManagerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.jms.dsl.Jms;
 
 /**
@@ -81,7 +80,7 @@ public class ManagerConfiguration {
 
 	@Bean
 	public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(requests()).handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
+		return IntegrationFlow.from(requests()).handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
 				.get();
 	}
 
@@ -95,7 +94,7 @@ public class ManagerConfiguration {
 
 	@Bean
 	public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("replies"))
+		return IntegrationFlow.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("replies"))
 				.channel(replies()).get();
 	}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/WorkerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotechunking/WorkerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.jms.dsl.Jms;
 
 /**
@@ -78,7 +77,7 @@ public class WorkerConfiguration {
 
 	@Bean
 	public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
+		return IntegrationFlow.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
 				.channel(requests()).get();
 	}
 
@@ -92,7 +91,7 @@ public class WorkerConfiguration {
 
 	@Bean
 	public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(replies()).handle(Jms.outboundAdapter(connectionFactory).destination("replies"))
+		return IntegrationFlow.from(replies()).handle(Jms.outboundAdapter(connectionFactory).destination("replies"))
 				.get();
 	}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/aggregating/ManagerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/aggregating/ManagerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.jms.dsl.Jms;
 
 /**
@@ -69,7 +68,7 @@ public class ManagerConfiguration {
 
 	@Bean
 	public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(requests()).handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
+		return IntegrationFlow.from(requests()).handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
 				.get();
 	}
 
@@ -83,7 +82,7 @@ public class ManagerConfiguration {
 
 	@Bean
 	public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("replies"))
+		return IntegrationFlow.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("replies"))
 				.channel(replies()).get();
 	}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/aggregating/WorkerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/aggregating/WorkerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.jms.dsl.Jms;
 
 /**
@@ -63,7 +62,7 @@ public class WorkerConfiguration {
 
 	@Bean
 	public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
+		return IntegrationFlow.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
 				.channel(requests()).get();
 	}
 
@@ -77,7 +76,7 @@ public class WorkerConfiguration {
 
 	@Bean
 	public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(replies()).handle(Jms.outboundAdapter(connectionFactory).destination("replies"))
+		return IntegrationFlow.from(replies()).handle(Jms.outboundAdapter(connectionFactory).destination("replies"))
 				.get();
 	}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/polling/ManagerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/polling/ManagerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.jms.dsl.Jms;
 
 /**
@@ -69,7 +68,7 @@ public class ManagerConfiguration {
 
 	@Bean
 	public IntegrationFlow outboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(requests()).handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
+		return IntegrationFlow.from(requests()).handle(Jms.outboundAdapter(connectionFactory).destination("requests"))
 				.get();
 	}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/polling/WorkerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/remotepartitioning/polling/WorkerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.jms.dsl.Jms;
 
 /**
@@ -63,7 +62,7 @@ public class WorkerConfiguration {
 
 	@Bean
 	public IntegrationFlow inboundFlow(ActiveMQConnectionFactory connectionFactory) {
-		return IntegrationFlows.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
+		return IntegrationFlow.from(Jms.messageDrivenChannelAdapter(connectionFactory).destination("requests"))
 				.channel(requests()).get();
 	}
 


### PR DESCRIPTION
With Spring Integration 6.0.0-M4, the factory `IntegrationFlows` is deprecated in favor of the same methods directly on `IntegrationFlow`. See spring-projects/spring-integration#3623.