### PR TITLE
Step names must be unique #3757

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,26 @@
 		<spring-javaformat-maven-plugin.version>0.0.39</spring-javaformat-maven-plugin.version>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>jcl-over-slf4j</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-simple</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -372,7 +372,7 @@ public abstract class AbstractJob implements Job, StepLocator, BeanNameAware, In
 		}
 	}
 
-	protected abstract void checkStepNamesUnicity() throws AlreadyUsedStepNameException ;
+	protected abstract void checkStepNamesUnicity() throws AlreadyUsedStepNameException;
 
 	private void stopObservation(JobExecution execution, Observation observation) {
 		List<Throwable> throwables = execution.getFailureExceptions();
@@ -431,9 +431,10 @@ public abstract class AbstractJob implements Job, StepLocator, BeanNameAware, In
 		return exitStatus;
 	}
 
-	protected static void addToMapCheckingUnicity(Map<String, Step> map, Step step, String name) throws AlreadyUsedStepNameException {
-		map.merge(name, step, (old, value)->{
-			if (!old.equals(value)){
+	protected static void addToMapCheckingUnicity(Map<String, Step> map, Step step, String name)
+			throws AlreadyUsedStepNameException {
+		map.merge(name, step, (old, value) -> {
+			if (!old.equals(value)) {
 				throw new AlreadyUsedStepNameException(name);
 			}
 			return old;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/AbstractJob.java
@@ -374,20 +374,6 @@ public abstract class AbstractJob implements Job, StepLocator, BeanNameAware, In
 
 	protected abstract void checkStepNamesUnicity() throws AlreadyUsedStepNameException ;
 
-	private Optional<String> findFirstDoubleElementInList(List<String> strings) {
-		if (strings==null){
-			return Optional.empty();
-		}
-		Set<String> alreadyChecked=new HashSet<>();
-		for (String value:strings){
-			if (alreadyChecked.contains(value)){
-				return Optional.of(value);
-			}
-			alreadyChecked.add(value);
-		}
-		return Optional.empty();
-	}
-
 	private void stopObservation(JobExecution execution, Observation observation) {
 		List<Throwable> throwables = execution.getFailureExceptions();
 		if (!throwables.isEmpty()) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
@@ -25,7 +25,6 @@ import org.springframework.batch.core.JobInterruptedException;
 import org.springframework.batch.core.StartLimitExceededException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.job.builder.AlreadyUsedStepNameException;
 import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.batch.core.step.StepLocator;
 
@@ -145,9 +144,8 @@ public class SimpleJob extends AbstractJob {
 	}
 
 	@Override
-	protected void checkStepNamesUnicity() throws AlreadyUsedStepNameException {
-		Map<String, Step> map = new HashMap<>();
-		steps.forEach(step->{addToMapCheckingUnicity(map, step, step.getName());});
+	protected void checkStepNamesUnicity() {
+		//noop : steps of SimpleJob can share the same name
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
@@ -16,9 +16,7 @@
 
 package org.springframework.batch.core.job;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -27,6 +25,7 @@ import org.springframework.batch.core.JobInterruptedException;
 import org.springframework.batch.core.StartLimitExceededException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.job.builder.AlreadyUsedStepNameException;
 import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.batch.core.step.StepLocator;
 
@@ -143,6 +142,12 @@ public class SimpleJob extends AbstractJob {
 			execution.upgradeStatus(stepExecution.getStatus());
 			execution.setExitStatus(stepExecution.getExitStatus());
 		}
+	}
+
+	@Override
+	protected void checkStepNamesUnicity() throws AlreadyUsedStepNameException {
+		Map<String, Step> map = new HashMap<>();
+		steps.forEach(step->{addToMapCheckingUnicity(map, step, step.getName());});
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,7 +145,7 @@ public class SimpleJob extends AbstractJob {
 
 	@Override
 	protected void checkStepNamesUnicity() {
-		//noop : steps of SimpleJob can share the same name
+		// noop : steps of SimpleJob can share the same name
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/AlreadyUsedStepNameException.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/AlreadyUsedStepNameException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2006-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.core.job.builder;
+
+/**
+ * Exception to indicate the name of a step is already used by a different step in the same flow.
+ * Step names must be unique within a flow definition because the search of the next step to find
+ * relies on the step name
+ *
+ * @author Fabrice Bibonne
+ *
+ */
+public class AlreadyUsedStepNameException extends RuntimeException{
+
+    public AlreadyUsedStepNameException(String name){
+        super("the name "+name+" is already used");
+    }
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/AlreadyUsedStepNameException.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/AlreadyUsedStepNameException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2024 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package org.springframework.batch.core.job.builder;
 
 /**
- * Exception to indicate the name of a step is already used by a different step in the same flow.
- * Step names must be unique within a flow definition because the search of the next step to find
- * relies on the step name
+ * Exception to indicate the name of a step is already used by a different step in the
+ * same flow. Step names must be unique within a flow definition because the search of the
+ * next step to find relies on the step name
  *
  * @author Fabrice Bibonne
  */

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/AlreadyUsedStepNameException.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/AlreadyUsedStepNameException.java
@@ -22,12 +22,11 @@ package org.springframework.batch.core.job.builder;
  * relies on the step name
  *
  * @author Fabrice Bibonne
- *
  */
-public class AlreadyUsedStepNameException extends RuntimeException{
+public class AlreadyUsedStepNameException extends RuntimeException {
 
-    public AlreadyUsedStepNameException(String name){
-        super("the name "+name+" is already used");
-    }
+	public AlreadyUsedStepNameException(String name) {
+		super("the name " + name + " is already used");
+	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,6 @@ public class FlowJob extends AbstractJob {
 		return stepMap.get(stepName);
 	}
 
-
 	/**
 	 * Initialize the step names
 	 */
@@ -98,14 +97,10 @@ public class FlowJob extends AbstractJob {
 					addToMapCheckingUnicity(this.stepMap, locator.getStep(name), name);
 				}
 			}
-			//TODO remove this else bock ? not executed during tests : the only State which implements StepHolder is StepState which already implements StepLocator
-			/*
-			Tests Coverage
-			Hits : 30
-				state instanceof StepHolder
-					true hits: 0
-					false hits : 30
-			*/
+			// TODO remove this else bock ? not executed during tests : the only State
+			// which implements StepHolder is StepState which already implements
+			// StepLocator
+			// within tests coverage `state instanceof StepHolder` is false 30 times/30
 			else if (state instanceof StepHolder stepHolder) {
 				Step step = stepHolder.getStep();
 				addToMapCheckingUnicity(this.stepMap, step, step.getName());

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
@@ -85,20 +85,20 @@ public class FlowJob extends AbstractJob {
 	 */
 	private void init() {
 		if (!initialized) {
-			findStepsThrowingIfNameNotUnique(flow, stepMap);
+			findStepsThrowingIfNameNotUnique(flow);
 			initialized = true;
 		}
 	}
 
-	private void findStepsThrowingIfNameNotUnique(Flow flow, Map<String, Step> map) {
+	private void findStepsThrowingIfNameNotUnique(Flow flow) {
 
 		for (State state : flow.getStates()) {
 			if (state instanceof StepLocator locator) {
 				for (String name : locator.getStepNames()) {
-					addToMapCheckingUnicity(map, locator.getStep(name), name);
+					addToMapCheckingUnicity(this.stepMap, locator.getStep(name), name);
 				}
 			}
-			//TODO remove this else bock ? not executed during tests : the only State wich implements StepHolder is StepState which implements also StepLocator
+			//TODO remove this else bock ? not executed during tests : the only State which implements StepHolder is StepState which already implements StepLocator
 			/*
 			Tests Coverage
 			Hits : 30
@@ -108,11 +108,11 @@ public class FlowJob extends AbstractJob {
 			*/
 			else if (state instanceof StepHolder stepHolder) {
 				Step step = stepHolder.getStep();
-				addToMapCheckingUnicity(map, step, step.getName());
+				addToMapCheckingUnicity(this.stepMap, step, step.getName());
 			}
 			else if (state instanceof FlowHolder flowHolder) {
 				for (Flow subflow : flowHolder.getFlows()) {
-					findStepsThrowingIfNameNotUnique(subflow, map);
+					findStepsThrowingIfNameNotUnique(subflow);
 				}
 			}
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
@@ -17,33 +17,20 @@ package org.springframework.batch.core.job;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobExecutionException;
-import org.springframework.batch.core.JobInterruptedException;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersInvalidException;
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.job.builder.AlreadyUsedStepNameException;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
-import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Dave Syer
@@ -218,8 +205,7 @@ class ExtendedAbstractJobTests {
 		}
 
 		@Override
-		protected void checkStepNamesUnicity() throws AlreadyUsedStepNameException {
-
+		protected void checkStepNamesUnicity(){
 		}
 
 		@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
@@ -25,6 +25,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.job.builder.AlreadyUsedStepNameException;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.StepSupport;
@@ -36,6 +37,7 @@ import org.springframework.lang.Nullable;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -213,6 +215,11 @@ class ExtendedAbstractJobTests {
 
 		@Override
 		protected void doExecute(JobExecution execution) throws JobExecutionException {
+		}
+
+		@Override
+		protected void checkStepNamesUnicity() throws AlreadyUsedStepNameException {
+
 		}
 
 		@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/ExtendedAbstractJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ class ExtendedAbstractJobTests {
 		}
 
 		@Override
-		protected void checkStepNamesUnicity(){
+		protected void checkStepNamesUnicity() {
 		}
 
 		@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -513,6 +513,25 @@ class SimpleJobTests {
 
 	}
 
+	@Test
+	public void testMultipleStepsWithSameName(){
+		job.setName("MultipleStepsWithSameName");
+		String sharedName="stepName";
+		final List<String> executionsCallbacks=new ArrayList<>();
+		StubStep sharedNameStep1=new StubStep(sharedName, jobRepository);
+		sharedNameStep1.setCallback(()->executionsCallbacks.add("step1"));
+		job.addStep(sharedNameStep1);
+		StubStep sharedNameStep2=new StubStep(sharedName, jobRepository);
+		sharedNameStep2.setCallback(()->executionsCallbacks.add("step2"));
+		job.addStep(sharedNameStep2);
+		StubStep sharedNameStep3=new StubStep(sharedName, jobRepository);
+		sharedNameStep3.setCallback(()->executionsCallbacks.add("step3"));
+		job.addStep(sharedNameStep3);
+		job.execute(jobExecution);
+		assertEquals(List.of("step1", "step2", "step3"), executionsCallbacks);
+		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+	}
+
 	/*
 	 * Check JobRepository to ensure status is being saved.
 	 */

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -514,18 +514,18 @@ class SimpleJobTests {
 	}
 
 	@Test
-	public void testMultipleStepsWithSameName(){
+	public void testMultipleStepsWithSameName() {
 		job.setName("MultipleStepsWithSameName");
-		String sharedName="stepName";
-		final List<String> executionsCallbacks=new ArrayList<>();
-		StubStep sharedNameStep1=new StubStep(sharedName, jobRepository);
-		sharedNameStep1.setCallback(()->executionsCallbacks.add("step1"));
+		String sharedName = "stepName";
+		final List<String> executionsCallbacks = new ArrayList<>();
+		StubStep sharedNameStep1 = new StubStep(sharedName, jobRepository);
+		sharedNameStep1.setCallback(() -> executionsCallbacks.add("step1"));
 		job.addStep(sharedNameStep1);
-		StubStep sharedNameStep2=new StubStep(sharedName, jobRepository);
-		sharedNameStep2.setCallback(()->executionsCallbacks.add("step2"));
+		StubStep sharedNameStep2 = new StubStep(sharedName, jobRepository);
+		sharedNameStep2.setCallback(() -> executionsCallbacks.add("step2"));
 		job.addStep(sharedNameStep2);
-		StubStep sharedNameStep3=new StubStep(sharedName, jobRepository);
-		sharedNameStep3.setCallback(()->executionsCallbacks.add("step3"));
+		StubStep sharedNameStep3 = new StubStep(sharedName, jobRepository);
+		sharedNameStep3.setCallback(() -> executionsCallbacks.add("step3"));
 		job.addStep(sharedNameStep3);
 		job.execute(jobExecution);
 		assertEquals(List.of("step1", "step2", "step3"), executionsCallbacks);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -365,102 +365,120 @@ class FlowJobBuilderTests {
 		assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
 	}
 
-	//https://github.com/spring-projects/spring-batch/issues/3757#issuecomment-1821593539
+	// https://github.com/spring-projects/spring-batch/issues/3757#issuecomment-1821593539
 	@Test
-	void testStepNamesMustBeUniqueWithinFlowDefinition() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+	void testStepNamesMustBeUniqueWithinFlowDefinition() throws JobInstanceAlreadyCompleteException,
+			JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
 		ApplicationContext context = new AnnotationConfigApplicationContext(JobConfigurationForStepNameUnique.class);
 		JobLauncher jobLauncher = context.getBean(JobLauncher.class);
 		Job job = context.getBean(Job.class);
-		JobExecution jobExecution=jobLauncher.run(job, new JobParametersBuilder().addLong("random", 2L).addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME).toJobParameters());
-		Assertions.assertTrue(jobExecution.getAllFailureExceptions().stream().map(Object::getClass).anyMatch(AlreadyUsedStepNameException.class::equals));
+		JobExecution jobExecution = jobLauncher.run(job,
+				new JobParametersBuilder().addLong("random", 2L)
+					.addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME)
+					.toJobParameters());
+		Assertions.assertTrue(jobExecution.getAllFailureExceptions()
+			.stream()
+			.map(Object::getClass)
+			.anyMatch(AlreadyUsedStepNameException.class::equals));
 		assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
-		jobExecution=jobLauncher.run(job, new JobParametersBuilder().addLong("random", 1L).addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME).toJobParameters());
-		Assertions.assertTrue(jobExecution.getAllFailureExceptions().stream().map(Object::getClass).anyMatch(AlreadyUsedStepNameException.class::equals));
+		jobExecution = jobLauncher.run(job,
+				new JobParametersBuilder().addLong("random", 1L)
+					.addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME)
+					.toJobParameters());
+		Assertions.assertTrue(jobExecution.getAllFailureExceptions()
+			.stream()
+			.map(Object::getClass)
+			.anyMatch(AlreadyUsedStepNameException.class::equals));
 		assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
 	}
 
 	@EnableBatchProcessing
 	@Configuration
-	static class JobConfigurationForStepNameUnique{
+	static class JobConfigurationForStepNameUnique {
 
-		private static final String SHARED_NAME ="sharedName";
+		private static final String SHARED_NAME = "sharedName";
 
 		private static final Log logger = LogFactory.getLog(FlowJobBuilderTests.class);
-
 
 		@Bean
 		@JobScope
 		public Step conditionalStep(JobRepository jobRepository, PlatformTransactionManager transactionManager,
-									@Value("#{jobParameters['random']}") Integer random) {
-			return new StepBuilder("conditionalStep", jobRepository).tasklet(
-					(StepContribution contribution, ChunkContext chunkContext) ->{
-						String exitStatus = (random % 2 == 0) ? "EVEN" : "ODD";
-						logger.info("'conditionalStep' with exitStatus "+exitStatus);
-						contribution.setExitStatus(new ExitStatus(exitStatus));
-						return RepeatStatus.FINISHED;
-					}, transactionManager
-			).build();
+				@Value("#{jobParameters['random']}") Integer random) {
+			return new StepBuilder("conditionalStep", jobRepository)
+				.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+					String exitStatus = (random % 2 == 0) ? "EVEN" : "ODD";
+					logger.info("'conditionalStep' with exitStatus " + exitStatus);
+					contribution.setExitStatus(new ExitStatus(exitStatus));
+					return RepeatStatus.FINISHED;
+				}, transactionManager)
+				.build();
 		}
 
 		@Bean
 		@JobScope
 		public Step stepTwo(JobRepository jobRepository, PlatformTransactionManager transactionManager,
-							@Value("#{jobParameters['stepTwo.name']}") String name) {
+				@Value("#{jobParameters['stepTwo.name']}") String name) {
 			return new StepBuilder(name, jobRepository)
-					.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
-						logger.info("Hello from stepTwo");
-						return RepeatStatus.FINISHED;
-					}, transactionManager)
-					.build();
+				.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+					logger.info("Hello from stepTwo");
+					return RepeatStatus.FINISHED;
+				}, transactionManager)
+				.build();
 		}
 
 		@Bean
 		public Step stepThree(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
 			return new StepBuilder(SHARED_NAME, jobRepository)
-					.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
-						logger.info("Hello from stepThree");
-						return RepeatStatus.FINISHED;
-					}, transactionManager)
-					.build();
+				.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+					logger.info("Hello from stepThree");
+					return RepeatStatus.FINISHED;
+				}, transactionManager)
+				.build();
 		}
 
 		@Bean
 		public Step stepFour(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
 			return new StepBuilder(SHARED_NAME, jobRepository)
-					.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
-						logger.info("Hello from stepFour");
-						return RepeatStatus.FINISHED;
-					}, transactionManager)
-					.build();
+				.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+					logger.info("Hello from stepFour");
+					return RepeatStatus.FINISHED;
+				}, transactionManager)
+				.build();
 		}
 
 		@Bean
 		public Job job(JobRepository jobRepository, @Qualifier("conditionalStep") Step conditionalStep,
-					   @Qualifier("stepFour") Step step4, @Qualifier("stepTwo") Step step2,
-					   @Qualifier("stepThree") Step step3) {
+				@Qualifier("stepFour") Step step4, @Qualifier("stepTwo") Step step2,
+				@Qualifier("stepThree") Step step3) {
 			JobBuilder jobBuilder = new JobBuilder("flow", jobRepository);
 			return jobBuilder.start(conditionalStep)
-					.on("ODD").to(step2)
-					.from(conditionalStep).on("EVEN").to(step3)
-					.from(step3)
-					.next(step4)
-					.from(step2).next(step4).end().build();
+				.on("ODD")
+				.to(step2)
+				.from(conditionalStep)
+				.on("EVEN")
+				.to(step3)
+				.from(step3)
+				.next(step4)
+				.from(step2)
+				.next(step4)
+				.end()
+				.build();
 		}
 
 		@Bean
 		public DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
-					.addScript("/org/springframework/batch/core/schema-hsqldb.sql")
-					.generateUniqueName(true)
-					.build();
+				.addScript("/org/springframework/batch/core/schema-hsqldb.sql")
+				.generateUniqueName(true)
+				.build();
 		}
 
 		@Bean
 		public JdbcTransactionManager transactionManager(DataSource dataSource) {
 			return new JdbcTransactionManager(dataSource);
 		}
-	}
 
+	}
 
 	@EnableBatchProcessing
 	@Configuration

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.core.job.builder;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,11 +30,13 @@ import org.springframework.batch.core.job.flow.support.SimpleFlow;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.StepSupport;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -362,35 +366,93 @@ class FlowJobBuilderTests {
 	//https://github.com/spring-projects/spring-batch/issues/3757#issuecomment-1821593539
 	@Test
 	void testStepNamesMustBeUniqueWithinFlowDefinition() {
-		Step conditionalStep = new StepSupport("conditionalStep") {
-			@Override
-			public void execute(StepExecution stepExecution) {
-				stepExecution.upgradeStatus(BatchStatus.COMPLETED);
-				stepExecution.setExitStatus(ExitStatus.COMPLETED);
-				String exitStatus = (System.currentTimeMillis() % 2 == 0) ? "EVEN" : "ODD";
-				stepExecution.setExitStatus(new ExitStatus(exitStatus));
-				jobRepository.update(stepExecution);
-			}
-		};
+		ApplicationContext context = new AnnotationConfigApplicationContext(JobConfigurationForStepNameUnique.class);
+		JobLauncher jobLauncher = context.getBean(JobLauncher.class);
+		Job job = context.getBean(Job.class);
+		assertThrows(AlreadyUsedStepNameException.class, ()->jobLauncher.run(job, new JobParametersBuilder().addLong("random", 2L).addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME).toJobParameters()));
+		assertThrows(AlreadyUsedStepNameException.class, ()->jobLauncher.run(job, new JobParametersBuilder().addLong("random", 1L).addString("stepTwo.name",JobConfigurationForStepNameUnique.SHARED_NAME).toJobParameters()));
+	}
 
-		StepSupport misnamedStep = new StepSupport("step3") {
-			@Override
-			public void execute(StepExecution stepExecution)
-					throws UnexpectedJobExecutionException {
+	@EnableBatchProcessing
+	@Configuration
+	static class JobConfigurationForStepNameUnique{
 
-				stepExecution.upgradeStatus(BatchStatus.COMPLETED);
-				stepExecution.setExitStatus(ExitStatus.COMPLETED);
-				jobRepository.update(stepExecution);
-			}
-		};
+		private static final String SHARED_NAME ="sharedName";
 
-		JobBuilder jobBuilder = new JobBuilder("flow", jobRepository);
-		FlowBuilder<FlowJobBuilder> flowBuilder = jobBuilder.start(conditionalStep)
-				.on("ODD").to(step2)
-				.from(conditionalStep).on("EVEN").to(step3)
-				.from(step3);
-		assertThrows(AlreadyUsedStepNameException.class, () -> flowBuilder.next(misnamedStep));
-		flowBuilder.end().build();
+		private static final Log logger = LogFactory.getLog(FlowJobBuilderTests.class);
+
+
+		@Bean
+		@JobScope
+		public Step conditionalStep(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+									@Value("#{jobParameters['random']}") Integer random) {
+			return new StepBuilder("conditionalStep", jobRepository).tasklet(
+					(StepContribution contribution, ChunkContext chunkContext) ->{
+						String exitStatus = (random % 2 == 0) ? "EVEN" : "ODD";
+						logger.info("'conditionalStep' with exitStatus "+exitStatus);
+						contribution.setExitStatus(new ExitStatus(exitStatus));
+						return RepeatStatus.FINISHED;
+					}, transactionManager
+			).build();
+		}
+
+		@Bean
+		@JobScope
+		public Step stepTwo(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+							@Value("#{jobParameters['stepTwo.name']}") String name) {
+			return new StepBuilder(name, jobRepository)
+					.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+						logger.info("Hello from stepTwo");
+						return RepeatStatus.FINISHED;
+					}, transactionManager)
+					.build();
+		}
+
+		@Bean
+		public Step stepThree(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+			return new StepBuilder(SHARED_NAME, jobRepository)
+					.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+						logger.info("Hello from stepThree");
+						return RepeatStatus.FINISHED;
+					}, transactionManager)
+					.build();
+		}
+
+		@Bean
+		public Step stepFour(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+			return new StepBuilder(SHARED_NAME, jobRepository)
+					.tasklet((StepContribution contribution, ChunkContext chunkContext) -> {
+						logger.info("Hello from stepFour");
+						return RepeatStatus.FINISHED;
+					}, transactionManager)
+					.build();
+		}
+
+		@Bean
+		public Job job(JobRepository jobRepository, @Qualifier("conditionalStep") Step conditionalStep,
+					   @Qualifier("stepFour") Step step4, @Qualifier("stepTwo") Step step2,
+					   @Qualifier("stepThree") Step step3) {
+			JobBuilder jobBuilder = new JobBuilder("flow", jobRepository);
+			return jobBuilder.start(conditionalStep)
+					.on("ODD").to(step2)
+					.from(conditionalStep).on("EVEN").to(step3)
+					.from(step3)
+					.next(step4)
+					.from(step2).next(step4).end().build();
+		}
+
+		@Bean
+		public DataSource dataSource() {
+			return new EmbeddedDatabaseBuilder().addScript("/org/springframework/batch/core/schema-drop-hsqldb.sql")
+					.addScript("/org/springframework/batch/core/schema-hsqldb.sql")
+					.generateUniqueName(true)
+					.build();
+		}
+
+		@Bean
+		public JdbcTransactionManager transactionManager(DataSource dataSource) {
+			return new JdbcTransactionManager(dataSource);
+		}
 	}
 
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Dave Syer
@@ -372,10 +372,10 @@ class FlowJobBuilderTests {
 		JobLauncher jobLauncher = context.getBean(JobLauncher.class);
 		Job job = context.getBean(Job.class);
 		JobExecution jobExecution=jobLauncher.run(job, new JobParametersBuilder().addLong("random", 2L).addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME).toJobParameters());
-		assertTrue(jobExecution.getAllFailureExceptions().stream().map(Object::getClass).anyMatch(AlreadyUsedStepNameException.class::equals));
+		Assertions.assertTrue(jobExecution.getAllFailureExceptions().stream().map(Object::getClass).anyMatch(AlreadyUsedStepNameException.class::equals));
 		assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
 		jobExecution=jobLauncher.run(job, new JobParametersBuilder().addLong("random", 1L).addString("stepTwo.name", JobConfigurationForStepNameUnique.SHARED_NAME).toJobParameters());
-		assertTrue(jobExecution.getAllFailureExceptions().stream().map(Object::getClass).anyMatch(AlreadyUsedStepNameException.class::equals));
+		Assertions.assertTrue(jobExecution.getAllFailureExceptions().stream().map(Object::getClass).anyMatch(AlreadyUsedStepNameException.class::equals));
 		assertEquals(ExitStatus.FAILED.getExitCode(), jobExecution.getExitStatus().getExitCode());
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
@@ -43,7 +43,6 @@ import org.springframework.batch.core.converter.JobParametersConverter;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.job.JobSupport;
-import org.springframework.batch.core.job.builder.AlreadyUsedStepNameException;
 import org.springframework.batch.core.launch.JobInstanceAlreadyExistsException;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.launch.NoSuchJobExecutionException;
@@ -457,7 +456,7 @@ class SimpleJobOperatorTests {
 		}
 
 		@Override
-		protected void checkStepNamesUnicity() throws AlreadyUsedStepNameException {
+		protected void checkStepNamesUnicity() {
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
@@ -43,6 +43,7 @@ import org.springframework.batch.core.converter.JobParametersConverter;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.job.JobSupport;
+import org.springframework.batch.core.job.builder.AlreadyUsedStepNameException;
 import org.springframework.batch.core.launch.JobInstanceAlreadyExistsException;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.launch.NoSuchJobExecutionException;
@@ -453,6 +454,10 @@ class SimpleJobOperatorTests {
 		@Override
 		protected void doExecute(JobExecution execution) throws JobExecutionException {
 
+		}
+
+		@Override
+		protected void checkStepNamesUnicity() throws AlreadyUsedStepNameException {
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/SimpleJobOperatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
 the names of different steps in a job must be different

Sloves #3757

A few comments :
  - pom is updated to have a have a version of slf4j-api corresponding to simple-slf4j
  - unicity of names is checked when starting the job , just before calling listeners because step names may be known only in JobScope
  - in FlowJob.findStepsThrowingIfNameNotUnique, I suggest to remove the else block when state is instance of StepHolder : it is never executed
