### PR TITLE
Remove Duplicate If Condition in SimpleJobTests

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -588,12 +588,7 @@ class SimpleJobTests {
 				stepExecution.addFailureException(exception);
 				return;
 			}
-			if (exception instanceof JobInterruptedException) {
-				stepExecution.setExitStatus(ExitStatus.FAILED);
-				stepExecution.setStatus(BatchStatus.FAILED);
-				stepExecution.addFailureException(exception);
-				return;
-			}
+
 			if (runnable != null) {
 				runnable.run();
 			}


### PR DESCRIPTION
There is already a section above that handles `JobInterruptedException`.
https://github.com/spring-projects/spring-batch/blob/425134c74e6b69dde40a81278e4fddbec4778f80/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java#L573-L578
Therefore, this part is unreachable.
https://github.com/spring-projects/spring-batch/blob/425134c74e6b69dde40a81278e4fddbec4778f80/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java#L591-L596