### PR TITLE
Honor `@NestedTestConfiguration` semantic in `BatchTestContextCustomizerFactory`

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,23 +17,25 @@ package org.springframework.batch.test.context;
 
 import java.util.List;
 
-import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.TestContextAnnotationUtils;
 
 /**
  * Factory for {@link BatchTestContextCustomizer}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 4.1
  */
 public class BatchTestContextCustomizerFactory implements ContextCustomizerFactory {
 
 	@Override
-	public ContextCustomizer createContextCustomizer(Class<?> testClass,
+	public @Nullable ContextCustomizer createContextCustomizer(Class<?> testClass,
 			List<ContextConfigurationAttributes> configAttributes) {
-		if (AnnotatedElementUtils.hasAnnotation(testClass, SpringBatchTest.class)) {
+		if (TestContextAnnotationUtils.hasAnnotation(testClass, SpringBatchTest.class)) {
 			return new BatchTestContextCustomizer();
 		}
 		return null;

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/BatchTestContextCustomizerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,38 +18,42 @@ package org.springframework.batch.test.context;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 class BatchTestContextCustomizerFactoryTests {
 
 	private final BatchTestContextCustomizerFactory factory = new BatchTestContextCustomizerFactory();
 
-	@Test
-	void testCreateContextCustomizer_whenAnnotationIsPresent() {
+	@ParameterizedTest
+	@ValueSource(classes = { MyJobTest.class, MyJobTest.MyNestedTest.class })
+	void testCreateContextCustomizer_whenAnnotationIsPresent(Class<?> testClass) {
 		// given
-		Class<MyJobTest> testClass = MyJobTest.class;
 		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
 
 		// when
 		ContextCustomizer contextCustomizer = this.factory.createContextCustomizer(testClass, configAttributes);
 
 		// then
-		assertNotNull(contextCustomizer);
+		assertInstanceOf(BatchTestContextCustomizer.class, contextCustomizer);
 	}
 
 	@Test
 	void testCreateContextCustomizer_whenAnnotationIsAbsent() {
 		// given
-		Class<MyOtherJobTest> testClass = MyOtherJobTest.class;
+		Class<?> testClass = MyOtherJobTest.class;
 		List<ContextConfigurationAttributes> configAttributes = Collections.emptyList();
 
 		// when
@@ -61,6 +65,11 @@ class BatchTestContextCustomizerFactoryTests {
 
 	@SpringBatchTest
 	private static class MyJobTest {
+
+		@Nested
+		class MyNestedTest {
+
+		}
 
 	}
 

--- a/spring-batch-test/src/test/java/org/springframework/batch/test/context/SpringBatchTestIntegrationTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/context/SpringBatchTestIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.test.context;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.JobRepositoryTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * @author Stefano Cordio
+ */
+@SpringJUnitConfig
+@SpringBatchTest
+class SpringBatchTestIntegrationTests {
+
+	@Autowired
+	ApplicationContext context;
+
+	@Nested
+	class InnerWithoutSpringBatchTest {
+
+		@Autowired
+		ApplicationContext context;
+
+		@Test
+		void test() {
+			assertSame(SpringBatchTestIntegrationTests.this.context, context);
+			assertNotNull(context.getBean(JobLauncherTestUtils.class));
+			assertNotNull(context.getBean(JobRepositoryTestUtils.class));
+		}
+
+	}
+
+	@Nested
+	@SpringBatchTest
+	class InnerWithSpringBatchTest {
+
+		@Autowired
+		ApplicationContext context;
+
+		@Test
+		void test() {
+			assertSame(SpringBatchTestIntegrationTests.this.context, context);
+			assertNotNull(context.getBean(JobLauncherTestUtils.class));
+			assertNotNull(context.getBean(JobRepositoryTestUtils.class));
+		}
+
+	}
+
+}


### PR DESCRIPTION
Prior to this commit, `BatchTestContextCustomizerFactory` only looked for `@SpringBatchTest` on the given test class as a marker annotation. While this works fine for top-level classes, it doesn't work correctly with JUnit `@Nested` classes, resulting in a distinct `ApplicationContext` for the nested class as a side effect.

With this change, the factory no longer uses [`AnnotatedElementUtils.hasAnnotation`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/annotation/AnnotatedElementUtils.html#hasAnnotation(java.lang.reflect.AnnotatedElement,java.lang.Class)) and favors instead [`TestContextAnnotationUtils.hasAnnotation`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/context/TestContextAnnotationUtils.html#hasAnnotation(java.lang.Class,java.lang.Class)), which honors the [`@NestedTestConfiguration`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/context/NestedTestConfiguration.html) semantic.

Fixes #4738.