### PR TITLE
Fix SystemCommandTasklet to propagate error when exit status is failed

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
@@ -124,11 +124,11 @@ public class SystemCommandTasklet implements StepExecutionListener, StoppableTas
 			if (systemCommandTask.isDone()) {
 				Integer exitCode = systemCommandTask.get();
 				ExitStatus exitStatus = systemProcessExitCodeMapper.getExitStatus(exitCode);
+				contribution.setExitStatus(exitStatus);
 				if (ExitStatus.FAILED.equals(exitStatus)) {
 					throw new SystemCommandException("Execution of system command failed with exit code " + exitCode);
 				}
 				else {
-					contribution.setExitStatus(exitStatus);
 					return RepeatStatus.FINISHED;
 				}
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import org.springframework.util.StringUtils;
  * @author Robert Kasanicky
  * @author Will Schipp
  * @author Mahmoud Ben Hassine
+ * @author Injae Kim
  */
 public class SystemCommandTasklet implements StepExecutionListener, StoppableTasklet, InitializingBean {
 
@@ -121,8 +122,15 @@ public class SystemCommandTasklet implements StepExecutionListener, StoppableTas
 			}
 
 			if (systemCommandTask.isDone()) {
-				contribution.setExitStatus(systemProcessExitCodeMapper.getExitStatus(systemCommandTask.get()));
-				return RepeatStatus.FINISHED;
+				Integer exitCode = systemCommandTask.get();
+				ExitStatus exitStatus = systemProcessExitCodeMapper.getExitStatus(exitCode);
+				if (ExitStatus.FAILED.equals(exitStatus)) {
+					throw new SystemCommandException("Execution of system command failed with exit code " + exitCode);
+				}
+				else {
+					contribution.setExitStatus(exitStatus);
+					return RepeatStatus.FINISHED;
+				}
 			}
 			else if (System.currentTimeMillis() - t0 > timeout) {
 				systemCommandTask.cancel(interruptOnCancel);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
@@ -325,6 +325,7 @@ class SystemCommandTaskletIntegrationTests {
 
 		Exception exception = assertThrows(SystemCommandException.class, () -> tasklet.execute(stepContribution, null));
 		assertTrue(exception.getMessage().contains("failed with exit code"));
+		assertEquals(ExitStatus.FAILED, stepContribution.getExitStatus());
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2023 the original author or authors.
+ * Copyright 2008-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,10 +323,8 @@ class SystemCommandTaskletIntegrationTests {
 		tasklet.setCommand(command);
 		tasklet.afterPropertiesSet();
 
-		RepeatStatus exitStatus = tasklet.execute(stepContribution, null);
-
-		assertEquals(RepeatStatus.FINISHED, exitStatus);
-		assertEquals(ExitStatus.FAILED, stepContribution.getExitStatus());
+		Exception exception = assertThrows(SystemCommandException.class, () -> tasklet.execute(stepContribution, null));
+		assertTrue(exception.getMessage().contains("failed with exit code"));
 	}
 
 }


### PR DESCRIPTION
Fixes #4483.

### Motivation
- On #4483, we found that `SystemCommandTasklet` does not propagate errors when command returns a `non-zero` exit code, which is mapped to `ExistStatus.FAILED`

### Modification
- Fix `SystemCommandTasklet` to propagate error when `ExistStatus.FAILED`