### PR TITLE
change assertTrue(a instanceof b) -> assertInstanceOf(a, b)

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,12 @@ import org.springframework.util.StringUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author jojoldu
  *
  */
 class FaultTolerantStepFactoryBeanRetryTests {
@@ -134,7 +136,7 @@ class FaultTolerantStepFactoryBeanRetryTests {
 	@SuppressWarnings("cast")
 	@Test
 	void testDefaultValue() throws Exception {
-		assertTrue(factory.getObject() instanceof Step);
+        assertInstanceOf(Step.class, factory.getObject());
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/RepeatOperationsStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/RepeatOperationsStepFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,13 @@ import org.springframework.batch.support.transaction.ResourcelessTransactionMana
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 
 /**
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author jojoldu
  *
  */
 class RepeatOperationsStepFactoryBeanTests {
@@ -66,7 +69,7 @@ class RepeatOperationsStepFactoryBeanTests {
 	@Test
 	@SuppressWarnings("cast")
 	void testDefaultValue() throws Exception {
-		assertTrue(factory.getObject() instanceof Step);
+        assertInstanceOf(Step.class, factory.getObject());
 	}
 
 	@Test


### PR DESCRIPTION
`assertInstanceOf` has been added since [Junit5(jupiter) version 5.8](https://github.com/junit-team/junit5/issues/2492). 
All existing test codes that used `assertTrue (a instanceOf b)` have been changed to simpler codes such as `assertInstanceOf(a, b)`.