### PR TITLE
Deprecate overrides of `StepBuilderHelper#repository` for removal

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilder.java
@@ -227,7 +227,16 @@ public class RemoteChunkingManagerStepBuilder<I, O> extends FaultTolerantStepBui
 		return this;
 	}
 
+	/**
+	 * Set the job repository
+	 * @param jobRepository the repository to set
+	 * @return this to enable fluent chaining
+	 * @deprecated use
+	 * {@link RemoteChunkingManagerStepBuilder#RemoteChunkingManagerStepBuilder(String, JobRepository)}
+	 */
 	@Override
+	@SuppressWarnings("removal")
+	@Deprecated(since = "5.1", forRemoval = true)
 	public RemoteChunkingManagerStepBuilder<I, O> repository(JobRepository jobRepository) {
 		super.repository(jobRepository);
 		return this;

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilder.java
@@ -242,7 +242,16 @@ public class RemotePartitioningManagerStepBuilder extends PartitionStepBuilder {
 		return this.inputChannel == null;
 	}
 
+	/**
+	 * Set the job repository
+	 * @param jobRepository the repository to set
+	 * @return this to enable fluent chaining
+	 * @deprecated use
+	 * {@link RemotePartitioningManagerStepBuilder#RemotePartitioningManagerStepBuilder(String, JobRepository)}
+	 */
 	@Override
+	@SuppressWarnings("removal")
+	@Deprecated(since = "5.1", forRemoval = true)
 	public RemotePartitioningManagerStepBuilder repository(JobRepository jobRepository) {
 		super.repository(jobRepository);
 		return this;

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningWorkerStepBuilder.java
@@ -157,7 +157,16 @@ public class RemotePartitioningWorkerStepBuilder extends StepBuilder {
 		return this;
 	}
 
+	/**
+	 * Set the job repository
+	 * @param jobRepository the repository to set
+	 * @return this to enable fluent chaining
+	 * @deprecated use
+	 * {@link RemotePartitioningWorkerStepBuilder#RemotePartitioningWorkerStepBuilder(String, JobRepository)}
+	 */
 	@Override
+	@SuppressWarnings("removal")
+	@Deprecated(since = "5.1", forRemoval = true)
 	public RemotePartitioningWorkerStepBuilder repository(JobRepository jobRepository) {
 		super.repository(jobRepository);
 		return this;

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilderTests.java
@@ -190,7 +190,6 @@ class RemoteChunkingManagerStepBuilderTests {
 					.reader(this.itemReader)
 					.writer(items -> {
 					})
-					.repository(this.jobRepository)
 					.transactionManager(this.transactionManager)
 					.inputChannel(this.inputChannel)
 					.outputChannel(this.outputChannel)


### PR DESCRIPTION
This is a follow-up on #4326. It deprecates also the overrides of `StepBuilderHelper#repository`.

The deprecation does not seem to be inherited by the overrides. At least my IDE does not highlight their use without explicit deprecations.