### PR TITLE
Improve performance of `JdbcStepExecutionDao::getLastStepExecution`

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JdbcStepExecutionDao.java
@@ -24,7 +24,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
@@ -41,6 +40,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.PreparedStatementCallback;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
 import org.springframework.lang.Nullable;
@@ -66,6 +66,7 @@ import org.springframework.util.Assert;
  * @author Mahmoud Ben Hassine
  * @author Baris Cubukcuoglu
  * @author Minsoo Kim
+ * @author Yanming Zhou
  * @see StepExecutionDao
  */
 public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implements StepExecutionDao, InitializingBean {
@@ -98,6 +99,7 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 			FROM %PREFIX%JOB_EXECUTION JE
 				JOIN %PREFIX%STEP_EXECUTION SE ON SE.JOB_EXECUTION_ID = JE.JOB_EXECUTION_ID
 			WHERE JE.JOB_INSTANCE_ID = ? AND SE.STEP_NAME = ?
+			ORDER BY SE.CREATE_TIME DESC, SE.JOB_EXECUTION_ID DESC
 			""";
 
 	private static final String CURRENT_VERSION_STEP_EXECUTION = """
@@ -116,10 +118,6 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 			DELETE FROM %PREFIX%STEP_EXECUTION
 			WHERE STEP_EXECUTION_ID = ?
 			""";
-
-	private static final Comparator<StepExecution> BY_CREATE_TIME_DESC_ID_DESC = Comparator
-		.comparing(StepExecution::getCreateTime, Comparator.reverseOrder())
-		.thenComparing(StepExecution::getId, Comparator.reverseOrder());
 
 	private int exitMessageLength = DEFAULT_EXIT_MESSAGE_LENGTH;
 
@@ -337,27 +335,34 @@ public class JdbcStepExecutionDao extends AbstractJdbcBatchMetadataDao implement
 		}
 	}
 
+	@Nullable
 	@Override
 	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
-		List<StepExecution> executions = getJdbcTemplate().query(getQuery(GET_LAST_STEP_EXECUTION), (rs, rowNum) -> {
-			Long jobExecutionId = rs.getLong(19);
-			JobExecution jobExecution = new JobExecution(jobExecutionId);
-			jobExecution.setStartTime(rs.getTimestamp(20) == null ? null : rs.getTimestamp(20).toLocalDateTime());
-			jobExecution.setEndTime(rs.getTimestamp(21) == null ? null : rs.getTimestamp(21).toLocalDateTime());
-			jobExecution.setStatus(BatchStatus.valueOf(rs.getString(22)));
-			jobExecution.setExitStatus(new ExitStatus(rs.getString(23), rs.getString(24)));
-			jobExecution.setCreateTime(rs.getTimestamp(25) == null ? null : rs.getTimestamp(25).toLocalDateTime());
-			jobExecution.setLastUpdated(rs.getTimestamp(26) == null ? null : rs.getTimestamp(26).toLocalDateTime());
-			jobExecution.setVersion(rs.getInt(27));
-			return new StepExecutionRowMapper(jobExecution).mapRow(rs, rowNum);
-		}, jobInstance.getInstanceId(), stepName);
-		executions.sort(BY_CREATE_TIME_DESC_ID_DESC);
-		if (executions.isEmpty()) {
-			return null;
-		}
-		else {
-			return executions.get(0);
-		}
+		return getJdbcTemplate().execute(getQuery(GET_LAST_STEP_EXECUTION),
+				(PreparedStatementCallback<StepExecution>) statement -> {
+					statement.setMaxRows(1);
+					statement.setLong(1, jobInstance.getInstanceId());
+					statement.setString(2, stepName);
+					try (ResultSet rs = statement.executeQuery()) {
+						if (rs.next()) {
+							Long jobExecutionId = rs.getLong(19);
+							JobExecution jobExecution = new JobExecution(jobExecutionId);
+							jobExecution.setStartTime(
+									rs.getTimestamp(20) == null ? null : rs.getTimestamp(20).toLocalDateTime());
+							jobExecution
+								.setEndTime(rs.getTimestamp(21) == null ? null : rs.getTimestamp(21).toLocalDateTime());
+							jobExecution.setStatus(BatchStatus.valueOf(rs.getString(22)));
+							jobExecution.setExitStatus(new ExitStatus(rs.getString(23), rs.getString(24)));
+							jobExecution.setCreateTime(
+									rs.getTimestamp(25) == null ? null : rs.getTimestamp(25).toLocalDateTime());
+							jobExecution.setLastUpdated(
+									rs.getTimestamp(26) == null ? null : rs.getTimestamp(26).toLocalDateTime());
+							jobExecution.setVersion(rs.getInt(27));
+							return new StepExecutionRowMapper(jobExecution).mapRow(rs, 0);
+						}
+						return null;
+					}
+				});
 	}
 
 	@Override


### PR DESCRIPTION
1. Use SQL order by clause instead of Java Comparator
2. Limit result set size to 1