### PR TITLE
Upgrade to Mockito 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<junit-vintage-engine.version>${junit-jupiter.version}</junit-vintage-engine.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<assertj.version>3.24.2</assertj.version>
-		<mockito.version>4.11.0</mockito.version> <!-- FIXME build hangs at BatchRegistrarTests with version 5.1.1 -->
+		<mockito.version>5.3.1</mockito.version>
 		<xmlunit.version>2.9.1</xmlunit.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<commons-dbcp2.version>2.9.0</commons-dbcp2.version>

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,19 +78,13 @@ class BatchRegistrarTests {
 	@Test
 	@DisplayName("When custom beans are provided, then default ones should not be used")
 	void testConfigurationWithUserDefinedBeans() {
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
-				JobConfigurationWithUserDefinedInfrastructureBeans.class);
+		var context = new AnnotationConfigApplicationContext(JobConfigurationWithUserDefinedInfrastructureBeans.class);
 
-		Assertions.assertEquals(JobConfigurationWithUserDefinedInfrastructureBeans.jobRepository,
-				context.getBean(JobRepository.class));
-		Assertions.assertEquals(JobConfigurationWithUserDefinedInfrastructureBeans.jobExplorer,
-				context.getBean(JobExplorer.class));
-		Assertions.assertEquals(JobConfigurationWithUserDefinedInfrastructureBeans.jobLauncher,
-				context.getBean(JobLauncher.class));
-		Assertions.assertEquals(JobConfigurationWithUserDefinedInfrastructureBeans.jobRegistry,
-				context.getBean(JobRegistry.class));
-		Assertions.assertEquals(JobConfigurationWithUserDefinedInfrastructureBeans.jobOperator,
-				context.getBean(JobOperator.class));
+		Assertions.assertTrue(Mockito.mockingDetails(context.getBean(JobRepository.class)).isMock());
+		Assertions.assertTrue(Mockito.mockingDetails(context.getBean(JobExplorer.class)).isMock());
+		Assertions.assertTrue(Mockito.mockingDetails(context.getBean(JobLauncher.class)).isMock());
+		Assertions.assertTrue(Mockito.mockingDetails(context.getBean(JobRegistry.class)).isMock());
+		Assertions.assertTrue(Mockito.mockingDetails(context.getBean(JobOperator.class)).isMock());
 	}
 
 	@Test
