### PR TITLE
Fix typo

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDao.java
@@ -290,7 +290,7 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 	 * Setter for {@link DataFieldMaxValueIncrementer} to be used when generating primary
 	 * keys for {@link JobInstance} instances.
 	 * @param jobIncrementer the {@link DataFieldMaxValueIncrementer}
-	 * @deprecated as of v5.0 in favor of using the {@link setJobInstanceIncrementer}
+	 * @deprecated as of v5.0 in favor of using the {@link #setJobInstanceIncrementer}
 	 */
 	@Deprecated
 	public void setJobIncrementer(DataFieldMaxValueIncrementer jobIncrementer) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -73,7 +73,7 @@ public class SimpleJobRepository implements JobRepository {
 	private ExecutionContextDao ecDao;
 
 	/**
-	 * Provide default constructor with low visibility in case user wants to use use
+	 * Provide default constructor with low visibility in case user wants to use
 	 * aop:proxy-target-class="true" for AOP interceptor.
 	 */
 	SimpleJobRepository() {


### PR DESCRIPTION
- Fix dubole "use" typo in SimpleJobRepository
- Add '#' to `@link` method in JdbcJobInstanceDao