### PR TITLE
Update the default value of skipLimit in FaultTolerantStepBuilder to 10

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -122,7 +122,7 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 
 	private final Set<SkipListener<? super I, ? super O>> skipListeners = new LinkedHashSet<>();
 
-	private int skipLimit = 0;
+	private int skipLimit = 10;
 
 	private SkipPolicy skipPolicy;
 
@@ -306,7 +306,7 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 	/**
 	 * Sets the maximum number of failed items to skip before the step fails. Ignored if
 	 * an explicit {@link #skipPolicy(SkipPolicy)} is provided.
-	 * @param skipLimit the skip limit to set
+	 * @param skipLimit the skip limit to set. Default is 10.
 	 * @return this for fluent chaining
 	 */
 	public FaultTolerantStepBuilder<I, O> skipLimit(int skipLimit) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -90,6 +90,7 @@ import org.springframework.util.Assert;
  * @author Chris Schaefer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Ian Choi
  * @since 2.2
  */
 public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/factory/FaultTolerantStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/factory/FaultTolerantStepFactoryBean.java
@@ -61,7 +61,7 @@ public class FaultTolerantStepFactoryBean<T, S> extends SimpleStepFactoryBean<T,
 
 	private int retryLimit = 0;
 
-	private int skipLimit = 0;
+	private int skipLimit = 10;
 
 	private SkipPolicy skipPolicy;
 
@@ -163,7 +163,7 @@ public class FaultTolerantStepFactoryBean<T, S> extends SimpleStepFactoryBean<T,
 	 * chunk processing will cause the item to be skipped and no exception propagated
 	 * until the limit is reached. If it is zero then all exceptions will be propagated
 	 * from the chunk and cause the step to abort.
-	 * @param skipLimit the value to set. Default is 0 (never skip).
+	 * @param skipLimit the value to set. Default is 10.
 	 */
 	public void setSkipLimit(int skipLimit) {
 		this.skipLimit = skipLimit;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/factory/FaultTolerantStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/factory/FaultTolerantStepFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.retry.policy.RetryContextCache;
  * @author Dave Syer
  * @author Robert Kasanicky
  * @author Morten Andersen-Gott
+ * @author Ian Choi
  *
  */
 public class FaultTolerantStepFactoryBean<T, S> extends SimpleStepFactoryBean<T, S> {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilderTests.java
@@ -22,6 +22,7 @@ import org.springframework.batch.core.configuration.xml.DummyItemReader;
 import org.springframework.batch.core.configuration.xml.DummyItemWriter;
 import org.springframework.batch.core.configuration.xml.DummyJobRepository;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -53,4 +54,15 @@ class FaultTolerantStepBuilderTests {
 		assertNotNull(step);
 	}
 
+	@Test
+	void testSkipLimitDefaultValue() throws NoSuchFieldException, IllegalAccessException {
+		FaultTolerantStepBuilder<?, ?> stepBuilder = new FaultTolerantStepBuilder<>(
+				new StepBuilder("step", new DummyJobRepository()));
+
+		Field field = stepBuilder.getClass().getDeclaredField("skipLimit");
+		field.setAccessible(true);
+		int skipLimit = (int) field.get(stepBuilder);
+
+		assertEquals(10, skipLimit);
+	}
 }

--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/configuring-skip.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/configuring-skip.adoc
@@ -31,6 +31,8 @@ public Step step1(JobRepository jobRepository, PlatformTransactionManager transa
 				.build();
 }
 ----
++
+Note: The `skipLimit` can be explicitly set using the `skipLimit()` method. If not specified, the default skip limit is set to 10.
 
 XML::
 +
@@ -91,6 +93,8 @@ public Step step1(JobRepository jobRepository, PlatformTransactionManager transa
 				.build();
 }
 ----
++
+Note: The `skipLimit` can be explicitly set using the `skipLimit()` method. If not specified, the default skip limit is set to 10.
 
 XML::
 +


### PR DESCRIPTION
I have submitted a pull request addressing the issue described in [#4661](https://github.com/spring-projects/spring-batch/issues/4661).
The changes include updating the default value of skipLimit in FaultTolerantStepBuilder to 10.