### PR TITLE
Attempt to close all delegate readers even when some fail

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2022 the original author or authors.
+ * Copyright 2008-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ import static org.springframework.batch.core.BatchStatus.UNKNOWN;
  * @author David Turanski
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
+ * @author Elimelec Burghelea
  */
 class TaskletStepExceptionTests {
 
@@ -212,8 +213,8 @@ class TaskletStepExceptionTests {
 
 		taskletStep.execute(stepExecution);
 		assertEquals(FAILED, stepExecution.getStatus());
-		assertTrue(stepExecution.getFailureExceptions().contains(taskletException));
-		assertTrue(stepExecution.getFailureExceptions().contains(exception));
+		assertEquals(stepExecution.getFailureExceptions().get(0), taskletException);
+		assertEquals(stepExecution.getFailureExceptions().get(1).getSuppressed()[0], exception);
 		assertEquals(2, jobRepository.getUpdateCount());
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletStepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -761,7 +761,7 @@ class TaskletStepTests {
 		Throwable ex = stepExecution.getFailureExceptions().get(0);
 
 		// The original rollback was caused by this one:
-		assertEquals("Bar", ex.getMessage());
+		assertEquals("Bar", ex.getSuppressed()[0].getMessage());
 	}
 
 	@Test
@@ -791,7 +791,7 @@ class TaskletStepTests {
 		assertEquals("", msg);
 		Throwable ex = stepExecution.getFailureExceptions().get(0);
 		// The original rollback was caused by this one:
-		assertEquals("Bar", ex.getMessage());
+		assertEquals("Bar", ex.getSuppressed()[0].getMessage());
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.support;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -27,6 +28,7 @@ import org.springframework.batch.item.ItemStreamReader;
  * implementation is not thread-safe.
  *
  * @author Mahmoud Ben Hassine
+ * @author Elimelec Burghelea
  * @param <T> type of objects to read
  * @since 5.2
  */
@@ -79,8 +81,22 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 
 	@Override
 	public void close() throws ItemStreamException {
+		List<Exception> exceptions = new ArrayList<>();
+
 		for (ItemStreamReader<? extends T> delegate : delegates) {
-			delegate.close();
+			try {
+				delegate.close();
+			}
+			catch (Exception e) {
+				exceptions.add(e);
+			}
+		}
+
+		if (!exceptions.isEmpty()) {
+			String message = String.format("Failed to close %d delegate(s) due to exceptions", exceptions.size());
+			ItemStreamException holder = new ItemStreamException(message);
+			exceptions.forEach(holder::addSuppressed);
+			throw holder;
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/CompositeItemReaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,14 @@ package org.springframework.batch.item.support;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,6 +35,7 @@ import static org.mockito.Mockito.when;
  * Test class for {@link CompositeItemReader}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Elimelec Burghelea
  */
 public class CompositeItemReaderTests {
 
@@ -101,6 +105,29 @@ public class CompositeItemReaderTests {
 
 		// when
 		compositeItemReader.close();
+
+		// then
+		verify(reader1).close();
+		verify(reader2).close();
+	}
+
+	@Test
+	void testCompositeItemReaderCloseWithDelegateThatThrowsException() {
+		// given
+		ItemStreamReader<String> reader1 = mock();
+		ItemStreamReader<String> reader2 = mock();
+		CompositeItemReader<String> compositeItemReader = new CompositeItemReader<>(Arrays.asList(reader1, reader2));
+
+		doThrow(new ItemStreamException("A failure")).when(reader1).close();
+
+		// when
+		try {
+			compositeItemReader.close();
+			Assertions.fail("Expected an ItemStreamException");
+		}
+		catch (ItemStreamException ignored) {
+
+		}
 
 		// then
 		verify(reader1).close();


### PR DESCRIPTION
Motivation:

When a delegate reader fails during close(), the original implementation would stop immediately, preventing other delegates from completing their cleanup.

Similar to https://github.com/spring-projects/spring-batch/pull/4750