### PR TITLE
Add SafeVarargs annotations

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
@@ -42,7 +42,7 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 
 	private List<SkipWrapper<W>> skips = new ArrayList<>();
 
-	private List<Exception> errors = new ArrayList<>();
+	private final List<Exception> errors = new ArrayList<>();
 
 	private Object userData;
 
@@ -50,10 +50,12 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 
 	private boolean busy;
 
+	@SafeVarargs
 	public Chunk(W... items) {
-		this(Arrays.stream(items).toList());
+		this(Arrays.asList(items));
 	}
 
+	@SafeVarargs
 	public static <W> Chunk<W> of(W... items) {
 		return new Chunk<>(items);
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 	 * Convenience constructor for setting the delegates.
 	 * @param delegates the array of delegates to use.
 	 */
+	@SafeVarargs
 	public CompositeItemWriter(ItemWriter<? super T>... delegates) {
 		this(Arrays.asList(delegates));
 	}


### PR DESCRIPTION
This PR adds `@SafeVarargs` to methods in `Chunk` and `CompositeItemWriter` that take a generic varargs parameter but don't perform unsafe operations on them. This prevents false positive warnings in the users' code when they use these methods.

In the constructor of `Chunk` with the generic varargs parameter, I've replaced `Arrays.stream(items).toList()` with `Arrays.asList(items)`. Both work fine regarding varargs safety in practice but the latter is explicitly annotated with `@SafeVarargs` itself, while `Arrays.stream` does not explicitly say that it works fine with an array of type `Object[]` in every case. Using `Array.asList` also saves one cop of the array, which is not needed as the array will be copied later anyway.