### PR TITLE
Change StepBuilerHelper#enhance parameter type to AbstractStep

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/AbstractTaskletStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/AbstractTaskletStepBuilder.java
@@ -21,12 +21,12 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.batch.core.ChunkListener;
-import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.annotation.AfterChunk;
 import org.springframework.batch.core.annotation.AfterChunkError;
 import org.springframework.batch.core.annotation.BeforeChunk;
 import org.springframework.batch.core.listener.StepListenerFactoryBean;
+import org.springframework.batch.core.step.AbstractStep;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.batch.item.ItemStream;
@@ -78,8 +78,8 @@ public abstract class AbstractTaskletStepBuilder<B extends AbstractTaskletStepBu
 
 	/**
 	 * Build the step from the components collected by the fluent setters. Delegates first
-	 * to {@link #enhance(Step)} and then to {@link #createTasklet()} in subclasses to
-	 * create the actual tasklet.
+	 * to {@link #enhance(AbstractStep)} and then to {@link #createTasklet()} in
+	 * subclasses to create the actual tasklet.
 	 * @return a tasklet step fully configured and ready to execute
 	 */
 	public TaskletStep build() {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
@@ -42,6 +42,7 @@ import org.springframework.batch.support.ReflectionUtils;
  *
  * @author Dave Syer
  * @author Michael Minella
+ * @author Taeik Lim
  * @author Mahmoud Ben Hassine
  * @since 2.2
  */
@@ -128,37 +129,30 @@ public abstract class StepBuilderHelper<B extends StepBuilderHelper<B>> {
 		return properties.allowStartIfComplete != null ? properties.allowStartIfComplete : false;
 	}
 
-	protected void enhance(Step target) {
+	protected void enhance(AbstractStep step) {
+		step.setJobRepository(properties.getJobRepository());
 
-		if (target instanceof AbstractStep) {
-
-			AbstractStep step = (AbstractStep) target;
-			step.setJobRepository(properties.getJobRepository());
-
-			ObservationRegistry observationRegistry = properties.getObservationRegistry();
-			if (observationRegistry != null) {
-				step.setObservationRegistry(observationRegistry);
-			}
-
-			MeterRegistry meterRegistry = properties.getMeterRegistry();
-			if (meterRegistry != null) {
-				step.setMeterRegistry(meterRegistry);
-			}
-
-			Boolean allowStartIfComplete = properties.allowStartIfComplete;
-			if (allowStartIfComplete != null) {
-				step.setAllowStartIfComplete(allowStartIfComplete);
-			}
-
-			step.setStartLimit(properties.startLimit);
-
-			List<StepExecutionListener> listeners = properties.stepExecutionListeners;
-			if (!listeners.isEmpty()) {
-				step.setStepExecutionListeners(listeners.toArray(new StepExecutionListener[0]));
-			}
-
+		ObservationRegistry observationRegistry = properties.getObservationRegistry();
+		if (observationRegistry != null) {
+			step.setObservationRegistry(observationRegistry);
 		}
 
+		MeterRegistry meterRegistry = properties.getMeterRegistry();
+		if (meterRegistry != null) {
+			step.setMeterRegistry(meterRegistry);
+		}
+
+		Boolean allowStartIfComplete = properties.allowStartIfComplete;
+		if (allowStartIfComplete != null) {
+			step.setAllowStartIfComplete(allowStartIfComplete);
+		}
+
+		step.setStartLimit(properties.startLimit);
+
+		List<StepExecutionListener> listeners = properties.stepExecutionListeners;
+		if (!listeners.isEmpty()) {
+			step.setStepExecutionListeners(listeners.toArray(new StepExecutionListener[0]));
+		}
 	}
 
 	public static class CommonStepProperties {


### PR DESCRIPTION
This commit moves `StepBuilerHelper#enhance` method to `AbstractStep`. It removes unnecessary casting to `AbstractStep`.

Currently, changing argument type to `AbstractStep` is enough. But until 4.3.x, there were [another casting code](https://github.com/spring-projects/spring-batch/blob/84b1e1f7027e4dfa480a87f3f092633d64a1e559/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java#L160-L163) (It’s been removed by https://github.com/spring-projects/spring-batch/commit/7c8fb172a7cfb8d61d54f530c564b836d83d0a21). But there may be similar cases in future. 

By moving enhance method to AbstractStep, we can use like followings for those cases.

```java
// in TaskletStep
@Override
public void enhance(StepProperties properties) {
    super.enhance(properties);
    this.transactionManager = properties.getTransactionManager();
}
```

This also can be applied to [JobBuilderHelper](https://github.com/spring-projects/spring-batch/blob/5da133ac3669343b05187aec7469e07ff37f5d36/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java#L158-L186).

I also extracted `StepProperties` to prevent dependency cycle (org.springframework.batch.core.step.builder <-> org.springframework.batch.core.step)