### PR TITLE
Replace deprecated `RetryListenerSupport`

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleRetryExceptionHandler.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/SimpleRetryExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import org.springframework.batch.repeat.support.RepeatSynchronizationManager;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.RetryPolicy;
-import org.springframework.retry.listener.RetryListenerSupport;
 
 import java.util.Collection;
 
@@ -36,7 +36,7 @@ import java.util.Collection;
  * @author Dave Syer
  *
  */
-public class SimpleRetryExceptionHandler extends RetryListenerSupport implements ExceptionHandler {
+public class SimpleRetryExceptionHandler implements RetryListener, ExceptionHandler {
 
 	/**
 	 * Attribute key, whose existence signals an exhausted retry.

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/ChunkElementParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/ChunkElementParserTests.java
@@ -41,7 +41,6 @@ import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.retry.RetryListener;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.StringUtils;
@@ -228,7 +227,7 @@ class ChunkElementParserTests {
 		boolean g = false;
 		boolean h = false;
 		for (RetryListener o : retryListeners) {
-			if (o instanceof RetryListenerSupport) {
+			if (o instanceof SecondDummyRetryListener) {
 				g = true;
 			}
 			else if (o instanceof DummyRetryListener) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/SecondDummyRetryListener.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/SecondDummyRetryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2023 the original author or authors.
+ * Copyright 2023-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,8 @@
  */
 package org.springframework.batch.core.configuration.xml;
 
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
 
-/**
- * @author Dan Garrette
- * @since 2.0
- */
-public class DummyRetryListener implements RetryListener {
-
-	@Override
-	public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
-		return false;
-	}
+public class SecondDummyRetryListener implements RetryListener {
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBeanTests.java
@@ -43,7 +43,7 @@ import org.springframework.batch.repeat.support.TaskExecutorRepeatTemplate;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.retry.listener.RetryListenerSupport;
+import org.springframework.retry.RetryListener;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
@@ -182,7 +182,8 @@ class StepParserStepFactoryBeanTests {
 		fb.setIsReaderTransactionalQueue(true);
 		fb.setRetryLimit(5);
 		fb.setSkipLimit(100);
-		fb.setRetryListeners(new RetryListenerSupport());
+		fb.setRetryListeners(new RetryListener() {
+		});
 		fb.setSkippableExceptionClasses(new HashMap<>());
 		fb.setRetryableExceptionClasses(new HashMap<>());
 		fb.setHasChunkElement(true);
@@ -239,7 +240,8 @@ class StepParserStepFactoryBeanTests {
 		fb.setRetryLimit(5);
 		fb.setSkipLimit(100);
 		fb.setThrottleLimit(10);
-		fb.setRetryListeners(new RetryListenerSupport());
+		fb.setRetryListeners(new RetryListener() {
+		});
 		@SuppressWarnings("unchecked")
 		Map<Class<? extends Throwable>, Boolean> exceptionMap = getExceptionMap(Exception.class);
 		fb.setSkippableExceptionClasses(exceptionMap);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepParserTests.java
@@ -53,7 +53,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.retry.RetryListener;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -433,7 +432,7 @@ public class StepParserTests {
 		retryable.put(FatalSkippableException.class, true);
 		retryable.put(ForceRollbackForWriteSkipException.class, true);
 		List<Class<? extends ItemStream>> streams = Arrays.asList(CompositeItemStream.class, TestReader.class);
-		List<Class<? extends RetryListener>> retryListeners = Arrays.asList(RetryListenerSupport.class,
+		List<Class<? extends RetryListener>> retryListeners = Arrays.asList(SecondDummyRetryListener.class,
 				DummyRetryListener.class);
 		List<Class<? extends StepExecutionListener>> stepListeners = Arrays.asList(DummyStepExecutionListener.class,
 				CompositeStepExecutionListener.class);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/TestRetryListener.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/TestRetryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2012 the original author or authors.
+ * Copyright 2008-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,6 @@ import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
 
 public class TestRetryListener extends AbstractTestComponent implements RetryListener {
-
-	@Override
-	public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
-			Throwable throwable) {
-	}
-
-	@Override
-	public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
-			Throwable throwable) {
-	}
 
 	@Override
 	public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/ChunkElementParentAttributeParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/ChunkElementParentAttributeParserTests-context.xml
@@ -101,7 +101,7 @@
 					</streams>
 					<retry-listeners>
 						<listener>
-							<beans:bean class="org.springframework.retry.listener.RetryListenerSupport"/>
+							<beans:bean class="org.springframework.batch.core.configuration.xml.SecondDummyRetryListener"/>
 						</listener>
 					</retry-listeners>
 				</chunk>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserParentAttributeTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserParentAttributeTests-context.xml
@@ -162,7 +162,7 @@
 				</streams>
 				<retry-listeners>
 					<listener>
-						<beans:bean class="org.springframework.retry.listener.RetryListenerSupport"/>
+						<beans:bean class="org.springframework.batch.core.configuration.xml.SecondDummyRetryListener"/>
 					</listener>
 				</retry-listeners>
 			</chunk>


### PR DESCRIPTION
The PR replaces Spring Retry's deprecated `RetryListenerSupport` with the interface `RetryListener` or with the new test class `SecondDummyRetryListener`, where tests depend on a bean that is different from `DummyRetryListener`.