### PR TITLE
Fix index creation statements in MongoDB DDL script

### DIFF
--- a/spring-batch-core/src/main/resources/org/springframework/batch/core/schema-mongodb.js
+++ b/spring-batch-core/src/main/resources/org/springframework/batch/core/schema-mongodb.js
@@ -10,9 +10,9 @@ db.getCollection("BATCH_SEQUENCES").insertOne({_id: "BATCH_JOB_EXECUTION_SEQ", c
 db.getCollection("BATCH_SEQUENCES").insertOne({_id: "BATCH_STEP_EXECUTION_SEQ", count: Long(0)});
 
 // INDICES
-db.getCollection("BATCH_JOB_INSTANCE").createIndex("job_name_idx", {"jobName": 1}, {});
-db.getCollection("BATCH_JOB_INSTANCE").createIndex("job_name_key_idx", {"jobName": 1, "jobKey": 1}, {});
-db.getCollection("BATCH_JOB_INSTANCE").createIndex("job_instance_idx", {"jobInstanceId": -1}, {});
-db.getCollection("BATCH_JOB_EXECUTION").createIndex("job_instance_idx", {"jobInstanceId": 1}, {});
-db.getCollection("BATCH_JOB_EXECUTION").createIndex("job_instance_idx", {"jobInstanceId": 1, "status": 1}, {});
-db.getCollection("BATCH_STEP_EXECUTION").createIndex("step_execution_idx", {"stepExecutionId": 1}, {});
+db.getCollection("BATCH_JOB_INSTANCE").createIndex( {"jobName": 1}, {"name": "job_name_idx"});
+db.getCollection("BATCH_JOB_INSTANCE").createIndex( {"jobName": 1, "jobKey": 1}, {"name": "job_name_key_idx"});
+db.getCollection("BATCH_JOB_INSTANCE").createIndex( {"jobInstanceId": -1}, {"name": "job_instance_idx"});
+db.getCollection("BATCH_JOB_EXECUTION").createIndex( {"jobInstanceId": 1}, {"name": "job_instance_idx"});
+db.getCollection("BATCH_JOB_EXECUTION").createIndex( {"jobInstanceId": 1, "status": 1}, {"name": "job_instance_status_idx"});
+db.getCollection("BATCH_STEP_EXECUTION").createIndex( {"stepExecutionId": 1}, {"name": "step_execution_idx"});

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryIntegrationTests.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -68,6 +70,18 @@ public class MongoDBJobRepositoryIntegrationTests {
 		mongoTemplate.createCollection("BATCH_JOB_EXECUTION");
 		mongoTemplate.createCollection("BATCH_STEP_EXECUTION");
 		mongoTemplate.createCollection("BATCH_SEQUENCES");
+		mongoTemplate.indexOps("BATCH_JOB_INSTANCE")
+				.ensureIndex(new Index().on("jobName", Sort.Direction.ASC).named("job_name_idx"));
+		mongoTemplate.indexOps("BATCH_JOB_INSTANCE")
+				.ensureIndex(new Index().on("jobName", Sort.Direction.ASC).on("jobKey", Sort.Direction.ASC).named("job_name_key_idx"));
+		mongoTemplate.indexOps("BATCH_JOB_INSTANCE")
+				.ensureIndex(new Index().on("jobInstanceId", Sort.Direction.DESC).named("job_instance_idx"));
+		mongoTemplate.indexOps("BATCH_JOB_EXECUTION")
+				.ensureIndex(new Index().on("jobInstanceId", Sort.Direction.ASC).named("job_instance_idx"));
+		mongoTemplate.indexOps("BATCH_JOB_EXECUTION")
+				.ensureIndex(new Index().on("jobInstanceId", Sort.Direction.ASC).on("status", Sort.Direction.ASC).named("job_instance_status_idx"));
+		mongoTemplate.indexOps("BATCH_STEP_EXECUTION")
+				.ensureIndex(new Index().on("stepExecutionId", Sort.Direction.ASC).named("step_execution_idx"));
 		mongoTemplate.getCollection("BATCH_SEQUENCES")
 			.insertOne(new Document(Map.of("_id", "BATCH_JOB_INSTANCE_SEQ", "count", 0L)));
 		mongoTemplate.getCollection("BATCH_SEQUENCES")


### PR DESCRIPTION
## Motivation
* Me and my colleague are recently trying MongoDB as a job repository.
* According to the [document](https://docs.spring.io/spring-batch/reference/schema-appendix.html#metaDataSchemaOverview) I was able to access the example DDL scripts.
* I run the script without reading it carefully, and it failed, and fixed it.
  * Usage of `createIndex()` was wrong.
  * Name of the index duplicated which made error as well.

## What I did
* Fixed `createIndex()` query.
  * According to the [syntax](https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/), it should have looked like `db.collection.createIndex(<keys>, <options>, <commitQuorum>)` but was like`db.collection.createIncex(<name>, <keys>, <commitQuorum>)`.
* Renamed duplicated index names of `BATCH_JOB_EXECUTION` collection.

## Note
* Unlike the script, I read through the document and found suggestions about [indexing metadata tables](https://docs.spring.io/spring-batch/reference/schema-appendix.html#recommendationsForIndexingMetaDataTables).
* Please let me know the duplicated name in the script is intended.
* In addition, improving [integration test case](https://github.com/spring-projects/spring-batch/blob/main/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryIntegrationTests.java#L63-L75) that is introduced in `What's new in Spring Batch 5.2` might be a good idea.