### PR TITLE
Make util classes to follow style guide

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/BeanDefinitionUtils.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/BeanDefinitionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,13 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
 /**
  * @author Dan Garrette
+ * @author Taeik Lim
  * @since 2.0.1
  */
-public class BeanDefinitionUtils {
+public abstract class BeanDefinitionUtils {
+
+	private BeanDefinitionUtils() {
+	}
 
 	/**
 	 * @param beanName a bean definition name

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/CoreNamespaceUtils.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/CoreNamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,12 @@ import java.util.Map;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  */
-public class CoreNamespaceUtils {
+public abstract class CoreNamespaceUtils {
+
+	private CoreNamespaceUtils() {
+	}
 
 	private static final String STEP_SCOPE_PROCESSOR_BEAN_NAME = "org.springframework.batch.core.scope.internalStepScope";
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcParameterUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcParameterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,13 @@ import java.util.List;
  * @author Thomas Risberg
  * @author Juergen Hoeller
  * @author Marten Deinum
+ * @author Taeik Lim
  * @since 2.0
  */
-public class JdbcParameterUtils {
+public abstract class JdbcParameterUtils {
+
+	private JdbcParameterUtils() {
+	}
 
 	/**
 	 * Count the occurrences of the character placeholder in an SQL string

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,13 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  * @since 2.0
  */
-public class SqlPagingQueryUtils {
+public abstract class SqlPagingQueryUtils {
+
+	private SqlPagingQueryUtils() {
+	}
 
 	/**
 	 * Generate SQL query string using a LIMIT clause

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/FileUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,9 @@ import org.springframework.util.Assert;
  *
  * @author Peter Zozom
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  */
-public final class FileUtils {
+public abstract class FileUtils {
 
 	// forbids instantiation
 	private FileUtils() {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodInvokerUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodInvokerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,13 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Lucas Ward
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  * @since 2.0
  */
-public class MethodInvokerUtils {
+public abstract class MethodInvokerUtils {
+
+	private MethodInvokerUtils() {
+	}
 
 	/**
 	 * Create a {@link MethodInvoker} using the provided method name to search.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/ReflectionUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,10 @@ import org.springframework.core.annotation.AnnotationUtils;
  *
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  * @since 2.2.6
  */
-public class ReflectionUtils {
+public abstract class ReflectionUtils {
 
 	private ReflectionUtils() {
 	}

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/ExecutionContextTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/ExecutionContextTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,14 @@ import org.springframework.lang.Nullable;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  * @since 2.1.4
  *
  */
-public class ExecutionContextTestUtils {
+public abstract class ExecutionContextTestUtils {
+
+	private ExecutionContextTestUtils() {
+	}
 
 	@SuppressWarnings("unchecked")
 	@Nullable

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobScopeTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobScopeTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,12 @@ import org.springframework.batch.core.scope.context.JobSynchronizationManager;
  * @author Dave Syer
  * @author Jimmy Praet
  * @author Mahmoud Ben Hassine
+ * @author Taeik Lim
  */
-public class JobScopeTestUtils {
+public abstract class JobScopeTestUtils {
+
+	private JobScopeTestUtils() {
+	}
 
 	public static <T> T doInJobScope(JobExecution jobExecution, Callable<T> callable) throws Exception {
 		try {

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/StepScopeTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/StepScopeTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,13 @@ import org.springframework.batch.core.scope.context.StepSynchronizationManager;
  * test case that happen to be step scoped in the application context.
  *
  * @author Dave Syer
+ * @author Taeik Lim
  *
  */
-public class StepScopeTestUtils {
+public abstract class StepScopeTestUtils {
+
+	private StepScopeTestUtils() {
+	}
 
 	public static <T> T doInStepScope(StepExecution stepExecution, Callable<T> callable) throws Exception {
 		try {


### PR DESCRIPTION
Make utils class to follow [spring utils style guide](https://github.com/spring-projects/spring-framework/wiki/Code-Style#utility-classes).

![Screenshot 2024-02-06 at 13 05 54](https://github.com/spring-projects/spring-batch/assets/24649991/2659c653-4305-4b2e-adc9-261202b85feb)

Change classes only in `src/java/main/...`.