### PR TITLE
Add DatabaseType POSTGRES for the product name EnterpriseDB

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
@@ -102,9 +102,11 @@ public enum DatabaseType {
 			else {
 				databaseProductName = JdbcUtils.commonDatabaseName(databaseProductName);
 			}
-		} else if (StringUtils.hasText(databaseProductName) && databaseProductName.startsWith("EnterpriseDB")) {
+		}
+		else if (StringUtils.hasText(databaseProductName) && databaseProductName.startsWith("EnterpriseDB")) {
 			databaseProductName = "PostgreSQL";
-		} else {
+		}
+		else {
 			databaseProductName = JdbcUtils.commonDatabaseName(databaseProductName);
 		}
 		return fromProductName(databaseProductName);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DatabaseType.java
@@ -102,8 +102,9 @@ public enum DatabaseType {
 			else {
 				databaseProductName = JdbcUtils.commonDatabaseName(databaseProductName);
 			}
-		}
-		else {
+		} else if (StringUtils.hasText(databaseProductName) && databaseProductName.startsWith("EnterpriseDB")) {
+			databaseProductName = "PostgreSQL";
+		} else {
 			databaseProductName = JdbcUtils.commonDatabaseName(databaseProductName);
 		}
 		return fromProductName(databaseProductName);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/DatabaseTypeTests.java
@@ -139,6 +139,13 @@ class DatabaseTypeTests {
 	}
 
 	@Test
+	void testFromMetaDataForEnterpriseDB() throws Exception {
+		DataSource ds = DatabaseTypeTestUtils.getMockDataSource("EnterpriseDB");
+		// Should return POSTGRES
+		assertEquals(POSTGRES, DatabaseType.fromMetaData(ds));
+	}
+
+	@Test
 	void testFromMetaDataForSybase() throws Exception {
 		DataSource ds = DatabaseTypeTestUtils.getMockDataSource("Adaptive Server Enterprise");
 		assertEquals(SYBASE, DatabaseType.fromMetaData(ds));


### PR DESCRIPTION
Issue: [#4627]
EnterpriseDB is an enterprise version of PostGres database, which identifies itself as EnterpriseDB.
Added support for EnterpriseDB by adding the following condition in DatabaseType enum.

```java
else if (StringUtils.hasText(databaseProductName) && databaseProductName.startsWith("EnterpriseDB")) {
			databaseProductName = "PostgreSQL";
		}
```
Since Enterprise version of PostGre requires license not able to add integration tests