### PR TITLE
Fix `BeanPostProcessorChecker` warnings

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/BatchBeanDefinitionRegistryPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/BatchBeanDefinitionRegistryPostProcessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.configuration.support;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+
+public class BatchBeanDefinitionRegistryPostProcessor implements BeanDefinitionRegistryPostProcessor {
+
+	private static final String JOB_REGISTRY = "jobRegistry";
+
+	private static final String BEAN_POST_PROCESSOR = "jobRegistryBeanPostProcessor";
+
+	@Override
+	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) {
+		if (!registry.containsBeanDefinition(JOB_REGISTRY)) {
+			var beanDefinition = BeanDefinitionBuilder.genericBeanDefinition(MapJobRegistry.class)
+				.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
+				.getBeanDefinition();
+			registry.registerBeanDefinition(JOB_REGISTRY, beanDefinition);
+		}
+
+		if (!registry.containsBeanDefinition(BEAN_POST_PROCESSOR)) {
+			var beanDefinition = BeanDefinitionBuilder.genericBeanDefinition(JobRegistryBeanPostProcessor.class)
+				.addPropertyReference(JOB_REGISTRY, JOB_REGISTRY)
+				.getBeanDefinition();
+			registry.registerBeanDefinition(BEAN_POST_PROCESSOR, beanDefinition);
+		}
+	}
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultBatchConfiguration.java
@@ -112,13 +112,18 @@ import org.springframework.transaction.annotation.Isolation;
  * @since 5.0
  */
 @Configuration(proxyBeanMethods = false)
-@Import(ScopeConfiguration.class)
+@Import({ ScopeConfiguration.class, BatchBeanDefinitionRegistryPostProcessor.class })
 public class DefaultBatchConfiguration implements ApplicationContextAware {
 
 	@Autowired
 	protected ApplicationContext applicationContext;
 
-	private final JobRegistry jobRegistry = new MapJobRegistry();
+	@Autowired
+	protected JobRegistry jobRegistry;
+
+	@Autowired
+	@Deprecated(forRemoval = true)
+	private JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor;
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -187,9 +192,17 @@ public class DefaultBatchConfiguration implements ApplicationContextAware {
 		}
 	}
 
-	@Bean
+	/**
+	 * Defines a {@link JobRegistry} bean.
+	 * @return a {@link JobRegistry} bean
+	 * @throws BatchConfigurationException if unable to register the bean
+	 * @since 5.0
+	 * @deprecated in favor of bean injection, and declaring a custom bean with name
+	 * {@code jobRegistry}
+	 */
+	@Deprecated(forRemoval = true)
 	public JobRegistry jobRegistry() throws BatchConfigurationException {
-		return this.jobRegistry; // FIXME returning a new instance here does not work
+		return this.jobRegistry;
 	}
 
 	@Bean
@@ -214,18 +227,12 @@ public class DefaultBatchConfiguration implements ApplicationContextAware {
 	 * @return a {@link JobRegistryBeanPostProcessor} bean
 	 * @throws BatchConfigurationException if unable to register the bean
 	 * @since 5.1
+	 * @deprecated in favor of bean injection, and declaring a custom bean with name
+	 * {@code jobRegistryBeanPostProcessor}
 	 */
-	@Bean
+	@Deprecated(forRemoval = true)
 	public JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor() throws BatchConfigurationException {
-		JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor = new JobRegistryBeanPostProcessor();
-		jobRegistryBeanPostProcessor.setJobRegistry(jobRegistry());
-		try {
-			jobRegistryBeanPostProcessor.afterPropertiesSet();
-			return jobRegistryBeanPostProcessor;
-		}
-		catch (Exception e) {
-			throw new BatchConfigurationException("Unable to configure the default job registry BeanPostProcessor", e);
-		}
+		return this.jobRegistryBeanPostProcessor;
 	}
 
 	/*

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/DefaultBatchConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/DefaultBatchConfigurationTests.java
@@ -160,7 +160,7 @@ class DefaultBatchConfigurationTests {
 		}
 
 		@Bean
-		public JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor(JobRegistry jobRegistry) {
+		public static JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor(JobRegistry jobRegistry) {
 			JobRegistryBeanPostProcessor postProcessor = new JobRegistryBeanPostProcessor();
 			postProcessor.setJobRegistry(jobRegistry);
 			return postProcessor;


### PR DESCRIPTION
This PR is a suggestion how #4519 could be addressed. It might also offer a solution to #4489, but I haven't really checked the case of XML configuration.

The severety of the logged warnings can be debated. On the one hand, they can probably be ignored by many users, so silencing them in the logging configuration of their applications is often viable. On the other hand, there may well be users who are negatively affected by the early bean initializations, and the more than 10 lines of warnings that are currently produced by a plain Spring Boot app fresh from the Spring Initializr are definitely detrimental to the Getting Started experience.

I think it would be great to have a fix with release 5.1.1 but I don't see a fix that is completely backwards compatible. The PR contains the most backwards compatible version that I could come up with. Unless a better solution is found, I think it should be considered for release 5.1.1 for the sake of the Getting Started experience.

The change is backwards compatible for users that use the respective methods on `DefaultBatchConfiguration` to only access the `JobRegistry` or the `JobRegistryBeanPostProcessor`, or don't use these methods at all. It is a breaking change for users that have overridden these methods to change the beans. These users would need to adapt and expose their replacements as beans with name `jobRegistry` or `jobRegistryBeanPostProcessor` respectively.

Another point to note is that declaring the `JobRegistry` as an infrastructure bean is a bit of a gray area. Many end-users may not be aware of it but there are most likely some who directly use it.

The result of the change is that only the `MapJobRegistry` is initialized early as it is required by the `JobRegistryBeanPostProcessor`, and no more warnings are logged by a plain Spring Boot app (or any other similar app that uses `DefaultBatchConfiguration`).

Please let me know if you are interested in the PR. I'll mark it as a draft until then. It's mostly fine, but I think some additional tests, a polish of the Javadoc, and an edit of the reference documentation would be nice.

Please feel free to close the PR, in case you want to pursue a different direction.