### PR TITLE
Upgrade Avro to 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<spring-ldap.version>3.2.0-SNAPSHOT</spring-ldap.version>
 
 		<jackson.version>2.15.2</jackson.version>
-		<avro.version>1.9.2</avro.version> <!-- FIXME build failure with version 1.11.2 -->
+		<avro.version>1.11.2</avro.version>
 		<gson.version>2.10.1</gson.version>
 		<hibernate-core.version>6.2.8.Final</hibernate-core.version>
 		<jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>

--- a/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/avro/plain-old-user-data-no-schema.avro
+++ b/spring-batch-infrastructure/src/test/resources/org/springframework/batch/item/avro/plain-old-user-data-no-schema.avro
@@ -1,3 +1,3 @@
-
-David(blueSuered
-AlanayellowJoepink
+blue(
+DavidredSueyellow
+AlanapinkJoe


### PR DESCRIPTION
The PR upgrades Avro to 1.11.2, which currently is the latest release.

In Avro 1.10, there has been a change in how schemas are reflectively determined from POJOs ([AVRO-3138](https://issues.apache.org/jira/browse/AVRO-3138)). This required the file `plain-old-user-data-no-schema.avro` to be re-generated with `AvroTestFixtures::createPlainOldUsersWithNoEmbeddedSchema`.