### PR TITLE
Use Threadlocal.remove() instead of  Threadlocal.set(null)

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/JobFlowExecutor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/JobFlowExecutor.java
@@ -58,7 +58,6 @@ public class JobFlowExecutor implements FlowExecutor {
 		this.jobRepository = jobRepository;
 		this.stepHandler = stepHandler;
 		this.execution = execution;
-		stepExecutionHolder.set(null);
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/JobFlowExecutor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/JobFlowExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.lang.Nullable;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Seungrae Kim
  *
  */
 public class JobFlowExecutor implements FlowExecutor {
@@ -117,7 +118,7 @@ public class JobFlowExecutor implements FlowExecutor {
 
 	@Override
 	public void close(FlowExecution result) {
-		stepExecutionHolder.set(null);
+		stepExecutionHolder.remove();
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkMonitor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.batch.item.support.CompositeItemStream;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Seungrae Kim
  * @since 2.0
  */
 public class ChunkMonitor extends ItemStreamSupport {
@@ -104,7 +105,7 @@ public class ChunkMonitor extends ItemStreamSupport {
 	@Override
 	public void close() throws ItemStreamException {
 		super.close();
-		holder.set(null);
+		holder.remove();
 		if (streamsRegistered) {
 			stream.close();
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/RepeatSynchronizationManager.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/RepeatSynchronizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.batch.repeat.RepeatOperations;
  * {@link RepeatOperations} implementations.
  *
  * @author Dave Syer
+ * @author Seungrae Kim
  *
  */
 public final class RepeatSynchronizationManager {
@@ -70,7 +71,7 @@ public final class RepeatSynchronizationManager {
 	 */
 	public static RepeatContext register(RepeatContext context) {
 		RepeatContext oldSession = getContext();
-		RepeatSynchronizationManager.contextHolder.set(context);
+		contextHolder.set(context);
 		return oldSession;
 	}
 
@@ -81,7 +82,7 @@ public final class RepeatSynchronizationManager {
 	 */
 	public static RepeatContext clear() {
 		RepeatContext context = getContext();
-		RepeatSynchronizationManager.contextHolder.set(null);
+		contextHolder.remove();
 		return context;
 	}
 


### PR DESCRIPTION
Hi Team,

This PR improves memory management by replacing instances of `ThreadLocal.set(null)` with `ThreadLocal.remove()` and removing the unnecessary `ThreadLocal.set(null)` in the constructor.

In the current implementation, `ThreadLocal.set(null)` is used to clear the `ThreadLocal` variable. This approach can leave the `ThreadLocal` variable in the thread's local variable map with a null value, potentially causing memory leaks. Using `ThreadLocal.remove()` instead properly removes the `ThreadLocal` variable from the thread's local variable map, preventing memory leaks.

Additionally, the constructor for `JobFlowExecutor` contains an unnecessary `ThreadLocal.set(null)`, which is redundant because the `ThreadLocal` variable is already initialized to `null` by default.