### PR TITLE
Fix the way of creating String for paging clause

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Db2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Db2PagingQueryProvider.java
@@ -25,6 +25,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class Db2PagingQueryProvider extends SqlWindowingPagingQueryProvider {
@@ -50,7 +51,7 @@ public class Db2PagingQueryProvider extends SqlWindowingPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("FETCH FIRST ").append(pageSize).append(" ROWS ONLY").toString();
+		return "FETCH FIRST " + pageSize + " ROWS ONLY";
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Db2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Db2PagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
@@ -23,6 +23,7 @@ package org.springframework.batch.item.database.support;
  *
  * @author Dave Syer
  * @author Henning Pöttker
+ * @author KyeongHoon Lee
  * @since 2.1
  */
 public class H2PagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -38,7 +39,7 @@ public class H2PagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("FETCH NEXT ").append(pageSize).append(" ROWS ONLY").toString();
+		return "FETCH NEXT " + pageSize + " ROWS ONLY";
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HanaPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HanaPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HanaPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HanaPagingQueryProvider.java
@@ -24,6 +24,7 @@ import org.springframework.util.StringUtils;
  * features.
  *
  * @author Jonathan Bregler
+ * @author KyeongHoon Lee
  * @since 5.0
  */
 public class HanaPagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -44,7 +45,7 @@ public class HanaPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HsqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HsqlPagingQueryProvider.java
@@ -26,6 +26,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class HsqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -46,7 +47,7 @@ public class HsqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+		return "TOP " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MariaDBPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MariaDBPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MariaDBPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MariaDBPagingQueryProvider.java
@@ -24,6 +24,7 @@ import org.springframework.util.StringUtils;
  * features.
  *
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 5.0
  */
 public class MariaDBPagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -44,7 +45,7 @@ public class MariaDBPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MySqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MySqlPagingQueryProvider.java
@@ -25,6 +25,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class MySqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -45,7 +46,7 @@ public class MySqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MySqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MySqlPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
@@ -23,6 +23,7 @@ package org.springframework.batch.item.database.support;
  *
  * @author Thomas Risberg
  * @author Michael Minella
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class OraclePagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -38,7 +39,7 @@ public class OraclePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildRowNumClause(int pageSize) {
-		return new StringBuilder().append("ROWNUM <= ").append(pageSize).toString();
+		return "ROWNUM <= " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/PostgresPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/PostgresPagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/PostgresPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/PostgresPagingQueryProvider.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class PostgresPagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -50,7 +51,7 @@ public class PostgresPagingQueryProvider extends AbstractSqlPagingQueryProvider 
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProvider.java
@@ -26,6 +26,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class SqlServerPagingQueryProvider extends SqlWindowingPagingQueryProvider {
@@ -51,7 +52,7 @@ public class SqlServerPagingQueryProvider extends SqlWindowingPagingQueryProvide
 	}
 
 	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+		return "TOP " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
@@ -25,6 +25,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Luke Taylor
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 3.0.0
  */
 public class SqlitePagingQueryProvider extends AbstractSqlPagingQueryProvider {
@@ -45,7 +46,7 @@ public class SqlitePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SybasePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SybasePagingQueryProvider.java
@@ -26,6 +26,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author KyeongHoon Lee
  * @since 2.0
  */
 public class SybasePagingQueryProvider extends SqlWindowingPagingQueryProvider {
@@ -51,7 +52,7 @@ public class SybasePagingQueryProvider extends SqlWindowingPagingQueryProvider {
 	}
 
 	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+		return "TOP " + pageSize;
 	}
 
 }


### PR DESCRIPTION
Hi!!
I have been looking into MySqlQueryProvider these days.
And I found that StringBuilder is used for building Limit(or Top, RowNum) clause.

However, "+" operator is few times faster than StringBuilder, when concatenate just two or three Strings.

I wrote a simple code to compare execution of "+"operator and StringBuilder.
| try count | "+" Operation average execution time(ns) |StringBuilder average execution time(ns)|
|---|---|---|
|100|150.04|799.56|
|1000|99.588|369.835|
|10000|87.3189|269.9823| 
