### PR TITLE
Update Continuous Inspection GitHub Action to not fail in forks

### DIFF
--- a/.github/workflows/continuous-inspection.yml
+++ b/.github/workflows/continuous-inspection.yml
@@ -24,6 +24,7 @@ jobs:
         run: mvn -P test-coverage verify
 
       - name: Analyse code quality with Sonar
+        if: github.repository == 'spring-projects/spring-batch'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_URL }}


### PR DESCRIPTION
Addresses #4346 

The idea is to only run the step that contains secrets if you are in the main repository.  

Forked branches should not and do not have access to secrets so any step that references a secret will fail.  Instead of letting this step fail and getting alerted about it, skip the step entirely.