### PR TITLE
Fix `ExecutionContext` dirty flag set to false on same value put or null put

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
@@ -133,7 +133,10 @@ public class ExecutionContext implements Serializable {
 		}
 		else {
 			Object result = this.map.remove(key);
-			this.dirty = result != null;
+
+			if (!this.dirty) {
+				this.dirty = result != null;
+			}
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.lang.Nullable;
  * @author Lucas Ward
  * @author Douglas Kaminsky
  * @author Mahmoud Ben Hassine
+ * @author Seokmun Heo
  */
 public class ExecutionContext implements Serializable {
 
@@ -124,7 +125,11 @@ public class ExecutionContext implements Serializable {
 	public void put(String key, @Nullable Object value) {
 		if (value != null) {
 			Object result = this.map.put(key, value);
-			this.dirty = result == null || !result.equals(value);
+			boolean newDirty = result == null || !result.equals(value);
+
+			if (!this.dirty) {
+				this.dirty = newDirty;
+			}
 		}
 		else {
 			Object result = this.map.remove(key);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.util.SerializationUtils;
 /**
  * @author Lucas Ward
  * @author Mahmoud Ben Hassine
- *
+ * @author Seokmun Heo
  */
 class ExecutionContextTests {
 
@@ -159,6 +159,15 @@ class ExecutionContextTests {
 	void testCopyConstructorNullInput() {
 		ExecutionContext context = new ExecutionContext((ExecutionContext) null);
 		assertTrue(context.isEmpty());
+	}
+
+	@Test
+	void testDirtyWithDuplicate() {
+		ExecutionContext context = new ExecutionContext();
+		context.put("1", "testString1");
+		assertTrue(context.isDirty());
+		context.put("1", "testString1"); // put the same value
+		assertTrue(context.isDirty());
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/ExecutionContextTests.java
@@ -88,11 +88,13 @@ class ExecutionContextTests {
 	}
 
 	@Test
-	void testNotDirtyWithRemoveMissing() {
+	void testDirtyWithRemoveMissing() {
 		context.putString("1", "test");
 		assertTrue(context.isDirty());
 		context.putString("1", null); // remove an item that was present
 		assertTrue(context.isDirty());
+
+		context.clearDirtyFlag();
 		context.putString("1", null); // remove a non-existent item
 		assertFalse(context.isDirty());
 	}


### PR DESCRIPTION
#### Description
Resolved an issue where the `dirty` flag was incorrectly set to `false` when a `put` operation used the same value as the existing one or when null was pushed. Now, the flag remains true if a prior change has occurred.

#### Solution
Adjusted the `put` method logic to correctly handle value comparisons:
```java
if (value != null) {
	Object result = this.map.put(key, value);
	boolean newDirty = result == null || !result.equals(value);

	if (!this.dirty) {
		this.dirty = newDirty;
	}
}
else {
	Object result = this.map.remove(key);

	if (!this.dirty) {
		this.dirty = result != null;
	}
}
```

#### Fix #4685 #4692