### PR TITLE
Incorrect link and closing tag for listeners in documentation

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/job/configuring.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/job/configuring.adoc
@@ -264,7 +264,7 @@ it with its own list of listeners to produce a
 ----
 
 [role="xmlContent"]
-See the section on <<inheritingFromParentStep,Inheriting from a Parent Step>>
+See the section on xref:step/chunk-oriented-processing/inheriting-from-parent.adoc[Inheriting from a Parent Step]
 for more detailed information.
 
 [[jobparametersvalidator]]

--- a/spring-batch-docs/modules/ROOT/pages/job/configuring.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/job/configuring.adoc
@@ -251,7 +251,7 @@ it with its own list of listeners to produce a
 <job id="baseJob" abstract="true">
     <listeners>
         <listener ref="listenerOne"/>
-    <listeners>
+    </listeners>
 </job>
 
 <job id="job1" parent="baseJob">
@@ -259,7 +259,7 @@ it with its own list of listeners to produce a
 
     <listeners merge="true">
         <listener ref="listenerTwo"/>
-    <listeners>
+    </listeners>
 </job>
 ----
 

--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/inheriting-from-parent.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/inheriting-from-parent.adoc
@@ -93,7 +93,7 @@ In the following example, the `Step` "concreteStep3", is created with two listen
 <step id="listenersParentStep" abstract="true">
     <listeners>
         <listener ref="listenerOne"/>
-    <listeners>
+    </listeners>
 </step>
 
 <step id="concreteStep3" parent="listenersParentStep">
@@ -102,7 +102,7 @@ In the following example, the `Step` "concreteStep3", is created with two listen
     </tasklet>
     <listeners merge="true">
         <listener ref="listenerTwo"/>
-    <listeners>
+    </listeners>
 </step>
 ----
 


### PR DESCRIPTION
Hi Team,

Corrected the incorrect closing tag for `<listeners>` in the Spring Batch documentation and fixed broken links.
