### PR TITLE
Fix typo in The Domain Language of Batch's Doc Page

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/domain.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/domain.adoc
@@ -141,7 +141,7 @@ following image shows:
 image::job-stereotypes-parameters.png[Job Parameters, scaledwidth="60%"]
 
 In the preceding example, where there are two instances, one for January 1st and another
-for January 2nd, there is really only one `Job`, but it has two `JobParameter` objects:
+for January 2nd, there is really only one `Job`, but it has two `JobInstance` objects:
 one that was started with a job parameter of 01-01-2017 and another that was started with
 a parameter of 01-02-2017. Thus, the contract can be defined as: `JobInstance` = `Job`
  + identifying `JobParameters`. This allows a developer to effectively control how a


### PR DESCRIPTION
Minor correction in The Domain Language of Batch documentation page text.