### PR TITLE
Check dirty flag of step execution context before update in inner loop

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -430,7 +430,9 @@ public class TaskletStep extends AbstractStep {
 				try {
 					// Going to attempt a commit. If it fails this flag will
 					// stay false and we can use that later.
-					getJobRepository().updateExecutionContext(stepExecution);
+					if (stepExecution.getExecutionContext().isDirty()) {
+						getJobRepository().updateExecutionContext(stepExecution);
+					}
 					stepExecution.incrementCommitCount();
 					if (logger.isDebugEnabled()) {
 						logger.debug("Saving step execution before commit: " + stepExecution);


### PR DESCRIPTION
The class `TaskletStep.ChunkTransactionCallback` persists updates of the `StepExecution` after each chunk. The update of the step execution context happens in a dedicated method, which is currently called independent of whether the step execution context has actually changed. As `ExecutionContext` provides a dirty flag, it can be checked before the update method is called.

The proposed change is a performance optimization for simple chunk-oriented steps that e.g. do not save state in between chunks. For such steps, the change results in one database round trip less per chunk.