### PR TITLE
Add ExecutionContextSerializer implementation based on Gson

### DIFF
--- a/spring-batch-core/pom.xml
+++ b/spring-batch-core/pom.xml
@@ -56,6 +56,11 @@
 			<version>${jackson.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>${gson.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-core</artifactId>
 			<version>${micrometer.version}</version>

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/GsonExecutionContextStringSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/GsonExecutionContextStringSerializer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository.dao;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import org.springframework.batch.core.repository.ExecutionContextSerializer;
+import org.springframework.util.Assert;
+
+/**
+ * This class is an implementation of {@link ExecutionContextSerializer}
+ * based on <a href="https://github.com/google/gson">Google Gson</a> library.
+ *
+ * @author Mahmoud Ben Hassine
+ * @since 5.0
+ */
+public class GsonExecutionContextStringSerializer implements ExecutionContextSerializer {
+
+    private Gson gson;
+
+    /**
+     * Create a new {@link GsonExecutionContextStringSerializer}.
+     *
+     * @param gson the Gson instance to use
+     */
+    public GsonExecutionContextStringSerializer(Gson gson) {
+        this.gson = gson;
+    }
+
+    @Override
+    public Map<String, Object> deserialize(InputStream inputStream) throws IOException {
+        Assert.notNull(inputStream, "An InputStream is required");
+        Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
+        try (JsonReader jsonReader = new JsonReader(new InputStreamReader(inputStream))) {
+            return this.gson.fromJson(jsonReader, mapType);
+        }
+    }
+
+    @Override
+    public void serialize(Map<String, Object> context, OutputStream outputStream) throws IOException {
+        Assert.notNull(context, "A context is required");
+        Assert.notNull(outputStream, "An OutputStream is required");
+        Type mapType = new TypeToken<Map<String, Object>>(){}.getType();
+        try (JsonWriter jsonWriter = new JsonWriter(new OutputStreamWriter(outputStream))) {
+            this.gson.toJson(context, mapType, jsonWriter);
+        }
+    }
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/GsonExecutionContextStringSerializerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/GsonExecutionContextStringSerializerTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+
+import org.springframework.batch.core.repository.dao.AbstractExecutionContextSerializerTests;
+import org.springframework.batch.core.repository.dao.GsonExecutionContextStringSerializer;
+
+/**
+ * Test class for {@link GsonExecutionContextStringSerializer}.
+ *
+ * @author Mahmoud Ben Hassine
+ */
+public class GsonExecutionContextStringSerializerTests extends AbstractExecutionContextSerializerTests {
+
+    @Override
+    protected ExecutionContextSerializer getSerializer() {
+        Gson gson = new GsonBuilder()
+                // TODO correctly configure gson to pass the test suite
+                .create();
+        return new GsonExecutionContextStringSerializer(gson);
+    }
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractExecutionContextSerializerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractExecutionContextSerializerTests.java
@@ -15,20 +15,24 @@
  */
 package org.springframework.batch.core.repository.dao;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.junit.jupiter.api.Test;
-import org.springframework.batch.core.JobParameter;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.repository.ExecutionContextSerializer;
-
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.repository.ExecutionContextSerializer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -54,7 +58,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -64,7 +68,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -74,7 +78,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -84,7 +88,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -94,7 +98,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -104,7 +108,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -117,7 +121,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -127,7 +131,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -149,7 +153,7 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
@@ -160,20 +164,13 @@ public abstract class AbstractExecutionContextSerializerTests {
 
 		Map<String, Object> m2 = serializationRoundTrip(m1);
 
-		compareContexts(m1, m2);
+		assertEquals(m1.entrySet(), m2.entrySet());
 	}
 
 	@Test
 	void testNullSerialization() {
 		ExecutionContextSerializer serializer = getSerializer();
 		assertThrows(IllegalArgumentException.class, () -> serializer.serialize(null, null));
-	}
-
-	protected void compareContexts(Map<String, Object> m1, Map<String, Object> m2) {
-
-		for (Map.Entry<String, Object> entry : m1.entrySet()) {
-			assertThat(m2, hasEntry(entry.getKey(), entry.getValue()));
-		}
 	}
 
 	protected Map<String, Object> serializationRoundTrip(Map<String, Object> m1) throws IOException {


### PR DESCRIPTION
This is a draft PR. Gson seems to deserialize custom types to `Map` instances instead of the original type (it looks like type information is not serialized).

TODO: Need to figure out if this should be done in the implementation of the serializer or as a configuration of the gson instance.

Issue #4151