### PR TITLE
Include script engine dependencies in tests for ScriptItemProcessor

### DIFF
--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -429,12 +429,18 @@
 			<version>${angus-mail.version}</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-jsr223</artifactId>
-            <version>4.0.23</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.groovy</groupId>
+			<artifactId>groovy-jsr223</artifactId>
+			<version>4.0.23</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.nashorn</groupId>
+			<artifactId>nashorn-core</artifactId>
+			<version>15.4</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- provided dependencies -->
 		<dependency>

--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -429,6 +429,12 @@
 			<version>${angus-mail.version}</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>4.0.23</version>
+            <scope>test</scope>
+        </dependency>
 
 		<!-- provided dependencies -->
 		<dependency>

--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -441,6 +441,12 @@
 			<version>15.4</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache-extras.beanshell</groupId>
+			<artifactId>bsh</artifactId>
+			<version>2.0b6</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- provided dependencies -->
 		<dependency>

--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -447,6 +447,12 @@
 			<version>2.0b6</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jruby</groupId>
+			<artifactId>jruby</artifactId>
+			<version>9.4.8.0</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- provided dependencies -->
 		<dependency>

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ScriptItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ScriptItemProcessorTests.java
@@ -82,7 +82,7 @@ class ScriptItemProcessorTests {
 		assumeTrue(languageExists("jruby"));
 
 		ScriptItemProcessor<String, Object> scriptItemProcessor = new ScriptItemProcessor<>();
-		scriptItemProcessor.setScriptSource("$item.upcase", "jruby");
+		scriptItemProcessor.setScriptSource("item.upcase", "jruby");
 		scriptItemProcessor.afterPropertiesSet();
 
 		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");
@@ -93,7 +93,7 @@ class ScriptItemProcessorTests {
 		assumeTrue(languageExists("jruby"));
 
 		ScriptItemProcessor<String, Object> scriptItemProcessor = new ScriptItemProcessor<>();
-		scriptItemProcessor.setScriptSource("def process(item) $item.upcase end \n process($item)", "jruby");
+		scriptItemProcessor.setScriptSource("def process(item) item.upcase end \n process(item)", "jruby");
 		scriptItemProcessor.afterPropertiesSet();
 
 		assertEquals("SS", scriptItemProcessor.process("ss"), "Incorrect transformed value");


### PR DESCRIPTION

Added script engine dependencies for Groovy, JavaScript, Bash, and Ruby in ScriptItemProcessor tests.

Fixed a script error in the Ruby test by refactoring the script to use local variables instead of global variables.

#### [related post](https://stackoverflow.com/questions/79056704/why-doesnt-spring-batch-include-script-engine-dependencies-in-tests-for-scripti/79065727#79065727)