@@ -203,39 +197,29 @@ class BatchRegistrarTests {
 	@EnableBatchProcessing
 	public static class JobConfigurationWithUserDefinedInfrastructureBeans {
 
-		public static JobRepository jobRepository = Mockito.mock(JobRepository.class);
-
-		public static JobExplorer jobExplorer = Mockito.mock(JobExplorer.class);
-
-		public static JobLauncher jobLauncher = Mockito.mock(JobLauncher.class);
-
-		public static JobRegistry jobRegistry = Mockito.mock(JobRegistry.class);
-
-		public static JobOperator jobOperator = Mockito.mock(JobOperator.class);
-
 		@Bean
 		public JobRepository jobRepository() {
-			return jobRepository;
+			return Mockito.mock(JobRepository.class);
 		}
 
 		@Bean
 		public JobExplorer jobExplorer() {
-			return jobExplorer;
+			return Mockito.mock(JobExplorer.class);
 		}
 
 		@Bean
 		public JobLauncher jobLauncher() {
-			return jobLauncher;
+			return Mockito.mock(JobLauncher.class);
 		}
 
 		@Bean
 		public JobRegistry jobRegistry() {
-			return jobRegistry;
+			return Mockito.mock(JobRegistry.class);
 		}
 
 		@Bean
 		public JobOperator jobOperator() {
-			return jobOperator;
+			return Mockito.mock(JobOperator.class);
 		}
 
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
@@ -37,7 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -109,71 +112,69 @@ class MongoItemReaderTests {
 
 	@Test
 	void testBasicQueryFirstPage() {
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query query = queryContainer.getValue();
-		assertEquals(50, query.getLimit());
-		assertEquals(0, query.getSkip());
-		assertEquals("{}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		verify(template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(0, query.getSkip());
+			assertEquals("{}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		}), eq(String.class));
 	}
 
 	@Test
 	void testBasicQuerySecondPage() {
 		reader.page = 2;
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
 
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query query = queryContainer.getValue();
-
-		assertEquals(50, query.getLimit());
-		assertEquals(100, query.getSkip());
-		assertEquals("{}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
-		assertTrue(query.getFieldsObject().isEmpty());
+		verify(template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(100, query.getSkip());
+			assertEquals("{}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+			assertTrue(query.getFieldsObject().isEmpty());
+		}), eq(String.class));
 	}
 
 	@Test
 	void testQueryWithFields() {
 		reader.setFields("{name : 1, age : 1, _id: 0}");
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
 
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query query = queryContainer.getValue();
-		assertEquals(50, query.getLimit());
-		assertEquals(0, query.getSkip());
-		assertEquals("{}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
-		assertEquals(1, query.getFieldsObject().get("name"));
-		assertEquals(1, query.getFieldsObject().get("age"));
-		assertEquals(0, query.getFieldsObject().get("_id"));
+		verify(template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(0, query.getSkip());
+			assertEquals("{}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+			assertEquals(1, query.getFieldsObject().get("name"));
+			assertEquals(1, query.getFieldsObject().get("age"));
+			assertEquals(0, query.getFieldsObject().get("_id"));
+		}), eq(String.class));
 	}
 
 	@Test
 	void testQueryWithHint() {
 		reader.setHint("{ $natural : 1}");
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
 
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query query = queryContainer.getValue();
-		assertEquals(50, query.getLimit());
-		assertEquals(0, query.getSkip());
-		assertEquals("{}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
-		assertEquals("{ $natural : 1}", query.getHint());
+		verify(template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(0, query.getSkip());
+			assertEquals("{}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+			assertEquals("{ $natural : 1}", query.getHint());
+		}), eq(String.class));
 	}
 
 	@Test
@@ -181,17 +182,17 @@ class MongoItemReaderTests {
 		reader.setParameterValues(Collections.singletonList("foo"));
 
 		reader.setQuery("{ name : ?0 }");
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
 
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query query = queryContainer.getValue();
-		assertEquals(50, query.getLimit());
-		assertEquals(0, query.getSkip());
-		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		verify(template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(0, query.getSkip());
+			assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		}), eq(String.class));
 	}
 
 	@Test
@@ -200,20 +201,17 @@ class MongoItemReaderTests {
 
 		reader.setQuery("{ name : ?0 }");
 		reader.setCollection("collection");
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		ArgumentCaptor<String> collectionContainer = ArgumentCaptor.forClass(String.class);
 
-		when(template.find(queryContainer.capture(), eq(String.class), collectionContainer.capture()))
-				.thenReturn(new ArrayList<>());
+		when(template.find(any(), any(), anyString())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query query = queryContainer.getValue();
-		assertEquals(50, query.getLimit());
-		assertEquals(0, query.getSkip());
-		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
-		assertEquals("collection", collectionContainer.getValue());
+		verify(template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(0, query.getSkip());
+			assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		}), eq(String.class), eq("collection"));
 	}
 
 	@Test
@@ -227,15 +225,14 @@ class MongoItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query actualQuery = queryContainer.getValue();
-		assertFalse(reader.doPageRead().hasNext());
-		assertEquals(10, actualQuery.getLimit());
-		assertEquals(0, actualQuery.getSkip());
+		verify(template).find(assertArg(actualQuery -> {
+			assertEquals(10, actualQuery.getLimit());
+			assertEquals(0, actualQuery.getSkip());
+		}), eq(String.class));
 	}
 
 	@Test
@@ -249,15 +246,14 @@ class MongoItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query actualQuery = queryContainer.getValue();
-		assertFalse(reader.doPageRead().hasNext());
-		assertEquals(10, actualQuery.getLimit());
-		assertEquals(0, actualQuery.getSkip());
+		verify(template).find(assertArg(actualQuery -> {
+			assertEquals(10, actualQuery.getLimit());
+			assertEquals(0, actualQuery.getSkip());
+		}), eq(String.class));
 	}
 
 	@Test
@@ -272,15 +268,14 @@ class MongoItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query actualQuery = queryContainer.getValue();
-		assertFalse(reader.doPageRead().hasNext());
-		assertEquals(100, actualQuery.getLimit());
-		assertEquals(0, actualQuery.getSkip());
+		verify(template).find(assertArg(actualQuery -> {
+			assertEquals(100, actualQuery.getLimit());
+			assertEquals(0, actualQuery.getSkip());
+		}), eq(String.class));
 	}
 
 	@Test
