### PR TITLE
Refactor RedisItemWriter and RedisItemReader logic

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
@@ -37,40 +37,48 @@ import org.springframework.util.Assert;
  * @param <K> type of keys
  * @param <V> type of values
  */
-public class RedisItemReader<K, V> implements ItemStreamReader<V> {
+public class RedisItemReader<K, V> implements ItemStreamReader<K> {
 
-	private final RedisTemplate<K, V> redisTemplate;
+    public static class KeyValue<K, V> {
 
-	private final ScanOptions scanOptions;
+        K key;
+        V value;
 
-	private Cursor<K> cursor;
+        KeyValue(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
 
-	public RedisItemReader(RedisTemplate<K, V> redisTemplate, ScanOptions scanOptions) {
-		Assert.notNull(redisTemplate, "redisTemplate must not be null");
-		Assert.notNull(scanOptions, "scanOptions must no be null");
-		this.redisTemplate = redisTemplate;
-		this.scanOptions = scanOptions;
-	}
+    private final RedisTemplate<K, V> redisTemplate;
 
-	@Override
-	public void open(ExecutionContext executionContext) throws ItemStreamException {
-		this.cursor = this.redisTemplate.scan(this.scanOptions);
-	}
+    private final ScanOptions scanOptions;
 
-	@Override
-	public V read() throws Exception {
-		if (this.cursor.hasNext()) {
-			K nextKey = this.cursor.next();
-			return this.redisTemplate.opsForValue().get(nextKey);
-		}
-		else {
-			return null;
-		}
-	}
+    private Cursor<K> cursor;
 
-	@Override
-	public void close() throws ItemStreamException {
-		this.cursor.close();
-	}
+    public RedisItemReader(RedisTemplate<K, V> redisTemplate, ScanOptions scanOptions) {
+        Assert.notNull(redisTemplate, "redisTemplate must not be null");
+        Assert.notNull(scanOptions, "scanOptions must no be null");
+        this.redisTemplate = redisTemplate;
+        this.scanOptions = scanOptions;
+    }
 
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        this.cursor = this.redisTemplate.scan(this.scanOptions);
+    }
+
+    @Override
+    public K read() throws Exception {
+        if (this.cursor.hasNext()) {
+            return this.cursor.next();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        this.cursor.close();
+    }
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemWriter.java
@@ -30,16 +30,15 @@ import org.springframework.util.Assert;
  * @author Mahmoud Ben Hassine
  * @since 5.1
  */
-public class RedisItemWriter<K, T> extends KeyValueItemWriter<K, T> {
+public class RedisItemWriter<T, K> extends KeyValueItemWriter<T, K> {
 
 	private RedisTemplate<K, T> redisTemplate;
 
 	@Override
-	protected void writeKeyValue(K key, T value) {
+	protected void writeKeyValue(T value, K key) {
 		if (this.delete) {
 			this.redisTemplate.delete(key);
-		}
-		else {
+		} else {
 			this.redisTemplate.opsForValue().set(key, value);
 		}
 	}
@@ -51,10 +50,10 @@ public class RedisItemWriter<K, T> extends KeyValueItemWriter<K, T> {
 
 	/**
 	 * Set the {@link RedisTemplate} to use.
+	 *
 	 * @param redisTemplate the template to use
 	 */
 	public void setRedisTemplate(RedisTemplate<K, T> redisTemplate) {
 		this.redisTemplate = redisTemplate;
 	}
-
 }


### PR DESCRIPTION
Hello,

I believe there might be a better way to implement the RedisItemReader and RedisItemWriter. Currently, the RedisItemReader stores the Redis data's value in the chunk. The RedisItemWriter then uses an ItemKeyMapper to derive the key from this value and executes the writeKeyValue function with the key and value.

However, I find it quite cumbersome to implement an ItemKeyMapper that derives the key from the value. In a key-value structure, retrieving the key based on the value seems to underutilize the key-value paradigm.

When I was setting up a batch job to delete specific Redis data, I found it inefficient to implement an ItemKeyMapper that derives the key from the value, so I customized the code accordingly. Instead, I implemented the ItemKeyMapper to return the value when given a key.

Therefore, I believe it would be more efficient for the RedisItemReader to store the Redis data's keys in the chunk. If my suggestion is not accepted, I would be very interested in understanding the reasoning behind that decision.

Thank you for considering my suggestion.
