### PR TITLE
Fix image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align="right" src="spring-batch-docs/src/main/asciidoc/images/spring-batch.png" width="200" height="200">
+<img align="right" src="spring-batch-docs/modules/ROOT/assets/images/spring-batch.png" width="200" height="200">
 
 # Spring Batch [![build status](https://github.com/spring-projects/spring-batch/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/spring-projects/spring-batch/actions/workflows/continuous-integration.yml)
 


### PR DESCRIPTION
Image link in `README.md` is broken.

<img width="982" alt="Screen Shot 2023-09-10 at 3 28 27" src="https://github.com/spring-projects/spring-batch/assets/24649991/02846b92-b9d8-4780-aa42-f80096356d39">

It seems moved in https://github.com/spring-projects/spring-batch/pull/4422.