### PR TITLE
Prefix for JobScope changed to scopedTarget

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/JobScope.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/JobScope.java
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.config.Scope;
  * this scope are &lt;aop:scoped-proxy/&gt; (no need to decorate the bean
  * definitions).<br>
  * <br>
- *
+ * <p>
  * In addition, support is provided for late binding of references accessible from the
  * {@link JobContext} using #{..} placeholders. Using this feature, bean properties can be
  * pulled from the job or job execution context and the job parameters. E.g.
@@ -44,7 +44,7 @@ import org.springframework.beans.factory.config.Scope;
  * 	&lt;property name=&quot;name&quot; value=&quot;#{jobExecutionContext['input.stem']}.txt&quot; /&gt;
  * &lt;/bean&gt;
  * </pre>
- *
+ * <p>
  * The {@link JobContext} is referenced using standard bean property paths (as per
  * {@link BeanWrapper}). The examples above all show the use of the Map accessors provided
  * as a convenience for job attributes.
@@ -56,9 +56,9 @@ import org.springframework.beans.factory.config.Scope;
  */
 public class JobScope extends BatchScopeSupport {
 
-	private static final String TARGET_NAME_PREFIX = "jobScopedTarget.";
+	private static final String TARGET_NAME_PREFIX = "scopedTarget.";
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
 	private final Object mutex = new Object();
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopeTestJobTest.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopeTestJobTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2009-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.test.scopes;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.SimpleJob;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.JobRepositoryTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This class will specifically test the capabilities of {@link JobRepositoryTestUtils} to
+ * test {@link SimpleJob}s.
+ *
+ * @author Dan Garrette
+ * @since 2.0
+ */
+@SpringJUnitConfig(
+		locations = { "/simple-job-launcher-context.xml", "/jobs/scopeTests.xml", "/job-runner-context.xml" })
+class ScopeTestJobTest {
+
+	@Autowired
+	private JobLauncherTestUtils jobLauncherTestUtils;
+
+	@Test
+	void testJob(@Autowired Job job) throws Exception {
+		this.jobLauncherTestUtils.setJob(job);
+		assertEquals(BatchStatus.COMPLETED, jobLauncherTestUtils.launchJob().getStatus());
+
+	}
+
+}

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopedConfiguration.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopedConfiguration.java
@@ -1,0 +1,49 @@
+package org.springframework.batch.test.scopes;
+
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class ScopedConfiguration {
+
+	@Bean
+	@Scope("step")
+	ScopedInterface stepScope() {
+		return new ScopedImplementation();
+	}
+
+	@Bean
+	@Scope("job")
+	ScopedInterface jobScope() {
+		return new ScopedImplementation();
+	}
+
+	@Bean
+	@StepScope
+	ScopedInterface stepScopeAnnotaion() {
+		return new ScopedImplementation();
+	}
+
+	@Bean
+	@JobScope
+	ScopedInterface jobScopeAnnotation() {
+		return new ScopedImplementation();
+	}
+
+	@Bean
+	Tasklet scopeTestTasklet() {
+		return ((contribution, chunkContext) -> {
+			System.out.println("StepScope:" + stepScope().getInstanceNumber());
+			System.out.println("StepScopeAnnotation:" + stepScopeAnnotaion().getInstanceNumber());
+			System.out.println("JobScope:" + jobScope().getInstanceNumber());
+			System.out.println("JobScopeAnnotation:" + jobScopeAnnotation().getInstanceNumber());
+			return RepeatStatus.FINISHED;
+		});
+	}
+
+}

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopedImplementation.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopedImplementation.java
@@ -1,0 +1,20 @@
+package org.springframework.batch.test.scopes;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ScopedImplementation implements ScopedInterface {
+
+	private final static AtomicInteger INSTANCE_COUNTER = new AtomicInteger();
+
+	private final int instance;
+
+	public ScopedImplementation() {
+		this.instance = INSTANCE_COUNTER.incrementAndGet();
+	}
+
+	@Override
+	public int getInstanceNumber() {
+		return instance;
+	}
+
+}

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopedInterface.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/scopes/ScopedInterface.java
@@ -1,0 +1,7 @@
+package org.springframework.batch.test.scopes;
+
+public interface ScopedInterface {
+
+	int getInstanceNumber();
+
+}

--- a/spring-batch-test/src/test/resources/jobs/scopeTests.xml
+++ b/spring-batch-test/src/test/resources/jobs/scopeTests.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/batch"
+             xmlns:beans="http://www.springframework.org/schema/beans"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.springframework.org/schema/beans
+       		https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/batch
+       		https://www.springframework.org/schema/batch/spring-batch.xsd">
+
+    <beans:bean class="org.springframework.batch.test.scopes.ScopedConfiguration"/>
+
+    <job id="scopeTest">
+        <step id="step1">
+            <tasklet ref="scopeTestTasklet"/>
+        </step>
+    </job>
+</beans:beans>


### PR DESCRIPTION
I had a problem with JobScope when xml and java-config is mixed.

I could solve it, with changing the TARGET_NAME_PREFIX in the class JobScope.
I also wrote a JUnit-Test for this fix.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md