### PR TITLE
#4458 - Make DefaultJobParametersExtractor copy missing ExecutionContext keys from JobParameters

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/job/DefaultJobParametersExtractor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/job/DefaultJobParametersExtractor.java
@@ -78,6 +78,8 @@ public class DefaultJobParametersExtractor implements JobParametersExtractor {
 		for (String key : keys) {
 			if (executionContext.containsKey(key)) {
 				properties.setProperty(key, executionContext.getString(key));
+			} else if (jobParameters.containsKey(key)) {
+				builder.addJobParameter(key, jobParameters.get(key));
 			}
 		}
 		builder.addJobParameters(this.jobParametersConverter.getJobParameters(properties));


### PR DESCRIPTION
Fix DefaultJobParametersExtractor to copy values from JobParameters when they are missing from ExecutionContext. Javadoc states this class is supposed to do just that, but seems to have broken in the 5.x API revamp.

Fixes #4458 