### PR TITLE
Add '@FunctionalInterface' to ChunkProcessor

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ import org.springframework.batch.item.Chunk;
 /**
  * Interface defined for processing {@link org.springframework.batch.item.Chunk}s.
  *
+ * @author KyeongHoon Lee
  * @since 2.0
  */
+@FunctionalInterface
 public interface ChunkProcessor<I> {
 
 	void process(StepContribution contribution, Chunk<I> chunk) throws Exception;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/RepeatCallback.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/RepeatCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,10 @@ package org.springframework.batch.repeat;
  *
  * @see RepeatOperations
  * @author Dave Syer
+ * @author KyeongHoon Lee
  *
  */
+@FunctionalInterface
 public interface RepeatCallback {
 
 	/**


### PR DESCRIPTION
Add '@FunctionalInterface' to ChunkProcessor.

> ChunkProcessor is implemented by using lambda expression in some tests.
> So, @FunctionalInterface annotation is needed.