### PR TITLE
Fix `JdbcJobExecutionDaoTests`

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobExecutionDaoTests.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Parent Test Class for {@link JdbcJobExecutionDao} and {@link MapJobExecutionDao}.
+ * Parent Test Class for {@link JdbcJobExecutionDao}.
  */
 public abstract class AbstractJobExecutionDaoTests {
 
@@ -241,8 +241,9 @@ public abstract class AbstractJobExecutionDaoTests {
 		Set<JobExecution> values = dao.findRunningJobExecutions(exec.getJobInstance().getJobName());
 
 		assertEquals(3, values.size());
-		JobExecution value = values.iterator().next();
-		assertEquals(exec, value);
+		Long jobExecutionId = exec.getId();
+		JobExecution value = values.stream().filter(jobExecution -> jobExecutionId.equals(jobExecution.getId()))
+				.findFirst().orElseThrow();
 		assertEquals(now.plus(3, ChronoUnit.SECONDS), value.getLastUpdated());
 
 	}


### PR DESCRIPTION
The commit bbf35b79f7f830e50545de2bbbf191382e3e7dd4 broke the build, and the test `JdbcJobExecutionDaoTests::testFindRunningExecutions` is currently failing.

It's a minor thing in the test, and this PR fixes it.