### PR TITLE
Support full regular expression on `PatterMatcher.match()`

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/PatternMatcher.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/PatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.springframework.util.Assert;
 
@@ -26,6 +27,7 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @author Dan Garrette
  * @author Marten Deinum
+ * @author Injae Kim
  */
 public class PatternMatcher<S> {
 
@@ -181,6 +183,19 @@ public class PatternMatcher<S> {
 	}
 
 	/**
+	 * Tests whether or not a string matches against a regular expression.
+	 * @param regex regular expression to match against. Must not be {@code null}.
+	 * @param str string which must be matched against the regular expression. Must not be {@code null}.
+	 * @return {@code true} if the string matches against the regular expression, or {@code false} otherwise.
+	 */
+	public static boolean matchRegex(String regex, String str) {
+		Assert.notNull(regex, "Regex must not be null");
+		Assert.notNull(str, "Str must not be null");
+
+		return Pattern.matches(regex, str);
+	}
+
+	/**
 	 * <p>
 	 * This method takes a String key and a map from Strings to values of any type. During
 	 * processing, the method will identify the most specific key in the map that matches
@@ -202,9 +217,20 @@ public class PatternMatcher<S> {
 		Assert.notNull(line, "A non-null key must be provided to match against.");
 
 		for (String key : sorted) {
-			if (PatternMatcher.match(key, line)) {
+			if (match(key, line)) {
 				value = map.get(key);
 				break;
+			}
+		}
+
+		if (value == null) {
+			for (String key : sorted) {
+				try {
+					if (matchRegex(key, line)) {
+						value = map.get(key);
+						break;
+					}
+				} catch (Throwable ignored) {}
 			}
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PatternMatcherTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/PatternMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Dan Garrette
+ * @author Injae Kim
  * @since 2.0
  */
 class PatternMatcherTests {
@@ -37,6 +39,7 @@ class PatternMatcherTests {
 		map.put("an*", 3);
 		map.put("a*", 2);
 		map.put("big*", 4);
+		map.put("bcd.*", 5);
 	}
 
 	private static final Map<String, Integer> defaultMap = new HashMap<>();
@@ -47,6 +50,15 @@ class PatternMatcherTests {
 		defaultMap.put("big*", 4);
 		defaultMap.put("big?*", 5);
 		defaultMap.put("*", 1);
+	}
+
+	private static final Map<String, Integer> regexMap = new HashMap<>();
+
+	static {
+		regexMap.put("abc.*", 1);
+		regexMap.put("a...e", 2);
+		regexMap.put("123.[0-9][0-9]\\d", 3);
+		regexMap.put("*............", 100); // invalid regex format
 	}
 
 	@Test
@@ -105,6 +117,29 @@ class PatternMatcherTests {
 	}
 
 	@Test
+	void testMatchRegex() {
+		assertTrue(PatternMatcher.matchRegex("abc.*", "abcde"));
+	}
+
+	@Test
+	void testMatchRegex_notMatched() {
+		assertFalse(PatternMatcher.matchRegex("abc.*", "cdefg"));
+		assertFalse(PatternMatcher.matchRegex("abc.", "abcde"));
+	}
+
+	@Test
+	void testMatchRegex_thrown_invalidRegexFormat() {
+		assertThrows(PatternSyntaxException.class, () -> PatternMatcher.matchRegex("*..", "abc"));
+	}
+
+	@Test
+	void testMatchRegex_thrown_notNullParam() {
+		assertThrows(IllegalArgumentException.class, () -> PatternMatcher.matchRegex("regex", null));
+		assertThrows(IllegalArgumentException.class, () -> PatternMatcher.matchRegex(null, "str"));
+	}
+
+
+	@Test
 	void testMatchPrefixSubsumed() {
 		assertEquals(2, new PatternMatcher<>(map).match("apple").intValue());
 	}
@@ -117,6 +152,11 @@ class PatternMatcherTests {
 	@Test
 	void testMatchPrefixUnrelated() {
 		assertEquals(4, new PatternMatcher<>(map).match("biggest").intValue());
+	}
+
+	@Test
+	void testMatchByRegex() {
+		assertEquals(5, new PatternMatcher<>(map).match("bcdef12345").intValue());
 	}
 
 	@Test
@@ -138,6 +178,26 @@ class PatternMatcherTests {
 	@Test
 	void testMatchPrefixDefaultValueNoMatch() {
 		assertEquals(1, new PatternMatcher<>(defaultMap).match("bat").intValue());
+	}
+
+	@Test
+	void testMatchRegexPrefix() {
+		assertEquals(1, new PatternMatcher<>(regexMap).match("abcdefg").intValue());
+	}
+
+	@Test
+	void testMatchRegexWildCards() {
+		assertEquals(2, new PatternMatcher<>(regexMap).match("a123e").intValue());
+	}
+
+	@Test
+	void testMatchRegexDigits() {
+		assertEquals(3, new PatternMatcher<>(regexMap).match("123-789").intValue());
+	}
+
+	@Test
+	void testMatchRegexNotMatched() {
+		assertThrows(IllegalStateException.class, () -> new PatternMatcher<>(regexMap).match("Hello world!"));
 	}
 
 }


### PR DESCRIPTION
related issue #4412

### Motivation:
- On #4412, we found that `PatternMatchingCompositeLineMapper` doesn't support regular expression matching
  - It only supports `AntPathMatcher` style matching now

### Modification:
- Support full regular expression on `PatterMatcher.match()` that used on `PatternMatchingCompositeLineMapper.mapLine()`

### Result:
- Now user can use full regular expression matching on `PatternMatchingCompositeLineMapper.mapLine()`
- Close #4412 issue