### PR TITLE
Fix unfinished step in parallel flow

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/SplitState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/SplitState.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
@@ -119,7 +120,7 @@ public class SplitState extends AbstractState implements FlowHolder {
 		FlowExecutionStatus parentSplitStatus = parentSplit == null ? null : parentSplit.handle(executor);
 
 		Collection<FlowExecution> results = new ArrayList<>();
-
+		List<Exception> exceptions = new ArrayList<>();
 		// Could use a CompletionService here?
 		for (Future<FlowExecution> task : tasks) {
 			try {
@@ -129,12 +130,16 @@ public class SplitState extends AbstractState implements FlowHolder {
 				// Unwrap the expected exceptions
 				Throwable cause = e.getCause();
 				if (cause instanceof Exception) {
-					throw (Exception) cause;
+					exceptions.add((Exception) cause);
 				}
 				else {
-					throw e;
+					exceptions.add(e);
 				}
 			}
+		}
+
+		if (!exceptions.isEmpty()) {
+			throw exceptions.get(0);
 		}
 
 		FlowExecutionStatus flowExecutionStatus = doAggregation(results, executor);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -16,11 +16,14 @@
 package org.springframework.batch.core.job.builder;
 
 import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
@@ -45,6 +48,8 @@ import org.springframework.batch.core.repository.support.JobRepositoryFactoryBea
 import org.springframework.batch.core.step.StepSupport;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -417,6 +422,40 @@ class FlowJobBuilderTests {
 			return new JdbcTransactionManager(dataSource);
 		}
 
+	}
+
+	@Test
+	public void testBuildSplitWithParallelFlow() throws InterruptedException {
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		Step longExecutingStep = new StepBuilder("longExecutingStep", jobRepository).tasklet((stepContribution, b) -> {
+			Thread.sleep(500L);
+			return RepeatStatus.FINISHED;
+		}, new ResourcelessTransactionManager()).build();
+
+		Step interruptedStep = new StepBuilder("interruptedStep", jobRepository).tasklet((stepContribution, b) -> {
+			stepContribution.getStepExecution().setTerminateOnly();
+			return RepeatStatus.FINISHED;
+		}, new ResourcelessTransactionManager()).build();
+
+		Step nonExecutableStep = new StepBuilder("nonExecutableStep", jobRepository).tasklet((stepContribution, b) -> {
+			countDownLatch.countDown();
+			return RepeatStatus.FINISHED;
+		}, new ResourcelessTransactionManager()).build();
+
+		Flow twoStepFlow = new FlowBuilder<SimpleFlow>("twoStepFlow").start(longExecutingStep)
+			.next(nonExecutableStep)
+			.build();
+		Flow interruptedFlow = new FlowBuilder<SimpleFlow>("interruptedFlow").start(interruptedStep).build();
+
+		Flow splitFlow = new FlowBuilder<Flow>("splitFlow").split(new SimpleAsyncTaskExecutor())
+			.add(interruptedFlow, twoStepFlow)
+			.build();
+		FlowJobBuilder jobBuilder = new JobBuilder("job", jobRepository).start(splitFlow).build();
+		jobBuilder.preventRestart().build().execute(execution);
+
+		boolean isExecutedNonExecutableStep = countDownLatch.await(1, TimeUnit.SECONDS);
+		assertEquals(BatchStatus.STOPPED, execution.getStatus());
+		Assertions.assertFalse(isExecutedNonExecutableStep);
 	}
 
 }


### PR DESCRIPTION
related issue #3939 

## Motivation
- On https://github.com/spring-projects/spring-batch/issues/3939, when two flows are executed in parallel, I found that even though one flow throw an interruption and terminated the job, the next step of the other flow was executed.
- And this abnormal behavior occurs only when the other flow was added secondly to the job
- Problem is that even if the job containing both flows were terminated and went into STOPPED status, the other flow couldn't recognize the interruption because interruption had been checked by STOPPING status.
https://github.com/spring-projects/spring-batch/blob/9a2b1bbc96f338017aaa5df51214896f5a32d1e5/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java#L290C16-L290C17
Because the job already had been terminated and in STOPPED status, a step in the other flow cannot recognize it and proceeded as like there had been no interruption.
- The reason why this behavior didn't occur when the interruptedFlow added secondly to the job is that secondly added flow was always executed secondly in SplitState. So, if the two step flow would be added firstly, first step in this flow will be processed before the interrupted flow made the job status STOPPED, so it can recognize the interruption when one step has been executed.
- If there are remaining tasks (steps) but the job was terminated due to an exception as like now, there is also a problem that the status of the job may be changed by the remaining tasks.

## Modification
- Changed to wait for all tasks to finish before throwing an exception.
- Changed a job to handle exceptions after waiting for tasks currently being processed to complete. Prevent the job from terminating even though there are remaining tasks.

## Result
- Job, Flow and Steps work same when an exception does not occur.
- Regardless of the order in which flows are added to the Job for parallel processing, if an interruption occurs, only the currently executing step is processed. That is, no further steps are executed after that.
- Close https://github.com/spring-projects/spring-batch/issues/3939
