### PR TITLE
#4648: Fix Column Type Issues in JdbcStepExecutionDao

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
@@ -281,9 +281,9 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 					stepExecution.getWriteSkipCount(), stepExecution.getRollbackCount(), lastUpdated,
 					stepExecution.getId(), stepExecution.getVersion() };
 			int count = getJdbcTemplate().update(getQuery(UPDATE_STEP_EXECUTION), parameters,
-					new int[] { Types.TIMESTAMP, Types.TIMESTAMP, Types.VARCHAR, Types.INTEGER, Types.INTEGER,
-							Types.INTEGER, Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.INTEGER, Types.INTEGER,
-							Types.INTEGER, Types.INTEGER, Types.INTEGER, Types.TIMESTAMP, Types.BIGINT,
+					new int[] { Types.TIMESTAMP, Types.TIMESTAMP, Types.VARCHAR, Types.BIGINT, Types.BIGINT,
+							Types.BIGINT, Types.BIGINT, Types.VARCHAR, Types.VARCHAR, Types.INTEGER, Types.BIGINT,
+							Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.TIMESTAMP, Types.BIGINT,
 							Types.INTEGER });
 
 			// Avoid concurrent modifications...
@@ -396,15 +396,15 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 			stepExecution.setStartTime(rs.getTimestamp(3) == null ? null : rs.getTimestamp(3).toLocalDateTime());
 			stepExecution.setEndTime(rs.getTimestamp(4) == null ? null : rs.getTimestamp(4).toLocalDateTime());
 			stepExecution.setStatus(BatchStatus.valueOf(rs.getString(5)));
-			stepExecution.setCommitCount(rs.getInt(6));
-			stepExecution.setReadCount(rs.getInt(7));
-			stepExecution.setFilterCount(rs.getInt(8));
-			stepExecution.setWriteCount(rs.getInt(9));
+			stepExecution.setCommitCount(rs.getLong(6));
+			stepExecution.setReadCount(rs.getLong(7));
+			stepExecution.setFilterCount(rs.getLong(8));
+			stepExecution.setWriteCount(rs.getLong(9));
 			stepExecution.setExitStatus(new ExitStatus(rs.getString(10), rs.getString(11)));
-			stepExecution.setReadSkipCount(rs.getInt(12));
-			stepExecution.setWriteSkipCount(rs.getInt(13));
-			stepExecution.setProcessSkipCount(rs.getInt(14));
-			stepExecution.setRollbackCount(rs.getInt(15));
+			stepExecution.setReadSkipCount(rs.getLong(12));
+			stepExecution.setWriteSkipCount(rs.getLong(13));
+			stepExecution.setProcessSkipCount(rs.getLong(14));
+			stepExecution.setRollbackCount(rs.getLong(15));
 			stepExecution.setLastUpdated(rs.getTimestamp(16) == null ? null : rs.getTimestamp(16).toLocalDateTime());
 			stepExecution.setVersion(rs.getInt(17));
 			stepExecution.setCreateTime(rs.getTimestamp(18) == null ? null : rs.getTimestamp(18).toLocalDateTime());


### PR DESCRIPTION
### Pull Request Description

This pull request addresses issue #4648 by updating the `JdbcStepExecutionDao` to ensure that all integer fields related to `StepExecution` are correctly handled as long types.

### Background

In version 5.0, the 'int' fields in `StepExecution` were updated to 'long'. While the `JdbcStepExecutionDao::buildStepExecutionParameters` was modified to use `Types.BIGINT` for these fields, the `updateStepExecution` method was not updated accordingly.

### Changes Made
- Updated the column types in JdbcStepExecutionDao::updateStepExecution to use Types.BIGINT for commitCount, readCount, filterCount, writeCount, readSkipCount, processSkipCount, writeSkipCount and rollbackCount.
- Ensured that the row mapper retrieves these counts as long values from the result set.

These changes improve consistency and ensure that the StepExecution counts are accurately represented in the database.


#### Note
As this is my first pull request modifying the source code, please let me know if there are any mistakes or areas that need further adjustments. I appreciate your guidance!