### PR TITLE
GH-4703: Enhance StoppableTasklet interface to support step-specific stop requests

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -84,6 +84,7 @@ import org.springframework.util.Assert;
  * @author Lucas Ward
  * @author Will Schipp
  * @author Mahmoud Ben Hassine
+ * @author Hyunsang Han
  * @since 2.0
  */
 public class SimpleJobOperator implements JobOperator, InitializingBean {
@@ -350,7 +351,7 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 								Tasklet tasklet = ((TaskletStep) step).getTasklet();
 								if (tasklet instanceof StoppableTasklet) {
 									StepSynchronizationManager.register(stepExecution);
-									((StoppableTasklet) tasklet).stop();
+									((StoppableTasklet) tasklet).stop(stepExecution);
 									StepSynchronizationManager.release();
 								}
 							}
@@ -363,7 +364,7 @@ public class SimpleJobOperator implements JobOperator, InitializingBean {
 			}
 		}
 		catch (NoSuchJobException e) {
-			logger.warn("Cannot find Job object in the job registry. StoppableTasklet#stop() will not be called", e);
+			logger.warn("Cannot find Job object in the job registry. StoppableTasklet#stop(StepExecution stepExecution) will not be called", e);
 		}
 
 		return true;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/StoppableTasklet.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/StoppableTasklet.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.step.tasklet;
 
+import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.launch.JobOperator;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.batch.core.launch.JobOperator;
  * so the appropriate thread safety and visibility controls should be put in place.
  *
  * @author Will Schipp
+ * @author Hyunsang Han
  * @since 3.0
  */
 public interface StoppableTasklet extends Tasklet {
@@ -38,4 +40,14 @@ public interface StoppableTasklet extends Tasklet {
 	 */
 	void stop();
 
+	/**
+	 * Used to signal that the job should stop, providing access to the current
+	 * {@link StepExecution} context.
+	 *
+	 * @param stepExecution the current {@link StepExecution} context in which the job
+	 * is being executed
+	 */
+	default void stop(StepExecution stepExecution) {
+		stop();
+	}
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/SystemCommandTasklet.java
@@ -61,6 +61,7 @@ import org.springframework.util.StringUtils;
  * @author Will Schipp
  * @author Mahmoud Ben Hassine
  * @author Injae Kim
+ * @author Hyunsang Han
  */
 public class SystemCommandTasklet implements StepExecutionListener, StoppableTasklet, InitializingBean {
 
@@ -273,6 +274,23 @@ public class SystemCommandTasklet implements StepExecutionListener, StoppableTas
 	@Override
 	public void stop() {
 		stopped = true;
+	}
+
+	/**
+	 * Interrupts the execution of the system command if the given {@link StepExecution}
+	 * matches the current execution context. This method allows for granular control over
+	 * stopping specific step executions, ensuring that only the intended command is halted.
+	 *
+	 * @param stepExecution the current {@link StepExecution} context; the execution is
+	 * interrupted if it matches the ongoing one.
+	 * @since 6.0
+	 * @see StoppableTasklet#stop(StepExecution)
+	 */
+	@Override
+	public void stop(StepExecution stepExecution) {
+		if (stepExecution.equals(execution)) {
+			stopped = true;
+		}
 	}
 
 }


### PR DESCRIPTION
Closes: https://github.com/spring-projects/spring-batch/issues/4703

Resolves a limitation in the `StoppableTasklet` interface where distinguishing which specific StepExecution to stop was not possible during concurrent job executions.