### PR TITLE
Update MySQL Connector/J and use new Maven coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<woodstox-core.version>6.3.1</woodstox-core.version>
 		<aspectj.version>1.9.9.1</aspectj.version>
-		<mysql-connector-java.version>8.0.30</mysql-connector-java.version>
+		<mysql-connector-j.version>8.0.31</mysql-connector-j.version>
 		<postgresql.version>42.5.0</postgresql.version>
 		<db2.version>11.5.7.0</db2.version>
 		<oracle.version>19.16.0.0</oracle.version>

--- a/spring-batch-core/pom.xml
+++ b/spring-batch-core/pom.xml
@@ -107,9 +107,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql-connector-java.version}</version>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>${mysql-connector-j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/MySQLJdbcJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/MySQLJdbcJobRepositoryIntegrationTests.java
@@ -67,7 +67,7 @@ class MySQLJdbcJobRepositoryIntegrationTests {
 
 	// TODO find the best way to externalize and manage image versions
 	// when implementing https://github.com/spring-projects/spring-batch/issues/3092
-	private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.24");
+	private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.31");
 
 	@Container
 	public static MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/MySQLJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/MySQLJobRepositoryIntegrationTests.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class MySQLJobRepositoryIntegrationTests {
 
 	// TODO find the best way to externalize and manage image versions
-	private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.25");
+	private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.31");
 
 	@Container
 	public static MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE);


### PR DESCRIPTION
This PR updates MySQL Connector/J to the latest release 8.0.31 and switches to the new Maven group id and artifact id: https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-31.html

Furthermore, it aligns the version of the MySQL docker image that is used in integration tests such that only one MySQL image is needed.