@@ -294,13 +289,11 @@ class MongoItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query actualQuery = queryContainer.getValue();
-		assertEquals(100, actualQuery.getLimit());
+		verify(template).find(assertArg(actualQuery -> assertEquals(100, actualQuery.getLimit())), eq(String.class));
 	}
 
 	@Test
@@ -313,13 +306,11 @@ class MongoItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		when(template.find(queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query actualQuery = queryContainer.getValue();
-		assertEquals(10, actualQuery.getLimit());
+		verify(template).find(assertArg(actualQuery -> assertEquals(10, actualQuery.getLimit())), eq(String.class));
 	}
 
 	@Test
@@ -334,18 +325,15 @@ class MongoItemReaderTests {
 
 		reader.afterPropertiesSet();
 
-		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
-		ArgumentCaptor<String> stringContainer = ArgumentCaptor.forClass(String.class);
-		when(template.find(queryContainer.capture(), eq(String.class), stringContainer.capture()))
-				.thenReturn(new ArrayList<>());
+		when(template.find(any(), any(), anyString())).thenReturn(new ArrayList<>());
 
 		assertFalse(reader.doPageRead().hasNext());
 
-		Query actualQuery = queryContainer.getValue();
-		assertFalse(reader.doPageRead().hasNext());
-		assertEquals(10, actualQuery.getLimit());
-		assertEquals(0, actualQuery.getSkip());
-		assertEquals("collection", stringContainer.getValue());
+		verify(template).find(assertArg(actualQuery -> {
+			assertFalse(reader.doPageRead().hasNext());
+			assertEquals(10, actualQuery.getLimit());
+			assertEquals(0, actualQuery.getSkip());
+		}), eq(String.class), eq("collection"));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.data.MongoItemReader;
@@ -36,7 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -55,54 +58,53 @@ class MongoItemReaderBuilderTests {
 
 	private Map<String, Sort.Direction> sortOptions;
 
-	private ArgumentCaptor<Query> queryContainer;
-
 	@BeforeEach
 	void setUp() {
 		this.sortOptions = new HashMap<>();
 		this.sortOptions.put("name", Sort.Direction.DESC);
-		this.queryContainer = ArgumentCaptor.forClass(Query.class);
 	}
 
 	@Test
 	void testBasic() throws Exception {
 		MongoItemReader<String> reader = getBasicBuilder().build();
 
-		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(this.template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals(50, query.getLimit());
-		assertEquals(0, query.getSkip());
-		assertEquals("{}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		verify(this.template).find(assertArg(query -> {
+			assertEquals(50, query.getLimit());
+			assertEquals(0, query.getSkip());
+			assertEquals("{}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		}), eq(String.class));
 	}
 
 	@Test
 	void testFields() throws Exception {
 		MongoItemReader<String> reader = getBasicBuilder().fields("{name : 1, age : 1, _id: 0}").build();
 
-		when(this.template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(this.template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals(1, query.getFieldsObject().get("name"));
-		assertEquals(1, query.getFieldsObject().get("age"));
-		assertEquals(0, query.getFieldsObject().get("_id"));
+		verify(this.template).find(assertArg(query -> {
+			assertEquals(1, query.getFieldsObject().get("name"));
+			assertEquals(1, query.getFieldsObject().get("age"));
+			assertEquals(0, query.getFieldsObject().get("_id"));
+		}), eq(String.class));
 	}
 
 	@Test
 	void testHint() throws Exception {
 		MongoItemReader<String> reader = getBasicBuilder().hint("{ $natural : 1}").build();
 
-		when(this.template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(this.template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals("{ $natural : 1}", query.getHint());
+		verify(this.template).find(assertArg(query -> assertEquals("{ $natural : 1}", query.getHint())),
+				eq(String.class));
 	}
 
 	@Test
@@ -110,17 +112,14 @@ class MongoItemReaderBuilderTests {
 		MongoItemReader<String> reader = getBasicBuilder().parameterValues(Collections.singletonList("foo"))
 				.jsonQuery("{ name : ?0 }").collection("collection").build();
 
-		ArgumentCaptor<String> collectionContainer = ArgumentCaptor.forClass(String.class);
-
-		when(this.template.find(this.queryContainer.capture(), eq(String.class), collectionContainer.capture()))
-				.thenReturn(new ArrayList<>());
+		when(this.template.find(any(), any(), anyString())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
-		assertEquals("collection", collectionContainer.getValue());
+		verify(this.template).find(assertArg(query -> {
+			assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		}), eq(String.class), eq("collection"));
 	}
 
 	@Test
@@ -128,17 +127,14 @@ class MongoItemReaderBuilderTests {
 		MongoItemReader<String> reader = getBasicBuilder().parameterValues("foo").jsonQuery("{ name : ?0 }")
 				.collection("collection").build();
 
-		ArgumentCaptor<String> collectionContainer = ArgumentCaptor.forClass(String.class);
-
-		when(this.template.find(this.queryContainer.capture(), eq(String.class), collectionContainer.capture()))
-				.thenReturn(new ArrayList<>());
+		when(this.template.find(any(), any(), anyString())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
-		assertEquals("{\"name\": -1}", query.getSortObject().toJson());
-		assertEquals("collection", collectionContainer.getValue());
+		verify(this.template).find(assertArg(query -> {
+			assertEquals("{\"name\": \"foo\"}", query.getQueryObject().toJson());
+			assertEquals("{\"name\": -1}", query.getSortObject().toJson());
+		}), eq(String.class), eq("collection"));
 	}
 
 	@Test
@@ -147,12 +143,11 @@ class MongoItemReaderBuilderTests {
 				.targetType(String.class).query(new Query()).sorts(this.sortOptions).name("mongoReaderTest")
 				.pageSize(50).build();
 
-		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals(50, query.getLimit());
+		verify(this.template).find(assertArg(query -> assertEquals(50, query.getLimit())), eq(String.class));
 	}
 
 	@Test
@@ -160,12 +155,11 @@ class MongoItemReaderBuilderTests {
 		MongoItemReader<String> reader = new MongoItemReaderBuilder<String>().template(this.template)
 				.targetType(String.class).query(new Query()).sorts(this.sortOptions).name("mongoReaderTest").build();
 
-		when(template.find(this.queryContainer.capture(), eq(String.class))).thenReturn(new ArrayList<>());
+		when(template.find(any(), any())).thenReturn(new ArrayList<>());
 
 		assertNull(reader.read(), "reader should not return result");
 
-		Query query = this.queryContainer.getValue();
-		assertEquals(10, query.getLimit());
+		verify(this.template).find(assertArg(query -> assertEquals(10, query.getLimit())), eq(String.class));
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2022 the original author or authors.
+ * Copyright 2008-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.sql.ResultSet;
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.jdbc.support.JdbcTransactionManager;
@@ -30,10 +29,9 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -123,17 +121,13 @@ class JdbcCursorItemReaderConfigTests {
 		final ExecutionContext ec = new ExecutionContext();
 		reader.open(ec);
 
-		ArgumentCaptor<Boolean> autoCommitCaptor = ArgumentCaptor.forClass(Boolean.class);
-		verify(con, times(1)).setAutoCommit(autoCommitCaptor.capture());
-		assertEquals(neededAutoCommit, autoCommitCaptor.getValue());
+		verify(con).setAutoCommit(eq(neededAutoCommit));
 
 		reset(con);
 		reader.close();
 
 		// Check restored autocommit value
-		autoCommitCaptor = ArgumentCaptor.forClass(Boolean.class);
-		verify(con, times(1)).setAutoCommit(autoCommitCaptor.capture());
-		assertEquals(initialAutoCommit, autoCommitCaptor.getValue());
+		verify(con).setAutoCommit(eq(initialAutoCommit));
 	}
 
 }

--- a/spring-batch-integration/pom.xml
+++ b/spring-batch-integration/pom.xml
@@ -79,6 +79,12 @@
 			<artifactId>spring-integration-test</artifactId>
 			<version>${spring-integration.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-inline</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR upgrades Mockito to version 5.3.1.

I refactored the test that previously stalled. The creation of the mocks seems to interfere with the proxying of the configuration class as the problem can also be solved by setting `proxyBeanMethods = false`.

I also replaced some of the `ArgumentCaptor`s with `assertArg` that is available since Mockito 5.3.