### PR TITLE
Take care of some deprecations

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchRegistrar.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchRegistrar.java
@@ -68,7 +68,7 @@ class BatchRegistrar implements ImportBeanDefinitionRegistrar {
 		registerAutomaticJobRegistrar(registry, batchAnnotation);
 		watch.stop();
 		LOGGER.info(LogMessage.format("Finished Spring Batch infrastructure beans configuration in %s ms.",
-				watch.getLastTaskTimeMillis()));
+				watch.lastTaskInfo().getTimeMillis()));
 	}
 
 	private void validateState(AnnotationMetadata importingClassMetadata) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SystemExiter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SystemExiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@ public interface SystemExiter {
 	/**
 	 * Terminate the currently running Java Virtual Machine.
 	 * @param status exit status.
-	 * @throws SecurityException if a security manager exists and its
-	 * <code>checkExit</code> method doesn't allow exit with the specified status.
 	 * @see System#exit(int)
 	 */
 	void exit(int status);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/CommandRunner.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/CommandRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@ public interface CommandRunner {
 	 * @param dir the working directory of the subprocess, or {@code null} if the
 	 * subprocess should inherit the working directory of the current process.
 	 * @return A new {@link Process} object for managing the subprocess
-	 * @throws SecurityException If a security manager exists and its
-	 * {@link SecurityManager#checkExec checkExec} method doesn't allow creation of the
-	 * subprocess
 	 * @throws IOException If an I/O error occurs
 	 * @throws NullPointerException If {@code command} is {@code null}, or one of the
 	 * elements of {@code envp} is {@code null}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepWithFaultTolerantProcessTaskJobParserTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/StepWithFaultTolerantProcessTaskJobParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.retry.RetryListener;
-import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Isolation;
@@ -90,7 +90,7 @@ class StepWithFaultTolerantProcessTaskJobParserTests {
 		Object txq = ReflectionTestUtils.getField(factory, "readerTransactionalQueue");
 		assertEquals(true, txq, "wrong reader-transactional-queue:");
 		Object te = ReflectionTestUtils.getField(factory, "taskExecutor");
-		assertEquals(ConcurrentTaskExecutor.class, te.getClass(), "wrong task-executor:");
+		assertEquals(SyncTaskExecutor.class, te.getClass(), "wrong task-executor:");
 		Object listeners = ReflectionTestUtils.getField(factory, "stepExecutionListeners");
 		assertEquals(2, ((Set<StepExecutionListener>) listeners).size(), "wrong number of listeners:");
 		Object retryListeners = ReflectionTestUtils.getField(factory, "retryListeners");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -181,7 +181,7 @@ class FlowJobBuilderTests {
 		FlowBuilder.SplitBuilder<SimpleFlow> splitBuilder = flowBuilder.split(taskExecutor);
 		splitBuilder.add(new FlowBuilder<Flow>("subflow1").from(step1).end());
 		splitBuilder.add(new FlowBuilder<Flow>("subflow2").from(step2).end());
-		Job job = new JobBuilder("job").repository(jobRepository).start(flowBuilder.build()).end().build();
+		Job job = new JobBuilder("job", jobRepository).start(flowBuilder.build()).end().build();
 		job.execute(execution);
 
 		assertEquals(BatchStatus.COMPLETED, execution.getStatus());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.ItemReadListener;
 import org.springframework.batch.core.JobParameters;
@@ -42,7 +43,6 @@ import org.springframework.batch.core.annotation.BeforeWrite;
 import org.springframework.batch.core.configuration.xml.DummyItemReader;
 import org.springframework.batch.core.configuration.xml.DummyItemWriter;
 import org.springframework.batch.core.job.SimpleJob;
-import org.springframework.batch.core.listener.ChunkListenerSupport;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.item.ItemReader;
@@ -237,7 +237,7 @@ class StepBuilderTests {
 
 	@Test
 	void testReturnedTypeOfChunkListenerIsAssignableToSimpleStepBuilder() throws Exception {
-		testReturnedTypeOfSetterIsAssignableToSimpleStepBuilder(builder -> builder.listener(new ChunkListenerSupport() {
+		testReturnedTypeOfSetterIsAssignableToSimpleStepBuilder(builder -> builder.listener(new ChunkListener() {
 		}));
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanTests.java
@@ -62,11 +62,11 @@ import org.springframework.batch.item.WriteFailedException;
 import org.springframework.batch.item.WriterNotOpenException;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.lang.Nullable;
-import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.StringUtils;
 
@@ -870,7 +870,7 @@ public class FaultTolerantStepFactoryBeanTests {
 		};
 
 		factory.setItemReader(reader);
-		factory.setTaskExecutor(new ConcurrentTaskExecutor());
+		factory.setTaskExecutor(new SyncTaskExecutor());
 
 		Step step = factory.getObject();
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserBadRetryListenerTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserBadRetryListenerTests-context.xml
@@ -44,6 +44,6 @@
 
 	<beans:bean id="retryListener" class="org.springframework.batch.core.configuration.xml.TestRetryListener" />
 
-	<beans:bean id="taskExecutor" class="org.springframework.scheduling.concurrent.ConcurrentTaskExecutor" />
+	<beans:bean id="taskExecutor" class="org.springframework.core.task.SyncTaskExecutor" />
 
 </beans:beans>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserTaskletAttributesTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepParserTaskletAttributesTests-context.xml
@@ -47,7 +47,7 @@
 
 	<beans:bean id="listener" class="org.springframework.batch.core.configuration.xml.TestListener" />
 
-	<beans:bean id="taskExecutor" class="org.springframework.scheduling.concurrent.ConcurrentTaskExecutor" />
+	<beans:bean id="taskExecutor" class="org.springframework.core.task.SyncTaskExecutor" />
 
 	<job-repository id="jobRepository" table-prefix="BATCH_"/>
 

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepWithFaultTolerantProcessTaskJobParserTests-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/xml/StepWithFaultTolerantProcessTaskJobParserTests-context.xml
@@ -53,6 +53,6 @@
 
 	<beans:bean id="retryListener" class="org.springframework.batch.core.configuration.xml.TestRetryListener" />
 
-	<beans:bean id="taskExecutor" class="org.springframework.scheduling.concurrent.ConcurrentTaskExecutor" />
+	<beans:bean id="taskExecutor" class="org.springframework.core.task.SyncTaskExecutor" />
 
 </beans:beans>


### PR DESCRIPTION
The PR takes care of some deprecations. In particular,

- it removes references to the Security Manager,
- it replaces a method of Spring Framework's `StopWatch` that will be deprecated with 6.1,
- it replaces Spring Framework's `ConcurrentTaskExecutor` whose zero-arguments constructor will be deprecated with 6.1