### PR TITLE
Migrate Spring Batch Test to JUnit Jupiter

### DIFF
--- a/spring-batch-test/pom.xml
+++ b/spring-batch-test/pom.xml
@@ -64,6 +64,12 @@
 
 		<!-- test dependencies -->
 		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>${junit-vintage-engine.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>${mockito.version}</version>

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/AssertFileTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/AssertFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2009 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.ComparisonFailure;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResource;
 
 /**
@@ -28,73 +29,48 @@ import org.springframework.core.io.FileSystemResource;
  * @author Dan Garrette
  * @since 2.0
  */
-public class AssertFileTests {
+class AssertFileTests {
 
 	private static final String DIRECTORY = "src/test/resources/data/input/";
 
 	@Test
-	public void testAssertEquals_equal() throws Exception {
-		executeAssertEquals("input1.txt", "input1.txt");
+	void testAssertEquals_equal() {
+		assertDoesNotThrow(() -> executeAssertEquals("input1.txt", "input1.txt"));
 	}
 
 	@Test
-	public void testAssertEquals_notEqual() throws Exception {
-		try {
-			executeAssertEquals("input1.txt", "input2.txt");
-			fail();
-		}
-		catch (ComparisonFailure e) {
-			assertTrue(e.getMessage().startsWith("Line number 3 does not match."));
-		}
+	void testAssertEquals_notEqual() {
+		Error error = assertThrows(ComparisonFailure.class, () -> executeAssertEquals("input1.txt", "input2.txt"));
+		assertTrue(error.getMessage().startsWith("Line number 3 does not match."));
 	}
 
 	@Test
-	public void testAssertEquals_tooLong() throws Exception {
-		try {
-			executeAssertEquals("input3.txt", "input1.txt");
-			fail();
-		}
-		catch (AssertionError e) {
-			assertTrue(e.getMessage().startsWith("More lines than expected.  There should not be a line number 4."));
-		}
+	void testAssertEquals_tooLong() {
+		Error error = assertThrows(AssertionError.class, () -> executeAssertEquals("input3.txt", "input1.txt"));
+		assertTrue(error.getMessage().startsWith("More lines than expected.  There should not be a line number 4."));
 	}
 
 	@Test
-	public void testAssertEquals_tooShort() throws Exception {
-		try {
-			executeAssertEquals("input1.txt", "input3.txt");
-			fail();
-		}
-		catch (AssertionError e) {
-			assertTrue(e.getMessage().startsWith("Line number 4 does not match."));
-		}
+	void testAssertEquals_tooShort() {
+		Error error = assertThrows(AssertionError.class, () -> executeAssertEquals("input1.txt", "input3.txt"));
+		assertTrue(error.getMessage().startsWith("Line number 4 does not match."));
 	}
 
 	@Test
-	public void testAssertEquals_blank_equal() throws Exception {
-		executeAssertEquals("blank.txt", "blank.txt");
+	void testAssertEquals_blank_equal() {
+		assertDoesNotThrow(() -> executeAssertEquals("blank.txt", "blank.txt"));
 	}
 
 	@Test
-	public void testAssertEquals_blank_tooLong() throws Exception {
-		try {
-			executeAssertEquals("blank.txt", "input1.txt");
-			fail();
-		}
-		catch (AssertionError e) {
-			assertTrue(e.getMessage().startsWith("More lines than expected.  There should not be a line number 1."));
-		}
+	void testAssertEquals_blank_tooLong() {
+		Error error = assertThrows(AssertionError.class, () -> executeAssertEquals("blank.txt", "input1.txt"));
+		assertTrue(error.getMessage().startsWith("More lines than expected.  There should not be a line number 1."));
 	}
 
 	@Test
-	public void testAssertEquals_blank_tooShort() throws Exception {
-		try {
-			executeAssertEquals("input1.txt", "blank.txt");
-			fail();
-		}
-		catch (AssertionError e) {
-			assertTrue(e.getMessage().startsWith("Line number 1 does not match."));
-		}
+	void testAssertEquals_blank_tooShort() {
+		Error error = assertThrows(AssertionError.class, () -> executeAssertEquals("input1.txt", "blank.txt"));
+		assertTrue(error.getMessage().startsWith("Line number 1 does not match."));
 	}
 
 	private void executeAssertEquals(String expected, String actual) throws Exception {
@@ -103,8 +79,8 @@ public class AssertFileTests {
 	}
 
 	@Test
-	public void testAssertLineCount() throws Exception {
-		AssertFile.assertLineCount(5, new FileSystemResource(DIRECTORY + "input1.txt"));
+	void testAssertLineCount() {
+		assertDoesNotThrow(() -> AssertFile.assertLineCount(5, new FileSystemResource(DIRECTORY + "input1.txt")));
 	}
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/ExecutionContextTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/ExecutionContextTestUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2009 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,20 @@
 
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Date;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
 
-public class ExecutionContextTestUtilsTests {
+class ExecutionContextTestUtilsTests {
 
 	@Test
-	public void testFromJob() throws Exception {
+	void testFromJob() {
 		Date date = new Date();
 		JobExecution jobExecution = MetaDataInstanceFactory.createJobExecution();
 		jobExecution.getExecutionContext().put("foo", date);
@@ -37,7 +38,7 @@ public class ExecutionContextTestUtilsTests {
 	}
 
 	@Test
-	public void testFromStepInJob() throws Exception {
+	void testFromStepInJob() {
 		Date date = new Date();
 		JobExecution jobExecution = MetaDataInstanceFactory.createJobExecutionWithStepExecutions(123L,
 				Arrays.asList("foo", "bar"));
@@ -47,17 +48,16 @@ public class ExecutionContextTestUtilsTests {
 		assertEquals(date, result);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testFromStepInJobNoSuchStep() throws Exception {
-		Date date = new Date();
+	@Test
+	void testFromStepInJobNoSuchStep() {
 		JobExecution jobExecution = MetaDataInstanceFactory.createJobExecutionWithStepExecutions(123L,
 				Arrays.asList("foo", "bar"));
-		Date result = ExecutionContextTestUtils.getValueFromStepInJob(jobExecution, "spam", "foo");
-		assertEquals(date, result);
+		assertThrows(IllegalArgumentException.class,
+				() -> ExecutionContextTestUtils.getValueFromStepInJob(jobExecution, "spam", "foo"));
 	}
 
 	@Test
-	public void testFromStep() throws Exception {
+	void testFromStep() {
 		Date date = new Date();
 		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution();
 		stepExecution.getExecutionContext().put("foo", date);

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobLauncherTestUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.test;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
@@ -42,17 +42,17 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * @author mminella
  * @author Mahmoud Ben Hassine
  */
-public class JobLauncherTestUtilsTests {
+class JobLauncherTestUtilsTests {
 
 	@Test
-	public void testStepExecutionWithJavaConfig() {
+	void testStepExecutionWithJavaConfig() {
 		ApplicationContext context = new AnnotationConfigApplicationContext(TestJobConfiguration.class);
 
 		JobLauncherTestUtils testUtils = context.getBean(JobLauncherTestUtils.class);
@@ -63,7 +63,7 @@ public class JobLauncherTestUtilsTests {
 	}
 
 	@Test
-	public void getUniqueJobParameters_doesNotRepeatJobParameters() {
+	void getUniqueJobParameters_doesNotRepeatJobParameters() {
 		ApplicationContext context = new AnnotationConfigApplicationContext(TestJobConfiguration.class);
 		JobLauncherTestUtils testUtils = context.getBean(JobLauncherTestUtils.class);
 		Set<JobParameters> jobParametersSeen = new HashSet<>();
@@ -76,7 +76,7 @@ public class JobLauncherTestUtilsTests {
 
 	@Configuration
 	@EnableBatchProcessing
-	public static class TestJobConfiguration {
+	static class TestJobConfiguration {
 
 		@Autowired
 		public JobBuilderFactory jobBuilderFactory;

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobRepositoryTestUtilsTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobRepositoryTestUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -23,9 +24,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -34,17 +34,15 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.lang.Nullable;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
 /**
  * @author Dave Syer
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/simple-job-launcher-context.xml")
-public class JobRepositoryTestUtilsTests {
+@SpringJUnitConfig(locations = "/simple-job-launcher-context.xml")
+class JobRepositoryTestUtilsTests {
 
 	private JobRepositoryTestUtils utils;
 
@@ -60,28 +58,28 @@ public class JobRepositoryTestUtilsTests {
 
 	private int beforeSteps;
 
-	@Before
-	public void init() {
+	@BeforeEach
+	void init() {
 		jdbcTemplate = new JdbcTemplate(dataSource);
 		beforeJobs = JdbcTestUtils.countRowsInTable(jdbcTemplate, "BATCH_JOB_EXECUTION");
 		beforeSteps = JdbcTestUtils.countRowsInTable(jdbcTemplate, "BATCH_STEP_EXECUTION");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testMandatoryProperties() throws Exception {
+	@Test
+	void testMandatoryProperties() {
 		utils = new JobRepositoryTestUtils();
-		utils.afterPropertiesSet();
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testMandatoryDataSource() throws Exception {
-		utils = new JobRepositoryTestUtils();
-		utils.setJobRepository(jobRepository);
-		utils.afterPropertiesSet();
+		assertThrows(IllegalArgumentException.class, utils::afterPropertiesSet);
 	}
 
 	@Test
-	public void testCreateJobExecutions() throws Exception {
+	void testMandatoryDataSource() {
+		utils = new JobRepositoryTestUtils();
+		utils.setJobRepository(jobRepository);
+		assertThrows(IllegalArgumentException.class, utils::afterPropertiesSet);
+	}
+
+	@Test
+	void testCreateJobExecutions() throws Exception {
 		utils = new JobRepositoryTestUtils(jobRepository, dataSource);
 		List<JobExecution> list = utils.createJobExecutions(3);
 		assertEquals(3, list.size());
@@ -93,7 +91,7 @@ public class JobRepositoryTestUtilsTests {
 	}
 
 	@Test
-	public void testRemoveJobExecutionsWithSameJobInstance() throws Exception {
+	void testRemoveJobExecutionsWithSameJobInstance() throws Exception {
 		utils = new JobRepositoryTestUtils(jobRepository, dataSource);
 		List<JobExecution> list = new ArrayList<>();
 		JobExecution jobExecution = jobRepository.createJobExecution("job", new JobParameters());
@@ -108,7 +106,7 @@ public class JobRepositoryTestUtilsTests {
 	}
 
 	@Test
-	public void testCreateJobExecutionsByName() throws Exception {
+	void testCreateJobExecutionsByName() throws Exception {
 		utils = new JobRepositoryTestUtils(jobRepository, dataSource);
 		List<JobExecution> list = utils.createJobExecutions("foo", new String[] { "bar", "spam" }, 3);
 		assertEquals(3, list.size());
@@ -120,7 +118,7 @@ public class JobRepositoryTestUtilsTests {
 	}
 
 	@Test
-	public void testRemoveJobExecutionsIncrementally() throws Exception {
+	void testRemoveJobExecutionsIncrementally() throws Exception {
 		utils = new JobRepositoryTestUtils(jobRepository, dataSource);
 		List<JobExecution> list1 = utils.createJobExecutions(3);
 		List<JobExecution> list2 = utils.createJobExecutions(2);
@@ -132,7 +130,7 @@ public class JobRepositoryTestUtilsTests {
 	}
 
 	@Test
-	public void testCreateJobExecutionsWithIncrementer() throws Exception {
+	void testCreateJobExecutionsWithIncrementer() throws Exception {
 		utils = new JobRepositoryTestUtils(jobRepository, dataSource);
 		utils.setJobParametersIncrementer(new JobParametersIncrementer() {
 			@Override

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobScopeTestExecutionListenerIntegrationTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobScopeTestExecutionListenerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,17 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
 /**
@@ -35,10 +33,9 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
  * @author Mahmoud Ben Hassine
  * @since 2.1
  */
-@ContextConfiguration
+@SpringJUnitConfig
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, JobScopeTestExecutionListener.class })
-@RunWith(SpringJUnit4ClassRunner.class)
-public class JobScopeTestExecutionListenerIntegrationTests {
+class JobScopeTestExecutionListenerIntegrationTests {
 
 	@Autowired
 	private ItemReader<String> reader;
@@ -46,7 +43,7 @@ public class JobScopeTestExecutionListenerIntegrationTests {
 	@Autowired
 	private ItemStream stream;
 
-	public JobExecution getJobExecution() {
+	JobExecution getJobExecution() {
 		// Assert that dependencies are already injected...
 		assertNotNull(reader);
 		// Then create the execution for the job scope...
@@ -56,7 +53,7 @@ public class JobScopeTestExecutionListenerIntegrationTests {
 	}
 
 	@Test
-	public void testJob() throws Exception {
+	void testJob() throws Exception {
 		stream.open(new ExecutionContext());
 		assertEquals("foo", reader.read());
 	}

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/JobScopeTestExecutionListenerTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/JobScopeTestExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.scope.context.JobContext;
 import org.springframework.batch.core.scope.context.JobSynchronizationManager;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestContextManager;
 
@@ -32,13 +32,13 @@ import org.springframework.test.context.TestContextManager;
  * @author Dave Syer
  * @since 2.1
  */
-@ContextConfiguration
-public class JobScopeTestExecutionListenerTests {
+@SpringJUnitConfig
+class JobScopeTestExecutionListenerTests {
 
-	private JobScopeTestExecutionListener listener = new JobScopeTestExecutionListener();
+	private final JobScopeTestExecutionListener listener = new JobScopeTestExecutionListener();
 
 	@Test
-	public void testDefaultJobContext() throws Exception {
+	void testDefaultJobContext() throws Exception {
 		TestContext testContext = getTestContext(new Object());
 		listener.prepareTestInstance(testContext);
 		listener.beforeTestMethod(testContext);
@@ -49,12 +49,12 @@ public class JobScopeTestExecutionListenerTests {
 	}
 
 	@Test
-	public void testWithJobExecutionFactory() throws Exception {
+	void testWithJobExecutionFactory() throws Exception {
 		testExecutionContext(new WithJobExecutionFactory());
 	}
 
 	@Test
-	public void testWithParameters() throws Exception {
+	void testWithParameters() throws Exception {
 		testJobParameters(new WithJobExecutionFactory());
 	}
 
@@ -104,7 +104,7 @@ public class JobScopeTestExecutionListenerTests {
 		return new MockTestContextManager(target, getClass()).getContext();
 	}
 
-	private final class MockTestContextManager extends TestContextManager {
+	private final static class MockTestContextManager extends TestContextManager {
 
 		private MockTestContextManager(Object target, Class<?> testClass) throws Exception {
 			super(testClass);

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/MetaDataInstanceFactoryTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/MetaDataInstanceFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
+import java.util.List;
 
-import org.junit.Test;
-import org.springframework.batch.core.JobExecution;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.converter.DefaultJobParametersConverter;
 import org.springframework.batch.support.PropertiesConverter;
@@ -29,118 +28,77 @@ import org.springframework.batch.support.PropertiesConverter;
  * @author Dave Syer
  *
  */
-public class MetaDataInstanceFactoryTests {
+class MetaDataInstanceFactoryTests {
 
-	private String jobName = "JOB";
+	private final String jobName = "JOB";
 
-	private Long instanceId = 321L;
+	private final Long instanceId = 321L;
 
-	private String jobParametersString = "foo=bar";
+	private final String jobParametersString = "foo=bar";
 
-	private JobParameters jobParameters = new DefaultJobParametersConverter()
+	private final JobParameters jobParameters = new DefaultJobParametersConverter()
 			.getJobParameters(PropertiesConverter.stringToProperties(jobParametersString));
 
-	private Long executionId = 4321L;
+	private final Long executionId = 4321L;
 
-	private String stepName = "step";
+	private final String stepName = "step";
 
-	private Long stepExecutionId = 11L;
+	private final Long stepExecutionId = 11L;
 
-	/**
-	 * Test method for {@link MetaDataInstanceFactory#createJobInstance(String, Long)} .
-	 */
 	@Test
-	public void testCreateJobInstanceStringLong() {
+	void testCreateJobInstanceStringLong() {
 		assertNotNull(MetaDataInstanceFactory.createJobInstance(jobName, instanceId));
 	}
 
-	/**
-	 * Test method for {@link MetaDataInstanceFactory#createJobInstance()} .
-	 */
 	@Test
-	public void testCreateJobInstance() {
+	void testCreateJobInstance() {
 		assertNotNull(MetaDataInstanceFactory.createJobInstance());
 	}
 
-	/**
-	 * Test method for {@link MetaDataInstanceFactory#createJobExecution()} .
-	 */
 	@Test
-	public void testCreateJobExecution() {
+	void testCreateJobExecution() {
 		assertNotNull(MetaDataInstanceFactory.createJobExecution());
 	}
 
-	/**
-	 * Test method for {@link MetaDataInstanceFactory#createJobExecution(Long)} .
-	 */
 	@Test
-	public void testCreateJobExecutionLong() {
+	void testCreateJobExecutionLong() {
 		assertNotNull(MetaDataInstanceFactory.createJobExecution(instanceId));
 	}
 
-	/**
-	 * Test method for
-	 * {@link MetaDataInstanceFactory#createJobExecution(String, Long, Long)} .
-	 */
 	@Test
-	public void testCreateJobExecutionStringLongLong() {
+	void testCreateJobExecutionStringLongLong() {
 		assertNotNull(MetaDataInstanceFactory.createJobExecution(jobName, instanceId, executionId));
 	}
 
-	/**
-	 * Test method for
-	 * {@link MetaDataInstanceFactory#createJobExecution(String, Long, Long, String)} .
-	 */
 	@Test
-	public void testCreateJobExecutionStringLongLongString() {
+	void testCreateJobExecutionStringLongLongString() {
 		assertNotNull(
 				MetaDataInstanceFactory.createJobExecution(jobName, instanceId, executionId, jobParametersString));
 	}
 
-	/**
-	 * Test method for
-	 * {@link MetaDataInstanceFactory#createJobExecution(String, Long, Long, JobParameters)}
-	 * .
-	 */
 	@Test
-	public void testCreateJobExecutionStringLongLongJobParameters() {
+	void testCreateJobExecutionStringLongLongJobParameters() {
 		assertNotNull(MetaDataInstanceFactory.createJobExecution(jobName, instanceId, executionId, jobParameters));
 	}
 
-	/**
-	 * Test method for {@link MetaDataInstanceFactory#createStepExecution()} .
-	 */
 	@Test
-	public void testCreateStepExecution() {
+	void testCreateStepExecution() {
 		assertNotNull(MetaDataInstanceFactory.createStepExecution());
 	}
 
-	/**
-	 * Test method for {@link MetaDataInstanceFactory#createStepExecution(String, Long)} .
-	 */
 	@Test
-	public void testCreateStepExecutionStringLong() {
+	void testCreateStepExecutionStringLong() {
 		assertNotNull(MetaDataInstanceFactory.createStepExecution(stepName, stepExecutionId));
 	}
 
-	/**
-	 * Test method for
-	 * {@link MetaDataInstanceFactory#createStepExecution(JobExecution, String, Long)} .
-	 */
 	@Test
-	public void testCreateStepExecutionJobExecutionStringLong() {
+	void testCreateStepExecutionJobExecutionStringLong() {
 		assertNotNull(MetaDataInstanceFactory.createStepExecution(stepName, stepExecutionId));
 	}
 
-	/**
-	 * Test method for
-	 * {@link MetaDataInstanceFactory#createJobExecutionWithStepExecutions(Long, java.util.Collection)}
-	 * .
-	 */
 	@Test
-	public void testCreateJobExecutionWithStepExecutions() {
-		assertNotNull(
-				MetaDataInstanceFactory.createJobExecutionWithStepExecutions(executionId, Arrays.asList(stepName)));
+	void testCreateJobExecutionWithStepExecutions() {
+		assertNotNull(MetaDataInstanceFactory.createJobExecutionWithStepExecutions(executionId, List.of(stepName)));
 	}
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SampleFlowJobTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SampleFlowJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
  */
 package org.springframework.batch.test;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.core.job.flow.FlowJob;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * This class will specifically test the capabilities of {@link JobRepositoryTestUtils} to
@@ -27,8 +25,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Dan Garrette
  * @since 2.0
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/jobs/sampleFlowJob.xml")
-public class SampleFlowJobTests extends AbstractSampleJobTests {
+@SpringJUnitConfig(locations = "/jobs/sampleFlowJob.xml")
+class SampleFlowJobTests extends AbstractSampleJobTests {
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SampleSimpleJobTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SampleSimpleJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2009-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
  */
 package org.springframework.batch.test;
 
-import org.junit.runner.RunWith;
 import org.springframework.batch.core.job.SimpleJob;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * This class will specifically test the capabilities of {@link JobRepositoryTestUtils} to
@@ -27,8 +25,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Dan Garrette
  * @since 2.0
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = "/jobs/sampleSimpleJob.xml")
-public class SampleSimpleJobTests extends AbstractSampleJobTests {
+@SpringJUnitConfig(locations = "/jobs/sampleSimpleJob.xml")
+class SampleSimpleJobTests extends AbstractSampleJobTests {
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SampleStepTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SampleStepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2021 the original author or authors.
+ * Copyright 2008-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -30,13 +29,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.jdbc.JdbcTestUtils;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "/simple-job-launcher-context.xml", "/jobs/sample-steps.xml" })
-public class SampleStepTests implements ApplicationContextAware {
+@SpringJUnitConfig(locations = { "/simple-job-launcher-context.xml", "/jobs/sample-steps.xml" })
+class SampleStepTests implements ApplicationContextAware {
 
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
@@ -51,19 +48,19 @@ public class SampleStepTests implements ApplicationContextAware {
 	@Autowired
 	private JobRepository jobRepository;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		jdbcTemplate.update("create table TESTS (ID integer, NAME varchar(40))");
 		stepRunner = new StepRunner(jobLauncher, jobRepository);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		JdbcTestUtils.dropTables(this.jdbcTemplate, "TESTS");
 	}
 
 	@Test
-	public void testTasklet() {
+	void testTasklet() {
 		Step step = (Step) context.getBean("s2");
 		assertEquals(BatchStatus.COMPLETED, stepRunner.launchStep(step).getStatus());
 		assertEquals(2, jdbcTemplate.queryForObject("SELECT ID from TESTS where NAME = 'SampleTasklet2'", Integer.class)

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit5Tests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit5Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.util.Arrays;
 
 import javax.sql.DataSource;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +42,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test cases for usage of {@link SpringBatchTest} annotation with JUnit 5.
@@ -51,7 +53,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Mahmoud Ben Hassine
  */
 @SpringBatchTest
-@ContextConfiguration
+@SpringJUnitConfig
 public class SpringBatchTestJUnit5Tests {
 
 	@Autowired
@@ -67,26 +69,26 @@ public class SpringBatchTestJUnit5Tests {
 	private ItemReader<String> jobScopedItemReader;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		this.jobRepositoryTestUtils.removeJobExecutions();
 	}
 
 	@Test
-	public void testStepScopedItemReader() throws Exception {
-		Assertions.assertEquals("foo", this.stepScopedItemReader.read());
-		Assertions.assertEquals("bar", this.stepScopedItemReader.read());
-		Assertions.assertNull(this.stepScopedItemReader.read());
+	void testStepScopedItemReader() throws Exception {
+		assertEquals("foo", this.stepScopedItemReader.read());
+		assertEquals("bar", this.stepScopedItemReader.read());
+		assertNull(this.stepScopedItemReader.read());
 	}
 
 	@Test
-	public void testJobScopedItemReader() throws Exception {
-		Assertions.assertEquals("foo", this.jobScopedItemReader.read());
-		Assertions.assertEquals("bar", this.jobScopedItemReader.read());
-		Assertions.assertNull(this.jobScopedItemReader.read());
+	void testJobScopedItemReader() throws Exception {
+		assertEquals("foo", this.jobScopedItemReader.read());
+		assertEquals("bar", this.jobScopedItemReader.read());
+		assertNull(this.jobScopedItemReader.read());
 	}
 
 	@Test
-	public void testJob() throws Exception {
+	void testJob() throws Exception {
 		// given
 		JobParameters jobParameters = this.jobLauncherTestUtils.getUniqueJobParameters();
 
@@ -94,16 +96,16 @@ public class SpringBatchTestJUnit5Tests {
 		JobExecution jobExecution = this.jobLauncherTestUtils.launchJob(jobParameters);
 
 		// then
-		Assertions.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+		assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
 	}
 
-	public StepExecution getStepExecution() {
+	StepExecution getStepExecution() {
 		StepExecution execution = MetaDataInstanceFactory.createStepExecution();
 		execution.getExecutionContext().putString("input.data", "foo,bar");
 		return execution;
 	}
 
-	public JobExecution getJobExecution() {
+	JobExecution getJobExecution() {
 		JobExecution execution = MetaDataInstanceFactory.createJobExecution();
 		execution.getExecutionContext().putString("input.data", "foo,bar");
 		return execution;

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/StepScopeAnnotatedListenerIntegrationTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/StepScopeAnnotatedListenerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,14 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -44,24 +43,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.lang.Nullable;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class StepScopeAnnotatedListenerIntegrationTests {
+@SpringJUnitConfig
+class StepScopeAnnotatedListenerIntegrationTests {
 
 	@Autowired
 	JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	public void test() {
+	void test() {
 		JobExecution jobExecution = jobLauncherTestUtils.launchStep("step-under-test");
 
 		assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
 	}
 
-	public static class StatefulItemReader implements ItemReader<String> {
+	static class StatefulItemReader implements ItemReader<String> {
 
 		private List<String> list;
 
@@ -92,7 +89,7 @@ public class StepScopeAnnotatedListenerIntegrationTests {
 
 	@Configuration
 	@EnableBatchProcessing
-	public static class TestConfig {
+	static class TestConfig {
 
 		@Autowired
 		private JobBuilderFactory jobBuilder;

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/StepScopeTestExecutionListenerIntegrationTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/StepScopeTestExecutionListenerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,17 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
 /**
@@ -35,10 +33,9 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
  * @author Mahmoud Ben Hassine
  * @since 2.1
  */
-@ContextConfiguration
+@SpringJUnitConfig
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, StepScopeTestExecutionListener.class })
-@RunWith(SpringJUnit4ClassRunner.class)
-public class StepScopeTestExecutionListenerIntegrationTests {
+class StepScopeTestExecutionListenerIntegrationTests {
 
 	@Autowired
 	private ItemReader<String> reader;
@@ -46,7 +43,7 @@ public class StepScopeTestExecutionListenerIntegrationTests {
 	@Autowired
 	private ItemStream stream;
 
-	public StepExecution getStepExecution() {
+	StepExecution getStepExecution() {
 		// Assert that dependencies are already injected...
 		assertNotNull(reader);
 		// Then create the execution for the step scope...
@@ -56,7 +53,7 @@ public class StepScopeTestExecutionListenerIntegrationTests {
 	}
 
 	@Test
-	public void testJob() throws Exception {
+	void testJob() throws Exception {
 		stream.open(new ExecutionContext());
 		assertEquals("foo", reader.read());
 	}

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/StepScopeTestExecutionListenerTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/StepScopeTestExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2010-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,17 @@
  */
 package org.springframework.batch.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.StepContext;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestContextManager;
 
@@ -33,13 +33,13 @@ import org.springframework.test.context.TestContextManager;
  * @author Dave Syer
  * @since 2.1
  */
-@ContextConfiguration
-public class StepScopeTestExecutionListenerTests {
+@SpringJUnitConfig
+class StepScopeTestExecutionListenerTests {
 
-	private StepScopeTestExecutionListener listener = new StepScopeTestExecutionListener();
+	private final StepScopeTestExecutionListener listener = new StepScopeTestExecutionListener();
 
 	@Test
-	public void testDefaultStepContext() throws Exception {
+	void testDefaultStepContext() throws Exception {
 		TestContext testContext = getTestContext(new Object());
 		listener.prepareTestInstance(testContext);
 		listener.beforeTestMethod(testContext);
@@ -50,12 +50,12 @@ public class StepScopeTestExecutionListenerTests {
 	}
 
 	@Test
-	public void testWithStepExecutionFactory() throws Exception {
+	void testWithStepExecutionFactory() throws Exception {
 		testExecutionContext(new WithStepExecutionFactory());
 	}
 
 	@Test
-	public void testWithParameters() throws Exception {
+	void testWithParameters() throws Exception {
 		testJobParameters(new WithStepExecutionFactory());
 	}
 
@@ -106,7 +106,7 @@ public class StepScopeTestExecutionListenerTests {
 		return new MockTestContextManager(target, getClass()).getContext();
 	}
 
-	private final class MockTestContextManager extends TestContextManager {
+	private final static class MockTestContextManager extends TestContextManager {
 
 		private MockTestContextManager(Object target, Class<?> testClass) throws Exception {
 			super(testClass);

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,21 +18,23 @@ package org.springframework.batch.test.context;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 /**
  * @author Mahmoud Ben Hassine
  */
-public class BatchTestContextCustomizerFactoryTests {
+class BatchTestContextCustomizerFactoryTests {
 
-	private BatchTestContextCustomizerFactory factory = new BatchTestContextCustomizerFactory();
+	private final BatchTestContextCustomizerFactory factory = new BatchTestContextCustomizerFactory();
 
 	@Test
-	public void testCreateContextCustomizer_whenAnnotationIsPresent() {
+	void testCreateContextCustomizer_whenAnnotationIsPresent() {
 		// given
 		Class<MyJobTest> testClass = MyJobTest.class;
 		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
@@ -41,11 +43,11 @@ public class BatchTestContextCustomizerFactoryTests {
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
 
 		// then
-		Assert.assertNotNull(contextCustomizer);
+		assertNotNull(contextCustomizer);
 	}
 
 	@Test
-	public void testCreateContextCustomizer_whenAnnotationIsAbsent() {
+	void testCreateContextCustomizer_whenAnnotationIsAbsent() {
 		// given
 		Class<MyOtherJobTest> testClass = MyOtherJobTest.class;
 		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
@@ -54,7 +56,7 @@ public class BatchTestContextCustomizerFactoryTests {
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
 
 		// then
-		Assert.assertNull(contextCustomizer);
+		assertNull(contextCustomizer);
 	}
 
 	@SpringBatchTest

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package org.springframework.batch.test.context;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.context.ConfigurableApplicationContext;
@@ -25,16 +24,18 @@ import org.springframework.test.context.MergedContextConfiguration;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Mahmoud Ben Hassine
  */
-public class BatchTestContextCustomizerTests {
+class BatchTestContextCustomizerTests {
 
-	private BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer();
+	private final BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer();
 
 	@Test
-	public void testCustomizeContext() {
+	void testCustomizeContext() {
 		// given
 		ConfigurableApplicationContext context = new GenericApplicationContext();
 		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
@@ -43,18 +44,18 @@ public class BatchTestContextCustomizerTests {
 		this.contextCustomizer.customizeContext(context, mergedConfig);
 
 		// then
-		Assert.assertTrue(context.containsBean("jobLauncherTestUtils"));
-		Assert.assertTrue(context.containsBean("jobRepositoryTestUtils"));
+		assertTrue(context.containsBean("jobLauncherTestUtils"));
+		assertTrue(context.containsBean("jobRepositoryTestUtils"));
 	}
 
 	@Test
-	public void testCustomizeContext_whenBeanFactoryIsNotAnInstanceOfBeanDefinitionRegistry() {
+	void testCustomizeContext_whenBeanFactoryIsNotAnInstanceOfBeanDefinitionRegistry() {
 		// given
 		ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
 		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
 
 		// when
-		final Exception expectedException = Assert.assertThrows(IllegalArgumentException.class,
+		final Exception expectedException = assertThrows(IllegalArgumentException.class,
 				() -> this.contextCustomizer.customizeContext(context, mergedConfig));
 
 		// then

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/observability/ObservabilitySampleStepTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/observability/ObservabilitySampleStepTests.java
@@ -18,8 +18,8 @@ package org.springframework.batch.test.observability;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.tck.MeterRegistryAssert;
 import io.micrometer.tracing.test.SampleTestRunner;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Import;
 import static io.micrometer.tracing.test.simple.SpansAssert.assertThat;
 
 @SpringBatchTest
-public class ObservabilitySampleStepTests extends SampleTestRunner {
+class ObservabilitySampleStepTests extends SampleTestRunner {
 
 	@Autowired
 	private JobLauncherTestUtils jobLauncherTestUtils;
@@ -59,7 +59,7 @@ public class ObservabilitySampleStepTests extends SampleTestRunner {
 			JobExecution jobExecution = this.jobLauncherTestUtils.launchJob(jobParameters);
 
 			// then
-			Assertions.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+			Assertions.assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
 
 			// and
 			assertThat(bb.getFinishedSpans()).haveSameTraceId().hasASpanWithName("job").hasASpanWithName("step");


### PR DESCRIPTION
Migrates the tests of Spring Batch Test to JUnit Jupiter as part of #4166.

`SpringBatchTestJUnit4Tests` remains as the only JUnit 4 test. The vintage engine is added as a test dependency to make sure that it will be executed in the build.