### PR TITLE
GH-3790: Poll the count of running step executions to fix OOM

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.core;
 
+import java.util.Set;
+
 /**
  * Enumeration representing the status of an execution.
  *
@@ -71,6 +73,8 @@ public enum BatchStatus {
 	 */
 	UNKNOWN;
 
+	public static final Set<BatchStatus> RUNNING_STATUSES = Set.of(STARTING, STARTED, STOPPING);
+
 	/**
 	 * Convenience method to return the higher value status of the statuses passed to the
 	 * method.
@@ -87,7 +91,7 @@ public enum BatchStatus {
 	 * @return true if the status is STARTING, STARTED, STOPPING
 	 */
 	public boolean isRunning() {
-		return this == STARTING || this == STARTED || this == STOPPING;
+		return RUNNING_STATUSES.contains(this);
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/explore/JobExplorer.java
@@ -18,6 +18,7 @@ package org.springframework.batch.core.explore;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
@@ -86,6 +87,14 @@ public interface JobExplorer {
 	 */
 	@Nullable
 	StepExecution getStepExecution(@Nullable Long jobExecutionId, @Nullable Long stepExecutionId);
+
+	/**
+	 * Find {@link StepExecution}s by IDs and parent {@link JobExecution} ID
+	 * @param jobExecutionId given job execution id
+	 * @param stepExecutionIds given step execution ids
+	 * @return collection of {@link StepExecution}
+	 */
+	Set<StepExecution> getStepExecutions(Long jobExecutionId, Set<Long> stepExecutionIds);
 
 	/**
 	 * @param instanceId {@link Long} The ID for the {@link JobInstance} to obtain.
@@ -169,5 +178,14 @@ public interface JobExplorer {
 	 * jobName specified.
 	 */
 	long getJobInstanceCount(@Nullable String jobName) throws NoSuchJobException;
+
+	/**
+	 * Retrieve number of step executions that match the step execution ids and the batch
+	 * statuses
+	 * @param stepExecutionIds given step execution ids
+	 * @param matchingBatchStatuses given batch statuses to match against
+	 * @return number of {@link StepExecution} matching the criteria
+	 */
+	long getStepExecutionCount(Set<Long> stepExecutionIds, Set<BatchStatus> matchingBatchStatuses);
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/AbstractJdbcBatchMetadataDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/AbstractJdbcBatchMetadataDao.java
@@ -17,6 +17,9 @@
 package org.springframework.batch.core.repository.dao;
 
 import java.sql.Types;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -51,6 +54,14 @@ public abstract class AbstractJdbcBatchMetadataDao implements InitializingBean {
 		return StringUtils.replace(base, "%PREFIX%", tablePrefix);
 	}
 
+	protected String getQuery(String base, Map<String, Collection<?>> collectionParams) {
+		String query = getQuery(base);
+		for (Map.Entry<String, Collection<?>> collectionParam : collectionParams.entrySet()) {
+			query = createParameterizedQuery(query, collectionParam.getKey(), collectionParam.getValue());
+		}
+		return query;
+	}
+
 	protected String getTablePrefix() {
 		return tablePrefix;
 	}
@@ -78,6 +89,18 @@ public abstract class AbstractJdbcBatchMetadataDao implements InitializingBean {
 
 	public void setClobTypeToUse(int clobTypeToUse) {
 		this.clobTypeToUse = clobTypeToUse;
+	}
+
+	/**
+	 * Replaces a given placeholder with a number of parameters (i.e. "?").
+	 * @param sqlTemplate given sql template
+	 * @param placeholder placeholder that is being used for parameters
+	 * @param parameters collection of parameters with variable size
+	 * @return sql query replaced with a number of parameters
+	 */
+	private static String createParameterizedQuery(String sqlTemplate, String placeholder, Collection<?> parameters) {
+		String params = parameters.stream().map(p -> "?").collect(Collectors.joining(", "));
+		return sqlTemplate.replace(placeholder, params);
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/StepExecutionDao.java
@@ -17,7 +17,9 @@
 package org.springframework.batch.core.repository.dao;
 
 import java.util.Collection;
+import java.util.Set;
 
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.StepExecution;
@@ -63,6 +65,15 @@ public interface StepExecutionDao {
 	StepExecution getStepExecution(JobExecution jobExecution, Long stepExecutionId);
 
 	/**
+	 * Get a collection of {@link StepExecution} matching job execution and step execution
+	 * ids.
+	 * @param jobExecution the parent job execution
+	 * @param stepExecutionIds the step execution ids
+	 * @return collection of {@link StepExecution}
+	 */
+	Set<StepExecution> getStepExecutions(JobExecution jobExecution, Set<Long> stepExecutionIds);
+
+	/**
 	 * Retrieve the last {@link StepExecution} for a given {@link JobInstance} ordered by
 	 * creation time and then id.
 	 * @param jobInstance the parent {@link JobInstance}
@@ -90,6 +101,15 @@ public interface StepExecutionDao {
 	default long countStepExecutions(JobInstance jobInstance, String stepName) {
 		throw new UnsupportedOperationException();
 	}
+
+	/**
+	 * Count {@link StepExecution} that match the ids and statuses of them - avoid loading
+	 * them into memory
+	 * @param stepExecutionIds given step execution ids
+	 * @param matchingBatchStatuses
+	 * @return the count of matching steps
+	 */
+	long countStepExecutions(Collection<Long> stepExecutionIds, Collection<BatchStatus> matchingBatchStatuses);
 
 	/**
 	 * Delete the given step execution.

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
@@ -552,6 +552,11 @@ class CommandLineJobRunnerTests {
 		}
 
 		@Override
+		public Set<StepExecution> getStepExecutions(Long jobExecutionId, Set<Long> stepExecutionIds) {
+			return Set.of();
+		}
+
+		@Override
 		public List<String> getJobNames() {
 			throw new UnsupportedOperationException();
 		}
@@ -577,6 +582,11 @@ class CommandLineJobRunnerTests {
 			else {
 				return count;
 			}
+		}
+
+		@Override
+		public long getStepExecutionCount(Set<Long> stepExecutionIds, Set<BatchStatus> matchingBatchStatuses) {
+			return 0;
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
@@ -202,7 +202,7 @@ class SimpleJobRepositoryTests {
 		assertNotNull(stepExecution.getLastUpdated());
 
 		LocalDateTime lastUpdated = stepExecution.getLastUpdated();
-		assertTrue(lastUpdated.isAfter(before));
+		assertFalse(lastUpdated.isBefore(before));
 	}
 
 	@Test
@@ -236,7 +236,7 @@ class SimpleJobRepositoryTests {
 		assertNotNull(stepExecution.getLastUpdated());
 
 		LocalDateTime lastUpdated = stepExecution.getLastUpdated();
-		assertTrue(lastUpdated.isAfter(before));
+		assertFalse(lastUpdated.isBefore(before));
 	}
 
 	@Test


### PR DESCRIPTION
Fix OutOfMemory issue by optimizing step result checks. Previously, thousands of steps were loaded into memory on each check, causing memory overload.

**We've had this code in production for over a year now**, and we no longer get any OutOfMemory errors — it works! However, with each Spring Boot upgrade in our services, we have to patch Spring Batch with this fix, which has been a constant inconvenience for us every time to make the ` .patch` , deploy the artifact etc.
 
That's why we've created this pull request, which essentially addresses the same problem as PR [3791](https://github.com/spring-projects/spring-batch/pull/3791). Although that PR was approved, it cannot be merged due to conflicts. @fmbenhassine asked that the conflicts be resolved [here ](https://github.com/spring-projects/spring-batch/pull/3791#issuecomment-1722852729), but this was not done. In my pull request, I've included the code with the latest changes

I would greatly appreciate it if you could review my pull request, so we can merge it and permanently resolve the OutOfMemory issue.

Closes https://github.com/spring-projects/spring-batch/issues/3790