### PR TITLE
Keep heap lean during remote polling

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2023 the original author or authors.
+ * Copyright 2009-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -251,24 +251,22 @@ public class MessageChannelPartitionHandler extends AbstractPartitionHandler imp
 
 	private Set<StepExecution> pollReplies(final StepExecution managerStepExecution, final Set<StepExecution> split)
 			throws Exception {
-		final Set<StepExecution> result = new HashSet<>(split.size());
+		Set<Long> partitionStepExecutionIds = split.stream().map(StepExecution::getId).collect(Collectors.toSet());
 
 		Callable<Set<StepExecution>> callback = () -> {
-			Set<Long> currentStepExecutionIds = split.stream().map(StepExecution::getId).collect(Collectors.toSet());
 			JobExecution jobExecution = jobExplorer.getJobExecution(managerStepExecution.getJobExecutionId());
-			jobExecution.getStepExecutions()
+			Set<StepExecution> finishedStopExecutions = jobExecution.getStepExecutions()
 				.stream()
-				.filter(stepExecution -> currentStepExecutionIds.contains(stepExecution.getId()))
-				.filter(stepExecution -> !result.contains(stepExecution))
+				.filter(stepExecution -> partitionStepExecutionIds.contains(stepExecution.getId()))
 				.filter(stepExecution -> !stepExecution.getStatus().isRunning())
-				.forEach(result::add);
+				.collect(Collectors.toSet());
 
 			if (logger.isDebugEnabled()) {
 				logger.debug(String.format("Currently waiting on %s partitions to finish", split.size()));
 			}
 
-			if (result.size() == split.size()) {
-				return result;
+			if (finishedStopExecutions.size() == split.size()) {
+				return finishedStopExecutions;
 			}
 			else {
 				return null;


### PR DESCRIPTION
Resolves #4598.

The polling in `MessageChannelPartitionHandler` repeatedly fetches the running job execution with all associated step executions from the job repository. At the moment, it also retains references to step executions that have completed since the last iteration. This can accrue a lot of heap memory as each step execution holds references to a job execution, and that job execution holds references to all step executions.

This PR proposes not to retain any references to step or job executions while there are still running step executions. Instead, the step executions from the last iteration are used to build the result. This works as completed step executions are not expected to change after completion. And it reduces the memory foot print as the objects created in intermediate iterations can be handled by the garbage collector.

No test is added or changed as the changed code is already covered by appropriate tests.