### PR TITLE
Add unit test for the ExecutionContext.get method in Issue #718

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
@@ -15,17 +15,16 @@
  */
 package org.springframework.batch.item;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.SerializationUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Lucas Ward
@@ -194,6 +193,64 @@ class ExecutionContextTests {
 			return true;
 		}
 
+	}
+
+	@DisplayName("testGetByType")
+	@Test
+	void givenAList_whenGettingAccordingToListType_thenReturnCorrectObject() {
+		// given - a list
+		String key = "aListObject";
+		List<String> value = List.of("value1", "value2");
+		context.put(key, value);
+		// when - getting according to list type
+		@SuppressWarnings("unchecked")
+		List<String> result = (List<String>) context.get(key, List.class);
+		// then - return the correct list
+		assertEquals(result, value);
+		assertEquals(result.get(0), value.get(0));
+		assertEquals(result.get(1), value.get(1));
+	}
+
+	@DisplayName("testGetNullByDefaultParam")
+	@Test
+	void givenANonExistingKey_whenGettingTheNullList_thenReturnNull() {
+		// given - a non existing key
+		String key = "aListObjectButNull";
+		// when - getting according to the key
+		@SuppressWarnings("unchecked")
+		List<String> result = (List<String>) context.get(key, List.class, null);
+		List<String> result2 = (List<String>) context.get(key, List.class);
+		// then - return the defined null list
+		assertNull(result);
+		assertNull(result2);
+	}
+
+	@DisplayName("testGetNullByNotNullDefaultParam")
+	@Test
+	void givenAnNullList_whenGettingNullWithNonNullDefault_thenReturnDefinedDefaultValue() {
+		// given - a non existing key
+		String key = "aListObjectButNull";
+		List<String> defaultValue = new ArrayList<>();
+		defaultValue.add("value1");
+		@SuppressWarnings("unchecked")
+		// when - getting according to list type and default value
+		List<String> result = (List<String>) context.get(key, List.class, defaultValue);
+		// then - return defined default value
+		assertNotNull(result);
+		assertEquals(result, defaultValue);
+		assertEquals(result.get(0), defaultValue.get(0));
+	}
+
+	@DisplayName("testGetWithWrongType")
+	@Test
+	void givenAList_whenGettingWithWrongType_thenThrowClassCastException() {
+		// given - another normal list
+		String key = "anotherListObject";
+		List<String> value = List.of("value1", "value2", "value3");
+		context.put(key, value);
+		// when - getting according to map type
+		// then - throw exception
+		assertThrows(ClassCastException.class, () -> context.get(key, Map.class));
 	}
 
 }


### PR DESCRIPTION
These are the unit tests for https://github.com/spring-projects/spring-batch/pull/718

They can cover the added 2 ExecutionContext.get methods.
- https://github.com/spring-projects/spring-batch/blob/53e33c06e9cabdd8794b748b4cd58a3fbd65e321/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java#L270-L276
- https://github.com/spring-projects/spring-batch/blob/53e33c06e9cabdd8794b748b4cd58a3fbd65e321/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java#L290-L300