### PR TITLE
When adding steps to the “Flow” via “next”, the task no longer goes into loop execution

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
@@ -250,10 +250,12 @@ public class FlowBuilder<Q> {
 		if (this.currentState == null) {
 			doStart(input);
 		}
-		State next = createState(input);
-		addTransition("COMPLETED", next);
-		addTransition("*", failedState);
-		this.currentState = next;
+		else {
+			State next = createState(input);
+			addTransition("COMPLETED", next);
+			addTransition("*", failedState);
+			this.currentState = next;
+		}
 	}
 
 	private void doStart(Object input) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -144,6 +144,15 @@ class FlowJobBuilderTests {
 	}
 
 	@Test
+	void testBuildSingleFlowAddingStepsViaNext() {
+		Flow flow = new FlowBuilder<Flow>("subflow").next(step1).next(step2).build();
+		FlowJobBuilder builder = new JobBuilder("flow", jobRepository).start(flow).end().preventRestart();
+		builder.build().execute(execution);
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(2, execution.getStepExecutions().size());
+	}
+
+	@Test
 	void testBuildOverTwoLines() {
 		FlowJobBuilder builder = new JobBuilder("flow", jobRepository).start(step1).on("COMPLETED").to(step2).end();
 		builder.preventRestart();


### PR DESCRIPTION
When adding steps to the “Flow” via “next”, the task no longer goes into loop execution
 
Fixes spring-projects/spring-batch#4432

The project is completed build. All tests were completed successful
