### PR TITLE
Revise the documentation to correct misleading information regarding the ItemWriteListener

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/intercepting-execution.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/intercepting-execution.adoc
@@ -207,9 +207,11 @@ public interface ItemWriteListener<S> extends StepListener {
 ----
 
 The `beforeWrite` method is called before `write` on the `ItemWriter` and is handed the
-list of items that is written. The `afterWrite` method is called after the item has been
-successfully written. If there was an error while writing, the `onWriteError` method is
-called. The exception encountered and the item that was attempted to be written are
+list of items that is written.
+The `afterWrite` method is called after the items have been successfully written, but it
+occurs before the commitment of the transaction associated with the chunk's processing.
+If there was an error while writing, the `onWriteError` method is called.
+The exception encountered and the item that was attempted to be written are
 provided, so that they can be logged.
 
 The annotations corresponding to this interface are:


### PR DESCRIPTION
The change satisfies the request made in #4400.

As issue recommended, `beforeWrite`, `write` process, `afterWrite` is executed in same transaction.