### PR TITLE
Reduce formatter initializations in `DefaultFieldSet`

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,17 +45,13 @@ public class DefaultFieldSet implements FieldSet {
 
 	private final static String DEFAULT_DATE_PATTERN = "yyyy-MM-dd";
 
-	private DateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
+	private DateFormat dateFormat;
 
-	{
-		dateFormat.setLenient(false);
-	}
+	private NumberFormat numberFormat;
 
-	private NumberFormat numberFormat = NumberFormat.getInstance(Locale.US);
+	private String grouping;
 
-	private String grouping = ",";
-
-	private String decimal = ".";
+	private String decimal;
 
 	/**
 	 * The fields wrapped by this '<code>FieldSet</code>' instance.
@@ -77,6 +73,10 @@ public class DefaultFieldSet implements FieldSet {
 		}
 	}
 
+	private static NumberFormat getDefaultNumberFormat() {
+		return NumberFormat.getInstance(Locale.US);
+	}
+
 	/**
 	 * The {@link DateFormat} to use for parsing dates. If unset the default pattern is
 	 * ISO standard <code>yyyy-MM-dd</code>.
@@ -86,6 +86,26 @@ public class DefaultFieldSet implements FieldSet {
 		this.dateFormat = dateFormat;
 	}
 
+	private static DateFormat getDefaultDateFormat() {
+		DateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
+		dateFormat.setLenient(false);
+		return dateFormat;
+	}
+
+	/**
+	 * Create a FieldSet with anonymous tokens. They can only be retrieved by column
+	 * number.
+	 * @param tokens the token values
+	 * @param dateFormat the {@link DateFormat} to use
+	 * @param numberFormat the {@link NumberFormat} to use
+	 * @see FieldSet#readString(int)
+	 */
+	public DefaultFieldSet(String[] tokens, @Nullable DateFormat dateFormat, @Nullable NumberFormat numberFormat) {
+		this.tokens = tokens == null ? null : tokens.clone();
+		setDateFormat(dateFormat == null ? getDefaultDateFormat() : dateFormat);
+		setNumberFormat(numberFormat == null ? getDefaultNumberFormat() : numberFormat);
+	}
+
 	/**
 	 * Create a FieldSet with anonymous tokens. They can only be retrieved by column
 	 * number.
@@ -93,8 +113,30 @@ public class DefaultFieldSet implements FieldSet {
 	 * @see FieldSet#readString(int)
 	 */
 	public DefaultFieldSet(String[] tokens) {
-		this.tokens = tokens == null ? null : tokens.clone();
-		setNumberFormat(NumberFormat.getInstance(Locale.US));
+		this(tokens, null, null);
+	}
+
+	/**
+	 * Create a FieldSet with named tokens. The token values can then be retrieved either
+	 * by name or by column number.
+	 * @param tokens the token values
+	 * @param names the names of the tokens
+	 * @param dateFormat the {@link DateFormat} to use
+	 * @param numberFormat the {@link NumberFormat} to use
+	 * @see FieldSet#readString(String)
+	 */
+	public DefaultFieldSet(String[] tokens, String[] names, @Nullable DateFormat dateFormat,
+			@Nullable NumberFormat numberFormat) {
+		Assert.notNull(tokens, "Tokens must not be null");
+		Assert.notNull(names, "Names must not be null");
+		if (tokens.length != names.length) {
+			throw new IllegalArgumentException("Field names must be same length as values: names="
+					+ Arrays.asList(names) + ", values=" + Arrays.asList(tokens));
+		}
+		this.tokens = tokens.clone();
+		this.names = Arrays.asList(names);
+		setDateFormat(dateFormat == null ? getDefaultDateFormat() : dateFormat);
+		setNumberFormat(numberFormat == null ? getDefaultNumberFormat() : numberFormat);
 	}
 
 	/**
@@ -105,15 +147,7 @@ public class DefaultFieldSet implements FieldSet {
 	 * @see FieldSet#readString(String)
 	 */
 	public DefaultFieldSet(String[] tokens, String[] names) {
-		Assert.notNull(tokens, "Tokens must not be null");
-		Assert.notNull(names, "Names must not be null");
-		if (tokens.length != names.length) {
-			throw new IllegalArgumentException("Field names must be same length as values: names="
-					+ Arrays.asList(names) + ", values=" + Arrays.asList(tokens));
-		}
-		this.tokens = tokens.clone();
-		this.names = Arrays.asList(names);
-		setNumberFormat(NumberFormat.getInstance(Locale.US));
+		this(tokens, names, null, null);
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSetFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSetFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2023 the original author or authors.
+ * Copyright 2009-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.batch.item.file.transform;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Default implementation of {@link FieldSetFactory} with no special knowledge of the
  * {@link FieldSet} required. Returns a {@link DefaultFieldSet} from both factory methods.
@@ -31,6 +33,22 @@ public class DefaultFieldSetFactory implements FieldSetFactory {
 	private DateFormat dateFormat;
 
 	private NumberFormat numberFormat;
+
+	/**
+	 * Default constructor.
+	 */
+	public DefaultFieldSetFactory() {
+	}
+
+	/**
+	 * Convenience constructor
+	 * @param dateFormat the {@link DateFormat} to use for parsing dates
+	 * @param numberFormat the {@link NumberFormat} to use for parsing numbers
+	 */
+	public DefaultFieldSetFactory(@Nullable DateFormat dateFormat, @Nullable NumberFormat numberFormat) {
+		this.dateFormat = dateFormat;
+		this.numberFormat = numberFormat;
+	}
 
 	/**
 	 * The {@link NumberFormat} to use for parsing numbers. If unset then
@@ -55,8 +73,7 @@ public class DefaultFieldSetFactory implements FieldSetFactory {
 	 */
 	@Override
 	public FieldSet create(String[] values, String[] names) {
-		DefaultFieldSet fieldSet = new DefaultFieldSet(values, names);
-		return enhance(fieldSet);
+		return new DefaultFieldSet(values, names, dateFormat, numberFormat);
 	}
 
 	/**
@@ -64,18 +81,7 @@ public class DefaultFieldSetFactory implements FieldSetFactory {
 	 */
 	@Override
 	public FieldSet create(String[] values) {
-		DefaultFieldSet fieldSet = new DefaultFieldSet(values);
-		return enhance(fieldSet);
-	}
-
-	private FieldSet enhance(DefaultFieldSet fieldSet) {
-		if (dateFormat != null) {
-			fieldSet.setDateFormat(dateFormat);
-		}
-		if (numberFormat != null) {
-			fieldSet.setNumberFormat(numberFormat);
-		}
-		return fieldSet;
+		return new DefaultFieldSet(values, dateFormat, numberFormat);
 	}
 
 }


### PR DESCRIPTION
Resolves #1694.

The PR addresses the problem that the default value for the field `numberFormat` of `DefaultFieldSet` is currently initialized twice: Once by the assignment in the declaration and once in the constructor. As the construction of the default number format is expensive, this should be avoided.

It also addresses the problem that the expensive construction of the default `numberFormat` and `dateFormat` currently cannot be avoided in the case where the default values are overwritten after calling the constructor.