### PR TITLE
Avoid collection copying

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/CommandLineJobRunner.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/CommandLineJobRunner.java
@@ -53,6 +53,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -405,7 +406,7 @@ public class CommandLineJobRunner {
 
 			for (JobInstance jobInstance : lastInstances) {
 				List<JobExecution> jobExecutions = jobExplorer.getJobExecutions(jobInstance);
-				if (jobExecutions == null || jobExecutions.isEmpty()) {
+				if (CollectionUtils.isEmpty(jobExecutions)) {
 					continue;
 				}
 				for (JobExecution jobExecution : jobExecutions) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
@@ -38,9 +38,9 @@ import java.util.Objects;
  */
 public class Chunk<W> implements Iterable<W>, Serializable {
 
-	private List<W> items = new ArrayList<>();
+	private final List<W> items = new ArrayList<>();
 
-	private List<SkipWrapper<W>> skips = new ArrayList<>();
+	private final List<SkipWrapper<W>> skips = new ArrayList<>();
 
 	private final List<Exception> errors = new ArrayList<>();
 
@@ -67,10 +67,10 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 	public Chunk(List<? extends W> items, List<SkipWrapper<W>> skips) {
 		super();
 		if (items != null) {
-			this.items = new ArrayList<>(items);
+			this.items.addAll(items);
 		}
 		if (skips != null) {
-			this.skips = new ArrayList<>(skips);
+			this.skips.addAll(skips);
 		}
 	}
 
@@ -103,7 +103,7 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 	 * @return a copy of the items to be processed as an unmodifiable list
 	 */
 	public List<W> getItems() {
-		return List.copyOf(items);
+		return Collections.unmodifiableList(items);
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoItemWriter.java
@@ -188,7 +188,7 @@ public class MongoItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 * @param chunk the chunk of items to be persisted.
 	 */
 	protected void doWrite(Chunk<? extends T> chunk) {
-		if (!CollectionUtils.isEmpty(chunk.getItems())) {
+		if (!chunk.isEmpty()) {
 			switch (this.mode) {
 				case INSERT -> insert(chunk);
 				case REMOVE -> remove(chunk);
@@ -263,7 +263,7 @@ public class MongoItemWriter<T> implements ItemWriter<T>, InitializingBean {
 				public void beforeCommit(boolean readOnly) {
 					Chunk<T> chunk = (Chunk<T>) TransactionSynchronizationManager.getResource(bufferKey);
 
-					if (!CollectionUtils.isEmpty(chunk.getItems())) {
+					if (!chunk.isEmpty()) {
 						if (!readOnly) {
 							doWrite(chunk);
 						}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/Neo4jItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/Neo4jItemWriter.java
@@ -89,7 +89,7 @@ public class Neo4jItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 */
 	@Override
 	public void write(Chunk<? extends T> chunk) throws Exception {
-		if (!CollectionUtils.isEmpty(chunk.getItems())) {
+		if (!chunk.isEmpty()) {
 			doWrite(chunk);
 		}
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
@@ -93,7 +93,7 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 	 */
 	@Override
 	public void write(Chunk<? extends T> chunk) throws Exception {
-		if (!CollectionUtils.isEmpty(chunk.getItems())) {
+		if (!chunk.isEmpty()) {
 			doWrite(chunk);
 		}
 	}


### PR DESCRIPTION
Removes the unnecessary copying of collections. I didn't do a thorough search, just a few items I came across while I was implementing a batch processor.