### PR TITLE
Replace `ListenableFuture` with `CompletableFuture`

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemReaderTests.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.NewTopic;
@@ -38,10 +39,8 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.util.concurrent.ListenableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -187,12 +186,12 @@ public class KafkaItemReaderTests {
 	@Test
 	public void testReadFromSinglePartition() throws ExecutionException, InterruptedException {
 		this.template.setDefaultTopic("topic1");
-		List<ListenableFuture<SendResult<String, String>>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<?>>();
 		futures.add(this.template.sendDefault("val0"));
 		futures.add(this.template.sendDefault("val1"));
 		futures.add(this.template.sendDefault("val2"));
 		futures.add(this.template.sendDefault("val3"));
-		for (ListenableFuture<SendResult<String, String>> future : futures) {
+		for (var future : futures) {
 			future.get();
 		}
 
@@ -221,12 +220,12 @@ public class KafkaItemReaderTests {
 	@Test
 	public void testReadFromSinglePartitionFromCustomOffset() throws ExecutionException, InterruptedException {
 		this.template.setDefaultTopic("topic5");
-		List<ListenableFuture<SendResult<String, String>>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<?>>();
 		futures.add(this.template.sendDefault("val0")); // <-- offset 0
 		futures.add(this.template.sendDefault("val1")); // <-- offset 1
 		futures.add(this.template.sendDefault("val2")); // <-- offset 2
 		futures.add(this.template.sendDefault("val3")); // <-- offset 3
-		for (ListenableFuture<SendResult<String, String>> future : futures) {
+		for (var future : futures) {
 			future.get();
 		}
 
@@ -257,10 +256,10 @@ public class KafkaItemReaderTests {
 		// first run: read a topic from the beginning
 
 		this.template.setDefaultTopic("topic6");
-		List<ListenableFuture<SendResult<String, String>>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<?>>();
 		futures.add(this.template.sendDefault("val0")); // <-- offset 0
 		futures.add(this.template.sendDefault("val1")); // <-- offset 1
-		for (ListenableFuture<SendResult<String, String>> future : futures) {
+		for (var future : futures) {
 			future.get();
 		}
 		this.reader = new KafkaItemReader<>(this.consumerProperties, "topic6", 0);
@@ -311,12 +310,12 @@ public class KafkaItemReaderTests {
 	@Test
 	public void testReadFromMultiplePartitions() throws ExecutionException, InterruptedException {
 		this.template.setDefaultTopic("topic2");
-		List<ListenableFuture<SendResult<String, String>>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<?>>();
 		futures.add(this.template.sendDefault("val0"));
 		futures.add(this.template.sendDefault("val1"));
 		futures.add(this.template.sendDefault("val2"));
 		futures.add(this.template.sendDefault("val3"));
-		for (ListenableFuture<SendResult<String, String>> future : futures) {
+		for (var future : futures) {
 			future.get();
 		}
 
@@ -339,13 +338,13 @@ public class KafkaItemReaderTests {
 	@Test
 	public void testReadFromSinglePartitionAfterRestart() throws ExecutionException, InterruptedException {
 		this.template.setDefaultTopic("topic3");
-		List<ListenableFuture<SendResult<String, String>>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<?>>();
 		futures.add(this.template.sendDefault("val0"));
 		futures.add(this.template.sendDefault("val1"));
 		futures.add(this.template.sendDefault("val2"));
 		futures.add(this.template.sendDefault("val3"));
 		futures.add(this.template.sendDefault("val4"));
-		for (ListenableFuture<SendResult<String, String>> future : futures) {
+		for (var future : futures) {
 			future.get();
 		}
 		ExecutionContext executionContext = new ExecutionContext();
@@ -375,7 +374,7 @@ public class KafkaItemReaderTests {
 
 	@Test
 	public void testReadFromMultiplePartitionsAfterRestart() throws ExecutionException, InterruptedException {
-		List<ListenableFuture<SendResult<String, String>>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<?>>();
 		futures.add(this.template.send("topic4", 0, null, "val0"));
 		futures.add(this.template.send("topic4", 0, null, "val2"));
 		futures.add(this.template.send("topic4", 0, null, "val4"));
@@ -385,7 +384,7 @@ public class KafkaItemReaderTests {
 		futures.add(this.template.send("topic4", 1, null, "val5"));
 		futures.add(this.template.send("topic4", 1, null, "val7"));
 
-		for (ListenableFuture<?> future : futures) {
+		for (var future : futures) {
 			future.get();
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/kafka/KafkaItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.batch.item.kafka;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
@@ -28,7 +29,6 @@ import org.mockito.junit.MockitoRule;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
-import org.springframework.util.concurrent.ListenableFuture;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -46,7 +46,7 @@ public class KafkaItemWriterTests {
 	private KafkaTemplate<String, String> kafkaTemplate;
 
 	@Mock
-	private ListenableFuture<SendResult<String, String>> future;
+	private CompletableFuture<SendResult<String, String>> future;
 
 	private KafkaItemKeyMapper itemKeyMapper;
 


### PR DESCRIPTION
The PR adjusts the code to the upstream change spring-projects/spring-kafka#2357.

Note that the commit of this PR won't compile as a whole as `io.micrometer.observation.Observation.KeyValuesProvider` has been removed. But that's a different issue.