### PR TITLE
Reduce use of deprecated APIs

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/job/DefaultJobParametersExtractor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/job/DefaultJobParametersExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.springframework.batch.core.step.job;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
@@ -72,7 +71,7 @@ public class DefaultJobParametersExtractor implements JobParametersExtractor {
 		ExecutionContext executionContext = stepExecution.getExecutionContext();
 		if (useAllParentParameters) {
 			for (String key : jobParameters.keySet()) {
-				builder.addParameter(key, jobParameters.get(key));
+				builder.addJobParameter(key, jobParameters.get(key));
 			}
 		}
 		Properties properties = new Properties();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/PartitionStepParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/PartitionStepParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Dave Syer
@@ -97,13 +96,10 @@ public class PartitionStepParserTests implements ApplicationContextAware {
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T> T accessPrivateField(Object o, String fieldName) {
-		Field field = ReflectionUtils.findField(o.getClass(), fieldName);
-		boolean previouslyAccessibleValue = field.isAccessible();
+	private <T> T accessPrivateField(Object o, String fieldName) throws ReflectiveOperationException {
+		Field field = o.getClass().getDeclaredField(fieldName);
 		field.setAccessible(true);
-		T val = (T) ReflectionUtils.getField(field, o);
-		field.setAccessible(previouslyAccessibleValue);
-		return val;
+		return (T) field.get(o);
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/concurrent/ConcurrentTransactionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/concurrent/ConcurrentTransactionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.jdbc.datasource.embedded.ConnectionProperties;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseConfigurer;
@@ -109,7 +108,7 @@ class ConcurrentTransactionTests {
 							return RepeatStatus.FINISHED;
 						}
 					}, transactionManager).build())
-					.next(new StepBuilder("flow.step2").repository(jobRepository).tasklet(new Tasklet() {
+					.next(new StepBuilder("flow.step2", jobRepository).tasklet(new Tasklet() {
 						@Nullable
 						@Override
 						public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxTestUtils.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,19 +29,15 @@ public final class StaxTestUtils {
 
 	public static XMLEventWriter getXmlEventWriter(Result r) throws Exception {
 		Method m = r.getClass().getDeclaredMethod("getXMLEventWriter");
-		boolean accessible = m.isAccessible();
 		m.setAccessible(true);
 		Object result = m.invoke(r);
-		m.setAccessible(accessible);
 		return (XMLEventWriter) result;
 	}
 
 	public static XMLEventReader getXmlEventReader(Source s) throws Exception {
 		Method m = s.getClass().getDeclaredMethod("getXMLEventReader");
-		boolean accessible = m.isAccessible();
 		m.setAccessible(true);
 		Object result = m.invoke(s);
-		m.setAccessible(accessible);
 		return (XMLEventReader) result;
 	}
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,8 +265,8 @@ class RemoteChunkingManagerStepBuilderTests {
 			}
 		};
 
-		TaskletStep taskletStep = new RemoteChunkingManagerStepBuilder<String, String>("step").reader(itemReader)
-				.readerIsTransactionalQueue().processor(itemProcessor).repository(this.jobRepository)
+		TaskletStep taskletStep = new RemoteChunkingManagerStepBuilder<String, String>("step", this.jobRepository)
+				.reader(itemReader).readerIsTransactionalQueue().processor(itemProcessor)
 				.transactionManager(this.transactionManager).transactionAttribute(transactionAttribute)
 				.inputChannel(this.inputChannel).outputChannel(this.outputChannel).listener(annotatedListener)
 				.listener(skipListener).listener(chunkListener).listener(stepExecutionListener)


### PR DESCRIPTION
The following APIs are currently deprecated:

- `org.springframework.util.Base64Utils`
- `org.springframework.util.SerializationUtils#deserialize`
- `java.lang.reflect.AccessibleObject#isAccessible`

This PR replaces their use in the code base:

- `Base64Utils` is replaced by using `java.util.Base64` directly.
- `SerializationUtils#deserialize` is replaced by using `ObjectInputStream` directly.
- Invocations of `isAccessible` are removed as they are not necessary when the respective objects are not cached.

I've also replaced `SerializationUtils#serialize` in `DefaultExecutionContextSerializer` by using `ObjectOutputStream` directly. This way, less objects are created during execution and the code for serialization and deserialization matches more closely.

There are also some straight-forward deprecations within the code base that have been addressed.