### PR TITLE
Disable BatchTestContextCustomizer after AOT processing

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizer.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizer.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.test.context;
 
+import org.springframework.aot.AotDetector;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.JobRepositoryTestUtils;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -30,7 +31,7 @@ import org.springframework.util.Assert;
  * ({@link JobLauncherTestUtils} and {@link JobRepositoryTestUtils}) as beans in the test
  * context.
  *
- * @author Mahmoud Ben Hassine
+ * @author Mahmoud Ben Hassine, Alexander Arshavskiy
  * @since 4.1
  */
 public class BatchTestContextCustomizer implements ContextCustomizer {
@@ -43,6 +44,11 @@ public class BatchTestContextCustomizer implements ContextCustomizer {
 
 	@Override
 	public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+
+		if (AotDetector.useGeneratedArtifacts()) {
+			return;
+		}
+
 		ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
 		Assert.isInstanceOf(BeanDefinitionRegistry.class, beanFactory,
 				"The bean factory must be an instance of BeanDefinitionRegistry");

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
@@ -15,24 +15,32 @@
  */
 package org.springframework.batch.test.context;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.SpringProperties;
 import org.springframework.test.context.MergedContextConfiguration;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Mahmoud Ben Hassine
+ * @author Mahmoud Ben Hassine, Alexander Arshavskiy
  */
 class BatchTestContextCustomizerTests {
 
 	private final BatchTestContextCustomizer contextCustomizer = new BatchTestContextCustomizer();
+
+	@AfterEach
+	void removeSystemProperty() {
+		SpringProperties.setProperty("spring.aot.enabled", null);
+	}
 
 	@Test
 	void testCustomizeContext() {
@@ -62,6 +70,22 @@ class BatchTestContextCustomizerTests {
 		// then
 		assertThat(expectedException.getMessage(),
 				containsString("The bean factory must be an instance of BeanDefinitionRegistry"));
+	}
+
+	@Test
+	void testCustomizeContext_whenUsingAotGeneratedArtifactsBatchTestContextIsNotRegistered() {
+		// given
+		SpringProperties.setProperty("spring.aot.enabled", "true");
+		ConfigurableApplicationContext context = new GenericApplicationContext();
+		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
+
+		// when
+		this.contextCustomizer.customizeContext(context, mergedConfig);
+
+		// then
+		assertFalse(context.containsBean("jobLauncherTestUtils"));
+		assertFalse(context.containsBean("jobRepositoryTestUtils"));
+		assertFalse(context.containsBean("batchTestContextBeanPostProcessor"));
 	}
 
 }


### PR DESCRIPTION
nativeTest not using generated testAot sources

I have created a small [reproducer](https://github.com/Hayvon/native-batch-test-reproducer) application with Spring Batch. It contains a simple test which is working in jvm-mode and aot mode (-Dspring.aot.enabled=true) but not when I execute nativeTest.

It fails with following message:

```csharp
org.springframework.boot.test.context.SpringBootTestAnnotation@d73e98da], contextLoader = org.springframework.boot.test.context.SpringBootContextLoader, parent = null]]
       org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:142)
       org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:127)
       org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependenciesInAotMode(DependencyInjectionTestExecutionListener.java:148)
       org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:94)
       org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:241)
       [...]
     Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'batchTestContextBeanPostProcessor': Runtime reflection is not supported for public org.springframework.batch.test.context.BatchTestContextBeanPostProcessor()
       org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1306)
       org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1198)
       org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:561)
       org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:521)
       org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326)
       [...]
     Caused by: com.oracle.svm.core.jdk.UnsupportedFeatureError: Runtime reflection is not supported for public org.springframework.batch.test.context.BatchTestContextBeanPostProcessor()
       org.graalvm.nativeimage.builder/com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:89)
       java.base@17.0.5/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:68)
       java.base@17.0.5/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:496)
       java.base@17.0.5/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
       org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:197)
       [...]
```

This PR fixes the issue by disabling the BatchTestContextCustomizer after AOT processing

  Used versions for reproducer:
  Spring Boot 3.0.1
  GraalVM Native Buildtools: 0.9.19
  Java 17