### PR TITLE
Add default component name in constructor of AvroItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/AvroItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/AvroItemReader.java
@@ -35,6 +35,7 @@ import org.springframework.batch.item.support.AbstractItemCountingItemStreamItem
 import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * An {@link ItemReader} that deserializes data from a {@link Resource} containing
@@ -42,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author David Turanski
  * @author Mahmoud Ben Hassine
+ * @author Song JaeGeun
  * @since 4.2
  */
 public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> {
@@ -61,6 +63,8 @@ public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 	 * @param clazz the data type to be deserialized.
 	 */
 	public AvroItemReader(Resource resource, Class<T> clazz) {
+		setName(ClassUtils.getShortName(AvroItemReader.class));
+		
 		Assert.notNull(resource, "'resource' is required.");
 		Assert.notNull(clazz, "'class' is required.");
 
@@ -78,6 +82,8 @@ public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 	 * @param schema the {@link Resource} containing the Avro schema.
 	 */
 	public AvroItemReader(Resource data, Resource schema) {
+		setName(ClassUtils.getShortName(AvroItemReader.class));
+		
 		Assert.notNull(data, "'data' is required.");
 		Assert.state(data.exists(), "'data' " + data.getFilename() + " does not exist.");
 		Assert.notNull(schema, "'schema' is required");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilder.java
@@ -22,7 +22,6 @@ import org.springframework.batch.item.avro.AvroItemReader;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * A builder implementation for the {@link AvroItemReader}.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilder.java
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
  *
  * @author David Turanski
  * @author Mahmoud Ben Hassine
+ * @author Song JaeGeun
  * @since 4.2
  */
 public class AvroItemReaderBuilder<T> {
@@ -169,10 +170,6 @@ public class AvroItemReaderBuilder<T> {
 		}
 
 		avroItemReader.setSaveState(this.saveState);
-
-		if (this.saveState) {
-			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
-		}
 
 		avroItemReader.setName(this.name);
 		avroItemReader.setCurrentItemCount(this.currentItemCount);


### PR DESCRIPTION
```java
public class AvroItemReaderBuilder<T> {

	private String name = AvroItemReader.class.getSimpleName();
```

AvroItemReaderBuilder's name field has defalut value (AvroItemReader.class.getSimpleName)

``` java
if (this.saveState) {
	Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
}
```

so that assert code is never throw error because name field has default value

and i'm adding code that initializing name field to AvroItemReader.class.getSimpleName