### PR TITLE
Use Files.delete() for better error reporting

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
+import java.nio.file.Files;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -61,6 +62,7 @@ import org.springframework.util.Assert;
  * @author Mahmoud Ben Hassine
  * @author Glenn Renfro
  * @author Remi Kaeffer
+ * @author Elimelec Burghelea
  * @since 4.1
  */
 public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWriter<T>
@@ -268,11 +270,9 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 				state.close();
 				if (state.linesWritten == 0 && shouldDeleteIfEmpty) {
 					try {
-						if (!resource.getFile().delete()) {
-							throw new ItemStreamException("Failed to delete empty file on close");
-						}
+						Files.delete(resource.getFile().toPath());
 					}
-					catch (IOException e) {
+					catch (IOException | SecurityException e) {
 						throw new ItemStreamException("Failed to delete empty file on close", e);
 					}
 				}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/FileUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2024 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.batch.item.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.util.Assert;
@@ -28,6 +29,7 @@ import org.springframework.util.Assert;
  * @author Peter Zozom
  * @author Mahmoud Ben Hassine
  * @author Taeik Lim
+ * @author Elimelec Burghelea
  */
 public abstract class FileUtils {
 
@@ -57,8 +59,11 @@ public abstract class FileUtils {
 						if (!overwriteOutputFile) {
 							throw new ItemStreamException("File already exists: [" + file.getAbsolutePath() + "]");
 						}
-						if (!file.delete()) {
-							throw new IOException("Could not delete file: " + file);
+						try {
+							Files.delete(file.toPath());
+						}
+						catch (IOException | SecurityException e) {
+							throw new IOException("Could not delete file: " + file, e);
 						}
 					}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,7 @@ import org.springframework.util.xml.StaxUtils;
  * @author Michael Minella
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
+ * @author Elimelec Burghelea
  */
 public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 		implements ResourceAwareItemWriterItemStream<T>, InitializingBean {
@@ -726,11 +728,9 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 			}
 			if (currentRecordCount == 0 && shouldDeleteIfEmpty) {
 				try {
-					if (!resource.getFile().delete()) {
-						throw new ItemStreamException("Failed to delete empty file on close");
-					}
+					Files.delete(resource.getFile().toPath());
 				}
-				catch (IOException e) {
+				catch (IOException | SecurityException e) {
 					throw new ItemStreamException("Failed to delete empty file on close", e);
 				}
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractFileItemWriterTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractFileItemWriterTest.java
@@ -17,7 +17,7 @@
 package org.springframework.batch.item.support;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -55,8 +55,7 @@ class AbstractFileItemWriterTests {
 				"Expected exception when file deletion fails");
 
 		assertEquals("Failed to delete empty file on close", exception.getMessage(), "Wrong exception message");
-		// FIXME: update after fix, because we will have a reason
-		assertNull(exception.getCause(), "Exception should not have a cause");
+		assertNotNull(exception.getCause(), "Exception should have a cause");
 	}
 
 	private static class TestFileItemWriter extends AbstractFileItemWriter<String> {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractFileItemWriterTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/AbstractFileItemWriterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.item.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ * Tests for common methods from {@link AbstractFileItemWriter}.
+ *
+ * @author Elimelec Burghelea
+ */
+class AbstractFileItemWriterTests {
+
+	@Test
+	void testFailedFileDeletionThrowsException() {
+		File outputFile = new File("target/data/output.tmp");
+		File mocked = Mockito.spy(outputFile);
+
+		TestFileItemWriter writer = new TestFileItemWriter();
+
+		writer.setResource(new FileSystemResource(mocked));
+		writer.setShouldDeleteIfEmpty(true);
+		writer.setName(writer.getClass().getSimpleName());
+		writer.open(new ExecutionContext());
+
+		when(mocked.delete()).thenReturn(false);
+
+		ItemStreamException exception = assertThrows(ItemStreamException.class, writer::close,
+				"Expected exception when file deletion fails");
+
+		assertEquals("Failed to delete empty file on close", exception.getMessage(), "Wrong exception message");
+		// FIXME: update after fix, because we will have a reason
+		assertNull(exception.getCause(), "Exception should not have a cause");
+	}
+
+	private static class TestFileItemWriter extends AbstractFileItemWriter<String> {
+
+		@Override
+		protected String doWrite(Chunk<? extends String> items) {
+			return String.join("\n", items);
+		}
+
+		@Override
+		public void afterPropertiesSet() {
+
+		}
+
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/FileUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/FileUtilsTests.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.util.Assert;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -210,8 +210,7 @@ class FileUtilsTests {
 			assertTrue(message.startsWith("Unable to create file"), "Wrong message: " + message);
 			assertTrue(ex.getCause() instanceof IOException);
 			assertTrue(ex.getCause().getMessage().startsWith("Could not delete file"), "Wrong message: " + message);
-			// FIXME: update after fix, because we will have a reason
-			assertNull(ex.getCause().getCause());
+			assertNotNull(ex.getCause().getCause(), "Exception should have a cause");
 		}
 		finally {
 			file.delete();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/FileUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/util/FileUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2022 the original author or authors.
+ * Copyright 2008-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.util.Assert;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link FileUtils}
  *
  * @author Robert Kasanicky
+ * @author Elimelec Burghelea
  */
 class FileUtilsTests {
 
@@ -172,6 +174,44 @@ class FileUtilsTests {
 		catch (ItemStreamException ex) {
 			String message = ex.getMessage();
 			assertTrue(message.startsWith("Output file was not created"), "Wrong message: " + message);
+		}
+		finally {
+			file.delete();
+		}
+	}
+
+	@Test
+	void testCannotDeleteFile() {
+
+		File file = new File("new file") {
+
+			@Override
+			public boolean createNewFile() {
+				return true;
+			}
+
+			@Override
+			public boolean exists() {
+				return true;
+			}
+
+			@Override
+			public boolean delete() {
+				return false;
+			}
+
+		};
+		try {
+			FileUtils.setUpOutputFile(file, false, false, true);
+			fail("Expected ItemStreamException because file cannot be deleted");
+		}
+		catch (ItemStreamException ex) {
+			String message = ex.getMessage();
+			assertTrue(message.startsWith("Unable to create file"), "Wrong message: " + message);
+			assertTrue(ex.getCause() instanceof IOException);
+			assertTrue(ex.getCause().getMessage().startsWith("Could not delete file"), "Wrong message: " + message);
+			// FIXME: update after fix, because we will have a reason
+			assertNull(ex.getCause().getCause());
 		}
 		finally {
 			file.delete();

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -852,8 +852,7 @@ class StaxEventItemWriterTests {
 				"Expected exception when file deletion fails");
 
 		assertEquals("Failed to delete empty file on close", exception.getMessage(), "Wrong exception message");
-		// FIXME: update after fix, because we will have a reason
-		assertNull(exception.getCause(), "Exception should not have a cause");
+		assertNotNull(exception.getCause(), "Exception should have a cause");
 	}
 
 	private void initWriterForSimpleCallbackTests() throws Exception {


### PR DESCRIPTION
Motivation:

`File.delete` provides only a simple boolean result. In case of failure, there's no information available. `Files.delete` will throw an exception with more details.

Example: Writer configured with `shouldDeleteIfEmpty` set to `true` fails to delete the empty file. No information is provided  other than a simple message: `"Failed to delete empty file on close"`.