### PR TITLE
GH-4708 : in multi-threaded step, enforce the first chunk to be written by first thread

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/AbstractTradeBatchTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/AbstractTradeBatchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.batch.repeat.support;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.BeforeEach;
 
@@ -42,12 +44,16 @@ abstract class AbstractTradeBatchTests {
 
 	Resource resource = new ClassPathResource("trades.csv", getClass());
 
-	protected TradeWriter processor = new TradeWriter();
+	protected TradeWriter processor;
 
 	protected TradeItemReader provider;
 
+	protected ArrayList<Trade> output;
+
 	@BeforeEach
 	void setUp() throws Exception {
+		output = new ArrayList<>();
+		processor = new TradeWriter(output);
 		provider = new TradeItemReader(resource);
 		provider.open(new ExecutionContext());
 	}
@@ -79,10 +85,17 @@ abstract class AbstractTradeBatchTests {
 
 		int count = 0;
 
+		private ArrayList<Trade> out;
+
+		public TradeWriter(ArrayList<Trade> out) {
+			this.out = out;
+		}
+
 		// This has to be synchronized because we are going to test the state
 		// (count) at the end of a concurrent batch run.
 		@Override
 		public synchronized void write(Chunk<? extends Trade> data) {
+			out.addAll(data.getItems());
 			count++;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateFirstChunkTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateFirstChunkTests.java
@@ -67,8 +67,8 @@ class TaskExecutorRepeatTemplateFirstChunkTests extends AbstractTradeBatchTests 
 	}
 
 	/**
-	 * Test method for {@link TaskExecutorRepeatTemplate#iterate(RepeatCallback)}.
-	 * Repeat the tests 20 times to increase the probability of detecting a concurrency.
+	 * Test method for {@link TaskExecutorRepeatTemplate#iterate(RepeatCallback)}. Repeat
+	 * the tests 20 times to increase the probability of detecting a concurrency.
 	 */
 	@Test
 	@RepeatedTest(value = 20)

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateFirstChunkTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplateFirstChunkTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.repeat.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Tests for concurrent behaviour in repeat template, dedicated to the first chunk, that
+ * must be managed first when output format has separator between items, like JSON.
+ *
+ * @author Gerald Lelarge
+ *
+ */
+class TaskExecutorRepeatTemplateFirstChunkTests extends AbstractTradeBatchTests {
+
+	private TaskExecutorRepeatTemplate template;
+
+	private int chunkSize = 5;
+
+	private final ThreadPoolTaskExecutor threadPool = new ThreadPoolTaskExecutor();
+
+	@BeforeEach
+	void setUp() throws Exception {
+
+		super.setUp();
+
+		threadPool.setMaxPoolSize(10);
+		threadPool.setCorePoolSize(10);
+		threadPool.setQueueCapacity(0);
+		threadPool.afterPropertiesSet();
+
+		template = new TaskExecutorRepeatTemplate();
+		template.setTaskExecutor(threadPool);
+		// Limit the number of threads to 2
+		template.setThrottleLimit(2);
+		// Limit the number of items to read to be able to test the second item from the
+		// output. If the chunkSize is greater than 2, the test could fail.
+		template.setCompletionPolicy(new SimpleCompletionPolicy(chunkSize));
+	}
+
+	@AfterEach
+	void tearDown() {
+		threadPool.destroy();
+	}
+
+	/**
+	 * Test method for {@link TaskExecutorRepeatTemplate#iterate(RepeatCallback)}.
+	 * Repeat the tests 20 times to increase the probability of detecting a concurrency.
+	 */
+	@Test
+	@RepeatedTest(value = 20)
+	void testExecute() {
+
+		// given
+		template.iterate(new ItemReaderRepeatCallback<>(provider, processor));
+
+		// then
+		// The first element is the first item of the input trades.csv.
+		assertEquals("UK21341EAH45", output.get(0).getIsin());
+		// The others can have different orders.
+		for (int i = 1; i < output.size(); i++) {
+			assertNotEquals("UK21341EAH45", output.get(i).getIsin());
+		}
+		assertEquals(chunkSize, processor.count);
+	}
+
+}


### PR DESCRIPTION
Fix for #4708 

In a muti-threaded step, chunks are written regardless the order of items read from input.
If the output format has separator between records (as for JSON), a format issue appear if the the first chunk it not written first.

**Wrong result**
Sometime the produced JSON is misformatted :
```json
[
,
 {"code":10002,"ref":"B2C3D4E5F6G7","type":11,"nature":6,"etat":2,"ref2":"B2C3D4E5F6G7"} {"code":10001,"ref":"A1B2C3D4E5F6","type":10,"nature":5,"etat":1,"ref2":"A1B2C3D4E5F6"},
 {"code":10003,"ref":"C3D4E5F6G7H8","type":12,"nature":7,"etat":3,"ref2":"C3D4E5F6G7H8"},
 {"code":10004,"ref":"D4E5F6G7H8I9","type":13,"nature":8,"etat":4,"ref2":"D4E5F6G7H8I9"}
]
```

**Expected result**
```json
[
 {"code":10001,"ref":"A1B2C3D4E5F6","type":10,"nature":5,"etat":1,"ref2":"A1B2C3D4E5F6"},
 {"code":10002,"ref":"B2C3D4E5F6G7","type":11,"nature":6,"etat":2,"ref2":"B2C3D4E5F6G7"},
 {"code":10003,"ref":"C3D4E5F6G7H8","type":12,"nature":7,"etat":3,"ref2":"C3D4E5F6G7H8"},
 {"code":10004,"ref":"D4E5F6G7H8I9","type":13,"nature":8,"etat":4,"ref2":"D4E5F6G7H8I9"}
]
```

Run tests with :
```bash
mvn -pl spring-batch-infrastructure -Dtest=TaskExecutorRepeatTemplateFirstChunkTests test
```