### PR TITLE
testing.adoc: add link to SB core documentation 

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/testing.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/testing.adoc
@@ -3,8 +3,8 @@
 = Unit Testing
 
 As with other application styles, it is extremely important to unit test any code written
-as part of a batch job. The Spring core documentation covers how to unit and integration
-test with Spring in great detail, so it is not be repeated here. It is important, however,
+as part of a batch job. The Spring core documentation covers link:$$https://docs.spring.io/spring-framework/reference/testing.html$$[how to unit and integration
+test]. with Spring in great detail, so it is not be repeated here. It is important, however,
 to think about how to "`end to end`" test a batch job, which is what this chapter covers.
 The `spring-batch-test` project includes classes that facilitate this end-to-end test
 approach.


### PR DESCRIPTION
Just a link to help reader to go to SB core documentation