### PR TITLE
Add static variable for metadata table string path

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
@@ -57,6 +57,7 @@ import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.resource.DatabaseResource;
 import org.springframework.batch.core.scope.context.JobContext;
 import org.springframework.batch.core.scope.context.StepContext;
 import org.springframework.batch.item.Chunk;
@@ -83,7 +84,7 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 				"java.util.concurrent.ConcurrentHashMap$Segment");
 
 		// resource hints
-		hints.resources().registerPattern("org/springframework/batch/core/schema-h2.sql");
+		hints.resources().registerPattern(DatabaseResource.SCHEMA_H2);
 		hints.resources().registerPattern("org/springframework/batch/core/schema-derby.sql");
 		hints.resources().registerPattern("org/springframework/batch/core/schema-hsqldb.sql");
 		hints.resources().registerPattern("org/springframework/batch/core/schema-sqlite.sql");

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/resource/DatabaseResource.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/resource/DatabaseResource.java
@@ -1,0 +1,8 @@
+package org.springframework.batch.core.resource;
+
+public class DatabaseResource {
+
+    public static final String SCHEMA_H2 = "/org/springframework/batch/core/schema-h2.sql";
+    public static final String SCHEMA_DROP_H2 = "/org/springframework/batch/core/schema-drop-h2.sql";
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/InlineDataSourceDefinitionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/InlineDataSourceDefinitionTests.java
@@ -27,6 +27,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.resource.DatabaseResource;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.ApplicationContext;
@@ -70,8 +71,8 @@ class InlineDataSourceDefinitionTests {
 		@Bean
 		public DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
-				.addScript("/org/springframework/batch/core/schema-drop-h2.sql")
-				.addScript("/org/springframework/batch/core/schema-h2.sql")
+				.addScript(DatabaseResource.SCHEMA_DROP_H2)
+				.addScript(DatabaseResource.SCHEMA_H2)
 				.generateUniqueName(true)
 				.build();
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerIntegrationTests.java
@@ -48,6 +48,7 @@ import org.springframework.batch.core.repository.JobExecutionAlreadyRunningExcep
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.batch.core.resource.DatabaseResource;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -203,7 +204,7 @@ class SimpleJobExplorerIntegrationTests {
 		@Bean
 		public DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
-				.addScript("/org/springframework/batch/core/schema-h2.sql")
+				.addScript(DatabaseResource.SCHEMA_H2)
 				.generateUniqueName(true)
 				.build();
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/H2CompatibilityModeJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/H2CompatibilityModeJobRepositoryIntegrationTests.java
@@ -30,6 +30,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.resource.DatabaseResource;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -76,7 +77,7 @@ class H2CompatibilityModeJobRepositoryIntegrationTests {
 				UUID.randomUUID(), compatibilityMode);
 		var dataSource = new SimpleDriverDataSource(new org.h2.Driver(), connectionUrl, "sa", "");
 		var populator = new ResourceDatabasePopulator();
-		var resource = new DefaultResourceLoader().getResource("/org/springframework/batch/core/schema-h2.sql");
+		var resource = new DefaultResourceLoader().getResource(DatabaseResource.SCHEMA_H2);
 		populator.addScript(resource);
 		DatabasePopulatorUtils.execute(populator, dataSource);
 		return dataSource;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/H2JobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/H2JobRepositoryIntegrationTests.java
@@ -28,6 +28,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.resource.DatabaseResource;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +75,7 @@ class H2JobRepositoryIntegrationTests {
 		@Bean
 		public DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
-				.addScript("/org/springframework/batch/core/schema-h2.sql")
+				.addScript(DatabaseResource.SCHEMA_H2)
 				.generateUniqueName(true)
 				.build();
 		}


### PR DESCRIPTION
Issue #4586

### Motivation
```java
@Bean
public DataSource dataSource() {
    return new EmbeddedDatabaseBuilder()
		.addScript("/org/springframework/batch/core/schema-h2.sql")
		.build();
}
```

- On https://github.com/spring-projects/spring-batch/issues/4586, I think it is better to use static variables to prevent typos in the metadata table creation script path string.

### Modification
```java
@Bean
public DataSource dataSource() {
    return new EmbeddedDatabaseBuilder()
		.addScript(DatabaseResource.SCHEMA_H2)
		.build();
}
```
- Add static variable for metadata table string path.