### PR TITLE
Auto-detect the class/interface to be mocked

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobParametersBuilderTests.java
@@ -61,7 +61,7 @@ class JobParametersBuilderTests {
 	@BeforeEach
 	void initialize() {
 		this.job = new SimpleJob("simpleJob");
-		this.jobExplorer = mock(JobExplorer.class);
+		this.jobExplorer = mock();
 		this.jobInstanceList = new ArrayList<>(1);
 		this.jobExecutionList = new ArrayList<>(1);
 		this.parametersBuilder = new JobParametersBuilder(this.jobExplorer);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
@@ -179,7 +179,7 @@ class BatchRegistrarTests {
 
 		@Bean
 		public DataSource dataSource() {
-			return Mockito.mock(DataSource.class);
+			return Mockito.mock();
 		}
 
 	}
@@ -190,27 +190,27 @@ class BatchRegistrarTests {
 
 		@Bean
 		public JobRepository jobRepository() {
-			return Mockito.mock(JobRepository.class);
+			return Mockito.mock();
 		}
 
 		@Bean
 		public JobExplorer jobExplorer() {
-			return Mockito.mock(JobExplorer.class);
+			return Mockito.mock();
 		}
 
 		@Bean
 		public JobLauncher jobLauncher() {
-			return Mockito.mock(JobLauncher.class);
+			return Mockito.mock();
 		}
 
 		@Bean
 		public JobRegistry jobRegistry() {
-			return Mockito.mock(JobRegistry.class);
+			return Mockito.mock();
 		}
 
 		@Bean
 		public JobOperator jobOperator() {
-			return Mockito.mock(JobOperator.class);
+			return Mockito.mock();
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/AutomaticJobRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/AutomaticJobRegistrarTests.java
@@ -183,7 +183,7 @@ class AutomaticJobRegistrarTests {
 	@Test
 	void testStartStopRunningWithCallback() {
 
-		Runnable callback = Mockito.mock(Runnable.class);
+		Runnable callback = Mockito.mock();
 		Resource[] jobPaths = new Resource[] {
 				new ClassPathResource("org/springframework/batch/core/launch/support/2jobs.xml") };
 		setUpApplicationContextFactories(jobPaths, null);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
@@ -54,8 +54,8 @@ class JobExplorerFactoryBeanTests {
 	void setUp() {
 
 		factory = new JobExplorerFactoryBean();
-		DataSource dataSource = mock(DataSource.class);
-		PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+		DataSource dataSource = mock();
+		PlatformTransactionManager transactionManager = mock();
 		factory.setDataSource(dataSource);
 		factory.setTransactionManager(transactionManager);
 		factory.setTablePrefix(tablePrefix);
@@ -73,7 +73,7 @@ class JobExplorerFactoryBeanTests {
 	@Test
 	void testCustomJdbcOperations() throws Exception {
 
-		JdbcOperations customJdbcOperations = mock(JdbcOperations.class);
+		JdbcOperations customJdbcOperations = mock();
 		factory.setJdbcOperations(customJdbcOperations);
 		factory.afterPropertiesSet();
 		assertEquals(customJdbcOperations, ReflectionTestUtils.getField(factory, "jdbcOperations"));
@@ -111,7 +111,7 @@ class JobExplorerFactoryBeanTests {
 	@Test
 	public void testCustomTransactionAttributesSource() throws Exception {
 		// given
-		TransactionAttributeSource transactionAttributeSource = Mockito.mock(TransactionAttributeSource.class);
+		TransactionAttributeSource transactionAttributeSource = Mockito.mock();
 		this.factory.setTransactionAttributeSource(transactionAttributeSource);
 		this.factory.afterPropertiesSet();
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerTests.java
@@ -65,10 +65,10 @@ class SimpleJobExplorerTests {
 	@BeforeEach
 	void setUp() {
 
-		jobExecutionDao = mock(JobExecutionDao.class);
-		jobInstanceDao = mock(JobInstanceDao.class);
-		stepExecutionDao = mock(StepExecutionDao.class);
-		ecDao = mock(ExecutionContextDao.class);
+		jobExecutionDao = mock();
+		jobInstanceDao = mock();
+		stepExecutionDao = mock();
+		ecDao = mock();
 
 		jobExplorer = new SimpleJobExplorer(jobInstanceDao, jobExecutionDao, stepExecutionDao, ecDao);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/CompositeJobParametersValidatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/CompositeJobParametersValidatorTests.java
@@ -52,7 +52,7 @@ class CompositeJobParametersValidatorTests {
 
 	@Test
 	void testDelegateIsInvoked() throws JobParametersInvalidException {
-		JobParametersValidator validator = mock(JobParametersValidator.class);
+		JobParametersValidator validator = mock();
 		validator.validate(parameters);
 		compositeJobParametersValidator.setValidators(Arrays.asList(validator));
 		compositeJobParametersValidator.validate(parameters);
@@ -60,7 +60,7 @@ class CompositeJobParametersValidatorTests {
 
 	@Test
 	void testDelegatesAreInvoked() throws JobParametersInvalidException {
-		JobParametersValidator validator = mock(JobParametersValidator.class);
+		JobParametersValidator validator = mock();
 		validator.validate(parameters);
 		validator.validate(parameters);
 		compositeJobParametersValidator.setValidators(Arrays.asList(validator, validator));

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -416,7 +416,7 @@ class SimpleJobTests {
 	void testInterruptWithListener() {
 		step1.setProcessException(new JobInterruptedException("job interrupted!"));
 
-		JobExecutionListener listener = mock(JobExecutionListener.class);
+		JobExecutionListener listener = mock();
 		listener.beforeJob(jobExecution);
 		listener.afterJob(jobExecution);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/support/state/SplitStateTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/support/state/SplitStateTests.java
@@ -43,8 +43,8 @@ class SplitStateTests {
 	void testBasicHandling() throws Exception {
 
 		Collection<Flow> flows = new ArrayList<>();
-		Flow flow1 = mock(Flow.class);
-		Flow flow2 = mock(Flow.class);
+		Flow flow1 = mock();
+		Flow flow2 = mock();
 		flows.add(flow1);
 		flows.add(flow2);
 
@@ -61,8 +61,8 @@ class SplitStateTests {
 	@Test
 	void testConcurrentHandling() throws Exception {
 
-		Flow flow1 = mock(Flow.class);
-		Flow flow2 = mock(Flow.class);
+		Flow flow1 = mock();
+		Flow flow2 = mock();
 
 		SplitState state = new SplitState(Arrays.asList(flow1, flow2), "foo");
 		state.setTaskExecutor(new SimpleAsyncTaskExecutor());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/TaskExecutorJobLauncherTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/TaskExecutorJobLauncherTests.java
@@ -72,7 +72,7 @@ class TaskExecutorJobLauncherTests {
 	void setUp() {
 
 		jobLauncher = new TaskExecutorJobLauncher();
-		jobRepository = mock(JobRepository.class);
+		jobRepository = mock();
 		jobLauncher.setJobRepository(jobRepository);
 
 	}
@@ -265,13 +265,13 @@ class TaskExecutorJobLauncherTests {
 
 	private void testRestartStepExecutionInvalidStatus(BatchStatus status) throws Exception {
 		String jobName = "test_job";
-		JobRepository jobRepository = mock(JobRepository.class);
+		JobRepository jobRepository = mock();
 		JobParameters parameters = new JobParametersBuilder().addLong("runtime", System.currentTimeMillis())
 			.toJobParameters();
-		JobExecution jobExecution = mock(JobExecution.class);
-		Job job = mock(Job.class);
-		JobParametersValidator validator = mock(JobParametersValidator.class);
-		StepExecution stepExecution = mock(StepExecution.class);
+		JobExecution jobExecution = mock();
+		Job job = mock();
+		JobParametersValidator validator = mock();
+		StepExecution stepExecution = mock();
 
 		when(job.getName()).thenReturn(jobName);
 		when(job.isRestartable()).thenReturn(true);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/DataFieldMaxValueJobParametersIncrementerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/DataFieldMaxValueJobParametersIncrementerTests.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
  */
 class DataFieldMaxValueJobParametersIncrementerTests {
 
-	private final DataFieldMaxValueIncrementer incrementer = mock(DataFieldMaxValueIncrementer.class);
+	private final DataFieldMaxValueIncrementer incrementer = mock();
 
 	@Test
 	void testInvalidKey() {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/JobOperatorFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/JobOperatorFactoryBeanTests.java
@@ -39,17 +39,17 @@ import org.springframework.transaction.interceptor.TransactionInterceptor;
  */
 class JobOperatorFactoryBeanTests {
 
-	private final PlatformTransactionManager transactionManager = Mockito.mock(PlatformTransactionManager.class);
+	private final PlatformTransactionManager transactionManager = Mockito.mock();
 
-	private final JobRepository jobRepository = Mockito.mock(JobRepository.class);
+	private final JobRepository jobRepository = Mockito.mock();
 
-	private final JobLauncher jobLauncher = Mockito.mock(JobLauncher.class);
+	private final JobLauncher jobLauncher = Mockito.mock();
 
-	private final JobRegistry jobRegistry = Mockito.mock(JobRegistry.class);
+	private final JobRegistry jobRegistry = Mockito.mock();
 
-	private final JobExplorer jobExplorer = Mockito.mock(JobExplorer.class);
+	private final JobExplorer jobExplorer = Mockito.mock();
 
-	private final JobParametersConverter jobParametersConverter = Mockito.mock(JobParametersConverter.class);
+	private final JobParametersConverter jobParametersConverter = Mockito.mock();
 
 	@Test
 	public void testJobOperatorCreation() throws Exception {
@@ -76,7 +76,7 @@ class JobOperatorFactoryBeanTests {
 	@Test
 	public void testCustomTransactionAttributesSource() throws Exception {
 		// given
-		TransactionAttributeSource transactionAttributeSource = Mockito.mock(TransactionAttributeSource.class);
+		TransactionAttributeSource transactionAttributeSource = Mockito.mock();
 		JobOperatorFactoryBean jobOperatorFactoryBean = new JobOperatorFactoryBean();
 		jobOperatorFactoryBean.setTransactionManager(this.transactionManager);
 		jobOperatorFactoryBean.setJobLauncher(this.jobLauncher);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
@@ -120,11 +120,11 @@ class SimpleJobOperatorTests {
 		jobOperator.setJobLauncher(
 				(job, jobParameters) -> new JobExecution(new JobInstance(123L, job.getName()), 999L, jobParameters));
 
-		jobExplorer = mock(JobExplorer.class);
+		jobExplorer = mock();
 
 		jobOperator.setJobExplorer(jobExplorer);
 
-		jobRepository = mock(JobRepository.class);
+		jobRepository = mock();
 		jobOperator.setJobRepository(jobRepository);
 
 		jobOperator.setJobParametersConverter(new DefaultJobParametersConverter() {
@@ -288,7 +288,7 @@ class SimpleJobOperatorTests {
 		// given
 		String jobName = "job";
 		JobParameters jobParameters = new JobParameters();
-		JobInstance jobInstance = mock(JobInstance.class);
+		JobInstance jobInstance = mock();
 
 		// when
 		when(this.jobExplorer.getJobInstance(jobName, jobParameters)).thenReturn(jobInstance);
@@ -338,14 +338,14 @@ class SimpleJobOperatorTests {
 	void testStopTasklet() throws Exception {
 		JobInstance jobInstance = new JobInstance(123L, job.getName());
 		JobExecution jobExecution = new JobExecution(jobInstance, 111L, jobParameters);
-		StoppableTasklet tasklet = mock(StoppableTasklet.class);
+		StoppableTasklet tasklet = mock();
 		TaskletStep taskletStep = new TaskletStep();
 		taskletStep.setTasklet(tasklet);
 		MockJob job = new MockJob();
 		job.taskletStep = taskletStep;
 
-		JobRegistry jobRegistry = mock(JobRegistry.class);
-		TaskletStep step = mock(TaskletStep.class);
+		JobRegistry jobRegistry = mock();
+		TaskletStep step = mock();
 
 		when(step.getTasklet()).thenReturn(tasklet);
 		when(step.getName()).thenReturn("test_job.step1");
@@ -363,9 +363,9 @@ class SimpleJobOperatorTests {
 	void testStopTaskletWhenJobNotRegistered() throws Exception {
 		JobInstance jobInstance = new JobInstance(123L, job.getName());
 		JobExecution jobExecution = new JobExecution(jobInstance, 111L, jobParameters);
-		StoppableTasklet tasklet = mock(StoppableTasklet.class);
-		JobRegistry jobRegistry = mock(JobRegistry.class);
-		TaskletStep step = mock(TaskletStep.class);
+		StoppableTasklet tasklet = mock();
+		JobRegistry jobRegistry = mock();
+		TaskletStep step = mock();
 
 		when(step.getTasklet()).thenReturn(tasklet);
 		when(jobRegistry.getJob(job.getName())).thenThrow(new NoSuchJobException("Unable to find job"));
@@ -399,8 +399,8 @@ class SimpleJobOperatorTests {
 		MockJob job = new MockJob();
 		job.taskletStep = taskletStep;
 
-		JobRegistry jobRegistry = mock(JobRegistry.class);
-		TaskletStep step = mock(TaskletStep.class);
+		JobRegistry jobRegistry = mock();
+		TaskletStep step = mock();
 
 		when(step.getTasklet()).thenReturn(tasklet);
 		when(step.getName()).thenReturn("test_job.step1");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeChunkListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeChunkListenerTests.java
@@ -39,7 +39,7 @@ class CompositeChunkListenerTests {
 	@BeforeEach
 	void setUp() {
 		chunkContext = new ChunkContext(null);
-		listener = mock(ChunkListener.class);
+		listener = mock();
 		compositeListener = new CompositeChunkListener();
 		compositeListener.register(listener);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemProcessListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemProcessListenerTests.java
@@ -37,7 +37,7 @@ class CompositeItemProcessListenerTests {
 	@SuppressWarnings("unchecked")
 	@BeforeEach
 	void setUp() {
-		listener = mock(ItemProcessListener.class);
+		listener = mock();
 		compositeListener = new CompositeItemProcessListener<>();
 		compositeListener.register(listener);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemReadListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemReadListenerTests.java
@@ -38,7 +38,7 @@ class CompositeItemReadListenerTests {
 	@SuppressWarnings("unchecked")
 	@BeforeEach
 	void setUp() {
-		listener = mock(ItemReadListener.class);
+		listener = mock();
 		compositeListener = new CompositeItemReadListener<>();
 		compositeListener.register(listener);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemWriteListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemWriteListenerTests.java
@@ -40,7 +40,7 @@ class CompositeItemWriteListenerTests {
 	@SuppressWarnings("unchecked")
 	@BeforeEach
 	void setUp() {
-		listener = mock(ItemWriteListener.class);
+		listener = mock();
 		compositeListener = new CompositeItemWriteListener<>();
 		compositeListener.register(listener);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcExecutionContextDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JdbcExecutionContextDaoTests.java
@@ -30,7 +30,7 @@ class JdbcExecutionContextDaoTests extends AbstractExecutionContextDaoTests {
 	@Test
 	void testNullSerializer() {
 		JdbcExecutionContextDao jdbcExecutionContextDao = new JdbcExecutionContextDao();
-		jdbcExecutionContextDao.setJdbcTemplate(mock(JdbcOperations.class));
+		jdbcExecutionContextDao.setJdbcTemplate(mock());
 		Exception exception = assertThrows(IllegalArgumentException.class,
 				() -> jdbcExecutionContextDao.setSerializer(null));
 		assertEquals("Serializer must not be null", exception.getMessage());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
@@ -78,11 +78,11 @@ class JobRepositoryFactoryBeanTests {
 	void setUp() {
 
 		factory = new JobRepositoryFactoryBean();
-		dataSource = mock(DataSource.class);
-		transactionManager = mock(PlatformTransactionManager.class);
+		dataSource = mock();
+		transactionManager = mock();
 		factory.setDataSource(dataSource);
 		factory.setTransactionManager(transactionManager);
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		factory.setIncrementerFactory(incrementerFactory);
 		factory.setTablePrefix(tablePrefix);
 
@@ -91,8 +91,8 @@ class JobRepositoryFactoryBeanTests {
 	@Test
 	void testNoDatabaseType() throws Exception {
 
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
-		Connection con = mock(Connection.class);
+		DatabaseMetaData dmd = mock();
+		Connection con = mock();
 		when(dataSource.getConnection()).thenReturn(con);
 		when(con.getMetaData()).thenReturn(dmd);
 		when(dmd.getDatabaseProductName()).thenReturn("Oracle");
@@ -115,7 +115,7 @@ class JobRepositoryFactoryBeanTests {
 
 		factory.setDatabaseType("ORACLE");
 
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ"))
@@ -135,7 +135,7 @@ class JobRepositoryFactoryBeanTests {
 
 		factory.setDatabaseType("ORACLE");
 
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ"))
@@ -158,7 +158,7 @@ class JobRepositoryFactoryBeanTests {
 
 		factory.setDatabaseType("ORACLE");
 
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ"))
@@ -178,7 +178,7 @@ class JobRepositoryFactoryBeanTests {
 
 		factory.setDatabaseType("ORACLE");
 
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ"))
@@ -199,7 +199,7 @@ class JobRepositoryFactoryBeanTests {
 
 		factory.setDatabaseType("ORACLE");
 
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ"))
@@ -219,7 +219,7 @@ class JobRepositoryFactoryBeanTests {
 
 		factory.setDatabaseType("ORACLE");
 
-		incrementerFactory = mock(DataFieldMaxValueIncrementerFactory.class);
+		incrementerFactory = mock();
 		when(incrementerFactory.isSupportedIncrementerType("ORACLE")).thenReturn(true);
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_SEQ")).thenReturn(new StubIncrementer());
 		when(incrementerFactory.getIncrementer("ORACLE", tablePrefix + "JOB_EXECUTION_SEQ"))
@@ -228,7 +228,7 @@ class JobRepositoryFactoryBeanTests {
 			.thenReturn(new StubIncrementer());
 		factory.setIncrementerFactory(incrementerFactory);
 
-		JdbcOperations customJdbcOperations = mock(JdbcOperations.class);
+		JdbcOperations customJdbcOperations = mock();
 		factory.setJdbcOperations(customJdbcOperations);
 
 		factory.afterPropertiesSet();
@@ -313,7 +313,7 @@ class JobRepositoryFactoryBeanTests {
 				DefaultTransactionDefinition.PROPAGATION_REQUIRES_NEW);
 		transactionDefinition.setIsolationLevel(DefaultTransactionDefinition.ISOLATION_SERIALIZABLE);
 		when(transactionManager.getTransaction(transactionDefinition)).thenReturn(null);
-		Connection conn = mock(Connection.class);
+		Connection conn = mock();
 		when(dataSource.getConnection()).thenReturn(conn);
 		Exception exception = assertThrows(IllegalArgumentException.class,
 				() -> repository.createJobExecution("foo", new JobParameters()));
@@ -331,7 +331,7 @@ class JobRepositoryFactoryBeanTests {
 				DefaultTransactionDefinition.PROPAGATION_REQUIRES_NEW);
 		transactionDefinition.setIsolationLevel(DefaultTransactionDefinition.ISOLATION_READ_UNCOMMITTED);
 		when(transactionManager.getTransaction(transactionDefinition)).thenReturn(null);
-		Connection conn = mock(Connection.class);
+		Connection conn = mock();
 		when(dataSource.getConnection()).thenReturn(conn);
 		Exception exception = assertThrows(IllegalArgumentException.class,
 				() -> repository.createJobExecution("foo", new JobParameters()));
@@ -341,7 +341,7 @@ class JobRepositoryFactoryBeanTests {
 	@Test
 	public void testCustomTransactionAttributesSource() throws Exception {
 		// given
-		TransactionAttributeSource transactionAttributeSource = Mockito.mock(TransactionAttributeSource.class);
+		TransactionAttributeSource transactionAttributeSource = Mockito.mock();
 		this.factory.setTransactionAttributeSource(transactionAttributeSource);
 
 		// when

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
@@ -96,10 +96,10 @@ class SimpleJobRepositoryTests {
 	@BeforeEach
 	void setUp() {
 
-		jobExecutionDao = mock(JobExecutionDao.class);
-		jobInstanceDao = mock(JobInstanceDao.class);
-		stepExecutionDao = mock(StepExecutionDao.class);
-		ecDao = mock(ExecutionContextDao.class);
+		jobExecutionDao = mock();
+		jobInstanceDao = mock();
+		stepExecutionDao = mock();
+		ecDao = mock();
 
 		jobRepository = new SimpleJobRepository(jobInstanceDao, jobExecutionDao, stepExecutionDao, ecDao);
 
@@ -348,9 +348,9 @@ class SimpleJobRepositoryTests {
 	@Test
 	void testDeleteJobExecution() {
 		// given
-		StepExecution stepExecution1 = mock(StepExecution.class);
-		StepExecution stepExecution2 = mock(StepExecution.class);
-		JobExecution jobExecution = mock(JobExecution.class);
+		StepExecution stepExecution1 = mock();
+		StepExecution stepExecution2 = mock();
+		JobExecution jobExecution = mock();
 		when(jobExecution.getStepExecutions()).thenReturn(Arrays.asList(stepExecution1, stepExecution2));
 
 		// when
@@ -369,9 +369,9 @@ class SimpleJobRepositoryTests {
 	@Test
 	void testDeleteJobInstance() {
 		// given
-		JobExecution jobExecution1 = mock(JobExecution.class);
-		JobExecution jobExecution2 = mock(JobExecution.class);
-		JobInstance jobInstance = mock(JobInstance.class);
+		JobExecution jobExecution1 = mock();
+		JobExecution jobExecution2 = mock();
+		JobInstance jobInstance = mock();
 		when(this.jobExecutionDao.findJobExecutions(jobInstance))
 			.thenReturn(Arrays.asList(jobExecution1, jobExecution2));
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanNonBufferingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanNonBufferingTests.java
@@ -88,7 +88,7 @@ class FaultTolerantStepFactoryBeanNonBufferingTests {
 	@Test
 	void testSkip() throws Exception {
 		@SuppressWarnings("unchecked")
-		SkipListener<Integer, String> skipListener = mock(SkipListener.class);
+		SkipListener<Integer, String> skipListener = mock();
 		skipListener.onSkipInWrite("3", exception);
 		skipListener.onSkipInWrite("4", exception);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/MethodInvokingTaskletAdapterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/MethodInvokingTaskletAdapterTests.java
@@ -42,8 +42,8 @@ class MethodInvokingTaskletAdapterTests {
 
 	@BeforeEach
 	void setUp() {
-		stepContribution = new StepContribution(mock(StepExecution.class));
-		chunkContext = mock(ChunkContext.class);
+		stepContribution = new StepContribution(mock());
+		chunkContext = mock();
 		tasklet = new TestTasklet();
 		adapter = new MethodInvokingTaskletAdapter();
 		adapter.setTargetObject(tasklet);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
@@ -292,8 +292,8 @@ class SystemCommandTaskletIntegrationTests {
 	@Test
 	public void testExecuteWithSuccessfulCommandRunnerMockExecution() throws Exception {
 		StepContribution stepContribution = stepExecution.createStepContribution();
-		CommandRunner commandRunner = mock(CommandRunner.class);
-		Process process = mock(Process.class);
+		CommandRunner commandRunner = mock();
+		Process process = mock();
 		String[] command = new String[] { "invalid command" };
 
 		when(commandRunner.exec(eq(command), any(), any())).thenReturn(process);
@@ -312,8 +312,8 @@ class SystemCommandTaskletIntegrationTests {
 	@Test
 	public void testExecuteWithFailedCommandRunnerMockExecution() throws Exception {
 		StepContribution stepContribution = stepExecution.createStepContribution();
-		CommandRunner commandRunner = mock(CommandRunner.class);
-		Process process = mock(Process.class);
+		CommandRunner commandRunner = mock();
+		Process process = mock();
 		String[] command = new String[] { "invalid command" };
 
 		when(commandRunner.exec(eq(command), any(), any())).thenReturn(process);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerTests.java
@@ -53,9 +53,9 @@ class BatchMessageListenerContainerTests {
 		container.setMessageListener((MessageListener) arg0 -> {
 		});
 
-		Session session = mock(Session.class);
-		MessageConsumer consumer = mock(MessageConsumer.class);
-		Message message = mock(Message.class);
+		Session session = mock();
+		MessageConsumer consumer = mock();
+		Message message = mock();
 
 		// Expect two calls to consumer (chunk size)...
 		when(session.getTransacted()).thenReturn(true);
@@ -73,8 +73,8 @@ class BatchMessageListenerContainerTests {
 		template.setCompletionPolicy(new SimpleCompletionPolicy(2));
 		container = getContainer(template);
 
-		Session session = mock(Session.class);
-		MessageConsumer consumer = mock(MessageConsumer.class);
+		Session session = mock();
+		MessageConsumer consumer = mock();
 		Message message = null;
 
 		// Expect one call to consumer (chunk size is 2 but terminates on
@@ -119,7 +119,7 @@ class BatchMessageListenerContainerTests {
 	}
 
 	private BatchMessageListenerContainer getContainer(RepeatTemplate template) {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		ConnectionFactory connectionFactory = mock();
 		// Yuck: we need to turn these method in base class to no-ops because the invoker
 		// is a private class
 		// we can't create for test purposes...
@@ -151,9 +151,9 @@ class BatchMessageListenerContainerTests {
 				throw (Error) t;
 		});
 
-		Session session = mock(Session.class);
-		MessageConsumer consumer = mock(MessageConsumer.class);
-		Message message = mock(Message.class);
+		Session session = mock();
+		MessageConsumer consumer = mock();
+		Message message = mock();
 
 		if (expectGetTransactionCount > 0) {
 			when(session.getTransacted()).thenReturn(true);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemReaderTests.java
@@ -44,7 +44,7 @@ class AmqpItemReaderTests {
 
 	@Test
 	void testNoItemType() {
-		final AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		final AmqpTemplate amqpTemplate = mock();
 		when(amqpTemplate.receiveAndConvert()).thenReturn("foo");
 
 		final AmqpItemReader<String> amqpItemReader = new AmqpItemReader<>(amqpTemplate);
@@ -53,7 +53,7 @@ class AmqpItemReaderTests {
 
 	@Test
 	void testNonMessageItemType() {
-		final AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		final AmqpTemplate amqpTemplate = mock();
 		when(amqpTemplate.receiveAndConvert()).thenReturn("foo");
 
 		final AmqpItemReader<String> amqpItemReader = new AmqpItemReader<>(amqpTemplate);
@@ -65,8 +65,8 @@ class AmqpItemReaderTests {
 
 	@Test
 	void testMessageItemType() {
-		final AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
-		final Message message = mock(Message.class);
+		final AmqpTemplate amqpTemplate = mock();
+		final Message message = mock();
 
 		when(amqpTemplate.receive()).thenReturn(message);
 
@@ -79,7 +79,7 @@ class AmqpItemReaderTests {
 
 	@Test
 	void testTypeMismatch() {
-		final AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		final AmqpTemplate amqpTemplate = mock();
 
 		when(amqpTemplate.receiveAndConvert()).thenReturn("foo");
 
@@ -93,7 +93,7 @@ class AmqpItemReaderTests {
 
 	@Test
 	void testNullItemType() {
-		final AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		final AmqpTemplate amqpTemplate = mock();
 
 		final AmqpItemReader<String> amqpItemReader = new AmqpItemReader<>(amqpTemplate);
 		assertThrows(IllegalArgumentException.class, () -> amqpItemReader.setItemType(null));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/AmqpItemWriterTests.java
@@ -42,7 +42,7 @@ class AmqpItemWriterTests {
 
 	@Test
 	void voidTestWrite() throws Exception {
-		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		AmqpTemplate amqpTemplate = mock();
 
 		amqpTemplate.convertAndSend("foo");
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
@@ -59,7 +59,7 @@ class AmqpItemReaderBuilderTests {
 
 	@Test
 	void testMessageItemType() {
-		final Message message = mock(Message.class);
+		final Message message = mock();
 
 		when(this.amqpTemplate.receive()).thenReturn(message);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemWriterBuilderTests.java
@@ -43,7 +43,7 @@ class AmqpItemWriterBuilderTests {
 
 	@Test
 	void voidTestWrite() throws Exception {
-		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		AmqpTemplate amqpTemplate = mock();
 
 		AmqpItemWriter<String> amqpItemWriter = new AmqpItemWriterBuilder<String>().amqpTemplate(amqpTemplate).build();
 		amqpItemWriter.write(Chunk.of("foo", "bar"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoItemWriterTests.java
@@ -252,9 +252,9 @@ class MongoItemWriterTests {
 		final String[] results = new String[limit];
 		for (int i = 0; i < limit; i++) {
 			final int index = i;
-			MongoOperations mongoOperations = mock(MongoOperations.class);
-			BulkOperations bulkOperations = mock(BulkOperations.class);
-			MongoConverter mongoConverter = mock(MongoConverter.class);
+			MongoOperations mongoOperations = mock();
+			BulkOperations bulkOperations = mock();
+			MongoConverter mongoConverter = mock();
 
 			when(mongoOperations.bulkOps(any(), any(Class.class))).thenReturn(bulkOperations);
 			when(mongoOperations.getConverter()).thenReturn(mongoConverter);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/RepositoryItemReaderTests.java
@@ -228,7 +228,7 @@ class RepositoryItemReaderTests {
 
 	@Test
 	void testDifferentTypes() throws Exception {
-		TestRepository differentRepository = mock(TestRepository.class);
+		TestRepository differentRepository = mock();
 		RepositoryItemReader<String> reader = new RepositoryItemReader<>();
 		sorts = Collections.singletonMap("id", Direction.ASC);
 		reader.setRepository(differentRepository);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
@@ -48,8 +48,8 @@ class ExtendedConnectionDataSourceProxyTests {
 
 	@Test
 	void testOperationWithDataSourceUtils() throws SQLException {
-		Connection con = mock(Connection.class);
-		DataSource ds = mock(DataSource.class);
+		Connection con = mock();
+		DataSource ds = mock();
 
 		when(ds.getConnection()).thenReturn(con); // con1
 		con.close();
@@ -94,8 +94,8 @@ class ExtendedConnectionDataSourceProxyTests {
 
 	@Test
 	void testOperationWithDirectCloseCall() throws SQLException {
-		Connection con = mock(Connection.class);
-		DataSource ds = mock(DataSource.class);
+		Connection con = mock();
+		DataSource ds = mock();
 
 		when(ds.getConnection()).thenReturn(con); // con1
 		con.close();
@@ -126,10 +126,10 @@ class ExtendedConnectionDataSourceProxyTests {
 	@Test
 	void testSuppressOfCloseWithJdbcTemplate() throws Exception {
 
-		Connection con = mock(Connection.class);
-		DataSource ds = mock(DataSource.class);
-		Statement stmt = mock(Statement.class);
-		ResultSet rs = mock(ResultSet.class);
+		Connection con = mock();
+		DataSource ds = mock();
+		Statement stmt = mock();
+		ResultSet rs = mock();
 
 		// open and start suppressing close
 		when(ds.getConnection()).thenReturn(con);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorItemReaderStatefulIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateCursorItemReaderStatefulIntegrationTests.java
@@ -44,9 +44,9 @@ class HibernateCursorItemReaderStatefulIntegrationTests extends AbstractHibernat
 	@SuppressWarnings("unchecked")
 	void testStatefulClose() {
 
-		SessionFactory sessionFactory = mock(SessionFactory.class);
-		Session session = mock(Session.class);
-		Query<Foo> scrollableResults = mock(Query.class);
+		SessionFactory sessionFactory = mock();
+		Session session = mock();
+		Query<Foo> scrollableResults = mock();
 		HibernateCursorItemReader<Foo> itemReader = new HibernateCursorItemReader<>();
 		itemReader.setSessionFactory(sessionFactory);
 		itemReader.setQueryString("testQuery");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemReaderHelperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemReaderHelperTests.java
@@ -36,12 +36,12 @@ class HibernateItemReaderHelperTests {
 
 	private final HibernateItemReaderHelper<String> helper = new HibernateItemReaderHelper<>();
 
-	private final SessionFactory sessionFactory = mock(SessionFactory.class);
+	private final SessionFactory sessionFactory = mock();
 
 	@Test
 	void testOneSessionForAllPages() {
 
-		StatelessSession session = mock(StatelessSession.class);
+		StatelessSession session = mock();
 		when(sessionFactory.openStatelessSession()).thenReturn(session);
 
 		helper.setSessionFactory(sessionFactory);
@@ -55,7 +55,7 @@ class HibernateItemReaderHelperTests {
 	@Test
 	void testSessionReset() {
 
-		StatelessSession session = mock(StatelessSession.class);
+		StatelessSession session = mock();
 		when(sessionFactory.openStatelessSession()).thenReturn(session);
 
 		helper.setSessionFactory(sessionFactory);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/HibernateItemWriterTests.java
@@ -46,8 +46,8 @@ class HibernateItemWriterTests {
 	@BeforeEach
 	void setUp() {
 		writer = new HibernateItemWriter<>();
-		factory = mock(SessionFactory.class);
-		currentSession = mock(Session.class);
+		factory = mock();
+		currentSession = mock();
 
 		when(this.factory.getCurrentSession()).thenReturn(this.currentSession);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterClassicTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterClassicTests.java
@@ -55,7 +55,7 @@ class JdbcBatchItemWriterClassicTests {
 
 	@BeforeEach
 	void setUp() {
-		ps = mock(PreparedStatement.class);
+		ps = mock();
 		jdbcTemplate = new JdbcTemplate() {
 			@Override
 			public <T> T execute(String sql, PreparedStatementCallback<T> action) throws DataAccessException {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
@@ -85,7 +85,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 
 	@BeforeEach
 	void setUp() {
-		namedParameterJdbcOperations = mock(NamedParameterJdbcOperations.class);
+		namedParameterJdbcOperations = mock();
 		writer.setSql(sql);
 		writer.setJdbcTemplate(namedParameterJdbcOperations);
 		writer.setItemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcCursorItemReaderConfigTests.java
@@ -41,10 +41,10 @@ class JdbcCursorItemReaderConfigTests {
 	 */
 	@Test
 	void testUsesCurrentTransaction() throws Exception {
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
+		DataSource ds = mock();
+		Connection con = mock();
 		when(con.getAutoCommit()).thenReturn(false);
-		PreparedStatement ps = mock(PreparedStatement.class);
+		PreparedStatement ps = mock();
 		when(con.prepareStatement("select foo from bar", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
 				ResultSet.HOLD_CURSORS_OVER_COMMIT))
 			.thenReturn(ps);
@@ -71,10 +71,10 @@ class JdbcCursorItemReaderConfigTests {
 	@Test
 	void testUsesItsOwnTransaction() throws Exception {
 
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
+		DataSource ds = mock();
+		Connection con = mock();
 		when(con.getAutoCommit()).thenReturn(false);
-		PreparedStatement ps = mock(PreparedStatement.class);
+		PreparedStatement ps = mock();
 		when(con.prepareStatement("select foo from bar", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
 			.thenReturn(ps);
 		when(ds.getConnection()).thenReturn(con);
@@ -98,10 +98,10 @@ class JdbcCursorItemReaderConfigTests {
 		boolean initialAutoCommit = false;
 		boolean neededAutoCommit = true;
 
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
+		DataSource ds = mock();
+		Connection con = mock();
 		when(con.getAutoCommit()).thenReturn(initialAutoCommit);
-		PreparedStatement ps = mock(PreparedStatement.class);
+		PreparedStatement ps = mock();
 		when(con.prepareStatement("select foo from bar", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
 			.thenReturn(ps);
 		when(ds.getConnection()).thenReturn(con);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaItemWriterTests.java
@@ -51,7 +51,7 @@ class JpaItemWriterTests {
 			TransactionSynchronizationManager.clearSynchronization();
 		}
 		writer = new JpaItemWriter<>();
-		emf = mock(EntityManagerFactory.class, "emf");
+		emf = mock();
 		writer.setEntityManagerFactory(emf);
 	}
 
@@ -65,7 +65,7 @@ class JpaItemWriterTests {
 
 	@Test
 	void testWriteAndFlushSunnyDay() {
-		EntityManager em = mock(EntityManager.class, "em");
+		EntityManager em = mock();
 		em.contains("foo");
 		em.contains("bar");
 		em.merge("bar");
@@ -82,7 +82,7 @@ class JpaItemWriterTests {
 	@Test
 	void testPersist() {
 		writer.setUsePersist(true);
-		EntityManager em = mock(EntityManager.class, "em");
+		EntityManager em = mock();
 		TransactionSynchronizationManager.bindResource(emf, new EntityManagerHolder(em));
 		Chunk<String> chunk = Chunk.of("persist1", "persist2");
 		writer.write(chunk);
@@ -94,7 +94,7 @@ class JpaItemWriterTests {
 	@Test
 	void testWriteAndFlushWithFailure() {
 		final RuntimeException ex = new RuntimeException("ERROR");
-		EntityManager em = mock(EntityManager.class, "em");
+		EntityManager em = mock();
 		em.contains("foo");
 		em.contains("bar");
 		em.merge("bar");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredprocedureItemReaderConfigTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/StoredprocedureItemReaderConfigTests.java
@@ -41,14 +41,14 @@ class StoredprocedureItemReaderConfigTests {
 	 */
 	@Test
 	void testUsesCurrentTransaction() throws Exception {
-		DataSource ds = mock(DataSource.class);
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
+		DataSource ds = mock();
+		DatabaseMetaData dmd = mock();
 		when(dmd.getDatabaseProductName()).thenReturn("Oracle");
-		Connection con = mock(Connection.class);
+		Connection con = mock();
 		when(con.getMetaData()).thenReturn(dmd);
 		when(con.getMetaData()).thenReturn(dmd);
 		when(con.getAutoCommit()).thenReturn(false);
-		CallableStatement cs = mock(CallableStatement.class);
+		CallableStatement cs = mock();
 		when(con.prepareCall("{call foo_bar()}", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
 				ResultSet.HOLD_CURSORS_OVER_COMMIT))
 			.thenReturn(cs);
@@ -75,14 +75,14 @@ class StoredprocedureItemReaderConfigTests {
 	@Test
 	void testUsesItsOwnTransaction() throws Exception {
 
-		DataSource ds = mock(DataSource.class);
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
+		DataSource ds = mock();
+		DatabaseMetaData dmd = mock();
 		when(dmd.getDatabaseProductName()).thenReturn("Oracle");
-		Connection con = mock(Connection.class);
+		Connection con = mock();
 		when(con.getMetaData()).thenReturn(dmd);
 		when(con.getMetaData()).thenReturn(dmd);
 		when(con.getAutoCommit()).thenReturn(false);
-		CallableStatement cs = mock(CallableStatement.class);
+		CallableStatement cs = mock();
 		when(con.prepareCall("{call foo_bar()}", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
 			.thenReturn(cs);
 		when(ds.getConnection()).thenReturn(con);
@@ -107,14 +107,14 @@ class StoredprocedureItemReaderConfigTests {
 	@Test
 	void testHandlesRefCursorPosition() throws Exception {
 
-		DataSource ds = mock(DataSource.class);
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
+		DataSource ds = mock();
+		DatabaseMetaData dmd = mock();
 		when(dmd.getDatabaseProductName()).thenReturn("Oracle");
-		Connection con = mock(Connection.class);
+		Connection con = mock();
 		when(con.getMetaData()).thenReturn(dmd);
 		when(con.getMetaData()).thenReturn(dmd);
 		when(con.getAutoCommit()).thenReturn(false);
-		CallableStatement cs = mock(CallableStatement.class);
+		CallableStatement cs = mock();
 		when(con.prepareCall("{call foo_bar(?, ?)}", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))
 			.thenReturn(cs);
 		when(ds.getConnection()).thenReturn(con);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilderTests.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class StoredProcedureItemReaderBuilderTests {
 
-	private final DataSource dataSource = Mockito.mock(DataSource.class);
+	private final DataSource dataSource = Mockito.mock();
 
 	@Test
 	void testConfiguration() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
@@ -69,8 +69,8 @@ class JpaNamedQueryProviderTests {
 	void testNamedQueryCreation() throws Exception {
 		// given
 		String namedQuery = "allFoos";
-		TypedQuery<Foo> query = mock(TypedQuery.class);
-		EntityManager entityManager = Mockito.mock(EntityManager.class);
+		TypedQuery<Foo> query = mock();
+		EntityManager entityManager = Mockito.mock();
 		when(entityManager.createNamedQuery(namedQuery, Foo.class)).thenReturn(query);
 		JpaNamedQueryProvider<Foo> jpaNamedQueryProvider = new JpaNamedQueryProvider<>();
 		jpaNamedQueryProvider.setEntityManager(entityManager);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/ColumnMapExecutionContextRowMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/ColumnMapExecutionContextRowMapperTests.java
@@ -39,7 +39,7 @@ class ColumnMapExecutionContextRowMapperTests {
 
 	@BeforeEach
 	void setUp() {
-		ps = mock(PreparedStatement.class);
+		ps = mock();
 		mapper = new ColumnMapItemPreparedStatementSetter();
 
 		key = new LinkedHashMap<>(2);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DefaultDataFieldMaxValueIncrementerFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DefaultDataFieldMaxValueIncrementerFactoryTests.java
@@ -48,7 +48,7 @@ class DefaultDataFieldMaxValueIncrementerFactoryTests {
 
 	@BeforeEach
 	void setUp() {
-		DataSource dataSource = mock(DataSource.class);
+		DataSource dataSource = mock();
 		factory = new DefaultDataFieldMaxValueIncrementerFactory(dataSource);
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DerbyPagingQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/DerbyPagingQueryProviderTests.java
@@ -43,9 +43,9 @@ class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProviderTests 
 
 	@Test
 	void testInit() throws Exception {
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
+		DataSource ds = mock();
+		Connection con = mock();
+		DatabaseMetaData dmd = mock();
 		when(dmd.getDatabaseProductVersion()).thenReturn("10.4.1.3");
 		when(con.getMetaData()).thenReturn(dmd);
 		when(ds.getConnection()).thenReturn(con);
@@ -54,9 +54,9 @@ class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProviderTests 
 
 	@Test
 	void testInitWithRecentVersion() throws Exception {
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
+		DataSource ds = mock();
+		Connection con = mock();
+		DatabaseMetaData dmd = mock();
 		when(dmd.getDatabaseProductVersion()).thenReturn("10.10.1.1");
 		when(con.getMetaData()).thenReturn(dmd);
 		when(ds.getConnection()).thenReturn(con);
@@ -65,9 +65,9 @@ class DerbyPagingQueryProviderTests extends AbstractSqlPagingQueryProviderTests 
 
 	@Test
 	void testInitWithUnsupportedVersion() throws Exception {
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
+		DataSource ds = mock();
+		Connection con = mock();
+		DatabaseMetaData dmd = mock();
 		when(dmd.getDatabaseProductVersion()).thenReturn("10.2.9.9");
 		when(con.getMetaData()).thenReturn(dmd);
 		when(ds.getConnection()).thenReturn(con);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HibernateNativeQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/HibernateNativeQueryProviderTests.java
@@ -47,8 +47,8 @@ class HibernateNativeQueryProviderTests {
 		String sqlQuery = "select * from T_FOOS";
 		hibernateQueryProvider.setSqlQuery(sqlQuery);
 
-		StatelessSession session = mock(StatelessSession.class);
-		NativeQuery<Foo> query = mock(NativeQuery.class);
+		StatelessSession session = mock();
+		NativeQuery<Foo> query = mock();
 
 		when(session.createNativeQuery(sqlQuery)).thenReturn(query);
 		when(query.addEntity(Foo.class)).thenReturn(query);
@@ -64,8 +64,8 @@ class HibernateNativeQueryProviderTests {
 		String sqlQuery = "select * from T_FOOS";
 		hibernateQueryProvider.setSqlQuery(sqlQuery);
 
-		Session session = mock(Session.class);
-		NativeQuery<Foo> query = mock(NativeQuery.class);
+		Session session = mock();
+		NativeQuery<Foo> query = mock();
 
 		when(session.createNativeQuery(sqlQuery)).thenReturn(query);
 		when(query.addEntity(Foo.class)).thenReturn(query);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/JpaNativeQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/JpaNativeQueryProviderTests.java
@@ -49,8 +49,8 @@ class JpaNativeQueryProviderTests {
 		String sqlQuery = "select * from T_FOOS where value >= :limit";
 		jpaQueryProvider.setSqlQuery(sqlQuery);
 
-		EntityManager entityManager = mock(EntityManager.class);
-		Query query = mock(Query.class);
+		EntityManager entityManager = mock();
+		Query query = mock();
 
 		when(entityManager.createNativeQuery(sqlQuery, Foo.class)).thenReturn(query);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/DefaultLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/DefaultLineMapperTests.java
@@ -50,11 +50,11 @@ class DefaultLineMapperTests {
 		final FieldSet fs = new DefaultFieldSet(new String[] { "token1", "token2" });
 		final String item = "ITEM";
 
-		LineTokenizer tokenizer = mock(LineTokenizer.class);
+		LineTokenizer tokenizer = mock();
 		when(tokenizer.tokenize(line)).thenReturn(fs);
 
 		@SuppressWarnings("unchecked")
-		FieldSetMapper<String> fsMapper = mock(FieldSetMapper.class);
+		FieldSetMapper<String> fsMapper = mock();
 		when(fsMapper.mapFieldSet(fs)).thenReturn(item);
 
 		tested.setLineTokenizer(tokenizer);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemReaderTests.java
@@ -37,7 +37,7 @@ class JmsItemReaderTests {
 
 	@Test
 	void testNoItemTypeSunnyDay() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 		when(jmsTemplate.receiveAndConvert()).thenReturn("foo");
 
 		itemReader.setJmsTemplate(jmsTemplate);
@@ -46,7 +46,7 @@ class JmsItemReaderTests {
 
 	@Test
 	void testSetItemTypeSunnyDay() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 		when(jmsTemplate.receiveAndConvert()).thenReturn("foo");
 
 		itemReader.setJmsTemplate(jmsTemplate);
@@ -56,7 +56,7 @@ class JmsItemReaderTests {
 
 	@Test
 	void testSetItemSubclassTypeSunnyDay() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 
 		Date date = new java.sql.Date(0L);
 		when(jmsTemplate.receiveAndConvert()).thenReturn(date);
@@ -70,7 +70,7 @@ class JmsItemReaderTests {
 
 	@Test
 	void testSetItemTypeMismatch() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 		when(jmsTemplate.receiveAndConvert()).thenReturn("foo");
 
 		JmsItemReader<Date> itemReader = new JmsItemReader<>();
@@ -82,8 +82,8 @@ class JmsItemReaderTests {
 
 	@Test
 	void testNextMessageSunnyDay() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
-		Message message = mock(Message.class);
+		JmsOperations jmsTemplate = mock();
+		Message message = mock();
 		when(jmsTemplate.receive()).thenReturn(message);
 
 		JmsItemReader<Message> itemReader = new JmsItemReader<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsItemWriterTests.java
@@ -31,7 +31,7 @@ class JmsItemWriterTests {
 
 	@Test
 	void testNoItemTypeSunnyDay() throws Exception {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 		jmsTemplate.convertAndSend("foo");
 		jmsTemplate.convertAndSend("bar");
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodArgumentsKeyGeneratorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodArgumentsKeyGeneratorTests.java
@@ -35,7 +35,7 @@ class JmsMethodArgumentsKeyGeneratorTests {
 
 	@Test
 	void testGetKeyFromMessage() throws Exception {
-		Message message = mock(Message.class);
+		Message message = mock();
 		when(message.getJMSMessageID()).thenReturn("foo");
 
 		JmsItemReader<Message> itemReader = new JmsItemReader<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodInvocationRecovererTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsMethodInvocationRecovererTests.java
@@ -31,7 +31,7 @@ class JmsMethodInvocationRecovererTests {
 
 	@Test
 	void testRecoverWithNoDestination() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 		jmsTemplate.convertAndSend("foo");
 
 		itemReader.setJmsTemplate(jmsTemplate);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsNewMethodArgumentsIdentifierTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/JmsNewMethodArgumentsIdentifierTests.java
@@ -35,7 +35,7 @@ class JmsNewMethodArgumentsIdentifierTests {
 
 	@Test
 	void testIsNewForMessage() throws Exception {
-		Message message = mock(Message.class);
+		Message message = mock();
 		when(message.getJMSRedelivered()).thenReturn(true);
 		assertFalse(newMethodArgumentsIdentifier.isNew(new Object[] { message }));
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemReaderBuilderTests.java
@@ -42,7 +42,7 @@ class JmsItemReaderBuilderTests {
 
 	@BeforeEach
 	void setupJmsTemplate() {
-		this.defaultJmsTemplate = mock(JmsOperations.class);
+		this.defaultJmsTemplate = mock();
 		when(this.defaultJmsTemplate.receiveAndConvert()).thenReturn("foo");
 	}
 
@@ -55,7 +55,7 @@ class JmsItemReaderBuilderTests {
 
 	@Test
 	void testSetItemSubclassType() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 
 		Date date = new java.sql.Date(0L);
 		when(jmsTemplate.receiveAndConvert()).thenReturn(date);
@@ -77,8 +77,8 @@ class JmsItemReaderBuilderTests {
 
 	@Test
 	void testMessageType() {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
-		Message message = mock(Message.class);
+		JmsOperations jmsTemplate = mock();
+		Message message = mock();
 		when(jmsTemplate.receive()).thenReturn(message);
 
 		JmsItemReader<Message> itemReader = new JmsItemReaderBuilder<Message>().jmsTemplate(jmsTemplate)

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/jms/builder/JmsItemWriterBuilderTests.java
@@ -37,7 +37,7 @@ class JmsItemWriterBuilderTests {
 
 	@Test
 	void testNoItem() throws Exception {
-		JmsOperations jmsTemplate = mock(JmsOperations.class);
+		JmsOperations jmsTemplate = mock();
 		JmsItemWriter<String> itemWriter = new JmsItemWriterBuilder<String>().jmsTemplate(jmsTemplate).build();
 		ArgumentCaptor<String> argCaptor = ArgumentCaptor.forClass(String.class);
 		itemWriter.write(Chunk.of("foo", "bar"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonFileItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/builder/JsonFileItemWriterBuilderTests.java
@@ -82,8 +82,8 @@ class JsonFileItemWriterBuilderTests {
 		boolean shouldDeleteIfExists = true;
 		String encoding = "UTF-8";
 		String lineSeparator = "#";
-		FlatFileHeaderCallback headerCallback = Mockito.mock(FlatFileHeaderCallback.class);
-		FlatFileFooterCallback footerCallback = Mockito.mock(FlatFileFooterCallback.class);
+		FlatFileHeaderCallback headerCallback = Mockito.mock();
+		FlatFileFooterCallback footerCallback = Mockito.mock();
 
 		// when
 		JsonFileItemWriter<String> writer = new JsonFileItemWriterBuilder<String>().name("jsonFileItemWriter")
@@ -114,8 +114,8 @@ class JsonFileItemWriterBuilderTests {
 		boolean shouldDeleteIfExists = true;
 		String encoding = StandardCharsets.UTF_8.name();
 		String lineSeparator = "#";
-		FlatFileHeaderCallback headerCallback = Mockito.mock(FlatFileHeaderCallback.class);
-		FlatFileFooterCallback footerCallback = Mockito.mock(FlatFileFooterCallback.class);
+		FlatFileHeaderCallback headerCallback = Mockito.mock();
+		FlatFileFooterCallback footerCallback = Mockito.mock();
 
 		// when
 		JsonFileItemWriter<String> writer = new JsonFileItemWriterBuilder<String>().name("jsonFileItemWriter")

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/SimpleMailMessageItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/SimpleMailMessageItemWriterTests.java
@@ -47,7 +47,7 @@ class SimpleMailMessageItemWriterTests {
 
 	private final SimpleMailMessageItemWriter writer = new SimpleMailMessageItemWriter();
 
-	private final MailSender mailSender = mock(MailSender.class);
+	private final MailSender mailSender = mock();
 
 	@BeforeEach
 	void setUp() {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/builder/SimpleMailMessageItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/builder/SimpleMailMessageItemWriterBuilderTests.java
@@ -52,7 +52,7 @@ class SimpleMailMessageItemWriterBuilderTests {
 
 	@BeforeEach
 	void setup() {
-		mailSender = mock(MailSender.class);
+		mailSender = mock();
 		this.foo = new SimpleMailMessage();
 		this.bar = new SimpleMailMessage();
 		this.items = new SimpleMailMessage[] { this.foo, this.bar };

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/javamail/MimeMessageItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/mail/javamail/MimeMessageItemWriterTests.java
@@ -49,7 +49,7 @@ class MimeMessageItemWriterTests {
 
 	private final MimeMessageItemWriter writer = new MimeMessageItemWriter();
 
-	private final JavaMailSender mailSender = mock(JavaMailSender.class);
+	private final JavaMailSender mailSender = mock();
 
 	private final Session session = Session.getDefaultInstance(new Properties());
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemProcessorTests.java
@@ -46,8 +46,8 @@ class CompositeItemProcessorTests {
 	@SuppressWarnings("unchecked")
 	@BeforeEach
 	void setUp() throws Exception {
-		processor1 = mock(ItemProcessor.class);
-		processor2 = mock(ItemProcessor.class);
+		processor1 = mock();
+		processor2 = mock();
 
 		composite.setDelegates(Arrays.asList(processor1, processor2));
 
@@ -80,8 +80,8 @@ class CompositeItemProcessorTests {
 	@SuppressWarnings("unchecked")
 	void testItemProcessorGenerics() throws Exception {
 		CompositeItemProcessor<String, String> composite = new CompositeItemProcessor<>();
-		final ItemProcessor<String, Integer> processor1 = mock(ItemProcessor.class);
-		final ItemProcessor<Integer, String> processor2 = mock(ItemProcessor.class);
+		final ItemProcessor<String, Integer> processor1 = mock();
+		final ItemProcessor<Integer, String> processor2 = mock();
 		composite.setDelegates(Arrays.asList(processor1, processor2));
 
 		composite.afterPropertiesSet();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemWriterTests.java
@@ -52,7 +52,7 @@ class CompositeItemWriterTests {
 
 		for (int i = 0; i < NUMBER_OF_WRITERS; i++) {
 			@SuppressWarnings("unchecked")
-			ItemWriter<? super Object> writer = mock(ItemWriter.class);
+			ItemWriter<? super Object> writer = mock();
 
 			writer.write(data);
 
@@ -76,7 +76,7 @@ class CompositeItemWriterTests {
 
 	private void doTestItemStream(boolean expectOpen) throws Exception {
 		@SuppressWarnings("unchecked")
-		ItemStreamWriter<? super Object> writer = mock(ItemStreamWriter.class);
+		ItemStreamWriter<? super Object> writer = mock();
 		Chunk<Object> data = Chunk.of(new Object());
 		ExecutionContext executionContext = new ExecutionContext();
 		if (expectOpen) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/builder/CompositeItemWriterBuilderTests.java
@@ -48,7 +48,7 @@ class CompositeItemWriterBuilderTests {
 		List<ItemWriter<? super Object>> writers = new ArrayList<>();
 
 		for (int i = 0; i < NUMBER_OF_WRITERS; i++) {
-			ItemWriter<? super Object> writer = mock(ItemWriter.class);
+			ItemWriter<? super Object> writer = mock();
 			writers.add(writer);
 		}
 		CompositeItemWriter<Object> itemWriter = new CompositeItemWriterBuilder<>().delegates(writers).build();
@@ -68,9 +68,9 @@ class CompositeItemWriterBuilderTests {
 
 		List<ItemWriter<? super Object>> writers = new ArrayList<>();
 
-		ItemWriter<? super Object> writer1 = mock(ItemWriter.class);
+		ItemWriter<? super Object> writer1 = mock();
 		writers.add(writer1);
-		ItemWriter<? super Object> writer2 = mock(ItemWriter.class);
+		ItemWriter<? super Object> writer2 = mock();
 		writers.add(writer2);
 
 		CompositeItemWriter<Object> itemWriter = new CompositeItemWriterBuilder<>().delegates(writer1, writer2).build();
@@ -90,7 +90,7 @@ class CompositeItemWriterBuilderTests {
 
 	@SuppressWarnings("unchecked")
 	private void ignoreItemStream(boolean ignoreItemStream) throws Exception {
-		ItemStreamWriter<? super Object> writer = mock(ItemStreamWriter.class);
+		ItemStreamWriter<? super Object> writer = mock();
 		Chunk<Object> data = Chunk.of(new Object());
 		ExecutionContext executionContext = new ExecutionContext();
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/ValidatingItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/validator/ValidatingItemProcessorTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class ValidatingItemProcessorTests {
 
 	@SuppressWarnings("unchecked")
-	private final Validator<String> validator = mock(Validator.class);
+	private final Validator<String> validator = mock();
 
 	private static final String ITEM = "item";
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -168,15 +168,15 @@ class StaxEventItemReaderTests {
 	@Test
 	void testNullEncoding() throws Exception {
 		// given
-		XMLEventReader eventReader = mock(XMLEventReader.class);
+		XMLEventReader eventReader = mock();
 		when(eventReader.peek()).thenReturn(mock(StartDocument.class));
 
-		Resource resource = mock(Resource.class);
-		InputStream inputStream = mock(InputStream.class);
+		Resource resource = mock();
+		InputStream inputStream = mock();
 		when(resource.getInputStream()).thenReturn(inputStream);
 		when(resource.isReadable()).thenReturn(true);
 		when(resource.exists()).thenReturn(true);
-		XMLInputFactory xmlInputFactory = mock(XMLInputFactory.class);
+		XMLInputFactory xmlInputFactory = mock();
 		when(xmlInputFactory.createXMLEventReader(inputStream)).thenReturn(eventReader);
 
 		StaxEventItemReader<Object> reader = new StaxEventItemReader<>();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
@@ -446,7 +446,7 @@ class StaxEventItemWriterTests {
 
 	@Test
 	void testNonExistantResource() throws Exception {
-		WritableResource doesntExist = mock(WritableResource.class);
+		WritableResource doesntExist = mock();
 		when(doesntExist.getFile()).thenReturn(File.createTempFile("arbitrary", null));
 		when(doesntExist.exists()).thenReturn(false);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventReaderWrapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventReaderWrapperTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
  */
 class AbstractEventReaderWrapperTests {
 
-	private final XMLEventReader xmlEventReader = mock(XMLEventReader.class);
+	private final XMLEventReader xmlEventReader = mock();
 
 	private final AbstractEventReaderWrapper eventReaderWrapper = new StubEventReader(xmlEventReader);
 
@@ -76,7 +76,7 @@ class AbstractEventReaderWrapperTests {
 	@Test
 	void testNextEvent() throws XMLStreamException {
 
-		XMLEvent event = mock(XMLEvent.class);
+		XMLEvent event = mock();
 		when(xmlEventReader.nextEvent()).thenReturn(event);
 		assertEquals(eventReaderWrapper.nextEvent(), event);
 	}
@@ -84,7 +84,7 @@ class AbstractEventReaderWrapperTests {
 	@Test
 	void testNextTag() throws XMLStreamException {
 
-		XMLEvent event = mock(XMLEvent.class);
+		XMLEvent event = mock();
 		when(xmlEventReader.nextTag()).thenReturn(event);
 		assertEquals(eventReaderWrapper.nextTag(), event);
 	}
@@ -92,7 +92,7 @@ class AbstractEventReaderWrapperTests {
 	@Test
 	void testPeek() throws XMLStreamException {
 
-		XMLEvent event = mock(XMLEvent.class);
+		XMLEvent event = mock();
 		when(xmlEventReader.peek()).thenReturn(event);
 		assertEquals(eventReaderWrapper.peek(), event);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventWriterWrapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/AbstractEventWriterWrapperTests.java
@@ -35,14 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class AbstractEventWriterWrapperTests {
 
-	private final XMLEventWriter xmlEventWriter = mock(XMLEventWriter.class);
+	private final XMLEventWriter xmlEventWriter = mock();
 
 	private final AbstractEventWriterWrapper eventWriterWrapper = new StubEventWriter(xmlEventWriter);
 
 	@Test
 	void testAdd() throws XMLStreamException {
 
-		XMLEvent event = mock(XMLEvent.class);
+		XMLEvent event = mock();
 		xmlEventWriter.add(event);
 		eventWriterWrapper.add(event);
 
@@ -51,7 +51,7 @@ class AbstractEventWriterWrapperTests {
 	@Test
 	void testAddReader() throws XMLStreamException {
 
-		XMLEventReader reader = mock(XMLEventReader.class);
+		XMLEventReader reader = mock();
 		xmlEventWriter.add(reader);
 		eventWriterWrapper.add(reader);
 	}
@@ -70,7 +70,7 @@ class AbstractEventWriterWrapperTests {
 
 	@Test
 	void testGetNamespaceContext() {
-		NamespaceContext context = mock(NamespaceContext.class);
+		NamespaceContext context = mock();
 		when(xmlEventWriter.getNamespaceContext()).thenReturn(context);
 		assertEquals(eventWriterWrapper.getNamespaceContext(), context);
 	}
@@ -92,7 +92,7 @@ class AbstractEventWriterWrapperTests {
 	@Test
 	void testSetNamespaceContext() throws XMLStreamException {
 
-		NamespaceContext context = mock(NamespaceContext.class);
+		NamespaceContext context = mock();
 		xmlEventWriter.setNamespaceContext(context);
 		eventWriterWrapper.setNamespaceContext(context);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentWriterTests.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.times;
  */
 class NoStartEndDocumentWriterTests {
 
-	private final XMLEventWriter wrappedWriter = mock(XMLEventWriter.class);
+	private final XMLEventWriter wrappedWriter = mock();
 
 	private final NoStartEndDocumentStreamWriter writer = new NoStartEndDocumentStreamWriter(wrappedWriter);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnclosedElementCollectingEventWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnclosedElementCollectingEventWriterTests.java
@@ -34,7 +34,7 @@ import org.mockito.Mockito;
  */
 class UnclosedElementCollectingEventWriterTests {
 
-	private final XMLEventWriter wrappedWriter = mock(XMLEventWriter.class);
+	private final XMLEventWriter wrappedWriter = mock();
 
 	private final UnclosedElementCollectingEventWriter writer = new UnclosedElementCollectingEventWriter(wrappedWriter);
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriterTests.java
@@ -62,8 +62,8 @@ class UnopenedElementClosingEventWriterTests {
 
 	@BeforeEach
 	void setUp() {
-		wrappedWriter = mock(XMLEventWriter.class);
-		ioWriter = mock(Writer.class);
+		wrappedWriter = mock();
+		ioWriter = mock();
 		unopenedElements.add(unopenedA);
 		unopenedElements.add(unopenedB);
 		writer = new UnopenedElementClosingEventWriter(wrappedWriter, ioWriter, unopenedElements);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTestUtils.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTestUtils.java
@@ -54,9 +54,9 @@ public class DatabaseTypeTestUtils {
 	}
 
 	public static DataSource getMockDataSource(String databaseProductName, String databaseVersion) throws Exception {
-		DatabaseMetaData dmd = mock(DatabaseMetaData.class);
-		DataSource ds = mock(DataSource.class);
-		Connection con = mock(Connection.class);
+		DatabaseMetaData dmd = mock();
+		DataSource ds = mock();
+		Connection con = mock();
 		when(ds.getConnection()).thenReturn(con);
 		when(con.getMetaData()).thenReturn(dmd);
 		when(dmd.getDatabaseProductName()).thenReturn(databaseProductName);
@@ -67,7 +67,7 @@ public class DatabaseTypeTestUtils {
 	}
 
 	public static DataSource getMockDataSource(Exception e) throws Exception {
-		DataSource ds = mock(DataSource.class);
+		DataSource ds = mock();
 		when(ds.getConnection()).thenReturn(null);
 		return ds;
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriterTests.java
@@ -53,7 +53,7 @@ class TransactionAwareBufferedWriterTests {
 
 	@BeforeEach
 	void init() {
-		fileChannel = mock(FileChannel.class);
+		fileChannel = mock();
 
 		writer = new TransactionAwareBufferedWriter(fileChannel, () -> {
 			try {
@@ -300,7 +300,7 @@ class TransactionAwareBufferedWriterTests {
 		final String[] results = new String[limit];
 		for (int i = 0; i < limit; i++) {
 			final int index = i;
-			FileChannel fileChannel = mock(FileChannel.class);
+			FileChannel fileChannel = mock();
 			when(fileChannel.write(any(ByteBuffer.class))).thenAnswer(invocation -> {
 				ByteBuffer buffer = (ByteBuffer) invocation.getArguments()[0];
 				String val = new String(buffer.array(), StandardCharsets.UTF_8);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
@@ -232,12 +232,12 @@ class RemoteChunkingManagerStepBuilderTests {
 		NoBackOffPolicy backOffPolicy = new NoBackOffPolicy();
 		ItemStreamSupport stream = new ItemStreamSupport() {
 		};
-		StepExecutionListener stepExecutionListener = mock(StepExecutionListener.class);
-		ItemReadListener<String> itemReadListener = mock(ItemReadListener.class);
-		ItemWriteListener<String> itemWriteListener = mock(ItemWriteListener.class);
-		ChunkListener chunkListener = mock(ChunkListener.class);
-		SkipListener<String, String> skipListener = mock(SkipListener.class);
-		RetryListener retryListener = mock(RetryListener.class);
+		StepExecutionListener stepExecutionListener = mock();
+		ItemReadListener<String> itemReadListener = mock();
+		ItemWriteListener<String> itemWriteListener = mock();
+		ChunkListener chunkListener = mock();
+		SkipListener<String, String> skipListener = mock();
+		RetryListener retryListener = mock();
 
 		when(retryListener.open(any(), any())).thenReturn(true);
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingGatewayTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingGatewayTests.java
@@ -45,7 +45,7 @@ class JobLaunchingGatewayTests {
 			.withPayload(new JobLaunchRequest(new JobSupport("testJob"), new JobParameters()))
 			.build();
 
-		final JobLauncher jobLauncher = mock(JobLauncher.class);
+		final JobLauncher jobLauncher = mock();
 		when(jobLauncher.run(any(Job.class), any(JobParameters.class)))
 			.thenThrow(new JobParametersInvalidException("This is a JobExecutionException."));
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
@@ -61,8 +61,8 @@ class MessageChannelPartitionHandlerTests {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
-		StepExecution managerStepExecution = mock(StepExecution.class);
-		StepExecutionSplitter stepExecutionSplitter = mock(StepExecutionSplitter.class);
+		StepExecution managerStepExecution = mock();
+		StepExecutionSplitter stepExecutionSplitter = mock();
 
 		// execute
 		Collection<StepExecution> executions = messageChannelPartitionHandler.handle(stepExecutionSplitter,
@@ -77,10 +77,10 @@ class MessageChannelPartitionHandlerTests {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
-		StepExecution managerStepExecution = mock(StepExecution.class);
-		StepExecutionSplitter stepExecutionSplitter = mock(StepExecutionSplitter.class);
-		MessagingTemplate operations = mock(MessagingTemplate.class);
-		Message message = mock(Message.class);
+		StepExecution managerStepExecution = mock();
+		StepExecutionSplitter stepExecutionSplitter = mock();
+		MessagingTemplate operations = mock();
+		Message message = mock();
 		// when
 		HashSet<StepExecution> stepExecutions = new HashSet<>();
 		stepExecutions.add(new StepExecution("step1", new JobExecution(5L)));
@@ -104,11 +104,11 @@ class MessageChannelPartitionHandlerTests {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
-		StepExecution managerStepExecution = mock(StepExecution.class);
-		StepExecutionSplitter stepExecutionSplitter = mock(StepExecutionSplitter.class);
-		MessagingTemplate operations = mock(MessagingTemplate.class);
-		Message message = mock(Message.class);
-		PollableChannel replyChannel = mock(PollableChannel.class);
+		StepExecution managerStepExecution = mock();
+		StepExecutionSplitter stepExecutionSplitter = mock();
+		MessagingTemplate operations = mock();
+		Message message = mock();
+		PollableChannel replyChannel = mock();
 		// when
 		HashSet<StepExecution> stepExecutions = new HashSet<>();
 		stepExecutions.add(new StepExecution("step1", new JobExecution(5L)));
@@ -134,10 +134,10 @@ class MessageChannelPartitionHandlerTests {
 		// execute with no default set
 		messageChannelPartitionHandler = new MessageChannelPartitionHandler();
 		// mock
-		StepExecution managerStepExecution = mock(StepExecution.class);
-		StepExecutionSplitter stepExecutionSplitter = mock(StepExecutionSplitter.class);
-		MessagingTemplate operations = mock(MessagingTemplate.class);
-		Message message = mock(Message.class);
+		StepExecution managerStepExecution = mock();
+		StepExecutionSplitter stepExecutionSplitter = mock();
+		MessagingTemplate operations = mock();
+		Message message = mock();
 		// when
 		HashSet<StepExecution> stepExecutions = new HashSet<>();
 		stepExecutions.add(new StepExecution("step1", new JobExecution(5L)));
@@ -158,9 +158,9 @@ class MessageChannelPartitionHandlerTests {
 		// mock
 		JobExecution jobExecution = new JobExecution(5L, new JobParameters());
 		StepExecution managerStepExecution = new StepExecution("step1", jobExecution, 1L);
-		StepExecutionSplitter stepExecutionSplitter = mock(StepExecutionSplitter.class);
-		MessagingTemplate operations = mock(MessagingTemplate.class);
-		JobExplorer jobExplorer = mock(JobExplorer.class);
+		StepExecutionSplitter stepExecutionSplitter = mock();
+		MessagingTemplate operations = mock();
+		JobExplorer jobExplorer = mock();
 		// when
 		HashSet<StepExecution> stepExecutions = new HashSet<>();
 		StepExecution partition1 = new StepExecution("step1:partition1", jobExecution, 2L);
@@ -210,9 +210,9 @@ class MessageChannelPartitionHandlerTests {
 		// mock
 		JobExecution jobExecution = new JobExecution(5L, new JobParameters());
 		StepExecution managerStepExecution = new StepExecution("step1", jobExecution, 1L);
-		StepExecutionSplitter stepExecutionSplitter = mock(StepExecutionSplitter.class);
-		MessagingTemplate operations = mock(MessagingTemplate.class);
-		JobExplorer jobExplorer = mock(JobExplorer.class);
+		StepExecutionSplitter stepExecutionSplitter = mock();
+		MessagingTemplate operations = mock();
+		JobExplorer jobExplorer = mock();
 		// when
 		HashSet<StepExecution> stepExecutions = new HashSet<>();
 		StepExecution partition1 = new StepExecution("step1:partition1", jobExecution, 2L);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilderTests.java
@@ -142,7 +142,7 @@ class RemotePartitioningManagerStepBuilderTests {
 	@Test
 	void testUnsupportedOperationExceptionWhenSpecifyingPartitionHandler() {
 		// given
-		PartitionHandler partitionHandler = Mockito.mock(PartitionHandler.class);
+		PartitionHandler partitionHandler = Mockito.mock();
 		final RemotePartitioningManagerStepBuilder builder = new RemotePartitioningManagerStepBuilder("step",
 				this.jobRepository);
 
@@ -165,7 +165,7 @@ class RemotePartitioningManagerStepBuilderTests {
 		long timeout = 1000L;
 		long pollInterval = 5000L;
 		DirectChannel outputChannel = new DirectChannel();
-		Partitioner partitioner = Mockito.mock(Partitioner.class);
+		Partitioner partitioner = Mockito.mock();
 		StepExecutionAggregator stepExecutionAggregator = (result, executions) -> {
 		};
 
@@ -208,7 +208,7 @@ class RemotePartitioningManagerStepBuilderTests {
 		int gridSize = 5;
 		int startLimit = 3;
 		DirectChannel outputChannel = new DirectChannel();
-		Partitioner partitioner = Mockito.mock(Partitioner.class);
+		Partitioner partitioner = Mockito.mock();
 		StepExecutionAggregator stepExecutionAggregator = (result, executions) -> {
 		};
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/order/OrderItemReaderTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/order/OrderItemReaderTests.java
@@ -36,7 +36,7 @@ class OrderItemReaderTests {
 	@BeforeEach
 	@SuppressWarnings("unchecked")
 	void setUp() {
-		input = mock(ItemReader.class);
+		input = mock();
 
 		provider = new OrderItemReader();
 		provider.setFieldSetReader(input);
@@ -76,7 +76,7 @@ class OrderItemReaderTests {
 		LineItem item = new LineItem();
 
 		@SuppressWarnings("rawtypes")
-		FieldSetMapper mapper = mock(FieldSetMapper.class);
+		FieldSetMapper mapper = mock();
 		when(mapper.mapFieldSet(headerFS)).thenReturn(order);
 		when(mapper.mapFieldSet(customerFS)).thenReturn(customer);
 		when(mapper.mapFieldSet(billingFS)).thenReturn(billing);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/CustomerUpdateProcessorTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/CustomerUpdateProcessorTests.java
@@ -41,8 +41,8 @@ class CustomerUpdateProcessorTests {
 
 	@BeforeEach
 	void init() {
-		customerDao = mock(CustomerDao.class);
-		logger = mock(InvalidCustomerLogger.class);
+		customerDao = mock();
+		logger = mock();
 		processor = new CustomerUpdateProcessor();
 		processor.setCustomerDao(customerDao);
 		processor.setInvalidCustomerLogger(logger);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/CustomerCreditUpdatePreparedStatementSetterTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/CustomerCreditUpdatePreparedStatementSetterTests.java
@@ -40,7 +40,7 @@ class CustomerCreditUpdatePreparedStatementSetterTests {
 
 	@BeforeEach
 	void setUp() {
-		ps = mock(PreparedStatement.class);
+		ps = mock();
 		credit = new CustomerCredit();
 		credit.setId(13);
 		credit.setCredit(new BigDecimal(12000));

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/CustomerCreditUpdateProcessorTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/CustomerCreditUpdateProcessorTests.java
@@ -35,7 +35,7 @@ class CustomerCreditUpdateProcessorTests {
 
 	@BeforeEach
 	void setUp() {
-		dao = mock(CustomerCreditDao.class);
+		dao = mock();
 
 		writer = new CustomerCreditUpdateWriter();
 		writer.setDao(dao);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/FlatFileCustomerCreditDaoTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/FlatFileCustomerCreditDaoTests.java
@@ -35,7 +35,7 @@ class FlatFileCustomerCreditDaoTests {
 
 	@BeforeEach
 	void setUp() {
-		output = mock(ResourceLifecycleItemWriter.class);
+		output = mock();
 
 		writer = new FlatFileCustomerCreditDao();
 		writer.setItemWriter(output);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/TradeProcessorTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/domain/trade/internal/TradeProcessorTests.java
@@ -31,7 +31,7 @@ class TradeProcessorTests {
 
 	@BeforeEach
 	void setUp() {
-		writer = mock(TradeDao.class);
+		writer = mock();
 
 		processor = new TradeWriter();
 		processor.setDao(writer);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/quartz/JobLauncherDetailsTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/quartz/JobLauncherDetailsTests.java
@@ -133,7 +133,7 @@ class JobLauncherDetailsTests {
 	private final class StubJobExecutionContext extends JobExecutionContextImpl {
 
 		private StubJobExecutionContext() {
-			super(mock(Scheduler.class), firedBundle, mock(Job.class));
+			super(mock(), firedBundle, mock());
 		}
 
 	}

--- a/spring-batch-samples/src/test/java/org/springframework/batch/sample/support/AbstractRowMapperTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/sample/support/AbstractRowMapperTests.java
@@ -38,7 +38,7 @@ public abstract class AbstractRowMapperTests<T> {
 	private static final int IGNORED_ROW_NUMBER = 0;
 
 	// mock result set
-	private final ResultSet rs = mock(ResultSet.class);
+	private final ResultSet rs = mock();
 
 	/**
 	 * @return Expected result of mapping the mock <code>ResultSet</code> by the mapper

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerTests.java
@@ -46,7 +46,7 @@ class BatchTestContextCustomizerTests {
 	void testCustomizeContext() {
 		// given
 		ConfigurableApplicationContext context = new GenericApplicationContext();
-		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
+		MergedContextConfiguration mergedConfig = Mockito.mock();
 
 		// when
 		this.contextCustomizer.customizeContext(context, mergedConfig);
@@ -60,8 +60,8 @@ class BatchTestContextCustomizerTests {
 	@Test
 	void testCustomizeContext_whenBeanFactoryIsNotAnInstanceOfBeanDefinitionRegistry() {
 		// given
-		ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
-		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
+		ConfigurableApplicationContext context = Mockito.mock();
+		MergedContextConfiguration mergedConfig = Mockito.mock();
 
 		// when
 		final Exception expectedException = assertThrows(IllegalArgumentException.class,
@@ -77,7 +77,7 @@ class BatchTestContextCustomizerTests {
 		// given
 		SpringProperties.setProperty("spring.aot.enabled", "true");
 		ConfigurableApplicationContext context = new GenericApplicationContext();
-		MergedContextConfiguration mergedConfig = Mockito.mock(MergedContextConfiguration.class);
+		MergedContextConfiguration mergedConfig = Mockito.mock();
 
 		// when
 		this.contextCustomizer.customizeContext(context, mergedConfig);


### PR DESCRIPTION
Just replace `mock(Class<T> classToMock)` with `mock()`.
Make code more clean.
All tests passed.