### PR TITLE
Incorrect code example in documentation

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/step/tasklet.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/tasklet.adoc
@@ -122,7 +122,7 @@ public class FileDeletingTasklet implements Tasklet, InitializingBean {
     public RepeatStatus execute(StepContribution contribution,
                                 ChunkContext chunkContext) throws Exception {
         File dir = directory.getFile();
-        Assert.state(dir.isDirectory());
+        Assert.state(dir.isDirectory(), "Directory does not exist");
 
         File[] files = dir.listFiles();
         for (int i = 0; i < files.length; i++) {
@@ -140,7 +140,7 @@ public class FileDeletingTasklet implements Tasklet, InitializingBean {
     }
 
     public void afterPropertiesSet() throws Exception {
-        Assert.state(directory != null, "directory must be set");
+        Assert.state(directory != null, "Directory must be set");
     }
 }
 ----

--- a/spring-batch-docs/modules/ROOT/pages/step/tasklet.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/tasklet.adoc
@@ -122,7 +122,7 @@ public class FileDeletingTasklet implements Tasklet, InitializingBean {
     public RepeatStatus execute(StepContribution contribution,
                                 ChunkContext chunkContext) throws Exception {
         File dir = directory.getFile();
-        Assert.state(dir.isDirectory(), "Directory does not exist");
+        Assert.state(dir.isDirectory(), "The resource must be a directory");
 
         File[] files = dir.listFiles();
         for (int i = 0; i < files.length; i++) {


### PR DESCRIPTION
- Message in `Assert.state(dir.isDirectory())` was missing.
- Message has been changed to start with a capital letter, consistent with other parts.