### PR TITLE
Add DataRowMapper in JdbcCursorItemReaderBuilder & JdbcPagingItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
@@ -25,6 +25,7 @@ import org.springframework.jdbc.core.ArgumentTypePreparedStatementSetter;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.DataClassRowMapper;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -38,6 +39,7 @@ import org.springframework.util.StringUtils;
  * @author Ankur Trapasiya
  * @author Parikshit Dutta
  * @author Fabio Molignoni
+ * @author Juyoung Kim
  * @since 4.0
  */
 public class JdbcCursorItemReaderBuilder<T> {
@@ -308,6 +310,18 @@ public class JdbcCursorItemReaderBuilder<T> {
 	 */
 	public JdbcCursorItemReaderBuilder<T> beanRowMapper(Class<T> mappedClass) {
 		this.rowMapper = new BeanPropertyRowMapper<>(mappedClass);
+
+		return this;
+	}
+
+	/**
+	 * Creates a {@link DataClassRowMapper} to be used as your {@link RowMapper}.
+	 * @param mappedClass the class for the row mapper
+	 * @return this instance for method chaining
+	 * @see DataClassRowMapper
+	 */
+	public JdbcCursorItemReaderBuilder<T> dataRowMapper(Class<T> mappedClass) {
+		this.rowMapper = new DataClassRowMapper<>(mappedClass);
 
 		return this;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcPagingItemReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.batch.item.database.support.SqlitePagingQueryProvider
 import org.springframework.batch.item.database.support.SybasePagingQueryProvider;
 import org.springframework.batch.support.DatabaseType;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.DataClassRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.MetaDataAccessException;
 import org.springframework.util.Assert;
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Drummond Dawson
  * @author Mahmoud Ben Hassine
  * @author Minsoo Kim
+ * @author Juyoung Kim
  * @since 4.0
  * @see JdbcPagingItemReader
  */
@@ -182,6 +184,18 @@ public class JdbcPagingItemReaderBuilder<T> {
 	 */
 	public JdbcPagingItemReaderBuilder<T> beanRowMapper(Class<T> mappedClass) {
 		this.rowMapper = new BeanPropertyRowMapper<>(mappedClass);
+
+		return this;
+	}
+
+	/**
+	 * Creates a {@link DataClassRowMapper} to be used as your {@link RowMapper}.
+	 * @param mappedClass the class for the row mapper
+	 * @return this instance for method chaining
+	 * @see DataClassRowMapper
+	 */
+	public JdbcPagingItemReaderBuilder<T> dataRowMapper(Class<T> mappedClass) {
+		this.rowMapper = new DataClassRowMapper<>(mappedClass);
 
 		return this;
 	}


### PR DESCRIPTION
related issue : #4578 


### Motivation:
```java
JdbcCursorItemReader<Foo> reader = new JdbcCursorItemReaderBuilder<Foo>()
        ...
	.rowMapper(new DataClassRowMapper<>(FooRecord.class))
        .build();

JdbcPagingItemReader<Foo> reader = new JdbcPagingItemReaderBuilder<Foo>()
        ...
	.rowMapper(new DataClassRowMapper<>(FooRecord.class))
        .build();
```
* When using JdbcCursorItemReaderBuilder & JdbcPagingItemReaderBuilder, we convert batch jobs to use Java record classes, we find ourselves needing to change .beanRowMapper(Foo.class) -> .rowMapper(new DataClassRowMapper<>(FooRecord.class)) over and over again like above
* On https://github.com/spring-projects/spring-batch/issues/4578, we found that there is no rowMapper for Java record class

### Modification:
* Add dataRowMapper method that returns DataClassRowMapper as rowMapper in JdbcCursorItemReaderBuilder and JdbcPagingItemReaderBuilder
```java
public JdbcCursorItemReaderBuilder<T> dataRowMapper(Class<T> mappedClass) {
	this.rowMapper = new DataClassRowMapper<>(mappedClass);

	return this;
}
```

### Result:
* Be able to easily configure a DataClassRowMapper when using JdbcCursorItemReaderBuilder & JdbcPagingItemReaderBuilder
* Close https://github.com/spring-projects/spring-batch/issues/4578 issue