### PR TITLE
Prefer `Slice` over `Page` in `RepositoryItemReader`

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@ import org.springframework.batch.item.adapter.AbstractMethodInvokingDelegator.In
 import org.springframework.batch.item.adapter.DynamicMethodInvocationException;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.lang.Nullable;
@@ -168,7 +168,7 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 				results = doPageRead();
 				page++;
 
-				if (results.size() <= 0) {
+				if (results.isEmpty()) {
 					return null;
 				}
 
@@ -219,7 +219,7 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 
 		invoker.setArguments(parameters.toArray());
 
-		Page<T> curPage = (Page<T>) doInvoke(invoker);
+		Slice<T> curPage = (Slice<T>) doInvoke(invoker);
 
 		return curPage.getContent();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.adapter.DynamicMethodInvocationException;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -229,7 +230,7 @@ class RepositoryItemReaderTests {
 
 		ArgumentCaptor<PageRequest> pageRequestContainer = ArgumentCaptor.forClass(PageRequest.class);
 		when(differentRepository.findFirstNames(pageRequestContainer.capture()))
-				.thenReturn(new PageImpl<>(singletonList("result")));
+				.thenReturn(new SliceImpl<>(singletonList("result")));
 
 		assertEquals("result", reader.doRead());
 
@@ -312,7 +313,7 @@ class RepositoryItemReaderTests {
 
 	public interface TestRepository extends PagingAndSortingRepository<Map, Long> {
 
-		Page<String> findFirstNames(Pageable pageable);
+		Slice<String> findFirstNames(Pageable pageable);
 
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.batch.item.data.RepositoryItemReader;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
@@ -58,7 +58,7 @@ class RepositoryItemReaderBuilderTests {
 	private TestRepository repository;
 
 	@Mock
-	private Page<String> page;
+	private Slice<String> slice;
 
 	private Map<String, Sort.Direction> sorts;
 
@@ -72,9 +72,9 @@ class RepositoryItemReaderBuilderTests {
 
 		List<String> testResult = new ArrayList<>();
 		testResult.add(TEST_CONTENT);
-		when(page.getContent()).thenReturn(testResult);
-		when(page.getSize()).thenReturn(5);
-		when(this.repository.foo(this.pageRequestContainer.capture())).thenReturn(this.page);
+		when(slice.getContent()).thenReturn(testResult);
+		when(slice.getSize()).thenReturn(5);
+		when(this.repository.foo(this.pageRequestContainer.capture())).thenReturn(this.slice);
 	}
 
 	@Test
@@ -151,7 +151,7 @@ class RepositoryItemReaderBuilderTests {
 		ArgumentCaptor<String> arg2Captor = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<String> arg3Captor = ArgumentCaptor.forClass(String.class);
 		when(this.repository.foo(arg1Captor.capture(), arg2Captor.capture(), arg3Captor.capture(),
-				this.pageRequestContainer.capture())).thenReturn(this.page);
+				this.pageRequestContainer.capture())).thenReturn(this.slice);
 
 		RepositoryItemReader<Object> reader = new RepositoryItemReaderBuilder<>().repository(this.repository)
 				.sorts(this.sorts).maxItemCount(5).methodName("foo").name("bar").arguments(args).build();
@@ -166,7 +166,7 @@ class RepositoryItemReaderBuilderTests {
 		ArgumentCaptor<String> arg2Captor = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<String> arg3Captor = ArgumentCaptor.forClass(String.class);
 		when(this.repository.foo(arg1Captor.capture(), arg2Captor.capture(), arg3Captor.capture(),
-				this.pageRequestContainer.capture())).thenReturn(this.page);
+				this.pageRequestContainer.capture())).thenReturn(this.slice);
 
 		RepositoryItemReader<Object> reader = new RepositoryItemReaderBuilder<>().repository(this.repository)
 				.sorts(this.sorts).maxItemCount(5).methodName("foo").name("bar").arguments(ARG1, ARG2, ARG3).build();

--- a/spring-batch-samples/src/main/java/org/springframework/batch/sample/data/CustomerCreditPagingAndSortingRepository.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/sample/data/CustomerCreditPagingAndSortingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package org.springframework.batch.sample.data;
 import java.math.BigDecimal;
 
 import org.springframework.batch.sample.domain.trade.CustomerCredit;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface CustomerCreditPagingAndSortingRepository extends PagingAndSortingRepository<CustomerCredit, Long> {
 
-	Page<CustomerCredit> findByCreditGreaterThan(BigDecimal credit, Pageable request);
+	Slice<CustomerCredit> findByCreditGreaterThan(BigDecimal credit, Pageable request);
 
 }


### PR DESCRIPTION
The `RepositoryItemReader` does not actually use the additional paging information that `Page` provides over `Slice`. As a `Slice` can be retrieved more efficiently than a `Page` and `Slice` is super-type of `Page`, the reader should be able to handle `Slice`s.

Resolves #4115 