### PR TITLE
Allow `SimpleJobBuilder` to start with `JobExecutionDecider`

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowJobBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowJobBuilder.java
@@ -19,6 +19,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.flow.Flow;
 import org.springframework.batch.core.job.flow.FlowJob;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
 import org.springframework.batch.core.step.builder.StepBuilderException;
 
 /**
@@ -59,6 +60,16 @@ public class FlowJobBuilder extends JobBuilderHelper<FlowJobBuilder> {
 	 */
 	public JobFlowBuilder start(Step step) {
 		return new JobFlowBuilder(this, step);
+	}
+
+	/**
+	 * Start a job with this decider, but expect to transition from there to other flows
+	 * or steps.
+	 * @param decider the decider to start with
+	 * @return a builder to enable fluent chaining
+	 */
+	public JobFlowBuilder start(JobExecutionDecider decider) {
+		return new JobFlowBuilder(this, decider);
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilder.java
@@ -17,6 +17,7 @@ package org.springframework.batch.core.job.builder;
 
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.flow.Flow;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
 import org.springframework.batch.core.repository.JobRepository;
 
 /**
@@ -62,16 +63,25 @@ public class JobBuilder extends JobBuilderHelper<JobBuilder> {
 	/**
 	 * Create a new job builder that will execute a flow.
 	 * @param flow a flow to execute
-	 * @return a {@link SimpleJobBuilder}
+	 * @return a {@link JobFlowBuilder}
 	 */
 	public JobFlowBuilder start(Flow flow) {
 		return new FlowJobBuilder(this).start(flow);
 	}
 
 	/**
+	 * Create a new job builder that will execute a decider.
+	 * @param decider a decider to execute
+	 * @return a {@link JobFlowBuilder}
+	 */
+	public JobFlowBuilder start(JobExecutionDecider decider) {
+		return new FlowJobBuilder(this).start(decider);
+	}
+
+	/**
 	 * Create a new job builder that will execute a step or sequence of steps.
 	 * @param step a step to execute
-	 * @return a {@link SimpleJobBuilder}
+	 * @return a {@link JobFlowBuilder}
 	 */
 	public JobFlowBuilder flow(Step step) {
 		return new FlowJobBuilder(this).start(step);


### PR DESCRIPTION
### Modification 
- Add below method to allow users to specify `JobExecutionDecider` in the `start(...)` method as an argument. 

`JobBuilder.java` 
```java 
public JobFlowBuilder start(JobExecutionDecider decider) {
  return new SimpleJobBuilder(this).start(decider);
}
```

I found that we already have `SimpleJobBuilder` method that can start with `JobExecutionDecider`. So I think it's possible to add a method that utilizes `SimpleJobBuilder`'s method(above mentioned) which will allow users to specify `JobExecutionDecider` as an argument of `start` method. 


Resolves: https://github.com/spring-projects/spring-batch/issues/4411