### PR TITLE
Fix typo in java-config.adoc

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/job/java-config.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/job/java-config.adoc
@@ -42,6 +42,7 @@ public class MyJobConfiguration {
 		return new JdbcTransactionManager(dataSource);
 	}
 
+	@Bean
 	public Job job(JobRepository jobRepository) {
 		return new JobBuilder("myJob", jobRepository)
 				//define job flow as needed


### PR DESCRIPTION
I noticed that on previous pages, methods with return type `Job` were being annotated with `@Bean`. 
I assume this is meant to be a Spring Bean in this example.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md