### PR TITLE
Add `JobRegistrySmartInitializingSingleton`

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingleton.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingleton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.batch.core.configuration.support;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,29 +31,28 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.util.Assert;
 
 /**
- * A {@link BeanPostProcessor} that registers {@link Job} beans with a
+ * A {@link SmartInitializingSingleton} that registers {@link Job} beans with a
  * {@link JobRegistry}. Include a bean of this type along with your job configuration and
  * use the same {@link JobRegistry} as a {@link JobLocator} when you need to locate a
  * {@link Job} to launch.
  * <p>
- * An alternative to this class is {@link JobRegistrySmartInitializingSingleton}, which is
- * recommended in cases where this class may cause early bean initializations. You must
- * include at most one of either of them as a bean.
+ * This class is an alternative to {@link JobRegistryBeanPostProcessor} and prevents early
+ * bean initializations. You must include at most one of either of them as a bean.
  *
- * @author Dave Syer
- * @author Mahmoud Ben Hassine
- *
+ * @author Henning Pöttker
+ * @since 5.1.1
  */
-public class JobRegistryBeanPostProcessor
-		implements BeanPostProcessor, BeanFactoryAware, InitializingBean, DisposableBean {
+public class JobRegistrySmartInitializingSingleton
+		implements SmartInitializingSingleton, BeanFactoryAware, InitializingBean, DisposableBean {
 
-	private static final Log logger = LogFactory.getLog(JobRegistryBeanPostProcessor.class);
+	private static final Log logger = LogFactory.getLog(JobRegistrySmartInitializingSingleton.class);
 
 	// It doesn't make sense for this to have a default value...
 	private JobRegistry jobRegistry = null;
@@ -61,7 +61,21 @@ public class JobRegistryBeanPostProcessor
 
 	private String groupName = null;
 
-	private DefaultListableBeanFactory beanFactory;
+	private ListableBeanFactory beanFactory;
+
+	/**
+	 * Default constructor.
+	 */
+	public JobRegistrySmartInitializingSingleton() {
+	}
+
+	/**
+	 * Convenience constructor for setting the {@link JobRegistry}.
+	 * @param jobRegistry the {@link JobRegistry} to register the {@link Job}s with
+	 */
+	public JobRegistrySmartInitializingSingleton(JobRegistry jobRegistry) {
+		this.jobRegistry = jobRegistry;
+	}
 
 	/**
 	 * The group name for jobs registered by this component. Optional (defaults to null,
@@ -77,29 +91,21 @@ public class JobRegistryBeanPostProcessor
 
 	/**
 	 * Injection setter for {@link JobRegistry}.
-	 * @param jobRegistry the jobConfigurationRegistry to set
+	 * @param jobRegistry the {@link JobRegistry} to register the {@link Job}s with
 	 */
 	public void setJobRegistry(JobRegistry jobRegistry) {
 		this.jobRegistry = jobRegistry;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.springframework.beans.factory.BeanFactoryAware#setBeanFactory(org
-	 * .springframework.beans.factory.BeanFactory)
-	 */
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		if (beanFactory instanceof DefaultListableBeanFactory) {
-			this.beanFactory = (DefaultListableBeanFactory) beanFactory;
+		if (beanFactory instanceof ListableBeanFactory listableBeanFactory) {
+			this.beanFactory = listableBeanFactory;
 		}
 	}
 
 	/**
 	 * Make sure the registry is set before use.
-	 *
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
@@ -109,7 +115,6 @@ public class JobRegistryBeanPostProcessor
 	/**
 	 * Unregister all the {@link Job} instances that were registered by this post
 	 * processor.
-	 * @see org.springframework.beans.factory.DisposableBean#destroy()
 	 */
 	@Override
 	public void destroy() throws Exception {
@@ -122,36 +127,36 @@ public class JobRegistryBeanPostProcessor
 		jobNames.clear();
 	}
 
-	/**
-	 * If the bean is an instance of {@link Job}, then register it.
-	 * @throws FatalBeanException if there is a {@link DuplicateJobException}.
-	 *
-	 * @see org.springframework.beans.factory.config.BeanPostProcessor#postProcessAfterInitialization(java.lang.Object,
-	 * java.lang.String)
-	 */
 	@Override
-	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-		if (bean instanceof Job job) {
-			try {
-				String groupName = this.groupName;
-				if (beanFactory != null && beanFactory.containsBean(beanName)) {
-					groupName = getGroupName(beanFactory.getBeanDefinition(beanName), job);
-				}
-				job = groupName == null ? job : new GroupAwareJob(groupName, job);
-				ReferenceJobFactory jobFactory = new ReferenceJobFactory(job);
-				String name = jobFactory.getJobName();
-				if (logger.isDebugEnabled()) {
-					logger.debug("Registering job: " + name);
-				}
-				jobRegistry.register(jobFactory);
-				jobNames.add(name);
-			}
-			catch (DuplicateJobException e) {
-				throw new FatalBeanException("Cannot register job configuration", e);
-			}
-			return job;
+	public void afterSingletonsInstantiated() {
+		if (beanFactory == null) {
+			return;
 		}
-		return bean;
+		Map<String, Job> jobs = beanFactory.getBeansOfType(Job.class, false, false);
+		for (var entry : jobs.entrySet()) {
+			postProcessAfterInitialization(entry.getValue(), entry.getKey());
+		}
+	}
+
+	private void postProcessAfterInitialization(Job job, String beanName) {
+		try {
+			String groupName = this.groupName;
+			if (beanFactory instanceof DefaultListableBeanFactory defaultListableBeanFactory
+					&& beanFactory.containsBean(beanName)) {
+				groupName = getGroupName(defaultListableBeanFactory.getBeanDefinition(beanName), job);
+			}
+			job = groupName == null ? job : new GroupAwareJob(groupName, job);
+			ReferenceJobFactory jobFactory = new ReferenceJobFactory(job);
+			String name = jobFactory.getJobName();
+			if (logger.isDebugEnabled()) {
+				logger.debug("Registering job: " + name);
+			}
+			jobRegistry.register(jobFactory);
+			jobNames.add(name);
+		}
+		catch (DuplicateJobException e) {
+			throw new FatalBeanException("Cannot register job configuration", e);
+		}
 	}
 
 	/**
@@ -164,17 +169,6 @@ public class JobRegistryBeanPostProcessor
 	 */
 	protected String getGroupName(BeanDefinition beanDefinition, Job job) {
 		return groupName;
-	}
-
-	/**
-	 * Do nothing.
-	 *
-	 * @see org.springframework.beans.factory.config.BeanPostProcessor#postProcessBeforeInitialization(java.lang.Object,
-	 * java.lang.String)
-	 */
-	@Override
-	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-		return bean;
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingletonTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingletonTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.configuration.support;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.configuration.DuplicateJobException;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.job.JobSupport;
+import org.springframework.beans.FatalBeanException;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Henning Pöttker
+ */
+class JobRegistrySmartInitializingSingletonTests {
+
+	private final JobRegistry jobRegistry = new MapJobRegistry();
+
+	private final JobRegistrySmartInitializingSingleton singleton = new JobRegistrySmartInitializingSingleton(
+			jobRegistry);
+
+	private final ListableBeanFactory beanFactory = mock(ListableBeanFactory.class);
+
+	@BeforeEach
+	void setUp() {
+		var job = new JobSupport();
+		job.setName("foo");
+		lenient().when(beanFactory.getBeansOfType(Job.class, false, false)).thenReturn(Map.of("bar", job));
+		singleton.setBeanFactory(beanFactory);
+	}
+
+	@Test
+	void testInitializationFails() {
+		singleton.setJobRegistry(null);
+		var exception = assertThrows(IllegalStateException.class, singleton::afterPropertiesSet);
+		assertTrue(exception.getMessage().contains("JobRegistry"));
+	}
+
+	@Test
+	void testAfterSingletonsInstantiated() {
+		singleton.afterSingletonsInstantiated();
+		assertEquals("[foo]", jobRegistry.getJobNames().toString());
+	}
+
+	@Test
+	void testAfterSingletonsInstantiatedWithGroupName() {
+		singleton.setGroupName("jobs");
+		singleton.afterSingletonsInstantiated();
+		assertEquals("[jobs.foo]", jobRegistry.getJobNames().toString());
+	}
+
+	@Test
+	void testAfterSingletonsInstantiatedWithDuplicate() {
+		singleton.afterSingletonsInstantiated();
+		var exception = assertThrows(FatalBeanException.class, singleton::afterSingletonsInstantiated);
+		assertTrue(exception.getCause() instanceof DuplicateJobException);
+	}
+
+	@Test
+	void testUnregisterOnDestroy() throws Exception {
+		singleton.afterSingletonsInstantiated();
+		singleton.destroy();
+		assertEquals("[]", jobRegistry.getJobNames().toString());
+	}
+
+	@Test
+	void testExecutionWithApplicationContext() throws Exception {
+		var context = new ClassPathXmlApplicationContext("test-context-with-smart-initializing-singleton.xml",
+				getClass());
+		var registry = context.getBean("registry", JobRegistry.class);
+		Collection<String> jobNames = registry.getJobNames();
+		String[] names = context.getBeanNamesForType(JobSupport.class);
+		int count = names.length;
+		// Each concrete bean of type JobConfiguration is registered...
+		assertEquals(count, jobNames.size());
+		// N.B. there is a failure / wonky mode where a parent bean is given an
+		// explicit name or beanName (using property setter): in this case then
+		// child beans will have the same name and will be re-registered (and
+		// override, if the registry supports that).
+		assertNotNull(registry.getJob("test-job"));
+		assertEquals(context.getBean("test-job-with-name"), registry.getJob("foo"));
+		assertEquals(context.getBean("test-job-with-bean-name"), registry.getJob("bar"));
+		assertEquals(context.getBean("test-job-with-parent-and-name"), registry.getJob("spam"));
+		assertEquals(context.getBean("test-job-with-parent-and-bean-name"), registry.getJob("bucket"));
+		assertEquals(context.getBean("test-job-with-concrete-parent"), registry.getJob("maps"));
+		assertEquals(context.getBean("test-job-with-concrete-parent-and-name"), registry.getJob("oof"));
+		assertEquals(context.getBean("test-job-with-concrete-parent-and-bean-name"), registry.getJob("rab"));
+	}
+
+}

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/test-context-with-smart-initializing-singleton.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/test-context-with-smart-initializing-singleton.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean
+		class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
+		<property name="jobRegistry" ref="registry" />
+	</bean>
+
+	<bean id="registry"
+		class="org.springframework.batch.core.configuration.support.MapJobRegistry" />
+
+	<bean id="test-job"
+		class="org.springframework.batch.core.job.JobSupport">
+		<property name="steps">
+			<bean id="step1" class="org.springframework.batch.core.step.factory.SimpleStepFactoryBean">
+				<property name="itemReader" ref="itemReader" />
+				<property name="itemWriter" ref="itemWriter" />
+				<property name="jobRepository" ref="jobRepository" />
+				<property name="transactionManager" ref="transactionManager"/>
+			</bean>
+		</property>
+	</bean>
+
+	<bean id="itemReader"
+		class="org.springframework.batch.item.support.ListItemReader">
+		<constructor-arg value="foo,bar,spam" />
+	</bean>
+
+	<bean id="itemWriter"
+		class="org.springframework.batch.core.launch.EmptyItemWriter" />
+
+	<bean id="jobRepository"
+		class="org.springframework.batch.core.step.JobRepositorySupport" />
+
+	<bean id="transactionManager"
+		class="org.springframework.batch.support.transaction.ResourcelessTransactionManager" />
+
+	<bean id="test-job-with-name"
+		class="org.springframework.batch.core.job.JobSupport">
+		<property name="name" value="foo" />
+	</bean>
+
+	<bean id="test-job-with-bean-name"
+		class="org.springframework.batch.core.job.JobSupport">
+		<property name="beanName" value="bar" />
+	</bean>
+
+	<bean id="abstract-job"
+		class="org.springframework.batch.core.job.JobSupport"
+		abstract="true" />
+
+	<bean id="test-job-with-parent" parent="abstract-job" />
+
+	<bean id="test-job-with-parent-and-name" parent="abstract-job"
+		p:name="spam" />
+
+	<bean id="test-job-with-parent-and-bean-name" parent="abstract-job"
+		p:name="bucket" />
+
+	<bean id="parent-job"
+		class="org.springframework.batch.core.job.JobSupport" />
+
+	<bean id="test-job-with-concrete-parent" parent="parent-job"
+		p:name="maps" />
+
+	<bean id="test-job-with-concrete-parent-and-name"
+		parent="parent-job" p:name="oof" />
+
+	<bean id="test-job-with-concrete-parent-and-bean-name"
+		parent="parent-job" p:beanName="rab" />
+
+</beans>


### PR DESCRIPTION
This PR adds `JobRegistrySmartInitializingSingleton` as an alternative to `JobRegistryBeanPostProcessor`. Using `JobRegistrySmartInitializingSingleton` instead of `JobRegistryBeanPostProcessor` allows users to solve problems like #4489, where  they configure their own application context and want a mechanism to automatically register job beans with the job registry.

As also discussed in #4520, the advantage of `JobRegistrySmartInitializingSingleton` over `JobRegistryBeanPostProcessor` is that it is not prone to trigger early initializations of beans.

One other difference is that `JobRegistrySmartInitializingSingleton` will instantiate all job beans that are declared as lazy (unless the property `allowEagerClassLoading` of `DefaultListableBeanFactory` is set to false). This shouldn't be a problem however as users who do use the `JobRegistry` are very unlikely to have lazily initialized job beans as that would imply that the `JobRegistry` is incomplete.