### PR TITLE
Do not proxy the `JobExplorer` by default

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
@@ -31,11 +31,11 @@ import org.mockito.Mockito;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.batch.core.explore.JobExplorer;
-import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.interceptor.NameMatchTransactionAttributeSource;
 import org.springframework.transaction.interceptor.TransactionAttributeSource;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 
@@ -92,12 +92,11 @@ class JobExplorerFactoryBeanTests {
 
 	@Test
 	void testMissingTransactionManager() {
-
+		factory.setTransactionAttributeSource(new NameMatchTransactionAttributeSource());
 		factory.setTransactionManager(null);
 		Exception exception = assertThrows(IllegalArgumentException.class, factory::afterPropertiesSet);
 		String message = exception.getMessage();
 		assertTrue(message.contains("TransactionManager"), "Wrong message: " + message);
-
 	}
 
 	@Test


### PR DESCRIPTION
To resolve #1307 and #4195, the possibility to wrap the `SimpleJobExplorer` in a transactional proxy was added. In addition, a new behavior was introduced to use such a proxy also by default with transaction propagation `SUPPORTS` and isolation level `READ_COMMITTED`.

This default behavior causes the issue #4230, i.e. it produces warnings that are harmless but might confuse many.

This PR proposes to return the **default** behavior to the previous behavior, i.e. no transactional proxy for the `JobExplorer`. As the `JobExplorer` is read-only, the difference between no transaction and the combination of `SUPPORTS` and `READ_COMMITTED` seems negligible to me for most cases. And the possibility for the user to add a transactional proxy still exists if required.

The commit for this PR does not build successfully. But this is independent of the PR and dealt with in #4236.