### PR TITLE
Improve `@SpringBatchTest` to autowire the job under test in `JobLauncherTestUtils` if it is unique 

### DIFF
--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/AMQPJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/AMQPJobFunctionalTests.java
@@ -17,7 +17,6 @@ package org.springframework.batch.sample;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,9 +49,8 @@ class AMQPJobFunctionalTests {
 	private JobExplorer jobExplorer;
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
+	void testLaunchJob() throws Exception {
 		// given
-		this.jobLauncherTestUtils.setJob(job);
 		this.jobLauncherTestUtils.launchJob();
 
 		// when

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/BeanWrapperMapperSampleJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/BeanWrapperMapperSampleJobFunctionalTests.java
@@ -18,7 +18,6 @@ package org.springframework.batch.sample;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -31,10 +30,7 @@ class BeanWrapperMapperSampleJobFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testJobLaunch(@Autowired Job job) throws Exception {
-		// given
-		this.jobLauncherTestUtils.setJob(job);
-
+	void testJobLaunch() throws Exception {
 		// when
 		this.jobLauncherTestUtils.launchJob();
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/CompositeItemWriterSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/CompositeItemWriterSampleFunctionalTests.java
@@ -28,7 +28,6 @@ import javax.sql.DataSource;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.sample.domain.trade.Trade;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,8 +61,7 @@ class CompositeItemWriterSampleFunctionalTests {
 	}
 
 	@Test
-	void testJobLaunch(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testJobLaunch() throws Exception {
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "TRADE");
 		int before = JdbcTestUtils.countRowsInTable(jdbcTemplate, "TRADE");
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/CustomerFilterJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/CustomerFilterJobFunctionalTests.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,8 +81,7 @@ class CustomerFilterJobFunctionalTests {
 	}
 
 	@Test
-	void testFilterJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testFilterJob() throws Exception {
 		JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
 		customers = Arrays.asList(new Customer("customer1", (credits.get("customer1"))),

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/DatabaseShutdownFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/DatabaseShutdownFunctionalTests.java
@@ -21,7 +21,6 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.test.JobLauncherTestUtils;
@@ -57,8 +56,7 @@ class DatabaseShutdownFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
 		Thread.sleep(1000);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/DelegatingJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/DelegatingJobFunctionalTests.java
@@ -17,7 +17,6 @@ package org.springframework.batch.sample;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.sample.domain.person.PersonService;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,8 +36,7 @@ class DelegatingJobFunctionalTests {
 	private PersonService personService;
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		jobLauncherTestUtils.launchJob();
 
 		assertTrue(personService.getReturnedCount() > 0);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/FootballJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/FootballJobFunctionalTests.java
@@ -19,7 +19,6 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -43,8 +42,7 @@ class FootballJobFunctionalTests {
 	}
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "PLAYERS", "GAMES", "PLAYER_SUMMARY");
 
 		jobLauncherTestUtils.launchJob();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/GracefulShutdownFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/GracefulShutdownFunctionalTests.java
@@ -21,7 +21,6 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -58,8 +57,7 @@ class GracefulShutdownFunctionalTests {
 	private JobOperator jobOperator;
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		final JobParameters jobParameters = new JobParametersBuilder().addLong("timestamp", System.currentTimeMillis())
 				.toJobParameters();
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/GroovyJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/GroovyJobFunctionalTests.java
@@ -23,7 +23,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -43,8 +42,7 @@ public class GroovyJobFunctionalTests {
 	}
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		assertFalse(new File("target/groovyJob/output/files.zip").exists());
 		jobLauncherTestUtils.launchJob();
 		assertTrue(new File("target/groovyJob/output/files.zip").exists());

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/HeaderFooterSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/HeaderFooterSampleFunctionalTests.java
@@ -20,7 +20,6 @@ import java.io.FileReader;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -45,8 +44,7 @@ class HeaderFooterSampleFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testJob() throws Exception {
 		this.jobLauncherTestUtils.launchJob();
 
 		BufferedReader inputReader = new BufferedReader(new FileReader(input.getFile()));

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/HibernateFailureJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/HibernateFailureJobFunctionalTests.java
@@ -25,7 +25,6 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.sample.domain.trade.internal.CustomerCreditIncreaseProcessor;
@@ -92,8 +91,7 @@ class HibernateFailureJobFunctionalTests {
 	}
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		validatePreConditions();
 
 		JobParameters params = new JobParametersBuilder().addString("key", "failureJob").toJobParameters();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/LoopFlowSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/LoopFlowSampleFunctionalTests.java
@@ -17,7 +17,6 @@ package org.springframework.batch.sample;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.sample.domain.trade.internal.ItemTrackingTradeItemWriter;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,8 +44,7 @@ class LoopFlowSampleFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testJobLaunch(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testJobLaunch() throws Exception {
 		this.jobLauncherTestUtils.launchJob();
 		// items processed = items read + 2 exceptions
 		assertEquals(10, itemWriter.getItems().size());

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/MailJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/MailJobFunctionalTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.sample.domain.mail.internal.TestMailErrorHandler;
 import org.springframework.batch.sample.domain.mail.internal.TestMailSender;
@@ -96,8 +95,7 @@ class MailJobFunctionalTests {
 	}
 
 	@Test
-	void testSkip(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testSkip() throws Exception {
 		this.createUsers(new Object[][] { USER1, USER2_SKIP, USER3, USER4_SKIP, USER5, USER6, USER7, USER8 });
 
 		JobExecution jobExecution = jobLauncherTestUtils.launchJob();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/MultilineJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/MultilineJobFunctionalTests.java
@@ -19,7 +19,6 @@ package org.springframework.batch.sample;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
@@ -44,8 +43,7 @@ class MultilineJobFunctionalTests {
 	private final Resource output = new FileSystemResource("target/test-outputs/20070122.testStream.multilineStep.txt");
 
 	@Test
-	void testJobLaunch(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testJobLaunch() throws Exception {
 		this.jobLauncherTestUtils.launchJob();
 		assertEquals(EXPECTED_RESULT, StringUtils.replace(IOUtils.toString(output.getInputStream(), "UTF-8"),
 				System.getProperty("line.separator"), ""));

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/MultilineOrderJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/MultilineOrderJobFunctionalTests.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -41,8 +40,7 @@ class MultilineOrderJobFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testJobLaunch(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testJobLaunch() throws Exception {
 		this.jobLauncherTestUtils.launchJob();
 		Path expectedFile = new ClassPathResource(EXPECTED).getFile().toPath();
 		Path actualFile = new FileSystemResource(ACTUAL).getFile().toPath();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/ParallelJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/ParallelJobFunctionalTests.java
@@ -21,7 +21,6 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +45,7 @@ class ParallelJobFunctionalTests {
 	}
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		int before = JdbcTestUtils.countRowsInTable(jdbcTemplate, "BATCH_STAGING");
 		JobExecution execution = jobLauncherTestUtils.launchJob();
 		int after = JdbcTestUtils.countRowsInTable(jdbcTemplate, "BATCH_STAGING");

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/PartitionFileJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/PartitionFileJobFunctionalTests.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -64,8 +63,7 @@ class PartitionFileJobFunctionalTests implements ApplicationContextAware {
 	 * Check the resulting credits correspond to inputs increased by fixed amount.
 	 */
 	@Test
-	void testUpdateCredit(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testUpdateCredit() throws Exception {
 		assertTrue(applicationContext.containsBeanDefinition("outputTestReader"),
 				"Define a prototype bean called 'outputTestReader' to check the output");
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/PartitionJdbcJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/PartitionJdbcJobFunctionalTests.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
@@ -64,8 +63,7 @@ class PartitionJdbcJobFunctionalTests implements ApplicationContextAware {
 	 * Check the resulting credits correspond to inputs increased by fixed amount.
 	 */
 	@Test
-	void testUpdateCredit(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testUpdateCredit() throws Exception {
 		assertTrue(applicationContext.containsBeanDefinition("outputTestReader"),
 				"Define a prototype bean called 'outputTestReader' to check the output");
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/RestartFileSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/RestartFileSampleFunctionalTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.batch.sample;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.item.Chunk;
@@ -54,8 +52,7 @@ class RestartFileSampleFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void runTest(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void runTest() throws Exception {
 		JobParameters jobParameters = jobLauncherTestUtils.getUniqueJobParameters();
 
 		JobExecution je1 = jobLauncherTestUtils.launchJob(jobParameters);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/RestartFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/RestartFunctionalTests.java
@@ -21,7 +21,6 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.converter.DefaultJobParametersConverter;
 import org.springframework.batch.support.PropertiesConverter;
@@ -70,8 +69,7 @@ class RestartFunctionalTests {
 	 * @throws Exception
 	 */
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		int before = JdbcTestUtils.countRowsInTable(jdbcTemplate, "TRADE");
 
 		JobExecution jobExecution = runJobForRestartTest();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/RetrySampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/RetrySampleFunctionalTests.java
@@ -17,7 +17,6 @@ package org.springframework.batch.sample;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.sample.domain.trade.internal.GeneratingTradeItemReader;
 import org.springframework.batch.sample.support.RetrySampleItemWriter;
 import org.springframework.batch.test.JobLauncherTestUtils;
@@ -48,8 +47,7 @@ class RetrySampleFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		this.jobLauncherTestUtils.launchJob();
 		// items processed = items read + 2 exceptions
 		assertEquals(itemGenerator.getLimit() + 2, itemProcessor.getCounter());

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/TaskletJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/TaskletJobFunctionalTests.java
@@ -19,7 +19,6 @@ package org.springframework.batch.sample;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.scope.context.ChunkContext;
@@ -37,8 +36,7 @@ class TaskletJobFunctionalTests {
 	private JobLauncherTestUtils jobLauncherTestUtils;
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		JobExecution jobExecution = jobLauncherTestUtils
 				.launchJob(new JobParametersBuilder().addString("value", "foo").toJobParameters());
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/TradeJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/TradeJobFunctionalTests.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.sample.domain.trade.Trade;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,8 +81,7 @@ class TradeJobFunctionalTests {
 	}
 
 	@Test
-	void testLaunchJob(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
+	void testLaunchJob() throws Exception {
 		this.jobLauncherTestUtils.launchJob();
 
 		customers = Arrays.asList(new Customer("customer1", (credits.get("customer1") - 98.34)),

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/AbstractIoSampleTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/AbstractIoSampleTests.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -65,9 +64,7 @@ abstract class AbstractIoSampleTests {
 	 * Check the resulting credits correspond to inputs increased by fixed amount.
 	 */
 	@Test
-	void testUpdateCredit(@Autowired Job job) throws Exception {
-		this.jobLauncherTestUtils.setJob(job);
-
+	void testUpdateCredit() throws Exception {
 		open(reader);
 		List<CustomerCredit> inputs = getCredits(reader);
 		close(reader);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/MultiLineFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/MultiLineFunctionalTests.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
@@ -49,10 +48,7 @@ class MultiLineFunctionalTests {
 	 * Output should be the same as input
 	 */
 	@Test
-	void testJob(@Autowired Job job) throws Exception {
-		// given
-		this.jobLauncherTestUtils.setJob(job);
-
+	void testJob() throws Exception {
 		// when
 		this.jobLauncherTestUtils.launchJob();
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/MultiRecordTypeFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/iosample/MultiRecordTypeFunctionalTests.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
@@ -49,10 +48,7 @@ class MultiRecordTypeFunctionalTests {
 	 * Output should be the same as input
 	 */
 	@Test
-	void testJob(@Autowired Job job) throws Exception {
-		// given
-		this.jobLauncherTestUtils.setJob(job);
-
+	void testJob() throws Exception {
 		// when
 		jobLauncherTestUtils.launchJob();
 

--- a/spring-batch-samples/src/test/resources/job-runner-context.xml
+++ b/spring-batch-samples/src/test/resources/job-runner-context.xml
@@ -7,4 +7,5 @@
 	<context:annotation-config/>
 
 	<bean class="org.springframework.batch.test.JobLauncherTestUtils"/>
+	<bean class="org.springframework.batch.test.context.BatchTestContextBeanPostProcessor"/>
 </beans>

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextBeanPostProcessor.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextBeanPostProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.test.context;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * {@link BeanPostProcessor} implementation that injects a job bean into
+ * {@link JobLauncherTestUtils} if there is a unique job bean.
+ *
+ * @author Henning Pöttker
+ * @since 5.0
+ */
+public class BatchTestContextBeanPostProcessor implements BeanPostProcessor {
+
+	private ObjectProvider<Job> jobProvider;
+
+	@Autowired
+	public void setJobProvider(ObjectProvider<Job> jobProvider) {
+		this.jobProvider = jobProvider;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if (bean instanceof JobLauncherTestUtils jobLauncherTestUtils) {
+			jobProvider.ifUnique(jobLauncherTestUtils::setJob);
+		}
+		return bean;
+	}
+
+}

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizer.java
@@ -15,13 +15,9 @@
  */
 package org.springframework.batch.test.context;
 
-import java.util.Objects;
-
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.JobRepositoryTestUtils;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -43,11 +39,7 @@ public class BatchTestContextCustomizer implements ContextCustomizer {
 
 	private static final String JOB_REPOSITORY_TEST_UTILS_BEAN_NAME = "jobRepositoryTestUtils";
 
-	private final boolean autowireJob;
-
-	public BatchTestContextCustomizer(boolean autowireJob) {
-		this.autowireJob = autowireJob;
-	}
+	private static final String BATCH_TEST_CONTEXT_BEAN_POST_PROCESSOR_BEAN_NAME = "batchTestContextBeanPostProcessor";
 
 	@Override
 	public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
@@ -56,34 +48,22 @@ public class BatchTestContextCustomizer implements ContextCustomizer {
 				"The bean factory must be an instance of BeanDefinitionRegistry");
 		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
 
-		registry.registerBeanDefinition(JOB_LAUNCHER_TEST_UTILS_BEAN_NAME, buildJobLauncherTestUtilsBeanDefinition());
+		registry.registerBeanDefinition(JOB_LAUNCHER_TEST_UTILS_BEAN_NAME,
+				new RootBeanDefinition(JobLauncherTestUtils.class));
 		registry.registerBeanDefinition(JOB_REPOSITORY_TEST_UTILS_BEAN_NAME,
 				new RootBeanDefinition(JobRepositoryTestUtils.class));
-	}
-
-	private BeanDefinition buildJobLauncherTestUtilsBeanDefinition() {
-		var beanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(JobLauncherTestUtils.class);
-		if (this.autowireJob) {
-			beanDefinitionBuilder.addAutowiredProperty("job");
-		}
-		return beanDefinitionBuilder.getBeanDefinition();
+		registry.registerBeanDefinition(BATCH_TEST_CONTEXT_BEAN_POST_PROCESSOR_BEAN_NAME,
+				new RootBeanDefinition(BatchTestContextBeanPostProcessor.class));
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null || getClass() != obj.getClass()) {
-			return false;
-		}
-		BatchTestContextCustomizer that = (BatchTestContextCustomizer) obj;
-		return this.autowireJob == that.autowireJob;
+		return obj != null && getClass() == obj.getClass();
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.autowireJob);
+		return getClass().hashCode();
 	}
 
 }

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,8 @@ public class BatchTestContextCustomizerFactory implements ContextCustomizerFacto
 	@Override
 	public ContextCustomizer createContextCustomizer(Class<?> testClass,
 			List<ContextConfigurationAttributes> configAttributes) {
-		var annotationAttributes = AnnotatedElementUtils.findMergedAnnotationAttributes(testClass,
-				SpringBatchTest.class, false, false);
-		if (annotationAttributes != null) {
-			return new BatchTestContextCustomizer(annotationAttributes.getBoolean("autowireJob"));
+		if (AnnotatedElementUtils.hasAnnotation(testClass, SpringBatchTest.class)) {
+			return new BatchTestContextCustomizer();
 		}
 		return null;
 	}

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,10 @@ public class BatchTestContextCustomizerFactory implements ContextCustomizerFacto
 	@Override
 	public ContextCustomizer createContextCustomizer(Class<?> testClass,
 			List<ContextConfigurationAttributes> configAttributes) {
-		if (AnnotatedElementUtils.hasAnnotation(testClass, SpringBatchTest.class)) {
-			return new BatchTestContextCustomizer();
+		var annotationAttributes = AnnotatedElementUtils.findMergedAnnotationAttributes(testClass,
+				SpringBatchTest.class, false, false);
+		if (annotationAttributes != null) {
+			return new BatchTestContextCustomizer(annotationAttributes.getBoolean("autowireJob"));
 		}
 		return null;
 	}

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/SpringBatchTest.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/SpringBatchTest.java
@@ -24,10 +24,14 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.JobRepositoryTestUtils;
 import org.springframework.batch.test.JobScopeTestExecutionListener;
 import org.springframework.batch.test.StepScopeTestExecutionListener;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -135,5 +139,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 		mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @ExtendWith(SpringExtension.class)
 public @interface SpringBatchTest {
+
+	/**
+	 * Indicate whether a {@link Job} bean shall be autowired into the registered
+	 * {@link JobLauncherTestUtils} bean. If set to true, and no {@link Job} bean exists,
+	 * then a {@link NoSuchBeanDefinitionException} will be thrown. If set to true, and
+	 * multiple {@link Job} beans exists but none has the name {@literal job} or is marked
+	 * with {@link Primary}, then a {@link NoUniqueBeanDefinitionException} will be
+	 * thrown.
+	 * @return if a {@link Job} shall be autowired. Defaults to {@code false}.
+	 */
+	boolean autowireJob() default false;
 
 }

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/SpringBatchTest.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/SpringBatchTest.java
@@ -24,14 +24,10 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import org.springframework.batch.core.Job;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.JobRepositoryTestUtils;
 import org.springframework.batch.test.JobScopeTestExecutionListener;
 import org.springframework.batch.test.StepScopeTestExecutionListener;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
-import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -139,16 +135,5 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 		mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @ExtendWith(SpringExtension.class)
 public @interface SpringBatchTest {
-
-	/**
-	 * Indicate whether a {@link Job} bean shall be autowired into the registered
-	 * {@link JobLauncherTestUtils} bean. If set to true, and no {@link Job} bean exists,
-	 * then a {@link NoSuchBeanDefinitionException} will be thrown. If set to true, and
-	 * multiple {@link Job} beans exists but none has the name {@literal job} or is marked
-	 * with {@link Primary}, then a {@link NoUniqueBeanDefinitionException} will be
-	 * thrown.
-	 * @return if a {@link Job} shall be autowired. Defaults to {@code false}.
-	 */
-	boolean autowireJob() default false;
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit4Tests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit4Tests.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Mahmoud Ben Hassine
  */
 @RunWith(SpringRunner.class)
-@SpringBatchTest
+@SpringBatchTest(autowireJob = true)
 @ContextConfiguration
 public class SpringBatchTestJUnit4Tests {
 
@@ -68,9 +68,6 @@ public class SpringBatchTestJUnit4Tests {
 
 	@Autowired
 	private ItemReader<String> jobScopedItemReader;
-
-	@Autowired
-	private Job jobUnderTest;
 
 	@Before
 	public void setUp() {
@@ -105,9 +102,6 @@ public class SpringBatchTestJUnit4Tests {
 
 	@Test
 	public void testJob() throws Exception {
-		// given
-		this.jobLauncherTestUtils.setJob(this.jobUnderTest);
-
 		// when
 		JobExecution jobExecution = this.jobLauncherTestUtils.launchJob();
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit4Tests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit4Tests.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Mahmoud Ben Hassine
  */
 @RunWith(SpringRunner.class)
-@SpringBatchTest(autowireJob = true)
+@SpringBatchTest
 @ContextConfiguration
 public class SpringBatchTestJUnit4Tests {
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit5Tests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit5Tests.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 
 import javax.sql.DataSource;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  *
  * @author Mahmoud Ben Hassine
  */
-@SpringBatchTest
+@SpringBatchTest(autowireJob = true)
 @SpringJUnitConfig
 public class SpringBatchTestJUnit5Tests {
 
@@ -72,8 +71,7 @@ public class SpringBatchTestJUnit5Tests {
 	private ItemReader<String> jobScopedItemReader;
 
 	@BeforeEach
-	void setup(@Autowired Job jobUnderTest) {
-		this.jobLauncherTestUtils.setJob(jobUnderTest);
+	void setup() {
 		this.jobRepositoryTestUtils.removeJobExecutions();
 	}
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit5Tests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/SpringBatchTestJUnit5Tests.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  *
  * @author Mahmoud Ben Hassine
  */
-@SpringBatchTest(autowireJob = true)
+@SpringBatchTest
 @SpringJUnitConfig
 public class SpringBatchTestJUnit5Tests {
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextBeanPostProcessorTest.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextBeanPostProcessorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.test.context;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.jdbc.support.JdbcTransactionManager;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author Henning Pöttker
+ */
+class BatchTestContextBeanPostProcessorTest {
+
+	private GenericApplicationContext applicationContext;
+
+	@BeforeEach
+	void setUp() {
+		applicationContext = new AnnotationConfigApplicationContext(BatchConfiguration.class);
+		applicationContext.registerBean(JobLauncherTestUtils.class);
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (applicationContext != null) {
+			applicationContext.close();
+		}
+	}
+
+	@Test
+	void testContextWithoutJobBean() {
+		var jobLauncherTestUtils = applicationContext.getBean(JobLauncherTestUtils.class);
+		assertNotNull(jobLauncherTestUtils);
+		assertNull(jobLauncherTestUtils.getJob());
+	}
+
+	@Test
+	void testContextWithUniqueJobBean() {
+		applicationContext.registerBean(MockJob.class);
+		var jobLauncherTestUtils = applicationContext.getBean(JobLauncherTestUtils.class);
+		assertNotNull(jobLauncherTestUtils.getJob());
+	}
+
+	@Test
+	void testContextWithTwoJobBeans() {
+		applicationContext.registerBean("jobA", MockJob.class);
+		applicationContext.registerBean("jobB", MockJob.class);
+		var jobLauncherTestUtils = applicationContext.getBean(JobLauncherTestUtils.class);
+		assertNotNull(jobLauncherTestUtils);
+		assertNull(jobLauncherTestUtils.getJob());
+	}
+
+	static class MockJob implements Job {
+
+		@Override
+		public String getName() {
+			return "name";
+		}
+
+		@Override
+		public void execute(JobExecution execution) {
+		}
+
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	static class BatchConfiguration {
+
+		@Bean
+		DataSource dataSource() {
+			return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.HSQL)
+					.addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
+					.addScript("/org/springframework/batch/core/schema-hsqldb.sql").build();
+		}
+
+		@Bean
+		JdbcTransactionManager transactionManager(DataSource dataSource) {
+			return new JdbcTransactionManager(dataSource);
+		}
+
+		@Bean
+		BatchTestContextBeanPostProcessor beanPostProcessor() {
+			return new BatchTestContextBeanPostProcessor();
+		}
+
+	}
+
+}

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.batch.test.context;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -37,20 +37,33 @@ class BatchTestContextCustomizerFactoryTests {
 	void testCreateContextCustomizer_whenAnnotationIsPresent() {
 		// given
 		Class<MyJobTest> testClass = MyJobTest.class;
-		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
+		List<ContextConfigurationAttributes> configAttributes = emptyList();
 
 		// when
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
 
 		// then
-		assertNotNull(contextCustomizer);
+		assertEquals(new BatchTestContextCustomizer(false), contextCustomizer);
+	}
+
+	@Test
+	void testCreateContextCustomizer_whenAnnotationIsPresentAndFlagSet() {
+		// given
+		Class<MyUniqueJobTest> testClass = MyUniqueJobTest.class;
+		List<ContextConfigurationAttributes> configAttributes = emptyList();
+
+		// when
+		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
+
+		// then
+		assertEquals(new BatchTestContextCustomizer(true), contextCustomizer);
 	}
 
 	@Test
 	void testCreateContextCustomizer_whenAnnotationIsAbsent() {
 		// given
 		Class<MyOtherJobTest> testClass = MyOtherJobTest.class;
-		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
+		List<ContextConfigurationAttributes> configAttributes = emptyList();
 
 		// when
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
@@ -61,6 +74,11 @@ class BatchTestContextCustomizerFactoryTests {
 
 	@SpringBatchTest
 	private static class MyJobTest {
+
+	}
+
+	@SpringBatchTest(autowireJob = true)
+	private static class MyUniqueJobTest {
 
 	}
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.test.context;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 
-import static java.util.Collections.emptyList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -37,33 +37,20 @@ class BatchTestContextCustomizerFactoryTests {
 	void testCreateContextCustomizer_whenAnnotationIsPresent() {
 		// given
 		Class<MyJobTest> testClass = MyJobTest.class;
-		List<ContextConfigurationAttributes> configAttributes = emptyList();
+		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
 
 		// when
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
 
 		// then
-		assertEquals(new BatchTestContextCustomizer(false), contextCustomizer);
-	}
-
-	@Test
-	void testCreateContextCustomizer_whenAnnotationIsPresentAndFlagSet() {
-		// given
-		Class<MyUniqueJobTest> testClass = MyUniqueJobTest.class;
-		List<ContextConfigurationAttributes> configAttributes = emptyList();
-
-		// when
-		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
-
-		// then
-		assertEquals(new BatchTestContextCustomizer(true), contextCustomizer);
+		assertNotNull(contextCustomizer);
 	}
 
 	@Test
 	void testCreateContextCustomizer_whenAnnotationIsAbsent() {
 		// given
 		Class<MyOtherJobTest> testClass = MyOtherJobTest.class;
-		List<ContextConfigurationAttributes> configAttributes = emptyList();
+		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
 
 		// when
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
@@ -74,11 +61,6 @@ class BatchTestContextCustomizerFactoryTests {
 
 	@SpringBatchTest
 	private static class MyJobTest {
-
-	}
-
-	@SpringBatchTest(autowireJob = true)
-	private static class MyUniqueJobTest {
 
 	}
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
@@ -16,8 +16,6 @@
 package org.springframework.batch.test.context;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import org.springframework.context.ConfigurableApplicationContext;
@@ -26,8 +24,6 @@ import org.springframework.test.context.MergedContextConfiguration;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,52 +32,36 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class BatchTestContextCustomizerTests {
 
-	@ParameterizedTest
-	@ValueSource(booleans = { true, false })
-	void testCustomizeContext(boolean autowireJob) {
+	private final BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer();
+
+	@Test
+	void testCustomizeContext() {
 		// given
-		BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer(autowireJob);
-		GenericApplicationContext context = new GenericApplicationContext();
+		ConfigurableApplicationContext context = new GenericApplicationContext();
 		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
 
 		// when
-		contextCustomizer.customizeContext(context, mergedConfig);
+		this.contextCustomizer.customizeContext(context, mergedConfig);
 
 		// then
 		assertTrue(context.containsBean("jobLauncherTestUtils"));
 		assertTrue(context.containsBean("jobRepositoryTestUtils"));
-
-		var beanDefinition = context.getBeanDefinition("jobLauncherTestUtils");
-		assertEquals(autowireJob, beanDefinition.getPropertyValues().contains("job"));
+		assertTrue(context.containsBean("batchTestContextBeanPostProcessor"));
 	}
 
 	@Test
 	void testCustomizeContext_whenBeanFactoryIsNotAnInstanceOfBeanDefinitionRegistry() {
 		// given
-		BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer(false);
 		ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
 		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
 
 		// when
 		final Exception expectedException = assertThrows(IllegalArgumentException.class,
-				() -> contextCustomizer.customizeContext(context, mergedConfig));
+				() -> this.contextCustomizer.customizeContext(context, mergedConfig));
 
 		// then
 		assertThat(expectedException.getMessage(),
 				containsString("The bean factory must be an instance of BeanDefinitionRegistry"));
-	}
-
-	@Test
-	void testEquals() {
-		assertEquals(new BatchTestContextCustomizer(true), new BatchTestContextCustomizer(true));
-		assertEquals(new BatchTestContextCustomizer(false), new BatchTestContextCustomizer(false));
-		assertNotEquals(new BatchTestContextCustomizer(true), new BatchTestContextCustomizer(false));
-	}
-
-	@Test
-	void testHashCode() {
-		assertNotEquals(new BatchTestContextCustomizer(true).hashCode(),
-				new BatchTestContextCustomizer(false).hashCode());
 	}
 
 }

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/observability/ObservabilitySampleStepTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/observability/ObservabilitySampleStepTests.java
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Import;
 
 import static io.micrometer.tracing.test.simple.SpansAssert.assertThat;
 
-@SpringBatchTest(autowireJob = true)
+@SpringBatchTest
 class ObservabilitySampleStepTests extends SampleTestRunner {
 
 	@Autowired

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/observability/ObservabilitySampleStepTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/observability/ObservabilitySampleStepTests.java
@@ -22,10 +22,8 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.test.SampleTestRunner;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 
 import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.observability.BatchMetrics;
@@ -38,7 +36,7 @@ import org.springframework.context.annotation.Import;
 
 import static io.micrometer.tracing.test.simple.SpansAssert.assertThat;
 
-@SpringBatchTest
+@SpringBatchTest(autowireJob = true)
 class ObservabilitySampleStepTests extends SampleTestRunner {
 
 	@Autowired
@@ -56,11 +54,6 @@ class ObservabilitySampleStepTests extends SampleTestRunner {
 	@Override
 	protected ObservationRegistry createObservationRegistry() {
 		return BatchMetrics.observationRegistry;
-	}
-
-	@BeforeEach
-	void setup(@Autowired Job job) {
-		this.jobLauncherTestUtils.setJob(job);
 	}
 
 	@AfterEach


### PR DESCRIPTION
To resolve #1237, the feature to always autowire a job into `JobLauncherTestUtils` was removed as the autowiring leads to issues if there is no unique candidate in the test context.

This PR adds the flag `autowireJob` to the annotation `@SpringBatchTest`. If set to `true`, the developer opts in to the old behavior.

Using narrowly defined test contexts when writing unit tests for jobs is a good practice in my opinion. Similar to using test slices for a Spring Boot application, it can have a strong influence on the run-time of build pipelines and thus tighten feedback cycles during development.

The proposed change is intended to be an incentive for test contexts that contain only the job to be tested. Additionally, it simplifies migration to Spring Batch 5 a bit for developers that relied on the old behavior.