### PR TITLE
Documentation Update to scalability.adoc

### DIFF
--- a/spring-batch-docs/src/main/asciidoc/scalability.adoc
+++ b/spring-batch-docs/src/main/asciidoc/scalability.adoc
@@ -302,6 +302,11 @@ configuration:
 </step>
 ----
 
+[role="xmlContent"]
+Similar to the multi-threaded step's `throttle-limit` attribute, the `grid-size`
+attribute prevents the task executor from being saturated with requests from a single
+step.
+
 [role="javaContent"]
 The following example shows the `PartitionStep` configuration when using Java
 configuration:
@@ -319,11 +324,6 @@ public Step step1Manager() {
         .build();
 }
 ----
-
-[role="xmlContent"]
-Similar to the multi-threaded step's `throttle-limit` attribute, the `grid-size`
-attribute prevents the task executor from being saturated with requests from a single
-step.
 
 [role="javaContent"]
 Similar to the multi-threaded step's `throttleLimit` method, the `gridSize`


### PR DESCRIPTION
Move commentary on xml configuration just below the configuration it's explaining, instead of having it in the middle of the Java configuration example.

This seems to me to fit the criteria for "obvious fix", but please let me know if you disagree.