### PR TITLE
Fix typo tnew to new in adoc files

### DIFF
--- a/spring-batch-docs/src/main/asciidoc/common-patterns.adoc
+++ b/spring-batch-docs/src/main/asciidoc/common-patterns.adoc
@@ -733,7 +733,7 @@ public Job job1(JobRepository jobRepository) {
 
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(reader())
 				.writer(savingWriter())

--- a/spring-batch-docs/src/main/asciidoc/job.adoc
+++ b/spring-batch-docs/src/main/asciidoc/job.adoc
@@ -409,7 +409,7 @@ The configuration of a validator is supported through the Java builders, as foll
 ----
 @Bean
 public Job job1(JobRepository jobRepository) {
-    return tnew JobBuilder("job1", jobRepository)
+    return new JobBuilder("job1", jobRepository)
                      .validator(parametersValidator())
                      ...
                      .build();

--- a/spring-batch-docs/src/main/asciidoc/processor.adoc
+++ b/spring-batch-docs/src/main/asciidoc/processor.adoc
@@ -220,7 +220,7 @@ public Job ioSampleJob(JobRepository jobRepository) {
 
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<Foo, Foobar>chunk(2, transactionManager)
 				.reader(fooReader())
 				.processor(compositeProcessor())

--- a/spring-batch-docs/src/main/asciidoc/step.adoc
+++ b/spring-batch-docs/src/main/asciidoc/step.adoc
@@ -360,7 +360,7 @@ public Job sampleJob(JobRepository jobRepository) {
 
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(itemReader())
 				.writer(itemWriter())
@@ -411,7 +411,7 @@ The following code fragment shows an example of a start limit configuration in J
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(itemReader())
 				.writer(itemWriter())
@@ -455,7 +455,7 @@ The following code fragment shows how to define a restartable job in Java:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(itemReader())
 				.writer(itemWriter())
@@ -634,7 +634,7 @@ The following Java example shows an example of using a skip limit:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(flatFileItemReader())
 				.writer(itemWriter())
@@ -686,7 +686,7 @@ The following Java example shows an example excluding a particular exception:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(flatFileItemReader())
 				.writer(itemWriter())
@@ -754,7 +754,7 @@ In Java, retry should be configured as follows:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(2, transactionManager)
 				.reader(itemReader())
 				.writer(itemWriter())
@@ -804,7 +804,7 @@ In Java, you can control rollback as follows:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(2, transactionManager)
 				.reader(itemReader())
 				.writer(itemWriter())
@@ -847,7 +847,7 @@ The following example shows how to create a reader that does not buffer items in
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(2, transactionManager)
 				.reader(itemReader())
 				.writer(itemWriter())
@@ -956,7 +956,7 @@ The following example shows how to register a `stream` on a `step` in Java:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(2, transactionManager)
 				.reader(itemReader())
 				.writer(compositeItemWriter())
@@ -1030,7 +1030,7 @@ The following example shows a listener applied at the chunk level in Java:
 ----
 @Bean
 public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-	return tnew StepBuilder("step1", jobRepository)
+	return new StepBuilder("step1", jobRepository)
 				.<String, String>chunk(10, transactionManager)
 				.reader(reader())
 				.writer(writer())


### PR DESCRIPTION
This PR fixes the typo "tnew" to "new" in adoc files.