### PR TITLE
Fix minor example in job.adoc

### DIFF
--- a/spring-batch-docs/src/main/asciidoc/job.adoc
+++ b/spring-batch-docs/src/main/asciidoc/job.adoc
@@ -1607,7 +1607,8 @@ The following example shows a typical bean definition for `SimpleJobOperator` in
  @Bean
  public SimpleJobOperator jobOperator(JobExplorer jobExplorer,
                                 JobRepository jobRepository,
-                                JobRegistry jobRegistry) {
+                                JobRegistry jobRegistry,
+                                JobLauncher jobLauncher) {
 
 	SimpleJobOperator jobOperator = new SimpleJobOperator();
 


### PR DESCRIPTION
Minor fix example for
https://docs.spring.io/spring-batch/docs/current/reference/html/job.html#JobOperator
forgot jobLauncher