### PR TITLE
Use annotation `@Override` consistently

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
@@ -187,11 +187,6 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 		return 7;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return String.format("exitCode=%s;exitDescription=%s", exitCode, exitDescription);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobExecution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobExecution.java
@@ -373,11 +373,6 @@ public class JobExecution extends Entity {
 		failureExceptions = new ArrayList<>();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.Entity#toString()
-	 */
 	@Override
 	public String toString() {
 		return super.toString() + String.format(

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/StepContribution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/StepContribution.java
@@ -194,11 +194,6 @@ public class StepContribution implements Serializable {
 		return stepExecution;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return "[StepContribution: read=" + readCount + ", written=" + writeCount + ", filtered=" + filterCount

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/StepExecution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/StepExecution.java
@@ -484,12 +484,6 @@ public class StepExecution extends Entity {
 		this.failureExceptions.add(throwable);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.container.common.domain.Entity#equals(java.
-	 * lang.Object)
-	 */
 	@Override
 	public boolean equals(Object obj) {
 
@@ -513,11 +507,6 @@ public class StepExecution extends Entity {
 		failureExceptions = new ArrayList<>();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.container.common.domain.Entity#hashCode()
-	 */
 	@Override
 	public int hashCode() {
 		Object jobExecutionId = getJobExecutionId();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GroupAwareJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GroupAwareJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,11 +97,6 @@ public class GroupAwareJob implements Job {
 		return delegate.getJobParametersValidator();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof GroupAwareJob) {
@@ -110,11 +105,6 @@ public class GroupAwareJob implements Job {
 		return false;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#hashCode()
-	 */
 	@Override
 	public int hashCode() {
 		return delegate.hashCode();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistryBeanPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistryBeanPostProcessor.java
@@ -79,12 +79,6 @@ public class JobRegistryBeanPostProcessor
 		this.jobRegistry = jobRegistry;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org
-	 * .springframework.beans.factory.BeanFactory)
-	 */
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		if (beanFactory instanceof DefaultListableBeanFactory) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
@@ -141,11 +141,6 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 		this.jobFactoryRef = jobFactoryRef;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see AbstractSingleBeanDefinitionParser#getBeanClass(Element)
-	 */
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return SimpleFlowFactoryBean.class;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
@@ -102,11 +102,6 @@ public class SimpleFlowFactoryBean implements FactoryBean<SimpleFlow>, Initializ
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.FactoryBean#getObject()
-	 */
 	@Override
 	public SimpleFlow getObject() throws Exception {
 		SimpleFlow flow = flowType.getConstructor(String.class).newInstance(name);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/SimpleJobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/support/SimpleJobExplorer.java
@@ -80,12 +80,6 @@ public class SimpleJobExplorer implements JobExplorer {
 		this.ecDao = ecDao;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#findJobExecutions(
-	 * org.springframework.batch.core.JobInstance)
-	 */
 	@Override
 	public List<JobExecution> getJobExecutions(JobInstance jobInstance) {
 		List<JobExecution> executions = jobExecutionDao.findJobExecutions(jobInstance);
@@ -98,13 +92,8 @@ public class SimpleJobExplorer implements JobExplorer {
 		return executions;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getLastJobExecution(
-	 * org.springframework.batch.core.JobInstance)
-	 */
 	@Nullable
+	@Override
 	public JobExecution getLastJobExecution(JobInstance jobInstance) {
 		JobExecution lastJobExecution = jobExecutionDao.getLastJobExecution(jobInstance);
 		if (lastJobExecution != null) {
@@ -116,12 +105,6 @@ public class SimpleJobExplorer implements JobExplorer {
 		return lastJobExecution;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#findRunningJobExecutions
-	 * (java.lang.String)
-	 */
 	@Override
 	public Set<JobExecution> findRunningJobExecutions(@Nullable String jobName) {
 		Set<JobExecution> executions = jobExecutionDao.findRunningJobExecutions(jobName);
@@ -134,12 +117,6 @@ public class SimpleJobExplorer implements JobExplorer {
 		return executions;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getJobExecution(java
-	 * .lang.Long)
-	 */
 	@Nullable
 	@Override
 	public JobExecution getJobExecution(@Nullable Long executionId) {
@@ -157,12 +134,6 @@ public class SimpleJobExplorer implements JobExplorer {
 		return jobExecution;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getStepExecution(java
-	 * .lang.Long)
-	 */
 	@Nullable
 	@Override
 	public StepExecution getStepExecution(@Nullable Long jobExecutionId, @Nullable Long executionId) {
@@ -176,70 +147,34 @@ public class SimpleJobExplorer implements JobExplorer {
 		return stepExecution;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getJobInstance(java
-	 * .lang.Long)
-	 */
 	@Nullable
 	@Override
 	public JobInstance getJobInstance(@Nullable Long instanceId) {
 		return jobInstanceDao.getJobInstance(instanceId);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getJobInstance(java
-	 * .lang.String, org.springframework.batch.core.JobParameters)
-	 */
 	@Nullable
 	@Override
 	public JobInstance getJobInstance(String jobName, JobParameters jobParameters) {
 		return jobInstanceDao.getJobInstance(jobName, jobParameters);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getLastJobInstance(java
-	 * .lang.String)
-	 */
 	@Nullable
 	@Override
 	public JobInstance getLastJobInstance(String jobName) {
 		return jobInstanceDao.getLastJobInstance(jobName);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getLastJobInstances
-	 * (java.lang.String, int)
-	 */
 	@Override
 	public List<JobInstance> getJobInstances(String jobName, int start, int count) {
 		return jobInstanceDao.getJobInstances(jobName, start, count);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.explore.JobExplorer#getJobNames()
-	 */
 	@Override
 	public List<String> getJobNames() {
 		return jobInstanceDao.getJobNames();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.explore.JobExplorer#getJobInstanceCount(java.lang.
-	 * String)
-	 */
 	@Override
 	public long getJobInstanceCount(@Nullable String jobName) throws NoSuchJobException {
 		return jobInstanceDao.getJobInstanceCount(jobName);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -158,11 +158,6 @@ public abstract class AbstractJob implements Job, StepLocator, BeanNameAware, In
 		this.name = name;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#getName()
-	 */
 	@Override
 	public String getName() {
 		return name;
@@ -214,11 +209,6 @@ public abstract class AbstractJob implements Job, StepLocator, BeanNameAware, In
 		this.jobParametersIncrementer = jobParametersIncrementer;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Job#getJobParametersIncrementer()
-	 */
 	@Override
 	@Nullable
 	public JobParametersIncrementer getJobParametersIncrementer() {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
@@ -94,11 +94,6 @@ public class SimpleJob extends AbstractJob {
 		this.steps.add(step);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.job.AbstractJob#getStep(java.lang.String)
-	 */
 	@Override
 	public Step getStep(String stepName) {
 		for (Step step : this.steps) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/DefaultStateTransitionComparator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/DefaultStateTransitionComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,6 @@ public class DefaultStateTransitionComparator implements Comparator<StateTransit
 
 	public static final String STATE_TRANSITION_COMPARATOR = "batch_state_transition_comparator";
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-	 */
 	@Override
 	public int compare(StateTransition arg0, StateTransition arg1) {
 		String value = arg1.getPattern();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/StateTransition.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/StateTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,11 +159,6 @@ public final class StateTransition {
 		return next == null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return String.format("StateTransition: [state=%s, pattern=%s, next=%s]", state == null ? null : state.getName(),

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/AbstractState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/AbstractState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,6 @@ public abstract class AbstractState implements State {
 		return name;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return getClass().getSimpleName() + ": name=[" + name + "]";

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/DecisionState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/DecisionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,11 +45,6 @@ public class DecisionState extends AbstractState {
 		return decider.decide(executor.getJobExecution(), executor.getStepExecution());
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.job.flow.State#isEndState()
-	 */
 	@Override
 	public boolean isEndState() {
 		return false;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/EndState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/EndState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,21 +137,11 @@ public class EndState extends AbstractState {
 		executor.addExitStatus(code);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.job.flow.State#isEndState()
-	 */
 	@Override
 	public boolean isEndState() {
 		return !status.isStop();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return super.toString() + " status=[" + status + "]";

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/FlowState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/FlowState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,6 @@ public class FlowState extends AbstractState implements FlowHolder {
 		return flow.start(executor).getStatus();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.job.flow.State#isEndState()
-	 */
 	@Override
 	public boolean isEndState() {
 		return false;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/SplitState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/SplitState.java
@@ -148,11 +148,6 @@ public class SplitState extends AbstractState implements FlowHolder {
 		return aggregator.aggregate(results);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.job.flow.State#isEndState()
-	 */
 	@Override
 	public boolean isEndState() {
 		return false;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/StepState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/StepState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,21 +73,11 @@ public class StepState extends AbstractState implements StepLocator, StepHolder 
 		return step;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.job.flow.State#isEndState()
-	 */
 	@Override
 	public boolean isEndState() {
 		return false;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.step.StepLocator#getStepNames()
-	 */
 	@Override
 	public Collection<String> getStepNames() {
 		List<String> names = new ArrayList<>();
@@ -101,11 +91,6 @@ public class StepState extends AbstractState implements StepLocator, StepHolder 
 		return names;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.step.StepLocator#getStep(java.lang.String)
-	 */
 	@Override
 	public Step getStep(String stepName) throws NoSuchStepException {
 		Step result = null;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/RuntimeExceptionTranslator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/RuntimeExceptionTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,6 @@ import org.aopalliance.intercept.MethodInvocation;
  */
 public class RuntimeExceptionTranslator implements MethodInterceptor {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.aopalliance.intercept.MethodInterceptor#invoke(org.aopalliance.intercept.
-	 * MethodInvocation)
-	 */
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
 		try {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -152,12 +152,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		this.jobLauncher = jobLauncher;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.launch.JobOperator#getExecutions(java.lang.Long)
-	 */
 	@Override
 	public List<Long> getExecutions(long instanceId) throws NoSuchJobInstanceException {
 		JobInstance jobInstance = jobExplorer.getJobInstance(instanceId);
@@ -171,21 +165,11 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		return list;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#getJobNames()
-	 */
 	@Override
 	public Set<String> getJobNames() {
 		return new TreeSet<>(jobRegistry.getJobNames());
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see JobOperator#getLastInstances(String, int, int)
-	 */
 	@Override
 	public List<Long> getJobInstances(String jobName, int start, int count) throws NoSuchJobException {
 		List<Long> list = new ArrayList<>();
@@ -199,23 +183,12 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		return list;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#getJobInstance(String,
-	 * JobParameters)
-	 */
+	@Override
 	@Nullable
 	public JobInstance getJobInstance(String jobName, JobParameters jobParameters) {
 		return this.jobExplorer.getJobInstance(jobName, jobParameters);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#getParameters(java.
-	 * lang.Long)
-	 */
 	@Override
 	public String getParameters(long executionId) throws NoSuchJobExecutionException {
 		JobExecution jobExecution = findExecutionById(executionId);
@@ -225,12 +198,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		return PropertiesConverter.propertiesToString(properties);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#getRunningExecutions
-	 * (java.lang.String)
-	 */
 	@Override
 	public Set<Long> getRunningExecutions(String jobName) throws NoSuchJobException {
 		Set<Long> set = new LinkedHashSet<>();
@@ -243,12 +210,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		return set;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#getStepExecutionSummaries
-	 * (java.lang.Long)
-	 */
 	@Override
 	public Map<Long, String> getStepExecutionSummaries(long executionId) throws NoSuchJobExecutionException {
 		JobExecution jobExecution = findExecutionById(executionId);
@@ -260,22 +221,12 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		return map;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#getSummary(java.lang .Long)
-	 */
 	@Override
 	public String getSummary(long executionId) throws NoSuchJobExecutionException {
 		JobExecution jobExecution = findExecutionById(executionId);
 		return jobExecution.toString();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#resume(java.lang.Long)
-	 */
 	@Override
 	public Long restart(long executionId) throws JobInstanceAlreadyCompleteException, NoSuchJobExecutionException,
 			NoSuchJobException, JobRestartException, JobParametersInvalidException {
@@ -302,12 +253,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#start(java.lang.String,
-	 * java.lang.String)
-	 */
 	@Override
 	@Deprecated(since = "5.0.1", forRemoval = true)
 	public Long start(String jobName, String parameters)
@@ -316,12 +261,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 		return start(jobName, properties);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#start(java.lang.String,
-	 * java.util.Properties)
-	 */
 	@Override
 	public Long start(String jobName, Properties parameters)
 			throws NoSuchJobException, JobInstanceAlreadyExistsException, JobParametersInvalidException {
@@ -360,11 +299,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see JobOperator#startNextInstance(String )
-	 */
 	@Override
 	public Long startNextInstance(String jobName)
 			throws NoSuchJobException, UnexpectedJobExecutionException, JobParametersInvalidException {
@@ -395,11 +329,6 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.launch.JobOperator#stop(java.lang.Long)
-	 */
 	@Override
 	public boolean stop(long executionId) throws NoSuchJobExecutionException, JobExecutionNotRunningException {
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/ChunkListenerSupport.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/ChunkListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,31 +28,15 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 @Deprecated
 public class ChunkListenerSupport implements ChunkListener {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.ChunkListener#afterChunk()
-	 */
 	@Override
 	public void afterChunk(ChunkContext context) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.ChunkListener#beforeChunk()
-	 */
 	@Override
 	public void beforeChunk(ChunkContext context) {
 	}
 
 	@Override
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.domain.ChunkListener#afterChunkError(ChunkContext)
-	 */
 	public void afterChunkError(ChunkContext context) {
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/JobExecutionListenerSupport.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/JobExecutionListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,22 +26,10 @@ import org.springframework.batch.core.JobExecutionListener;
 @Deprecated
 public class JobExecutionListenerSupport implements JobExecutionListener {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.JobListener#afterJob()
-	 */
 	@Override
 	public void afterJob(JobExecution jobExecution) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.domain.JobListener#beforeJob(org.springframework.
-	 * batch.core.domain.JobExecution)
-	 */
 	@Override
 	public void beforeJob(JobExecution jobExecution) {
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/SkipListenerSupport.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/SkipListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,31 +28,14 @@ import org.springframework.batch.core.SkipListener;
 @Deprecated
 public class SkipListenerSupport<T, S> implements SkipListener<T, S> {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.SkipListener#onSkipInRead(java.lang.Throwable)
-	 */
 	@Override
 	public void onSkipInRead(Throwable t) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.SkipListener#onSkipInWrite(java.lang.Object,
-	 * java.lang.Throwable)
-	 */
 	@Override
 	public void onSkipInWrite(S item, Throwable t) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.SkipListener#onSkipInProcess(java.lang.Object,
-	 * java.lang.Throwable)
-	 */
 	@Override
 	public void onSkipInProcess(T item, Throwable t) {
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/StepExecutionListenerSupport.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/StepExecutionListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,25 +28,12 @@ import org.springframework.lang.Nullable;
 @Deprecated
 public class StepExecutionListenerSupport implements StepExecutionListener {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.StepListener#afterStep(StepExecution
-	 * stepExecution)
-	 */
 	@Nullable
 	@Override
 	public ExitStatus afterStep(StepExecution stepExecution) {
 		return null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.domain.StepListener#open(org.springframework.batch.
-	 * item.ExecutionContext)
-	 */
 	@Override
 	public void beforeStep(StepExecution stepExecution) {
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializer.java
@@ -140,6 +140,7 @@ public class Jackson2ExecutionContextStringSerializer implements ExecutionContex
 		this.objectMapper.registerModule(new JobParametersModule());
 	}
 
+	@Override
 	public Map<String, Object> deserialize(InputStream in) throws IOException {
 
 		TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() {
@@ -147,6 +148,7 @@ public class Jackson2ExecutionContextStringSerializer implements ExecutionContex
 		return objectMapper.readValue(in, typeRef);
 	}
 
+	@Override
 	public void serialize(Map<String, Object> context, OutputStream out) throws IOException {
 
 		Assert.notNull(context, "A context is required");

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcExecutionContextDao.java
@@ -254,6 +254,7 @@ public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implem
 	 * Delete the execution context of the given {@link JobExecution}.
 	 * @param jobExecution {@link JobExecution} that contains the context to delete.
 	 */
+	@Override
 	public void deleteExecutionContext(JobExecution jobExecution) {
 		getJdbcTemplate().update(getQuery(DELETE_JOB_EXECUTION_CONTEXT), jobExecution.getId());
 	}
@@ -262,6 +263,7 @@ public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implem
 	 * Delete the execution context of the given {@link StepExecution}.
 	 * @param stepExecution {@link StepExecution} that contains the context to delete.
 	 */
+	@Override
 	public void deleteExecutionContext(StepExecution stepExecution) {
 		getJdbcTemplate().update(getQuery(DELETE_STEP_EXECUTION_CONTEXT), stepExecution.getId());
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobExecutionDao.java
@@ -352,12 +352,6 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobExecutionDao#
-	 * getLastJobExecution(java.lang.String)
-	 */
 	@Override
 	@Nullable
 	public JobExecution getJobExecution(Long executionId) {
@@ -370,12 +364,6 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobExecutionDao#
-	 * findRunningJobExecutions(java.lang.String)
-	 */
 	@Override
 	public Set<JobExecution> findRunningJobExecutions(String jobName) {
 
@@ -405,6 +393,7 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 	 * Delete the given job execution.
 	 * @param jobExecution the job execution to delete
 	 */
+	@Override
 	public void deleteJobExecution(JobExecution jobExecution) {
 		getJdbcTemplate().update(getQuery(DELETE_JOB_EXECUTION), jobExecution.getId());
 	}
@@ -413,6 +402,7 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 	 * Delete the parameters associated with the given job execution.
 	 * @param jobExecution the job execution for which job parameters should be deleted
 	 */
+	@Override
 	public void deleteJobExecutionParameters(JobExecution jobExecution) {
 		getJdbcTemplate().update(getQuery(DELETE_JOB_EXECUTION_PARAMETERS), jobExecution.getId());
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcJobInstanceDao.java
@@ -195,12 +195,6 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobInstanceDao#getJobInstance
-	 * (java.lang.Long)
-	 */
 	@Override
 	@Nullable
 	public JobInstance getJobInstance(@Nullable Long instanceId) {
@@ -214,22 +208,11 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobInstanceDao#getJobNames ()
-	 */
 	@Override
 	public List<String> getJobNames() {
 		return getJdbcTemplate().query(getQuery(FIND_JOB_NAMES), (rs, rowNum) -> rs.getString(1));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobInstanceDao#
-	 * getLastJobInstances(java.lang.String, int)
-	 */
 	@Override
 	public List<JobInstance> getJobInstances(String jobName, final int start, final int count) {
 
@@ -256,12 +239,6 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 		return getJdbcTemplate().query(getQuery(FIND_LAST_JOBS_BY_NAME), extractor, jobName);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobInstanceDao#
-	 * getLastJobInstance(java.lang.String)
-	 */
 	@Override
 	@Nullable
 	public JobInstance getLastJobInstance(String jobName) {
@@ -274,12 +251,6 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.dao.JobInstanceDao#getJobInstance
-	 * (org.springframework.batch.core.JobExecution)
-	 */
 	@Override
 	@Nullable
 	public JobInstance getJobInstance(JobExecution jobExecution) {
@@ -293,13 +264,6 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.dao.JobInstanceDao#getJobInstanceCount(
-	 * java.lang.String)
-	 */
 	@Override
 	public long getJobInstanceCount(@Nullable String jobName) throws NoSuchJobException {
 
@@ -315,6 +279,7 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 	 * Delete the job instance.
 	 * @param jobInstance the job instance to delete
 	 */
+	@Override
 	public void deleteJobInstance(JobInstance jobInstance) {
 		getJdbcTemplate().update(getQuery(DELETE_JOB_INSTANCE), jobInstance.getId());
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
@@ -372,6 +372,7 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 	 * Delete the given step execution.
 	 * @param stepExecution the step execution to delete
 	 */
+	@Override
 	public void deleteStepExecution(StepExecution stepExecution) {
 		getJdbcTemplate().update(getQuery(DELETE_STEP_EXECUTION), stepExecution.getId());
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/ChunkContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/ChunkContext.java
@@ -63,11 +63,6 @@ public class ChunkContext extends AttributeAccessorSupport {
 		this.complete = true;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return String.format("ChunkContext: attributes=%s, complete=%b, stepContext=%s",

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -114,11 +114,6 @@ public class TaskletStep extends AbstractStep {
 		super(name);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.step.AbstractStep#afterPropertiesSet()
-	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobExecutionExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobExecutionExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,11 @@ package org.springframework.batch.core;
  */
 public class JobExecutionExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobExecutionException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobExecutionException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/JobInterruptedExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/JobInterruptedExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,11 @@ package org.springframework.batch.core;
  */
 public class JobInterruptedExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobInterruptedException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new RuntimeException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/PooledEmbeddedDataSource.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/PooledEmbeddedDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,95 +42,51 @@ public class PooledEmbeddedDataSource implements EmbeddedDatabase {
 		this.dataSource = dataSource;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see javax.sql.DataSource#getConnection()
-	 */
 	@Override
 	public Connection getConnection() throws SQLException {
 		return this.dataSource.getConnection();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see javax.sql.DataSource#getConnection(java.lang.String, java.lang.String)
-	 */
 	@Override
 	public Connection getConnection(String username, String password) throws SQLException {
 		return this.dataSource.getConnection(username, password);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see javax.sql.CommonDataSource#getLogWriter()
-	 */
 	@Override
 	public PrintWriter getLogWriter() throws SQLException {
 		return this.dataSource.getLogWriter();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see javax.sql.CommonDataSource#setLogWriter(java.io.PrintWriter)
-	 */
 	@Override
 	public void setLogWriter(PrintWriter out) throws SQLException {
 		this.dataSource.setLogWriter(out);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see javax.sql.CommonDataSource#getLoginTimeout()
-	 */
 	@Override
 	public int getLoginTimeout() throws SQLException {
 		return this.dataSource.getLoginTimeout();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see javax.sql.CommonDataSource#setLoginTimeout(int)
-	 */
 	@Override
 	public void setLoginTimeout(int seconds) throws SQLException {
 		this.dataSource.setLoginTimeout(seconds);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.sql.Wrapper#unwrap(java.lang.Class)
-	 */
 	@Override
 	public <T> T unwrap(Class<T> iface) throws SQLException {
 		return this.dataSource.unwrap(iface);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.sql.Wrapper#isWrapperFor(java.lang.Class)
-	 */
 	@Override
 	public boolean isWrapperFor(Class<?> iface) throws SQLException {
 		return this.dataSource.isWrapperFor(iface);
 	}
 
+	@Override
 	public Logger getParentLogger() {
 		return Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.jdbc.datasource.embedded.EmbeddedDatabase#shutdown()
-	 */
 	@Override
 	public void shutdown() {
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/DuplicateJobExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/DuplicateJobExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class DuplicateJobExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new DuplicateJobException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new DuplicateJobException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/StepScopeConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/StepScopeConfigurationTests.java
@@ -230,6 +230,7 @@ public class StepScopeConfigurationTests {
 			this.value = value;
 		}
 
+		@Override
 		public String call() throws Exception {
 			return value;
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/DefaultBatchConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/DefaultBatchConfigurationTests.java
@@ -155,6 +155,7 @@ class DefaultBatchConfigurationTests {
 	static class MyJobConfigurationWithCustomInfrastructureBean extends MyJobConfiguration {
 
 		@Bean
+		@Override
 		public JobRepository jobRepository() {
 			return new DummyJobRepository();
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/converter/JobParametersConverterSupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/converter/JobParametersConverterSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,13 +40,6 @@ public class JobParametersConverterSupport implements JobParametersConverter {
 		return builder.toJobParameters();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.converter.JobParametersConverter#getProperties(org.
-	 * springframework.batch.core.JobParameters)
-	 */
 	@Override
 	public Properties getProperties(@Nullable JobParameters params) {
 		Properties properties = new Properties();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/JobSupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/JobSupport.java
@@ -23,14 +23,12 @@ import java.util.Map;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobParametersIncrementer;
 import org.springframework.batch.core.JobParametersValidator;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.UnexpectedJobExecutionException;
 import org.springframework.batch.core.step.NoSuchStepException;
 import org.springframework.batch.core.step.StepLocator;
 import org.springframework.beans.factory.BeanNameAware;
-import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -49,8 +47,6 @@ public class JobSupport implements BeanNameAware, Job, StepLocator {
 	private String name;
 
 	private boolean restartable = false;
-
-	private int startLimit = Integer.MAX_VALUE;
 
 	private DefaultJobParametersValidator jobParametersValidator = new DefaultJobParametersValidator();
 
@@ -96,11 +92,6 @@ public class JobSupport implements BeanNameAware, Job, StepLocator {
 		this.name = name;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#getName()
-	 */
 	@Override
 	public String getName() {
 		return name;
@@ -124,39 +115,15 @@ public class JobSupport implements BeanNameAware, Job, StepLocator {
 		this.steps.put(step.getName(), step);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#getStartLimit()
-	 */
-	public int getStartLimit() {
-		return startLimit;
-	}
-
-	public void setStartLimit(int startLimit) {
-		this.startLimit = startLimit;
-	}
-
 	public void setRestartable(boolean restartable) {
 		this.restartable = restartable;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#isRestartable()
-	 */
 	@Override
 	public boolean isRestartable() {
 		return restartable;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.Job#run(org.springframework.batch
-	 * .core.domain.JobExecution)
-	 */
 	@Override
 	public void execute(JobExecution execution) throws UnexpectedJobExecutionException {
 		throw new UnsupportedOperationException(
@@ -166,17 +133,6 @@ public class JobSupport implements BeanNameAware, Job, StepLocator {
 	@Override
 	public String toString() {
 		return ClassUtils.getShortName(getClass()) + ": [name=" + name + "]";
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Job#getJobParametersIncrementer()
-	 */
-	@Nullable
-	@Override
-	public JobParametersIncrementer getJobParametersIncrementer() {
-		return null;
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -559,12 +559,6 @@ class SimpleJobTests {
 			this.runnable = runnable;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.step.StepSupport#execute(org.
-		 * springframework.batch.core.StepExecution)
-		 */
 		@Override
 		public void execute(StepExecution stepExecution)
 				throws JobInterruptedException, UnexpectedJobExecutionException {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobExecutionNotFailedExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobExecutionNotFailedExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class JobExecutionNotFailedExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobExecutionNotFailedException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobExecutionNotFailedException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobInstanceAlreadyExistsExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobInstanceAlreadyExistsExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class JobInstanceAlreadyExistsExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobInstanceAlreadyExistsException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobInstanceAlreadyExistsException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobParametersNotFoundExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobParametersNotFoundExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class JobParametersNotFoundExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobParametersNotFoundException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobParametersNotFoundException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/NoSuchJobExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/NoSuchJobExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.springframework.batch.core.launch;
 
 import org.springframework.batch.core.AbstractExceptionTests;
-import org.springframework.batch.core.launch.NoSuchJobException;
 
 /**
  * @author Dave Syer
@@ -24,25 +23,11 @@ import org.springframework.batch.core.launch.NoSuchJobException;
  */
 public class NoSuchJobExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new NoSuchJobException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new NoSuchJobException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/NoSuchJobExecutionExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/NoSuchJobExecutionExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class NoSuchJobExecutionExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new NoSuchJobExecutionException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new NoSuchJobExecutionException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/NoSuchJobInstanceExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/NoSuchJobInstanceExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class NoSuchJobInstanceExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new NoSuchJobInstanceException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new NoSuchJobInstanceException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/MulticasterBatchListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/MulticasterBatchListenerTests.java
@@ -608,11 +608,6 @@ class MulticasterBatchListenerTests {
 			super.onReadError(ex);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#afterChunk ()
-		 */
 		@Override
 		public void afterChunk(ChunkContext context) {
 			count++;
@@ -622,12 +617,6 @@ class MulticasterBatchListenerTests {
 			super.afterChunk(context);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#afterRead
-		 * (java.lang.Object)
-		 */
 		@Override
 		public void afterRead(Integer item) {
 			count++;
@@ -637,12 +626,6 @@ class MulticasterBatchListenerTests {
 			super.afterRead(item);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#afterStep
-		 * (org.springframework.batch.core.StepExecution)
-		 */
 		@Nullable
 		@Override
 		public ExitStatus afterStep(StepExecution stepExecution) {
@@ -653,11 +636,6 @@ class MulticasterBatchListenerTests {
 			return super.afterStep(stepExecution);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#beforeChunk ()
-		 */
 		@Override
 		public void beforeChunk(ChunkContext context) {
 			count++;
@@ -667,11 +645,6 @@ class MulticasterBatchListenerTests {
 			super.beforeChunk(context);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#beforeRead ()
-		 */
 		@Override
 		public void beforeRead() {
 			count++;
@@ -681,12 +654,6 @@ class MulticasterBatchListenerTests {
 			super.beforeRead();
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#beforeStep
-		 * (org.springframework.batch.core.StepExecution)
-		 */
 		@Override
 		public void beforeStep(StepExecution stepExecution) {
 			count++;
@@ -696,12 +663,6 @@ class MulticasterBatchListenerTests {
 			super.beforeStep(stepExecution);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#afterWrite
-		 * (java.util.List)
-		 */
 		@Override
 		public void afterWrite(Chunk<? extends String> items) {
 			count++;
@@ -711,12 +672,6 @@ class MulticasterBatchListenerTests {
 			super.afterWrite(items);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#beforeWrite
-		 * (java.util.List)
-		 */
 		@Override
 		public void beforeWrite(Chunk<? extends String> items) {
 			count++;
@@ -726,12 +681,6 @@ class MulticasterBatchListenerTests {
 			super.beforeWrite(items);
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.springframework.batch.core.listener.StepListenerSupport#onWriteError
-		 * (java.lang.Exception, java.util.List)
-		 */
 		@Override
 		public void onWriteError(Exception exception, Chunk<? extends String> items) {
 			count++;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/JobExecutionAlreadyRunningExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/JobExecutionAlreadyRunningExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class JobExecutionAlreadyRunningExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobExecutionAlreadyRunningException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobExecutionAlreadyRunningException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/JobInstanceAlreadyCompleteExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/JobInstanceAlreadyCompleteExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class JobInstanceAlreadyCompleteExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobInstanceAlreadyCompleteException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobInstanceAlreadyCompleteException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/JobRestartExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/JobRestartExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,11 @@ import org.springframework.batch.core.AbstractExceptionTests;
  */
 public class JobRestartExceptionTests extends AbstractExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String)
-	 */
 	@Override
 	public Exception getException(String msg) throws Exception {
 		return new JobRestartException(msg);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.exception.AbstractExceptionTests#getException(java.
-	 * lang.String, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable t) throws Exception {
 		return new JobRestartException(msg, t);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,38 +32,14 @@ import org.springframework.lang.Nullable;
  */
 public class JobRepositorySupport implements JobRepository {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.container.common.repository.JobRepository#findOrCreateJob
-	 * (org.springframework.batch.container.common.domain.JobConfiguration)
-	 */
 	@Override
 	public JobExecution createJobExecution(String jobName, JobParameters jobParameters) {
 		JobInstance jobInstance = new JobInstance(0L, jobName);
 		return new JobExecution(jobInstance, 11L, jobParameters);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.container.common.repository.JobRepository#saveOrUpdate(
-	 * org.springframework.batch.container.common.domain.JobExecution)
-	 */
 	@Override
 	public void update(JobExecution jobExecution) {
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.container.common.repository.JobRepository#update(org.
-	 * springframework.batch.container.common.domain.Job)
-	 */
-	public void update(JobInstance job) {
 	}
 
 	@Nullable
@@ -83,14 +59,6 @@ public class JobRepositorySupport implements JobRepository {
 		return 0;
 	}
 
-	public int getJobExecutionCount(JobInstance jobInstance) {
-		return 0;
-	}
-
-	public JobExecution getLastJobExecution(JobInstance jobInstance) {
-		return null;
-	}
-
 	@Override
 	public void add(StepExecution stepExecution) {
 	}
@@ -103,13 +71,6 @@ public class JobRepositorySupport implements JobRepository {
 	public void updateExecutionContext(StepExecution stepExecution) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.JobRepository#isJobInstanceExists(java.
-	 * lang.String, org.springframework.batch.core.JobParameters)
-	 */
 	@Override
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 		return false;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ForceRollbackForWriteSkipExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ForceRollbackForWriteSkipExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import org.springframework.batch.core.AbstractExceptionWithCauseTests;
  */
 public class ForceRollbackForWriteSkipExceptionTests extends AbstractExceptionWithCauseTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.listener.AbstractDoubleExceptionTests#getException(
-	 * java.lang.String, java.lang.RuntimeException, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable e) throws Exception {
 		return new ForceRollbackForWriteSkipException(msg, e);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/NonSkippableReadExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/NonSkippableReadExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import org.springframework.batch.core.AbstractExceptionWithCauseTests;
  */
 public class NonSkippableReadExceptionTests extends AbstractExceptionWithCauseTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.listener.AbstractDoubleExceptionTests#getException(
-	 * java.lang.String, java.lang.RuntimeException, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable e) throws Exception {
 		return new NonSkippableReadException(msg, e);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/NonSkippableWriteExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/NonSkippableWriteExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import org.springframework.batch.core.AbstractExceptionWithCauseTests;
  */
 public class NonSkippableWriteExceptionTests extends AbstractExceptionWithCauseTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.listener.AbstractDoubleExceptionTests#getException(
-	 * java.lang.String, java.lang.RuntimeException, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, Throwable e) throws Exception {
 		return new NonSkippableWriteException(msg, e);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/SkipListenerFailedExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/SkipListenerFailedExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import org.springframework.batch.core.listener.AbstractDoubleExceptionTests;
  */
 public class SkipListenerFailedExceptionTests extends AbstractDoubleExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.listener.AbstractDoubleExceptionTests#getException(
-	 * java.lang.String, java.lang.RuntimeException, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, RuntimeException cause, Throwable e) throws Exception {
 		return new SkipListenerFailedException(msg, cause, e);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/SkipPolicyFailedExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/skip/SkipPolicyFailedExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,6 @@ import org.springframework.batch.core.listener.AbstractDoubleExceptionTests;
  */
 public class SkipPolicyFailedExceptionTests extends AbstractDoubleExceptionTests {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.listener.AbstractDoubleExceptionTests#getException(
-	 * java.lang.String, java.lang.RuntimeException, java.lang.Throwable)
-	 */
 	@Override
 	public Exception getException(String msg, RuntimeException cause, Throwable e) throws Exception {
 		return new SkipPolicyFailedException(msg, cause, e);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/football/internal/PlayerSummaryMapper.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/football/internal/PlayerSummaryMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,6 @@ import org.springframework.jdbc.core.RowMapper;
  */
 public class PlayerSummaryMapper implements RowMapper<PlayerSummary> {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.jdbc.core.RowMapper#mapRow(java.sql.ResultSet, int)
-	 */
 	@Override
 	public PlayerSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/football/internal/PlayerSummaryRowMapper.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/football/internal/PlayerSummaryRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,6 @@ import org.springframework.jdbc.core.RowMapper;
  */
 public class PlayerSummaryRowMapper implements RowMapper<PlayerSummary> {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.jdbc.core.RowMapper#mapRow(java.sql.ResultSet, int)
-	 */
 	@Override
 	public PlayerSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/ldif/MyMapper.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/ldif/MyMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2019 the original author or authors.
+ * Copyright 2005-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.ldap.core.LdapAttributes;
  */
 public class MyMapper implements RecordMapper<LdapAttributes> {
 
+	@Override
 	@Nullable
 	public LdapAttributes mapRecord(LdapAttributes attributes) {
 		return attributes;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/JobSupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/JobSupport.java
@@ -21,13 +21,11 @@ import java.util.List;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobParametersIncrementer;
 import org.springframework.batch.core.JobParametersValidator;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.UnexpectedJobExecutionException;
 import org.springframework.batch.core.job.DefaultJobParametersValidator;
 import org.springframework.beans.factory.BeanNameAware;
-import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -45,8 +43,6 @@ public class JobSupport implements BeanNameAware, Job {
 	private String name;
 
 	private boolean restartable = false;
-
-	private int startLimit = Integer.MAX_VALUE;
 
 	private JobParametersValidator jobParametersValidator = new DefaultJobParametersValidator();
 
@@ -93,11 +89,6 @@ public class JobSupport implements BeanNameAware, Job {
 		this.name = name;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#getName()
-	 */
 	@Override
 	public String getName() {
 		return name;
@@ -123,42 +114,13 @@ public class JobSupport implements BeanNameAware, Job {
 		return steps;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#getStartLimit()
-	 */
-	public int getStartLimit() {
-		return startLimit;
-	}
-
-	public void setStartLimit(int startLimit) {
-		this.startLimit = startLimit;
-	}
-
 	public void setRestartable(boolean restartable) {
 		this.restartable = restartable;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.IJob#isRestartable()
-	 */
 	@Override
 	public boolean isRestartable() {
 		return restartable;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Job#getJobParametersIncrementer()
-	 */
-	@Nullable
-	@Override
-	public JobParametersIncrementer getJobParametersIncrementer() {
-		return null;
 	}
 
 	@Override
@@ -166,13 +128,6 @@ public class JobSupport implements BeanNameAware, Job {
 		return jobParametersValidator;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.domain.Job#run(org.springframework.batch.core.domain
-	 * .JobExecution)
-	 */
 	@Override
 	public void execute(JobExecution execution) throws UnexpectedJobExecutionException {
 		throw new UnsupportedOperationException(

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
@@ -201,11 +201,6 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 		this.userData = userData;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return String.format("[items=%s, skips=%s]", items, skips);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
@@ -385,11 +385,6 @@ public class ExecutionContext implements Serializable {
 		return this.map.containsValue(value);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof ExecutionContext rhs)) {
@@ -401,21 +396,11 @@ public class ExecutionContext implements Serializable {
 		return this.entrySet().equals(rhs.entrySet());
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#hashCode()
-	 */
 	@Override
 	public int hashCode() {
 		return this.map.hashCode();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return this.map.toString();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -31,11 +31,6 @@ public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, Initial
 
 	protected boolean delete;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.ItemWriter#write(java.util.List)
-	 */
 	@Override
 	public void write(Chunk<? extends V> items) throws Exception {
 		if (items == null) {
@@ -84,11 +79,6 @@ public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, Initial
 		this.delete = delete;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
-	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(itemKeyMapper != null, "itemKeyMapper requires a Converter type.");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/SpELItemKeyMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/SpELItemKeyMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -33,11 +33,6 @@ public class SpELItemKeyMapper<K, V> implements Converter<V, K> {
 		parsedExpression = parser.parseExpression(keyExpression);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.ItemKeyMapper#mapKey(java.lang.Object)
-	 */
 	@SuppressWarnings("unchecked")
 	@Override
 	public K convert(V item) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxy.java
@@ -345,6 +345,7 @@ public class ExtendedConnectionDataSourceProxy implements SmartDataSource, Initi
 	/**
 	 * Added due to JDK 7 compatibility.
 	 */
+	@Override
 	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
 		MethodInvoker invoker = new MethodInvoker();
 		invoker.setTargetObject(dataSource);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcBatchItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcBatchItemWriter.java
@@ -156,11 +156,6 @@ public class JdbcBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.ItemWriter#write(java.util.List)
-	 */
 	@SuppressWarnings("unchecked")
 	@Override
 	public void write(final Chunk<? extends T> chunk) throws Exception {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqliteMaxValueIncrementer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqliteMaxValueIncrementer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,13 +40,6 @@ class SqliteMaxValueIncrementer extends AbstractColumnMaxValueIncrementer {
 		super(dataSource, incrementerName, columnName);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.jdbc.support.incrementer.AbstractDataFieldMaxValueIncrementer#
-	 * getNextKey()
-	 */
 	@Override
 	protected long getNextKey() {
 		Connection con = DataSourceUtils.getConnection(getDataSource());

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,25 +29,11 @@ import org.springframework.util.StringUtils;
  */
 public class SqlitePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.item.database.support.AbstractSqlPagingQueryProvider#
-	 * generateFirstPageQuery(int)
-	 */
 	@Override
 	public String generateFirstPageQuery(int pageSize) {
 		return SqlPagingQueryUtils.generateLimitSqlQuery(this, false, buildLimitClause(pageSize));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.item.database.support.AbstractSqlPagingQueryProvider#
-	 * generateRemainingPagesQuery(int)
-	 */
 	@Override
 	public String generateRemainingPagesQuery(int pageSize) {
 		if (StringUtils.hasText(getGroupClause())) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapper.java
@@ -109,12 +109,6 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 
 	private boolean isCustomEditorsSet;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org
-	 * .springframework.beans.factory.BeanFactory)
-	 */
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PassThroughFieldSetMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PassThroughFieldSetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,12 +26,6 @@ import org.springframework.batch.item.file.transform.FieldSet;
  */
 public class PassThroughFieldSetMapper implements FieldSetMapper<FieldSet> {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.FieldSetMapper#mapLine(org.springframework
-	 * .batch.io.file.FieldSet)
-	 */
 	@Override
 	public FieldSet mapFieldSet(FieldSet fs) {
 		return fs;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
@@ -50,22 +50,11 @@ public class PatternMatchingCompositeLineMapper<T> implements LineMapper<T>, Ini
 
 	private PatternMatcher<FieldSetMapper<T>> patternMatcher;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.LineMapper#mapLine(java.lang
-	 * .String, int)
-	 */
 	@Override
 	public T mapLine(String line, int lineNumber) throws Exception {
 		return patternMatcher.match(line).mapFieldSet(this.tokenizer.tokenize(line));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
-	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		this.tokenizer.afterPropertiesSet();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
@@ -116,11 +116,6 @@ public class DefaultFieldSet implements FieldSet {
 		setNumberFormat(NumberFormat.getInstance(Locale.US));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#getNames()
-	 */
 	@Override
 	public String[] getNames() {
 		if (names == null) {
@@ -129,95 +124,46 @@ public class DefaultFieldSet implements FieldSet {
 		return names.toArray(new String[0]);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.FieldSet#hasNames()
-	 */
 	@Override
 	public boolean hasNames() {
 		return names != null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#getValues()
-	 */
 	@Override
 	public String[] getValues() {
 		return tokens.clone();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readString(int)
-	 */
 	@Override
 	public String readString(int index) {
 		return readAndTrim(index);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readString(java
-	 * .lang.String)
-	 */
 	@Override
 	public String readString(String name) {
 		return readString(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readRawString(int)
-	 */
 	@Override
 	public String readRawString(int index) {
 		return tokens[index];
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readRawString(java
-	 * .lang.String)
-	 */
 	@Override
 	public String readRawString(String name) {
 		return readRawString(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBoolean(int)
-	 */
 	@Override
 	public boolean readBoolean(int index) {
 		return readBoolean(index, "true");
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBoolean(java
-	 * .lang.String)
-	 */
 	@Override
 	public boolean readBoolean(String name) {
 		return readBoolean(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBoolean(int,
-	 * java.lang.String)
-	 */
 	@Override
 	public boolean readBoolean(int index, String trueValue) {
 		Assert.notNull(trueValue, "'trueValue' cannot be null.");
@@ -227,22 +173,11 @@ public class DefaultFieldSet implements FieldSet {
 		return trueValue.equals(value);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBoolean(java
-	 * .lang.String, java.lang.String)
-	 */
 	@Override
 	public boolean readBoolean(String name, String trueValue) {
 		return readBoolean(indexOf(name), trueValue);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readChar(int)
-	 */
 	@Override
 	public char readChar(int index) {
 		String value = readAndTrim(index);
@@ -252,85 +187,41 @@ public class DefaultFieldSet implements FieldSet {
 		return value.charAt(0);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readChar(java.lang
-	 * .String)
-	 */
 	@Override
 	public char readChar(String name) {
 		return readChar(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readByte(int)
-	 */
 	@Override
 	public byte readByte(int index) {
 		return Byte.parseByte(readAndTrim(index));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readByte(java.lang
-	 * .String)
-	 */
 	@Override
 	public byte readByte(String name) {
 		return readByte(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readShort(int)
-	 */
 	@Override
 	public short readShort(int index) {
 		return Short.parseShort(readAndTrim(index));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readShort(java.
-	 * lang.String)
-	 */
 	@Override
 	public short readShort(String name) {
 		return readShort(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readInt(int)
-	 */
 	@Override
 	public int readInt(int index) {
 		return parseNumber(readAndTrim(index)).intValue();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readInt(java.lang
-	 * .String)
-	 */
 	@Override
 	public int readInt(String name) {
 		return readInt(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readInt(int, int)
-	 */
 	@Override
 	public int readInt(int index, int defaultValue) {
 		String value = readAndTrim(index);
@@ -338,43 +229,21 @@ public class DefaultFieldSet implements FieldSet {
 		return StringUtils.hasLength(value) ? Integer.parseInt(value) : defaultValue;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readInt(java.lang
-	 * .String, int)
-	 */
 	@Override
 	public int readInt(String name, int defaultValue) {
 		return readInt(indexOf(name), defaultValue);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readLong(int)
-	 */
 	@Override
 	public long readLong(int index) {
 		return parseNumber(readAndTrim(index)).longValue();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readLong(java.lang
-	 * .String)
-	 */
 	@Override
 	public long readLong(String name) {
 		return readLong(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readLong(int, long)
-	 */
 	@Override
 	public long readLong(int index, long defaultValue) {
 		String value = readAndTrim(index);
@@ -382,86 +251,41 @@ public class DefaultFieldSet implements FieldSet {
 		return StringUtils.hasLength(value) ? Long.parseLong(value) : defaultValue;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readLong(java.lang
-	 * .String, long)
-	 */
 	@Override
 	public long readLong(String name, long defaultValue) {
 		return readLong(indexOf(name), defaultValue);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readFloat(int)
-	 */
 	@Override
 	public float readFloat(int index) {
 		return parseNumber(readAndTrim(index)).floatValue();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readFloat(java.
-	 * lang.String)
-	 */
 	@Override
 	public float readFloat(String name) {
 		return readFloat(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDouble(int)
-	 */
 	@Override
 	public double readDouble(int index) {
 		return parseNumber(readAndTrim(index)).doubleValue();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDouble(java
-	 * .lang.String)
-	 */
 	@Override
 	public double readDouble(String name) {
 		return readDouble(indexOf(name));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBigDecimal(int)
-	 */
 	@Override
 	public BigDecimal readBigDecimal(int index) {
 		return readBigDecimal(index, null);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBigDecimal(
-	 * java.lang.String)
-	 */
 	@Override
 	public BigDecimal readBigDecimal(String name) {
 		return readBigDecimal(name, null);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBigDecimal(int,
-	 * java.math.BigDecimal)
-	 */
 	@Override
 	public BigDecimal readBigDecimal(int index, BigDecimal defaultValue) {
 		String candidate = readAndTrim(index);
@@ -483,12 +307,6 @@ public class DefaultFieldSet implements FieldSet {
 		return candidate.replace(grouping, "").replace(decimal, ".");
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readBigDecimal(
-	 * java.lang.String, java.math.BigDecimal)
-	 */
 	@Override
 	public BigDecimal readBigDecimal(String name, BigDecimal defaultValue) {
 		try {
@@ -502,34 +320,17 @@ public class DefaultFieldSet implements FieldSet {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDate(int)
-	 */
 	@Override
 	public Date readDate(int index) {
 		return parseDate(readAndTrim(index), dateFormat);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.transform.FieldSet#readDate(int,
-	 * java.util.Date)
-	 */
 	@Override
 	public Date readDate(int index, Date defaultValue) {
 		String candidate = readAndTrim(index);
 		return StringUtils.hasText(candidate) ? parseDate(candidate, dateFormat) : defaultValue;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDate(java.lang
-	 * .String)
-	 */
 	@Override
 	public Date readDate(String name) {
 		try {
@@ -540,12 +341,6 @@ public class DefaultFieldSet implements FieldSet {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.transform.FieldSet#readDate(int,
-	 * java.util.Date)
-	 */
 	@Override
 	public Date readDate(String name, Date defaultValue) {
 		try {
@@ -556,12 +351,6 @@ public class DefaultFieldSet implements FieldSet {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDate(int,
-	 * java.lang.String)
-	 */
 	@Override
 	public Date readDate(int index, String pattern) {
 		SimpleDateFormat sdf = new SimpleDateFormat(pattern);
@@ -569,24 +358,12 @@ public class DefaultFieldSet implements FieldSet {
 		return parseDate(readAndTrim(index), sdf);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDate(int,
-	 * java.lang.String)
-	 */
 	@Override
 	public Date readDate(int index, String pattern, Date defaultValue) {
 		String candidate = readAndTrim(index);
 		return StringUtils.hasText(candidate) ? readDate(index, pattern) : defaultValue;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDate(java.lang
-	 * .String, java.lang.String)
-	 */
 	@Override
 	public Date readDate(String name, String pattern) {
 		try {
@@ -597,12 +374,6 @@ public class DefaultFieldSet implements FieldSet {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#readDate(int,
-	 * java.lang.String)
-	 */
 	@Override
 	public Date readDate(String name, String pattern, Date defaultValue) {
 		try {
@@ -613,11 +384,6 @@ public class DefaultFieldSet implements FieldSet {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#getFieldCount()
-	 */
 	@Override
 	public int getFieldCount() {
 		return tokens.length;
@@ -701,11 +467,6 @@ public class DefaultFieldSet implements FieldSet {
 		return result;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.mapping.IFieldSet#getProperties()
-	 */
 	@Override
 	public Properties getProperties() {
 		if (names == null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/IncorrectTokenCountException.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/IncorrectTokenCountException.java
@@ -70,6 +70,7 @@ public class IncorrectTokenCountException extends FlatFileFormatException {
 	 * @return the line that caused the exception
 	 * @since 2.2.6
 	 */
+	@Override
 	public String getInput() {
 		return input;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,22 +38,11 @@ public class PatternMatchingCompositeLineTokenizer implements LineTokenizer, Ini
 
 	private PatternMatcher<LineTokenizer> tokenizers = null;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.item.file.transform.LineTokenizer#tokenize(
-	 * java.lang.String)
-	 */
 	@Override
 	public FieldSet tokenize(@Nullable String line) {
 		return tokenizers.match(line).tokenize(line);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
-	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(this.tokenizers != null, "The 'tokenizers' property must be non-empty");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RecursiveCollectionLineAggregator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RecursiveCollectionLineAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,13 +41,6 @@ public class RecursiveCollectionLineAggregator<T> implements LineAggregator<Coll
 		this.delegate = delegate;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.item.file.transform.LineAggregator#aggregate(java.lang.
-	 * Object)
-	 */
 	@Override
 	public String aggregate(Collection<T> items) {
 		StringBuilder builder = new StringBuilder();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/LdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/LdifReader.java
@@ -174,11 +174,13 @@ public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAtt
 	 * Establishes the resource that will be used as the input for the LdifReader.
 	 * @param resource the resource that will be read.
 	 */
+	@Override
 	public void setResource(Resource resource) {
 		this.resource = resource;
 		this.ldifParser = new LdifParser(resource);
 	}
 
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(resource != null, "A resource is required to parse.");
 		Assert.state(ldifParser != null, "A parser is required");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/MappingLdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/MappingLdifReader.java
@@ -171,11 +171,13 @@ public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemRead
 		}
 	}
 
+	@Override
 	public void setResource(Resource resource) {
 		this.resource = resource;
 		this.ldifParser = new LdifParser(resource);
 	}
 
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(resource != null, "A resource is required to parse.");
 		Assert.state(ldifParser != null, "A parser is required");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemReader.java
@@ -46,6 +46,7 @@ public class SynchronizedItemReader<T> implements ItemReader<T> {
 	 * This method delegates to the {@code read} method of the delegate and is
 	 * synchronized with a lock.
 	 */
+	@Override
 	@Nullable
 	public T read() throws Exception {
 		this.lock.lock();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamReader.java
@@ -55,6 +55,7 @@ public class SynchronizedItemStreamReader<T> implements ItemStreamReader<T>, Ini
 	/**
 	 * This delegates to the read method of the <code>delegate</code>
 	 */
+	@Override
 	@Nullable
 	public T read() throws Exception {
 		this.lock.lock();
@@ -66,14 +67,17 @@ public class SynchronizedItemStreamReader<T> implements ItemStreamReader<T>, Ini
 		}
 	}
 
+	@Override
 	public void close() {
 		this.delegate.close();
 	}
 
+	@Override
 	public void open(ExecutionContext executionContext) {
 		this.delegate.open(executionContext);
 	}
 
+	@Override
 	public void update(ExecutionContext executionContext) {
 		this.delegate.update(executionContext);
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/UnclosedElementCollectingEventWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/UnclosedElementCollectingEventWriter.java
@@ -40,13 +40,6 @@ public class UnclosedElementCollectingEventWriter extends AbstractEventWriterWra
 		super(wrappedEventWriter);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.item.xml.stax.AbstractEventWriterWrapper#add(javax.xml.
-	 * stream.events.XMLEvent)
-	 */
 	@Override
 	public void add(XMLEvent event) throws XMLStreamException {
 		if (event.isStartElement()) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/UnopenedElementClosingEventWriter.java
@@ -50,13 +50,6 @@ public class UnopenedElementClosingEventWriter extends AbstractEventWriterWrappe
 		this.ioWriter = ioWriter;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.item.xml.stax.AbstractEventWriterWrapper#add(javax.xml.
-	 * stream.events.XMLEvent)
-	 */
 	@Override
 	public void add(XMLEvent event) throws XMLStreamException {
 		if (isUnopenedElementCloseEvent(event)) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/RepeatContextSupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/RepeatContextSupport.java
@@ -48,52 +48,27 @@ public class RepeatContextSupport extends SynchronizedAttributeAccessor implemen
 		this.parent = parent;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#isCompleteOnly()
-	 */
 	@Override
 	public boolean isCompleteOnly() {
 		return completeOnly;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#setCompleteOnly()
-	 */
 	@Override
 	public void setCompleteOnly() {
 		completeOnly = true;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#isTerminateOnly()
-	 */
 	@Override
 	public boolean isTerminateOnly() {
 		return terminateOnly;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#setTerminateOnly()
-	 */
 	@Override
 	public void setTerminateOnly() {
 		terminateOnly = true;
 		setCompleteOnly();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#getParent()
-	 */
 	@Override
 	public RepeatContext getParent() {
 		return parent;
@@ -106,22 +81,11 @@ public class RepeatContextSupport extends SynchronizedAttributeAccessor implemen
 		count++;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#getStartedCount()
-	 */
 	@Override
 	public synchronized int getStartedCount() {
 		return count;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#registerDestructionCallback
-	 * (java.lang.String, java.lang.Runnable)
-	 */
 	@Override
 	public void registerDestructionCallback(String name, Runnable callback) {
 		synchronized (callbacks) {
@@ -130,11 +94,6 @@ public class RepeatContextSupport extends SynchronizedAttributeAccessor implemen
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.RepeatContext#close()
-	 */
 	@Override
 	public void close() {
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
@@ -40,11 +40,6 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 
 	};
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.core.AttributeAccessor#attributeNames()
-	 */
 	@Override
 	public String[] attributeNames() {
 		synchronized (support) {
@@ -52,11 +47,6 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
 	@Override
 	public boolean equals(Object other) {
 		if (this == other) {
@@ -77,11 +67,6 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.core.AttributeAccessor#getAttribute(java.lang.String)
-	 */
 	@Override
 	public Object getAttribute(String name) {
 		synchronized (support) {
@@ -89,11 +74,6 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.core.AttributeAccessor#hasAttribute(java.lang.String)
-	 */
 	@Override
 	public boolean hasAttribute(String name) {
 		synchronized (support) {
@@ -101,21 +81,11 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#hashCode()
-	 */
 	@Override
 	public int hashCode() {
 		return support.hashCode();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.core.AttributeAccessor#removeAttribute(java.lang.String)
-	 */
 	@Override
 	public Object removeAttribute(String name) {
 		synchronized (support) {
@@ -123,12 +93,6 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.core.AttributeAccessor#setAttribute(java.lang.String,
-	 * java.lang.Object)
-	 */
 	@Override
 	public void setAttribute(String name, Object value) {
 		synchronized (support) {
@@ -154,11 +118,6 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 		return null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		StringBuilder buffer = new StringBuilder("SynchronizedAttributeAccessor: [");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/RethrowOnThresholdExceptionHandler.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/RethrowOnThresholdExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,11 +127,6 @@ public class RethrowOnThresholdExceptionHandler implements ExceptionHandler {
 			return value;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see java.lang.Object#toString()
-		 */
 		@Override
 		public String toString() {
 			return ObjectUtils.getIdentityHexString(this) + "." + value;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/listener/CompositeRepeatListener.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/listener/CompositeRepeatListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,13 +87,6 @@ public class CompositeRepeatListener implements RepeatListener {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatListener#after(org.springframework.batch.
-	 * repeat.RepeatContext, org.springframework.batch.repeat.ExitStatus)
-	 */
 	@Override
 	public void after(RepeatContext context, RepeatStatus result) {
 		for (RepeatListener listener : listeners) {
@@ -101,13 +94,6 @@ public class CompositeRepeatListener implements RepeatListener {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatListener#before(org.springframework.batch.
-	 * repeat.RepeatContext)
-	 */
 	@Override
 	public void before(RepeatContext context) {
 		for (RepeatListener listener : listeners) {
@@ -115,13 +101,6 @@ public class CompositeRepeatListener implements RepeatListener {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatListener#close(org.springframework.batch.
-	 * repeat.RepeatContext)
-	 */
 	@Override
 	public void close(RepeatContext context) {
 		for (RepeatListener listener : listeners) {
@@ -129,13 +108,6 @@ public class CompositeRepeatListener implements RepeatListener {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatListener#onError(org.springframework.batch.
-	 * repeat.RepeatContext, java.lang.Throwable)
-	 */
 	@Override
 	public void onError(RepeatContext context, Throwable e) {
 		for (RepeatListener listener : listeners) {
@@ -143,13 +115,6 @@ public class CompositeRepeatListener implements RepeatListener {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatListener#open(org.springframework.batch.
-	 * repeat.RepeatContext)
-	 */
 	@Override
 	public void open(RepeatContext context) {
 		for (RepeatListener listener : listeners) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/CountingCompletionPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/CountingCompletionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,36 +81,17 @@ public abstract class CountingCompletionPolicy extends DefaultResultCompletionPo
 		return 0;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.policy.CompletionPolicySupport#isComplete(org.
-	 * springframework.batch.repeat.BatchContext)
-	 */
 	@Override
 	final public boolean isComplete(RepeatContext context) {
 		int count = ((CountingBatchContext) context).getCounter().getCount();
 		return count >= maxCount;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.policy.CompletionPolicySupport#start(org.
-	 * springframework.batch.repeat.BatchContext)
-	 */
 	@Override
 	public RepeatContext start(RepeatContext parent) {
 		return new CountingBatchContext(parent);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.policy.CompletionPolicySupport#update(org.
-	 * springframework.batch.repeat.BatchContext)
-	 */
 	@Override
 	final public void update(RepeatContext context) {
 		super.update(context);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/SimpleCompletionPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/SimpleCompletionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,11 +114,6 @@ public class SimpleCompletionPolicy extends DefaultResultCompletionPolicy {
 
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		return ClassUtils.getShortName(SimpleCompletionPolicy.class) + ": chunkSize=" + chunkSize;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/RepeatInternalStateSupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/RepeatInternalStateSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,6 @@ public class RepeatInternalStateSupport implements RepeatInternalState {
 	// Accumulation of failed results.
 	private final Set<Throwable> throwables = new HashSet<>();
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.support.BatchInternalState#getThrowables()
-	 */
 	@Override
 	public Collection<Throwable> getThrowables() {
 		return throwables;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ResultHolderResultQueue.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ResultHolderResultQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,11 +59,6 @@ public class ResultHolderResultQueue implements ResultQueue<ResultHolder> {
 		return results.isEmpty();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.support.ResultQueue#isExpecting()
-	 */
 	@Override
 	public boolean isExpecting() {
 		// Base the decision about whether we expect more results on a

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueue.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,6 @@ public class ThrottleLimitResultQueue<T> implements ResultQueue<T> {
 		return results.isEmpty();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.repeat.support.ResultQueue#isExpecting()
-	 */
 	@Override
 	public boolean isExpecting() {
 		// Base the decision about whether we expect more results on a

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
@@ -76,12 +76,6 @@ public class SimpleMethodInvoker implements MethodInvoker {
 		this.object = object;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.configuration.util.MethodInvoker#invokeMethod
-	 * (java.lang.Object[])
-	 */
 	@Nullable
 	@Override
 	public Object invokeMethod(Object... args) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -172,11 +172,6 @@ public class TransactionAwareBufferedWriter extends Writer {
 		return TransactionSynchronizationManager.isActualTransactionActive();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.io.Writer#close()
-	 */
 	@Override
 	public void close() throws IOException {
 		if (transactionActive()) {
@@ -188,11 +183,6 @@ public class TransactionAwareBufferedWriter extends Writer {
 		closeCallback.run();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.io.Writer#flush()
-	 */
 	@Override
 	public void flush() throws IOException {
 		if (!transactionActive() && forceSync) {
@@ -200,11 +190,6 @@ public class TransactionAwareBufferedWriter extends Writer {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.io.Writer#write(char[], int, int)
-	 */
 	@Override
 	public void write(char[] cbuf, int off, int len) throws IOException {
 
@@ -224,11 +209,6 @@ public class TransactionAwareBufferedWriter extends Writer {
 		buffer.append(cbuf, off, len);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.io.Writer#write(String, int, int)
-	 */
 	@Override
 	public void write(String str, int off, int len) throws IOException {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/CompositeKeyFooDao.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/CompositeKeyFooDao.java
@@ -34,11 +34,6 @@ public class CompositeKeyFooDao extends JdbcDaoSupport implements FooDao {
 		this.setDataSource(dataSource);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.io.sql.scratch.FooDao#getFoo(java.lang.Object)
-	 */
 	@Override
 	public Foo getFoo(Object key) {
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
@@ -327,6 +327,7 @@ class ExtendedConnectionDataSourceProxyTests {
 		/**
 		 * Added due to JDK 7.
 		 */
+		@Override
 		@SuppressWarnings("unused")
 		public Logger getParentLogger() throws SQLFeatureNotSupportedException {
 			throw new SQLFeatureNotSupportedException();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ItemReaderRepeatCallback.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ItemReaderRepeatCallback.java
@@ -38,13 +38,6 @@ public class ItemReaderRepeatCallback<T> implements RepeatCallback {
 		this.reader = reader;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatCallback#doInIteration(org.springframework.
-	 * batch.repeat.RepeatContext)
-	 */
 	@Override
 	public RepeatStatus doInIteration(RepeatContext context) throws Exception {
 		T item = reader.read();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/ReflectionUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/ReflectionUtilsTests.java
@@ -82,6 +82,7 @@ class ReflectionUtilsTests {
 		public void methodOne() {
 		}
 
+		@Override
 		@Transactional
 		public String toString() {
 			return "AnnotatedClass";
@@ -91,6 +92,7 @@ class ReflectionUtilsTests {
 
 	public static class AnnotatedSubClass extends AnnotatedClass {
 
+		@Override
 		@Transactional
 		public void methodOne() {
 		}

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemProcessor.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemProcessor.java
@@ -59,6 +59,7 @@ public class AsyncItemProcessor<I, O> implements ItemProcessor<I, Future<O>>, In
 	 *
 	 * @see InitializingBean#afterPropertiesSet()
 	 */
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(delegate != null, "The delegate must be set.");
 	}
@@ -87,6 +88,7 @@ public class AsyncItemProcessor<I, O> implements ItemProcessor<I, Future<O>>, In
 	 *
 	 * @see ItemProcessor#process(Object)
 	 */
+	@Override
 	@Nullable
 	public Future<O> process(final I item) throws Exception {
 		final StepExecution stepExecution = getStepExecution();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -38,6 +38,7 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 
 	private ItemWriter<T> delegate;
 
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(delegate != null, "A delegate ItemWriter must be provided.");
 	}
@@ -60,6 +61,7 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 	 * delegate
 	 * @throws Exception The exception returned by the Future if one was thrown
 	 */
+	@Override
 	public void write(Chunk<? extends Future<T>> items) throws Exception {
 		List<T> list = new ArrayList<>();
 		for (Future<T> future : items) {

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkMessageChannelItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkMessageChannelItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,7 @@ public class ChunkMessageChannelItemWriter<T>
 		this.replyChannel = replyChannel;
 	}
 
+	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 
 		// Block until expecting <= throttle limit
@@ -155,10 +156,12 @@ public class ChunkMessageChannelItemWriter<T>
 		return ExitStatus.COMPLETED.addExitDescription("Waited for " + expecting + " results.");
 	}
 
+	@Override
 	public void close() throws ItemStreamException {
 		localState.reset();
 	}
 
+	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		if (executionContext.containsKey(EXPECTED)) {
 			localState.open(executionContext.getInt(EXPECTED), executionContext.getInt(ACTUAL));
@@ -168,11 +171,13 @@ public class ChunkMessageChannelItemWriter<T>
 		}
 	}
 
+	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		executionContext.putInt(EXPECTED, localState.expected.intValue());
 		executionContext.putInt(ACTUAL, localState.actual.intValue());
 	}
 
+	@Override
 	public Collection<StepContribution> getStepContributions() {
 		List<StepContribution> contributions = new ArrayList<>();
 		for (ChunkResponse response : localState.pollChunkResponses()) {

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkProcessorChunkHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkProcessorChunkHandler.java
@@ -50,11 +50,7 @@ public class ChunkProcessorChunkHandler<S> implements ChunkHandler<S>, Initializ
 
 	private ChunkProcessor<S> chunkProcessor;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
-	 */
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(chunkProcessor != null, "A ChunkProcessor must be provided");
 	}
@@ -71,6 +67,7 @@ public class ChunkProcessorChunkHandler<S> implements ChunkHandler<S>, Initializ
 	 *
 	 * @see ChunkHandler#handleChunk(ChunkRequest)
 	 */
+	@Override
 	@ServiceActivator
 	public ChunkResponse handleChunk(ChunkRequest<S> chunkRequest) throws Exception {
 

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/MessageSourcePollerInterceptor.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/MessageSourcePollerInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2010-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
 import org.apache.commons.logging.Log;
@@ -54,6 +69,7 @@ public class MessageSourcePollerInterceptor implements ChannelInterceptor, Initi
 	 * Asserts that mandatory properties are set.
 	 * @see InitializingBean#afterPropertiesSet()
 	 */
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(source != null, "A MessageSource must be provided");
 	}

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkHandlerFactoryBean.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkHandlerFactoryBean.java
@@ -91,6 +91,7 @@ public class RemoteChunkHandlerFactoryBean<T> implements FactoryBean<ChunkHandle
 	 *
 	 * @see FactoryBean#getObjectType()
 	 */
+	@Override
 	public Class<?> getObjectType() {
 		return ChunkHandler.class;
 	}
@@ -100,6 +101,7 @@ public class RemoteChunkHandlerFactoryBean<T> implements FactoryBean<ChunkHandle
 	 *
 	 * @see FactoryBean#isSingleton()
 	 */
+	@Override
 	public boolean isSingleton() {
 		return true;
 	}
@@ -111,6 +113,7 @@ public class RemoteChunkHandlerFactoryBean<T> implements FactoryBean<ChunkHandle
 	 *
 	 * @see FactoryBean#getObject()
 	 */
+	@Override
 	public ChunkHandler<T> getObject() throws Exception {
 
 		if (stepContributionSource == null) {

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkingManagerStepBuilder.java
@@ -190,6 +190,7 @@ public class RemoteChunkingManagerStepBuilder<I, O> extends FaultTolerantStepBui
 	 * @return the configured manager step
 	 * @see RemoteChunkHandlerFactoryBean
 	 */
+	@Override
 	public TaskletStep build() {
 		Assert.notNull(this.inputChannel, "An InputChannel must be provided");
 		Assert.state(this.outputChannel == null || this.messagingTemplate == null,

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/config/xml/BatchIntegrationNamespaceHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/config/xml/BatchIntegrationNamespaceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,7 @@ import org.springframework.integration.config.xml.AbstractIntegrationNamespaceHa
  */
 public class BatchIntegrationNamespaceHandler extends AbstractIntegrationNamespaceHandler {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.xml.NamespaceHandler#init()
-	 */
+	@Override
 	public void init() {
 		this.registerBeanDefinitionParser("job-launching-gateway", new JobLaunchingGatewayParser());
 		RemoteChunkingManagerParser remoteChunkingManagerParser = new RemoteChunkingManagerParser();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ public class JobLaunchingMessageHandler implements JobLaunchRequestHandler {
 		this.jobLauncher = jobLauncher;
 	}
 
+	@Override
 	@ServiceActivator
 	public JobExecution launch(JobLaunchRequest request) throws JobExecutionException {
 		Job job = request.getJob();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/BeanFactoryStepLocator.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/BeanFactoryStepLocator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.partition;
 
 import java.util.Arrays;
@@ -23,6 +38,7 @@ public class BeanFactoryStepLocator implements StepLocator, BeanFactoryAware {
 
 	private BeanFactory beanFactory;
 
+	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
 	}
@@ -31,6 +47,7 @@ public class BeanFactoryStepLocator implements StepLocator, BeanFactoryAware {
 	 * Look up a bean with the provided name of type {@link Step}.
 	 * @see StepLocator#getStep(String)
 	 */
+	@Override
 	public Step getStep(String stepName) {
 		return beanFactory.getBean(stepName, Step.class);
 	}
@@ -40,6 +57,7 @@ public class BeanFactoryStepLocator implements StepLocator, BeanFactoryAware {
 	 * @throws IllegalStateException if the {@link BeanFactory} is not listable
 	 * @see StepLocator#getStepNames()
 	 */
+	@Override
 	public Collection<String> getStepNames() {
 		Assert.state(beanFactory instanceof ListableBeanFactory, "BeanFactory is not listable.");
 		return Arrays.asList(((ListableBeanFactory) beanFactory).getBeanNamesForType(Step.class));

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilder.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/RemotePartitioningManagerStepBuilder.java
@@ -192,6 +192,7 @@ public class RemotePartitioningManagerStepBuilder extends PartitionStepBuilder {
 		return this;
 	}
 
+	@Override
 	public Step build() {
 		Assert.state(this.outputChannel == null || this.messagingTemplate == null,
 				"You must specify either an outputChannel or a messagingTemplate but not both.");

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobRepositorySupport.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobRepositorySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,104 +34,60 @@ import org.springframework.lang.Nullable;
  */
 public class JobRepositorySupport implements JobRepository {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.JobRepository#createJobExecution(org.
-	 * springframework.batch.core.Job, org.springframework.batch.core.JobParameters)
-	 */
+	@Override
 	public JobExecution createJobExecution(String jobName, JobParameters jobParameters)
 			throws JobExecutionAlreadyRunningException, JobRestartException, JobInstanceAlreadyCompleteException {
 		return new JobExecution(new JobInstance(0L, jobName), jobParameters);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.JobRepository#getJobInstance(java.lang.
-	 * String, org.springframework.batch.core.JobParameters)
-	 */
+	@Override
 	public JobInstance getJobInstance(String jobName, JobParameters jobParameters) {
 		return null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.JobRepository#getLastStepExecution(org.
-	 * springframework.batch.core.JobInstance, org.springframework.batch.core.Step)
-	 */
+	@Override
 	@Nullable
 	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
 		return null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.JobRepository#getStepExecutionCount(org.
-	 * springframework.batch.core.JobInstance, org.springframework.batch.core.Step)
-	 */
+	@Override
 	public long getStepExecutionCount(JobInstance jobInstance, String stepName) {
 		return 0;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.JobRepository#saveOrUpdate(org.
-	 * springframework.batch.core.JobExecution)
-	 */
+	@Override
 	public void update(JobExecution jobExecution) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.JobRepository#saveOrUpdate(org.
-	 * springframework.batch.core.StepExecution)
-	 */
-	public void saveOrUpdate(StepExecution stepExecution) {
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.repository.JobRepository#
-	 * saveOrUpdateExecutionContext(org.springframework.batch.core.StepExecution)
-	 */
+	@Override
 	public void updateExecutionContext(StepExecution stepExecution) {
 	}
 
+	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
 	}
 
+	@Override
 	public void add(StepExecution stepExecution) {
 	}
 
+	@Override
 	public void update(StepExecution stepExecution) {
 	}
 
+	@Override
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 		return false;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.core.repository.JobRepository#getLastJobExecution(java.
-	 * lang.String, org.springframework.batch.core.JobParameters)
-	 */
+	@Override
 	@Nullable
 	public JobExecution getLastJobExecution(String jobName, JobParameters jobParameters) {
 		return null;
 	}
 
+	@Override
 	public void addAll(Collection<StepExecution> stepExecutions) {
 		if (stepExecutions != null) {
 			for (StepExecution stepExecution : stepExecutions) {
@@ -140,6 +96,7 @@ public class JobRepositorySupport implements JobRepository {
 		}
 	}
 
+	@Override
 	public JobInstance createJobInstance(String jobName, JobParameters jobParameters) {
 		return null;
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobSupport.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobSupport.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobParametersIncrementer;
-import org.springframework.batch.core.JobParametersValidator;
-import org.springframework.batch.core.job.DefaultJobParametersValidator;
-import org.springframework.lang.Nullable;
 
 public class JobSupport implements Job {
 
@@ -15,24 +26,18 @@ public class JobSupport implements Job {
 		this.name = name;
 	}
 
+	@Override
 	public void execute(JobExecution execution) {
 	}
 
+	@Override
 	public String getName() {
 		return name;
 	}
 
+	@Override
 	public boolean isRestartable() {
 		return false;
-	}
-
-	@Nullable
-	public JobParametersIncrementer getJobParametersIncrementer() {
-		return null;
-	}
-
-	public JobParametersValidator getJobParametersValidator() {
-		return new DefaultJobParametersValidator();
 	}
 
 }

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/StepSupport.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/StepSupport.java
@@ -38,40 +38,18 @@ public class StepSupport implements Step {
 		this.name = name;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Step#execute(org.springframework.batch.core.
-	 * StepExecution)
-	 */
+	@Override
 	public void execute(StepExecution stepExecution) throws JobInterruptedException {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Step#getName()
-	 */
+	@Override
 	public String getName() {
 		return name;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Step#getStartLimit()
-	 */
+	@Override
 	public int getStartLimit() {
 		return startLimit;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.Step#isAllowStartIfComplete()
-	 */
-	public boolean isAllowStartIfComplete() {
-		return false;
 	}
 
 	/**

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/async/AsyncItemProcessorTests.java
@@ -30,18 +30,12 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.test.MetaDataInstanceFactory;
 import org.springframework.batch.test.StepScopeTestUtils;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.lang.Nullable;
 
 class AsyncItemProcessorTests {
 
 	private final AsyncItemProcessor<String, String> processor = new AsyncItemProcessor<>();
 
-	private ItemProcessor<String, String> delegate = new ItemProcessor<>() {
-		@Nullable
-		public String process(String item) throws Exception {
-			return item + item;
-		}
-	};
+	private ItemProcessor<String, String> delegate = item -> item + item;
 
 	@Test
 	void testNoDelegate() {
@@ -57,13 +51,10 @@ class AsyncItemProcessorTests {
 
 	@Test
 	void testExecutionInStepScope() throws Exception {
-		delegate = new ItemProcessor<>() {
-			@Nullable
-			public String process(String item) throws Exception {
-				StepContext context = StepSynchronizationManager.getContext();
-				assertTrue(context != null && context.getStepExecution() != null);
-				return item + item;
-			}
+		delegate = item -> {
+			StepContext context = StepSynchronizationManager.getContext();
+			assertTrue(context != null && context.getStepExecution() != null);
+			return item + item;
 		};
 		processor.setDelegate(delegate);
 		Future<String> result = StepScopeTestUtils.doInStepScope(MetaDataInstanceFactory.createStepExecution(),

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/MessageSourcePollerInterceptorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/MessageSourcePollerInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the original author or authors.
+ * Copyright 2010-2023 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ class MessageSourcePollerInterceptorTests {
 			this.payload = payload;
 		}
 
+		@Override
 		public Message<String> receive() {
 			return new GenericMessage<>(payload);
 		}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/TestItemReader.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/TestItemReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.chunk;
 
 import java.util.ArrayList;
@@ -40,6 +55,7 @@ public class TestItemReader<T> implements ItemReader<T> {
 		this.items = items;
 	}
 
+	@Override
 	@Nullable
 	public T read() throws Exception, UnexpectedInputException, ParseException {
 

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/TestItemWriter.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/TestItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public class TestItemWriter<T> implements ItemWriter<T> {
 	 */
 	public static final String WAIT_ON = "wait";
 
+	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 
 		for (T item : items) {

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/launch/JobLaunchingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2022 the original author or authors.
+ * Copyright 2008-2023 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ class JobLaunchingMessageHandlerTests {
 
 		AtomicLong jobId = new AtomicLong();
 
+		@Override
 		public JobExecution run(Job job, JobParameters jobParameters) {
 			jobs.add(job);
 			parameters.add(jobParameters);

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/BeanFactoryStepLocatorTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/BeanFactoryStepLocatorTests.java
@@ -53,19 +53,18 @@ class BeanFactoryStepLocatorTests {
 			this.name = name;
 		}
 
+		@Override
 		public void execute(StepExecution stepExecution) throws JobInterruptedException {
 		}
 
+		@Override
 		public String getName() {
 			return name;
 		}
 
+		@Override
 		public int getStartLimit() {
 			return 0;
-		}
-
-		public boolean isAllowStartIfComplete() {
-			return false;
 		}
 
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/ExampleItemReader.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/ExampleItemReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.partition;
 
 import org.apache.commons.logging.Log;
@@ -24,6 +39,7 @@ public class ExampleItemReader implements ItemReader<String>, ItemStream {
 	/**
 	 * Reads next record from input
 	 */
+	@Override
 	@Nullable
 	public String read() throws Exception {
 		if (index >= input.length) {
@@ -45,13 +61,12 @@ public class ExampleItemReader implements ItemReader<String>, ItemStream {
 		return input[index++];
 	}
 
-	public void close() throws ItemStreamException {
-	}
-
+	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		index = (int) executionContext.getLong("POSITION", 0);
 	}
 
+	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		executionContext.putLong("POSITION", index);
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/ExampleItemWriter.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/ExampleItemWriter.java
@@ -31,6 +31,7 @@ public class ExampleItemWriter implements ItemWriter<Object> {
 	/**
 	 * @see ItemWriter#write(Chunk)
 	 */
+	@Override
 	public void write(Chunk<?> data) throws Exception {
 		log.info(data);
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RepeatTransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RepeatTransactionalPollingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2022 the original author or authors.
+ * Copyright 2008-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ class RepeatTransactionalPollingIntegrationTests implements ApplicationContextAw
 
 	private volatile static int count = 0;
 
+	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		bus = (Lifecycle) applicationContext;
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryRepeatTransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryRepeatTransactionalPollingIntegrationTests.java
@@ -52,6 +52,7 @@ class RetryRepeatTransactionalPollingIntegrationTests implements ApplicationCont
 
 	private Lifecycle lifecycle;
 
+	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		lifecycle = (Lifecycle) applicationContext;
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryTransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/RetryTransactionalPollingIntegrationTests.java
@@ -51,6 +51,7 @@ public class RetryTransactionalPollingIntegrationTests implements ApplicationCon
 
 	private Lifecycle bus;
 
+	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		bus = (Lifecycle) applicationContext;
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/SimpleRecoverer.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/SimpleRecoverer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.retry;
 
 import java.util.ArrayList;
@@ -26,6 +41,7 @@ public final class SimpleRecoverer implements MethodInvocationRecoverer<String> 
 		return recovered;
 	}
 
+	@Override
 	public String recover(Object[] data, Throwable cause) {
 		if (data == null) {
 			return null;

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/SimpleService.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/SimpleService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.batch.integration.retry;
 
 import java.util.ArrayList;
@@ -33,6 +48,7 @@ public class SimpleService implements Service {
 		return processed;
 	}
 
+	@Override
 	@ServiceActivator(inputChannel = "requests", outputChannel = "replies")
 	public String process(String message) {
 		String result = message + ": " + count.incrementAndGet();

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/TransactionalPollingIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/retry/TransactionalPollingIntegrationTests.java
@@ -52,6 +52,7 @@ class TransactionalPollingIntegrationTests implements ApplicationContextAware {
 
 	private Lifecycle bus;
 
+	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		bus = (Lifecycle) applicationContext;
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/step/TestTasklet.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/step/TestTasklet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ public class TestTasklet implements Tasklet {
 		this.fail = fail;
 	}
 
+	@Override
 	@Nullable
 	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
 		if (fail) {

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/common/StagingItemWriter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/common/StagingItemWriter.java
@@ -95,23 +95,12 @@ public class StagingItemWriter<T> extends JdbcDaoSupport implements StepExecutio
 				});
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.StepListener#afterStep(StepExecution )
-	 */
 	@Nullable
 	@Override
 	public ExitStatus afterStep(StepExecution stepExecution) {
 		return null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.core.domain.StepListener#beforeStep(org.
-	 * springframework.batch.core.domain.StepExecution)
-	 */
 	@Override
 	public void beforeStep(StepExecution stepExecution) {
 		this.stepExecution = stepExecution;

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/CompositeCustomerUpdateLineTokenizer.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/CompositeCustomerUpdateLineTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,13 +40,6 @@ public class CompositeCustomerUpdateLineTokenizer implements StepExecutionListen
 
 	private StepExecution stepExecution;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.item.file.transform.LineTokenizer#tokenize(java.lang.
-	 * String)
-	 */
 	@Override
 	public FieldSet tokenize(@Nullable String line) {
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/CommonsLoggingInvalidCustomerLogger.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/CommonsLoggingInvalidCustomerLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,12 +30,6 @@ public class CommonsLoggingInvalidCustomerLogger implements InvalidCustomerLogge
 
 	protected static final Log LOG = LogFactory.getLog(CommandLineJobRunner.class);
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.samples.domain.trade.InvalidCustomerLogger#log(org.
-	 * springframework.batch.sample.domain.trade.CustomerUpdate)
-	 */
 	@Override
 	public void log(CustomerUpdate customerUpdate) {
 		LOG.error("invalid customer encountered: [ " + customerUpdate + "]");

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/CustomerCreditUpdatePreparedStatementSetter.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/CustomerCreditUpdatePreparedStatementSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,13 +31,6 @@ public class CustomerCreditUpdatePreparedStatementSetter implements ItemPrepared
 
 	public static final BigDecimal FIXED_AMOUNT = new BigDecimal(1000);
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.io.support.ItemPreparedStatementSetter#setValues(java.
-	 * lang.Object, java.sql.PreparedStatement)
-	 */
 	@Override
 	public void setValues(CustomerCredit customerCredit, PreparedStatement ps) throws SQLException {
 		ps.setBigDecimal(1, customerCredit.getCredit().add(FIXED_AMOUNT));

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/FlatFileCustomerCreditDao.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/FlatFileCustomerCreditDao.java
@@ -72,11 +72,6 @@ public class FlatFileCustomerCreditDao implements CustomerCreditDao, DisposableB
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.DisposableBean#destroy()
-	 */
 	@Override
 	public void destroy() throws Exception {
 		close();

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/HibernateCreditDao.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/internal/HibernateCreditDao.java
@@ -51,13 +51,6 @@ public class HibernateCreditDao implements CustomerCreditDao, RepeatListener {
 		return errors;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.samples.domain.trade.internal.CustomerCreditWriter#write(
-	 * org.springframework.batch.samples.domain.CustomerCredit)
-	 */
 	@Override
 	public void writeCredit(CustomerCredit customerCredit) {
 		if (customerCredit.getId() == failOnFlush) {
@@ -73,11 +66,6 @@ public class HibernateCreditDao implements CustomerCreditDao, RepeatListener {
 		}
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.batch.io.OutputSource#write(java.lang.Object)
-	 */
 	public void write(Object output) {
 		writeCredit((CustomerCredit) output);
 	}
@@ -95,46 +83,18 @@ public class HibernateCreditDao implements CustomerCreditDao, RepeatListener {
 		errors.add(e);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatInterceptor#after(org.springframework.batch.
-	 * repeat.RepeatContext, org.springframework.batch.repeat.ExitStatus)
-	 */
 	@Override
 	public void after(RepeatContext context, RepeatStatus result) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatInterceptor#before(org.springframework.batch
-	 * .repeat.RepeatContext)
-	 */
 	@Override
 	public void before(RepeatContext context) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatInterceptor#close(org.springframework.batch.
-	 * repeat.RepeatContext)
-	 */
 	@Override
 	public void close(RepeatContext context) {
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * org.springframework.batch.repeat.RepeatInterceptor#open(org.springframework.batch.
-	 * repeat.RepeatContext)
-	 */
 	@Override
 	public void open(RepeatContext context) {
 	}

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/football/internal/PlayerSummaryMapper.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/football/internal/PlayerSummaryMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,6 @@ import org.springframework.jdbc.core.RowMapper;
  */
 public class PlayerSummaryMapper implements RowMapper<PlayerSummary> {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.jdbc.core.RowMapper#mapRow(java.sql.ResultSet, int)
-	 */
 	@Override
 	public PlayerSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/football/internal/PlayerSummaryRowMapper.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/football/internal/PlayerSummaryRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,6 @@ import org.springframework.jdbc.core.RowMapper;
  */
 public class PlayerSummaryRowMapper implements RowMapper<PlayerSummary> {
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.jdbc.core.RowMapper#mapRow(java.sql.ResultSet, int)
-	 */
 	@Override
 	public PlayerSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/misc/jmx/SimpleMessageApplicationEvent.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/misc/jmx/SimpleMessageApplicationEvent.java
@@ -33,11 +33,6 @@ public class SimpleMessageApplicationEvent extends ApplicationEvent {
 		this.message = message;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.util.EventObject#toString()
-	 */
 	@Override
 	public String toString() {
 		return "message=[" + message + "], " + super.toString();

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/filter/CustomerFilterJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/filter/CustomerFilterJobFunctionalTests.java
@@ -131,11 +131,6 @@ class CustomerFilterJobFunctionalTests {
 			return name;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see java.lang.Object#hashCode()
-		 */
 		@Override
 		public int hashCode() {
 			final int PRIME = 31;
@@ -147,11 +142,6 @@ class CustomerFilterJobFunctionalTests {
 			return result;
 		}
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see java.lang.Object#equals(java.lang.Object)
-		 */
 		@Override
 		public boolean equals(Object obj) {
 			if (this == obj)

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/jmx/SimpleMessageApplicationEvent.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/jmx/SimpleMessageApplicationEvent.java
@@ -32,11 +32,6 @@ public class SimpleMessageApplicationEvent extends ApplicationEvent {
 		this.message = message;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see java.util.EventObject#toString()
-	 */
 	@Override
 	public String toString() {
 		return "message=[" + message + "], " + super.toString();

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/jmx/StepExecutionApplicationEventAdvice.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/jmx/StepExecutionApplicationEventAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,6 @@ public class StepExecutionApplicationEventAdvice implements ApplicationEventPubl
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.context.ApplicationEventPublisherAware#
-	 * setApplicationEventPublisher(org.springframework.context.ApplicationEventPublisher)
-	 */
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;


### PR DESCRIPTION
The codebase currently contains some comments with "non-Javadoc", which, I think, are predeccesors in spirit to the `@Override` annotation and have been auto-generated by IDEs in the past.

This PR removes these remnants and adds the annotation `@Override` where it is currently missing.

In the test code, I've also removed some methods in support classes that actually don't override anything.