### PR TITLE
Introduce ErrorProne, fix compiler warnings

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,61 @@
 					<release>${java.version}</release>
 					<compilerArgs>
 						<compilerArg>-parameters</compilerArg>
+						<!-- https://errorprone.info/docs/installation#maven -->
+						<compilerArg>-XDcompilePolicy=simple</compilerArg>
+						<compilerArg>--should-stop=ifError=FLOW</compilerArg>
+						<compilerArg>
+							-Xplugin:ErrorProne
+							-Xep:AlmostJavadoc:OFF
+							-Xep:BadInstanceof:OFF <!-- FIXME gh-4839 -->
+							-Xep:ByteBufferBackingArray:OFF
+							-Xep:ClassCanBeStatic:OFF
+							-Xep:CollectionUndefinedEquality:OFF
+							-Xep:DefaultCharset:OFF
+							-Xep:DirectInvocationOnMock:OFF
+							-Xep:DoNotCallSuggester:OFF
+							-Xep:EmptyCatch:OFF
+							-Xep:EqualsGetClass:OFF
+							-Xep:Finally:OFF
+							-Xep:FutureReturnValueIgnored:OFF
+							-Xep:HidingField:OFF
+							-Xep:ImmutableEnumChecker:OFF
+							-Xep:InlineMeSuggester:OFF
+							-Xep:InputStreamSlowMultibyteRead:OFF
+							-Xep:JavaTimeDefaultTimeZone:OFF
+							-Xep:JavaUtilDate:OFF
+							-Xep:JdkObsolete:OFF
+							-Xep:MissingSummary:OFF
+							-Xep:MixedMutabilityReturnType:OFF
+							-Xep:MutablePublicArray:OFF
+							-Xep:NonAtomicVolatileUpdate:OFF
+							-Xep:RedundantControlFlow:OFF
+							-Xep:ReferenceEquality:OFF
+							-Xep:StaticAssignmentInConstructor:OFF
+							-Xep:StaticAssignmentOfThrowable:OFF
+							-Xep:StaticMockMember:OFF
+							-Xep:StreamResourceLeak:OFF
+							-Xep:StringCaseLocaleUsage:OFF
+							-Xep:StringSplitter:OFF
+							-Xep:SynchronizeOnNonFinalField:OFF
+							-Xep:ThreadLocalUsage:OFF
+							-Xep:ThreadPriorityCheck:OFF
+							-Xep:TypeParameterUnusedInFormals:OFF
+							-Xep:UndefinedEquals:OFF
+							-Xep:UnnecessaryStringBuilder:OFF
+							-Xep:UnusedMethod:OFF
+							-Xep:UnusedVariable:OFF
+							-Xep:WaitNotInLoop:OFF
+						</compilerArg>
 					</compilerArgs>
+					<failOnWarning>true</failOnWarning>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>com.google.errorprone</groupId>
+							<artifactId>error_prone_core</artifactId>
+							<version>2.38.0</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,6 @@
 						<compilerArg>
 							-Xplugin:ErrorProne
 							-Xep:AlmostJavadoc:OFF
-							-Xep:BadInstanceof:OFF <!-- FIXME gh-4839 -->
 							-Xep:ByteBufferBackingArray:OFF
 							-Xep:ClassCanBeStatic:OFF
 							-Xep:CollectionUndefinedEquality:OFF

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/Entity.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/Entity.java
@@ -146,7 +146,7 @@ public class Entity implements Serializable {
 	@Override
 	public int hashCode() {
 		if (id == null) {
-			return super.hashCode();
+			return System.identityHashCode(this);
 		}
 		return 39 + 87 * id.hashCode();
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobExecution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobExecution.java
@@ -18,6 +18,7 @@ package org.springframework.batch.core;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -203,7 +204,7 @@ public class JobExecution extends Entity {
 	/**
 	 * Convenience getter for the {@code id} of the enclosing job. Useful for DAO
 	 * implementations.
-	 * @return the @{code id} of the enclosing job.
+	 * @return the {@code id} of the enclosing job.
 	 */
 	public Long getJobId() {
 		if (jobInstance != null) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/JobParameters.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/JobParameters.java
@@ -373,7 +373,7 @@ public class JobParameters implements Serializable {
 		for (Map.Entry<String, JobParameter<?>> entry : this.parameters.entrySet()) {
 			parameters.add(String.format("'%s':'%s'", entry.getKey(), entry.getValue()));
 		}
-		return new StringBuilder("{").append(String.join(",", parameters)).append("}").toString();
+		return "{" + String.join(",", parameters) + "}";
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/StepExecution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/StepExecution.java
@@ -492,7 +492,7 @@ public class StepExecution extends Entity {
 			return super.equals(obj);
 		}
 
-		return stepName.equals(other.getStepName()) && (jobExecutionId.equals(other.getJobExecutionId()))
+		return stepName.equals(other.getStepName()) && jobExecutionId.equals(other.getJobExecutionId())
 				&& getId().equals(other.getId());
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
@@ -130,7 +130,7 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 				.proxiedInterfaces(SpringProxy.class, Advised.class, DecoratingProxy.class));
 
 		// reflection hints
-		hints.reflection().registerType(Types.class, MemberCategory.DECLARED_FIELDS);
+		hints.reflection().registerType(Types.class, MemberCategory.ACCESS_DECLARED_FIELDS);
 		hints.reflection().registerType(JobContext.class, MemberCategory.INVOKE_PUBLIC_METHODS);
 		hints.reflection().registerType(StepContext.class, MemberCategory.INVOKE_PUBLIC_METHODS);
 		hints.reflection().registerType(JobParameter.class, MemberCategory.values());

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchObservabilityBeanPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchObservabilityBeanPostProcessor.java
@@ -50,11 +50,11 @@ public class BatchObservabilityBeanPostProcessor implements BeanFactoryPostProce
 		try {
 			if (bean instanceof AbstractJob || bean instanceof AbstractStep) {
 				ObservationRegistry observationRegistry = this.beanFactory.getBean(ObservationRegistry.class);
-				if (bean instanceof AbstractJob) {
-					((AbstractJob) bean).setObservationRegistry(observationRegistry);
+				if (bean instanceof AbstractJob job) {
+					job.setObservationRegistry(observationRegistry);
 				}
-				if (bean instanceof AbstractStep) {
-					((AbstractStep) bean).setObservationRegistry(observationRegistry);
+				if (bean instanceof AbstractStep step) {
+					step.setObservationRegistry(observationRegistry);
 				}
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchRegistrar.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchRegistrar.java
@@ -49,8 +49,6 @@ class BatchRegistrar implements ImportBeanDefinitionRegistrar {
 
 	private static final Log LOGGER = LogFactory.getLog(BatchRegistrar.class);
 
-	private static final String MISSING_ANNOTATION_ERROR_MESSAGE = "EnableBatchProcessing is not present on importing class '%s' as expected";
-
 	private static final String JOB_REPOSITORY = "jobRepository";
 
 	private static final String JOB_OPERATOR = "jobOperator";
@@ -79,7 +77,8 @@ class BatchRegistrar implements ImportBeanDefinitionRegistrar {
 	private void validateState(AnnotationMetadata importingClassMetadata) {
 		if (!importingClassMetadata.isAnnotated(EnableBatchProcessing.class.getName())) {
 			String className = importingClassMetadata.getClassName();
-			String errorMessage = String.format(MISSING_ANNOTATION_ERROR_MESSAGE, className);
+			String errorMessage = "EnableBatchProcessing is not present on importing class '%s' as expected"
+				.formatted(className);
 			throw new IllegalStateException(errorMessage);
 		}
 	}
@@ -238,6 +237,7 @@ class BatchRegistrar implements ImportBeanDefinitionRegistrar {
 		if (registry.containsBeanDefinition(taskExecutorRef)) {
 			beanDefinitionBuilder.addPropertyReference("taskExecutor", taskExecutorRef);
 		}
+		@SuppressWarnings("removal")
 		String jobParametersConverterRef = batchAnnotation.jobParametersConverterRef();
 		if (registry.containsBeanDefinition(jobParametersConverterRef)) {
 			beanDefinitionBuilder.addPropertyReference("jobParametersConverter", jobParametersConverterRef);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AbstractApplicationContextFactory.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AbstractApplicationContextFactory.java
@@ -19,6 +19,7 @@ package org.springframework.batch.core.configuration.support;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -196,13 +197,11 @@ public abstract class AbstractApplicationContextFactory implements ApplicationCo
 	protected void prepareBeanFactory(ConfigurableListableBeanFactory parent,
 			ConfigurableListableBeanFactory beanFactory) {
 		if (copyConfiguration && parent != null) {
-			List<BeanPostProcessor> parentPostProcessors = new ArrayList<>();
-			List<BeanPostProcessor> childPostProcessors = new ArrayList<>();
-
-			childPostProcessors.addAll(beanFactory instanceof AbstractBeanFactory
-					? ((AbstractBeanFactory) beanFactory).getBeanPostProcessors() : new ArrayList<>());
-			parentPostProcessors.addAll(parent instanceof AbstractBeanFactory
-					? ((AbstractBeanFactory) parent).getBeanPostProcessors() : new ArrayList<>());
+			List<BeanPostProcessor> childPostProcessors = new ArrayList<>(
+					beanFactory instanceof AbstractBeanFactory factory ? factory.getBeanPostProcessors()
+							: new ArrayList<>());
+			List<BeanPostProcessor> parentPostProcessors = new ArrayList<>(parent instanceof AbstractBeanFactory factory
+					? factory.getBeanPostProcessors() : new ArrayList<>());
 
 			try {
 				Class<?> applicationContextAwareProcessorClass = ClassUtils.forName(
@@ -237,8 +236,8 @@ public abstract class AbstractApplicationContextFactory implements ApplicationCo
 
 			beanFactory.copyConfigurationFrom(parent);
 
-			List<BeanPostProcessor> beanPostProcessors = beanFactory instanceof AbstractBeanFactory
-					? ((AbstractBeanFactory) beanFactory).getBeanPostProcessors() : new ArrayList<>();
+			List<BeanPostProcessor> beanPostProcessors = beanFactory instanceof AbstractBeanFactory abstractBeanFactory
+					? abstractBeanFactory.getBeanPostProcessors() : new ArrayList<>();
 
 			beanPostProcessors.clear();
 			beanPostProcessors.addAll(aggregatedPostProcessors);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AutomaticJobRegistrar.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AutomaticJobRegistrar.java
@@ -79,8 +79,8 @@ public class AutomaticJobRegistrar implements Ordered, SmartLifecycle, Applicati
 	 * use
 	 */
 	public void addApplicationContextFactory(ApplicationContextFactory applicationContextFactory) {
-		if (applicationContextFactory instanceof ApplicationContextAware) {
-			((ApplicationContextAware) applicationContextFactory).setApplicationContext(applicationContext);
+		if (applicationContextFactory instanceof ApplicationContextAware applicationContextAware) {
+			applicationContextAware.setApplicationContext(applicationContext);
 		}
 		this.applicationContextFactories.add(applicationContextFactory);
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultJobLoader.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultJobLoader.java
@@ -253,11 +253,11 @@ public class DefaultJobLoader implements JobLoader, InitializingBean {
 		jobRegistry.register(job);
 
 		if (stepRegistry != null) {
-			if (!(job instanceof StepLocator)) {
+			if (!(job instanceof StepLocator stepLocator)) {
 				throw new UnsupportedOperationException("Cannot locate steps from a Job that is not a StepLocator: job="
 						+ job.getName() + " does not implement StepLocator");
 			}
-			stepRegistry.register(job.getName(), getSteps((StepLocator) job, context));
+			stepRegistry.register(job.getName(), getSteps(stepLocator, context));
 		}
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactory.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GenericApplicationContextFactory.java
@@ -126,7 +126,7 @@ public class GenericApplicationContextFactory extends AbstractApplicationContext
 				GenericApplicationContextFactory.this.prepareBeanFactory(parentBeanFactory, beanFactory);
 				for (Class<? extends BeanFactoryPostProcessor> cls : getBeanFactoryPostProcessorClasses()) {
 					for (String name : parent.getBeanNamesForType(cls)) {
-						beanFactory.registerSingleton(name, (parent.getBean(name)));
+						beanFactory.registerSingleton(name, parent.getBean(name));
 					}
 				}
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GroupAwareJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/GroupAwareJob.java
@@ -99,8 +99,8 @@ public class GroupAwareJob implements Job {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof GroupAwareJob) {
-			return ((GroupAwareJob) obj).delegate.equals(delegate);
+		if (obj instanceof GroupAwareJob groupAwareJob) {
+			return groupAwareJob.delegate.equals(delegate);
 		}
 		return false;
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractFlowParser.java
@@ -404,7 +404,7 @@ public abstract class AbstractFlowParser extends AbstractSingleBeanDefinitionPar
 			endBuilder.addConstructorArgValue(exitCodeExists ? exitCode : status.getName());
 
 			String endName = (status == FlowExecutionStatus.STOPPED ? STOP_ELE
-					: status == FlowExecutionStatus.FAILED ? FAIL_ELE : END_ELE) + (endCounter++);
+					: status == FlowExecutionStatus.FAILED ? FAIL_ELE : END_ELE) + endCounter++;
 			endBuilder.addConstructorArgValue(endName);
 
 			endBuilder.addConstructorArgValue(abandon);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractStepParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/AbstractStepParser.java
@@ -118,16 +118,13 @@ public abstract class AbstractStepParser {
 					new TaskletParser().parseTasklet(stepElement, nestedElement, bd, parserContext, stepUnderspecified);
 				}
 				else if (FLOW_ELE.equals(name)) {
-					boolean stepUnderspecified = CoreNamespaceUtils.isUnderspecified(stepElement);
-					parseFlow(stepElement, nestedElement, bd, parserContext, stepUnderspecified);
+					parseFlow(stepElement, nestedElement, bd);
 				}
 				else if (PARTITION_ELE.equals(name)) {
-					boolean stepUnderspecified = CoreNamespaceUtils.isUnderspecified(stepElement);
-					parsePartition(stepElement, nestedElement, bd, parserContext, stepUnderspecified, jobFactoryRef);
+					parsePartition(stepElement, nestedElement, bd, parserContext, jobFactoryRef);
 				}
 				else if (JOB_ELE.equals(name)) {
-					boolean stepUnderspecified = CoreNamespaceUtils.isUnderspecified(stepElement);
-					parseJob(stepElement, nestedElement, bd, parserContext, stepUnderspecified);
+					parseJob(nestedElement, bd, parserContext);
 				}
 				else if ("description".equals(name)) {
 					bd.setDescription(nestedElement.getTextContent());
@@ -199,7 +196,7 @@ public abstract class AbstractStepParser {
 	}
 
 	private void parsePartition(Element stepElement, Element partitionElement, AbstractBeanDefinition bd,
-			ParserContext parserContext, boolean stepUnderspecified, String jobFactoryRef) {
+			ParserContext parserContext, String jobFactoryRef) {
 
 		bd.setBeanClass(StepParserStepFactoryBean.class);
 		bd.setAttribute("isNamespaceStep", true);
@@ -258,8 +255,7 @@ public abstract class AbstractStepParser {
 
 	}
 
-	private void parseJob(Element stepElement, Element jobElement, AbstractBeanDefinition bd,
-			ParserContext parserContext, boolean stepUnderspecified) {
+	private void parseJob(Element jobElement, AbstractBeanDefinition bd, ParserContext parserContext) {
 
 		bd.setBeanClass(StepParserStepFactoryBean.class);
 		bd.setAttribute("isNamespaceStep", true);
@@ -285,8 +281,7 @@ public abstract class AbstractStepParser {
 
 	}
 
-	private void parseFlow(Element stepElement, Element flowElement, AbstractBeanDefinition bd,
-			ParserContext parserContext, boolean stepUnderspecified) {
+	private void parseFlow(Element stepElement, Element flowElement, AbstractBeanDefinition bd) {
 
 		bd.setBeanClass(StepParserStepFactoryBean.class);
 		bd.setAttribute("isNamespaceStep", true);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/CoreNamespacePostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/CoreNamespacePostProcessor.java
@@ -115,15 +115,13 @@ public class CoreNamespacePostProcessor
 	 * @return the bean with default collaborators injected into it
 	 */
 	private Object injectDefaults(Object bean) {
-		if (bean instanceof JobParserJobFactoryBean) {
-			JobParserJobFactoryBean fb = (JobParserJobFactoryBean) bean;
+		if (bean instanceof JobParserJobFactoryBean fb) {
 			JobRepository jobRepository = fb.getJobRepository();
 			if (jobRepository == null) {
 				fb.setJobRepository((JobRepository) applicationContext.getBean(DEFAULT_JOB_REPOSITORY_NAME));
 			}
 		}
-		else if (bean instanceof StepParserStepFactoryBean) {
-			StepParserStepFactoryBean<?, ?> fb = (StepParserStepFactoryBean<?, ?>) bean;
+		else if (bean instanceof StepParserStepFactoryBean<?, ?> fb) {
 			JobRepository jobRepository = fb.getJobRepository();
 			if (jobRepository == null) {
 				fb.setJobRepository((JobRepository) applicationContext.getBean(DEFAULT_JOB_REPOSITORY_NAME));

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/ExceptionElementParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/ExceptionElementParser.java
@@ -32,8 +32,8 @@ public class ExceptionElementParser {
 		if (children.size() == 1) {
 			ManagedMap<TypedStringValue, Boolean> map = new ManagedMap<>();
 			Element exceptionClassesElement = children.get(0);
-			addExceptionClasses("include", true, exceptionClassesElement, map, parserContext);
-			addExceptionClasses("exclude", false, exceptionClassesElement, map, parserContext);
+			addExceptionClasses("include", true, exceptionClassesElement, map);
+			addExceptionClasses("exclude", false, exceptionClassesElement, map);
 			map.put(new TypedStringValue(ForceRollbackForWriteSkipException.class.getName(), Class.class), true);
 			return map;
 		}
@@ -46,7 +46,7 @@ public class ExceptionElementParser {
 	}
 
 	private void addExceptionClasses(String elementName, boolean include, Element exceptionClassesElement,
-			ManagedMap<TypedStringValue, Boolean> map, ParserContext parserContext) {
+			ManagedMap<TypedStringValue, Boolean> map) {
 		for (Element child : DomUtils.getChildElementsByTagName(exceptionClassesElement, elementName)) {
 			String className = child.getAttribute("class");
 			map.put(new TypedStringValue(className, Class.class), include);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/JobParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/JobParser.java
@@ -103,7 +103,7 @@ public class JobParser extends AbstractSingleBeanDefinitionParser {
 			builder.addPropertyValue("restartable", restartableAttribute);
 		}
 
-		String incrementer = (element.getAttribute("incrementer"));
+		String incrementer = element.getAttribute("incrementer");
 		if (StringUtils.hasText(incrementer)) {
 			builder.addPropertyReference("jobParametersIncrementer", incrementer);
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/SimpleFlowFactoryBean.java
@@ -205,7 +205,7 @@ public class SimpleFlowFactoryBean implements FactoryBean<SimpleFlow>, Initializ
 
 		@Override
 		public Collection<Flow> getFlows() {
-			return (state instanceof FlowHolder) ? ((FlowHolder) state).getFlows() : Collections.<Flow>emptyList();
+			return (state instanceof FlowHolder flowHolder) ? flowHolder.getFlows() : Collections.emptyList();
 		}
 
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/StepParserStepFactoryBean.java
@@ -272,8 +272,8 @@ public class StepParserStepFactoryBean<I, O> implements FactoryBean<Step>, BeanN
 			builder.startLimit(startLimit);
 		}
 		for (Object listener : stepExecutionListeners) {
-			if (listener instanceof StepExecutionListener) {
-				builder.listener((StepExecutionListener) listener);
+			if (listener instanceof StepExecutionListener stepExecutionListener) {
+				builder.listener(stepExecutionListener);
 			}
 		}
 	}
@@ -565,14 +565,14 @@ public class StepParserStepFactoryBean<I, O> implements FactoryBean<Step>, BeanN
 	 * @return {@code true} if the object has a value
 	 */
 	private boolean isPresent(Object o) {
-		if (o instanceof Integer) {
-			return isPositive((Integer) o);
+		if (o instanceof Integer i) {
+			return isPositive(i);
 		}
-		if (o instanceof Collection) {
-			return !((Collection<?>) o).isEmpty();
+		if (o instanceof Collection<?> collection) {
+			return !collection.isEmpty();
 		}
-		if (o instanceof Map) {
-			return !((Map<?, ?>) o).isEmpty();
+		if (o instanceof Map<?, ?> map) {
+			return !map.isEmpty();
 		}
 		return o != null;
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/TaskletParser.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/xml/TaskletParser.java
@@ -213,7 +213,7 @@ public class TaskletParser {
 			ManagedList<TypedStringValue> list = new ManagedList<>();
 			list.setMergeEnabled(exceptionClassesElement.hasAttribute(MERGE_ATTR)
 					&& Boolean.parseBoolean(exceptionClassesElement.getAttribute(MERGE_ATTR)));
-			addExceptionClasses("include", exceptionClassesElement, list, parserContext);
+			addExceptionClasses("include", exceptionClassesElement, list);
 			propertyValues.addPropertyValue(propertyName, list);
 		}
 		else if (children.size() > 1) {
@@ -224,7 +224,7 @@ public class TaskletParser {
 	}
 
 	private void addExceptionClasses(String elementName, Element exceptionClassesElement,
-			ManagedList<TypedStringValue> list, ParserContext parserContext) {
+			ManagedList<TypedStringValue> list) {
 		for (Element child : DomUtils.getChildElementsByTagName(exceptionClassesElement, elementName)) {
 			String className = child.getAttribute("class");
 			list.add(new TypedStringValue(className, Class.class));

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/SimpleJob.java
@@ -79,8 +79,8 @@ public class SimpleJob extends AbstractJob {
 		for (Step step : steps) {
 			names.add(step.getName());
 
-			if (step instanceof StepLocator) {
-				names.addAll(((StepLocator) step).getStepNames());
+			if (step instanceof StepLocator stepLocator) {
+				names.addAll(stepLocator.getStepNames());
 			}
 		}
 		return names;
@@ -100,8 +100,8 @@ public class SimpleJob extends AbstractJob {
 			if (step.getName().equals(stepName)) {
 				return step;
 			}
-			else if (step instanceof StepLocator) {
-				Step result = ((StepLocator) step).getStep(stepName);
+			else if (step instanceof StepLocator stepLocator) {
+				Step result = stepLocator.getStep(stepName);
 				if (result != null) {
 					return result;
 				}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobFlowBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobFlowBuilder.java
@@ -63,9 +63,9 @@ public class JobFlowBuilder extends FlowBuilder<FlowJobBuilder> {
 	public FlowJobBuilder build() {
 		Flow flow = flow();
 
-		if (flow instanceof InitializingBean) {
+		if (flow instanceof InitializingBean initializingBean) {
 			try {
-				((InitializingBean) flow).afterPropertiesSet();
+				initializingBean.afterPropertiesSet();
 			}
 			catch (Exception e) {
 				throw new FlowBuilderException(e);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/SimpleJobBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/SimpleJobBuilder.java
@@ -156,7 +156,7 @@ public class SimpleJobBuilder extends JobBuilderHelper<SimpleJobBuilder> {
 	 * @param executor instance of {@link TaskExecutor} to be used.
 	 * @return builder for fluent chaining
 	 */
-	public JobFlowBuilder.SplitBuilder<FlowJobBuilder> split(TaskExecutor executor) {
+	public FlowBuilder.SplitBuilder<FlowJobBuilder> split(TaskExecutor executor) {
 		for (Step step : steps) {
 			if (builder == null) {
 				builder = new JobFlowBuilder(new FlowJobBuilder(this), step);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/FlowJob.java
@@ -96,13 +96,13 @@ public class FlowJob extends AbstractJob {
 					map.put(name, locator.getStep(name));
 				}
 			}
-			else if (state instanceof StepHolder) {
-				Step step = ((StepHolder) state).getStep();
+			else if (state instanceof StepHolder stepHolder) {
+				Step step = stepHolder.getStep();
 				String name = step.getName();
 				stepMap.put(name, step);
 			}
-			else if (state instanceof FlowHolder) {
-				for (Flow subflow : ((FlowHolder) state).getFlows()) {
+			else if (state instanceof FlowHolder flowHolder) {
+				for (Flow subflow : flowHolder.getFlows()) {
 					findSteps(subflow, map);
 				}
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/JobFlowExecutor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/JobFlowExecutor.java
@@ -40,7 +40,7 @@ import org.springframework.lang.Nullable;
  */
 public class JobFlowExecutor implements FlowExecutor {
 
-	private final ThreadLocal<StepExecution> stepExecutionHolder = new ThreadLocal<>();
+	private static final ThreadLocal<StepExecution> stepExecutionHolder = new ThreadLocal<>();
 
 	private final JobExecution execution;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/SimpleFlow.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/SimpleFlow.java
@@ -243,9 +243,8 @@ public class SimpleFlow implements Flow, InitializingBean {
 	}
 
 	protected boolean isFlowContinued(State state, FlowExecutionStatus status, StepExecution stepExecution) {
-		boolean continued = true;
 
-		continued = state != null && status != FlowExecutionStatus.STOPPED;
+		boolean continued = state != null && status != FlowExecutionStatus.STOPPED;
 
 		if (stepExecution != null) {
 			Boolean reRun = (Boolean) stepExecution.getExecutionContext().get("batch.restart");

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/SplitState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/SplitState.java
@@ -129,8 +129,8 @@ public class SplitState extends AbstractState implements FlowHolder {
 			catch (ExecutionException e) {
 				// Unwrap the expected exceptions
 				Throwable cause = e.getCause();
-				if (cause instanceof Exception) {
-					exceptions.add((Exception) cause);
+				if (cause instanceof Exception exception) {
+					exceptions.add(exception);
 				}
 				else {
 					exceptions.add(e);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/StepState.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/flow/support/state/StepState.java
@@ -84,8 +84,8 @@ public class StepState extends AbstractState implements StepLocator, StepHolder 
 
 		names.add(step.getName());
 
-		if (step instanceof StepLocator) {
-			names.addAll(((StepLocator) step).getStepNames());
+		if (step instanceof StepLocator stepLocator) {
+			names.addAll(stepLocator.getStepNames());
 		}
 
 		return names;
@@ -98,8 +98,8 @@ public class StepState extends AbstractState implements StepLocator, StepHolder 
 		if (step.getName().equals(stepName)) {
 			result = step;
 		}
-		else if (step instanceof StepLocator) {
-			result = ((StepLocator) step).getStep(stepName);
+		else if (step instanceof StepLocator stepLocator) {
+			result = stepLocator.getStep(stepName);
 		}
 
 		return result;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/CommandLineJobRunner.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/CommandLineJobRunner.java
@@ -352,7 +352,7 @@ public class CommandLineJobRunner {
 				try {
 					job = jobLocator.getJob(jobName);
 				}
-				catch (NoSuchJobException e) {
+				catch (NoSuchJobException ignored) {
 				}
 			}
 			if (job == null) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/JobOperatorFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/JobOperatorFactoryBean.java
@@ -174,6 +174,7 @@ public class JobOperatorFactoryBean implements FactoryBean<JobOperator>, Initial
 		return (JobOperator) this.proxyFactory.getProxy(getClass().getClassLoader());
 	}
 
+	@SuppressWarnings("removal")
 	private TaskExecutorJobOperator getTarget() throws Exception {
 		TaskExecutorJobOperator taskExecutorJobOperator = new TaskExecutorJobOperator();
 		taskExecutorJobOperator.setJobRegistry(this.jobRegistry);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -124,6 +124,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		this.jobRegistry = jobRegistry;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public Long start(String jobName, Properties parameters)
@@ -134,7 +135,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 
 		JobParameters jobParameters = jobParametersConverter.getJobParameters(parameters);
 
-		if (jobRepository.isJobInstanceExists(jobName, jobParameters)) {
+		if (jobRepository.getJobInstance(jobName, jobParameters) != null) {
 			throw new JobInstanceAlreadyExistsException(
 					String.format("Cannot start a job instance that already exists with name=%s and parameters={%s}",
 							jobName, parameters));
@@ -163,6 +164,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public Long restart(long executionId) throws JobInstanceAlreadyCompleteException, NoSuchJobExecutionException,
@@ -211,6 +213,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public Long startNextInstance(String jobName)
@@ -269,6 +272,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public boolean stop(long executionId) throws NoSuchJobExecutionException, JobExecutionNotRunningException {
@@ -293,19 +297,19 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 
 		try {
 			Job job = jobRegistry.getJob(jobExecution.getJobInstance().getJobName());
-			if (job instanceof StepLocator) {// can only process as StepLocator is the
-				// only way to get the step object
+			if (job instanceof StepLocator stepLocator) {
+				// can only process as StepLocator is the only way to get the step object
 				// get the current stepExecution
 				for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
 					if (stepExecution.getStatus().isRunning()) {
 						try {
 							// have the step execution that's running -> need to 'stop' it
-							Step step = ((StepLocator) job).getStep(stepExecution.getStepName());
-							if (step instanceof TaskletStep) {
-								Tasklet tasklet = ((TaskletStep) step).getTasklet();
-								if (tasklet instanceof StoppableTasklet) {
+							Step step = stepLocator.getStep(stepExecution.getStepName());
+							if (step instanceof TaskletStep taskletStep) {
+								Tasklet tasklet = taskletStep.getTasklet();
+								if (tasklet instanceof StoppableTasklet stoppableTasklet) {
 									StepSynchronizationManager.register(stepExecution);
-									((StoppableTasklet) tasklet).stop();
+									stoppableTasklet.stop();
 									StepSynchronizationManager.release();
 								}
 							}
@@ -324,6 +328,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return true;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public JobExecution abandon(long jobExecutionId)
@@ -350,12 +355,14 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return jobExecution;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public Set<String> getJobNames() {
 		return new TreeSet<>(jobRegistry.getJobNames());
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public List<Long> getExecutions(long instanceId) throws NoSuchJobInstanceException {
@@ -370,6 +377,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return list;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public List<Long> getJobInstances(String jobName, int start, int count) throws NoSuchJobException {
@@ -384,6 +392,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return list;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Nullable
 	@Deprecated(since = "6.0", forRemoval = true)
@@ -391,6 +400,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return this.jobRepository.getJobInstance(jobName, jobParameters);
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public String getParameters(long executionId) throws NoSuchJobExecutionException {
@@ -401,6 +411,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return PropertiesConverter.propertiesToString(properties);
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public Set<Long> getRunningExecutions(String jobName) throws NoSuchJobException {
@@ -414,6 +425,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return set;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public Map<Long, String> getStepExecutionSummaries(long executionId) throws NoSuchJobExecutionException {
@@ -426,6 +438,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		return map;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public String getSummary(long executionId) throws NoSuchJobExecutionException {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
@@ -173,11 +173,11 @@ public class TaskExecutorJobLauncher implements JobLauncher, InitializingBean {
 				}
 
 				private void rethrow(Throwable t) {
-					if (t instanceof RuntimeException) {
-						throw (RuntimeException) t;
+					if (t instanceof RuntimeException runtimeException) {
+						throw runtimeException;
 					}
-					else if (t instanceof Error) {
-						throw (Error) t;
+					else if (t instanceof Error error) {
+						throw error;
 					}
 					throw new IllegalStateException(t);
 				}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperator.java
@@ -39,12 +39,14 @@ import org.springframework.batch.core.repository.JobRepository;
  * @author Mahmoud Ben Hassine
  * @since 6.0
  */
+@SuppressWarnings("removal")
 public class TaskExecutorJobOperator extends SimpleJobOperator {
 
 	/**
 	 * Public setter for the {@link ListableJobLocator}.
 	 * @param jobRegistry the {@link ListableJobLocator} to set
 	 */
+	@Override
 	public void setJobRegistry(ListableJobLocator jobRegistry) {
 		this.jobRegistry = jobRegistry;
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/AbstractListenerFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/AbstractListenerFactoryBean.java
@@ -150,8 +150,8 @@ public abstract class AbstractListenerFactoryBean<T> implements FactoryBean<Obje
 		// create a proxy listener for only the interfaces that have methods to
 		// be called
 		ProxyFactory proxyFactory = new ProxyFactory();
-		if (delegate instanceof Advised) {
-			proxyFactory.setTargetSource(((Advised) delegate).getTargetSource());
+		if (delegate instanceof Advised advised) {
+			proxyFactory.setTargetSource(advised.getTargetSource());
 		}
 		else {
 			proxyFactory.setTarget(delegate);
@@ -214,15 +214,13 @@ public abstract class AbstractListenerFactoryBean<T> implements FactoryBean<Obje
 		if (listenerType.isInstance(target)) {
 			return true;
 		}
-		if (target instanceof Advised) {
-			TargetSource targetSource = ((Advised) target).getTargetSource();
-			if (targetSource != null && targetSource.getTargetClass() != null
-					&& listenerType.isAssignableFrom(targetSource.getTargetClass())) {
+		if (target instanceof Advised advised) {
+			TargetSource targetSource = advised.getTargetSource();
+			if (targetSource.getTargetClass() != null && listenerType.isAssignableFrom(targetSource.getTargetClass())) {
 				return true;
 			}
 
-			if (targetSource != null && targetSource.getTargetClass() != null
-					&& targetSource.getTargetClass().isInterface()) {
+			if (targetSource.getTargetClass() != null && targetSource.getTargetClass().isInterface()) {
 				logger.warn(String.format(
 						"%s is an interface. The implementing class will not be queried for annotation based listener configurations. If using @StepScope on a @Bean method, be sure to return the implementing class so listener annotations can be used.",
 						targetSource.getTargetClass().getName()));

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/MethodInvokerMethodInterceptor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/MethodInvokerMethodInterceptor.java
@@ -68,12 +68,12 @@ public class MethodInvokerMethodInterceptor implements MethodInterceptor {
 		ExitStatus status = null;
 		for (MethodInvoker invoker : invokers) {
 			Object retVal = invoker.invokeMethod(invocation.getArguments());
-			if (retVal instanceof ExitStatus) {
+			if (retVal instanceof ExitStatus exitStatus) {
 				if (status != null) {
-					status = status.and((ExitStatus) retVal);
+					status = status.and(exitStatus);
 				}
 				else {
-					status = (ExitStatus) retVal;
+					status = exitStatus;
 				}
 			}
 		}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/MulticasterBatchListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/MulticasterBatchListener.java
@@ -78,11 +78,11 @@ public class MulticasterBatchListener<T, S> implements StepExecutionListener, Ch
 	 * @param listener the {@link StepListener} instance to be registered.
 	 */
 	public void register(StepListener listener) {
-		if (listener instanceof StepExecutionListener) {
-			this.stepListener.register((StepExecutionListener) listener);
+		if (listener instanceof StepExecutionListener stepExecutionListener) {
+			this.stepListener.register(stepExecutionListener);
 		}
-		if (listener instanceof ChunkListener) {
-			this.chunkListener.register((ChunkListener) listener);
+		if (listener instanceof ChunkListener cl) {
+			this.chunkListener.register(cl);
 		}
 		if (listener instanceof ItemReadListener<?>) {
 			@SuppressWarnings("unchecked")
@@ -323,8 +323,8 @@ public class MulticasterBatchListener<T, S> implements StepExecutionListener, Ch
 	 */
 	private Throwable getTargetException(RuntimeException e) {
 		Throwable cause = e.getCause();
-		if (cause != null && cause instanceof InvocationTargetException) {
-			return ((InvocationTargetException) cause).getTargetException();
+		if (cause instanceof InvocationTargetException invocationTargetException) {
+			return invocationTargetException.getTargetException();
 		}
 		return e;
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/observability/BatchMetrics.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/observability/BatchMetrics.java
@@ -176,7 +176,7 @@ public final class BatchMetrics {
 		StringBuilder formattedDuration = new StringBuilder();
 		long hours = duration.toHours();
 		long minutes = duration.toMinutes();
-		long seconds = duration.getSeconds();
+		long seconds = duration.toSeconds();
 		long millis = duration.toMillis();
 		if (hours != 0) {
 			formattedDuration.append(hours).append("h");

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
@@ -193,9 +193,9 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter, Initi
 			result = partitioner.partition(splitSize);
 		}
 		else {
-			if (partitioner instanceof PartitionNameProvider) {
+			if (partitioner instanceof PartitionNameProvider partitionNameProvider) {
 				result = new HashMap<>();
-				Collection<String> names = ((PartitionNameProvider) partitioner).getPartitionNames(splitSize);
+				Collection<String> names = partitionNameProvider.getPartitionNames(splitSize);
 				for (String name : names) {
 					/*
 					 * We need to return the same keys as the original (failed) execution,

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/Jackson2ExecutionContextStringSerializer.java
@@ -173,7 +173,8 @@ public class Jackson2ExecutionContextStringSerializer implements ExecutionContex
 			addSerializer(JobParameter.class, new JobParameterSerializer(JobParameter.class));
 		}
 
-		private abstract class JobParametersMixIn {
+		@SuppressWarnings("unused")
+		private abstract static class JobParametersMixIn {
 
 			@JsonIgnore
 			abstract boolean isEmpty();
@@ -183,7 +184,7 @@ public class Jackson2ExecutionContextStringSerializer implements ExecutionContex
 
 		}
 
-		private class JobParameterSerializer extends StdSerializer<JobParameter> {
+		private static class JobParameterSerializer extends StdSerializer<JobParameter> {
 
 			protected JobParameterSerializer(Class<JobParameter> type) {
 				super(type);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDao.java
@@ -61,8 +61,10 @@ import org.springframework.util.StringUtils;
  */
 public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements JobInstanceDao, InitializingBean {
 
+	@SuppressWarnings("unused")
 	private static final String STAR_WILDCARD = "*";
 
+	@SuppressWarnings("unused")
 	private static final String SQL_WILDCARD = "%";
 
 	private static final String CREATE_JOB_INSTANCE = """
@@ -333,6 +335,7 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 	 * @deprecated since v6.0 and scheduled for removal in v6.2. Use
 	 * {@link #getJobInstances(String, int, int)} instead.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(forRemoval = true)
 	@Override
 	public List<JobInstance> findJobInstancesByName(String jobName, final int start, final int count) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
@@ -147,6 +147,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	 * @deprecated since v6.0 and scheduled for removal in v6.2. Use
 	 * {@link #getJobInstances(String, int, int)} instead.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(forRemoval = true)
 	@Override
 	public List<JobInstance> findJobInstancesByName(String jobName, int start, int count) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/JdbcJobExplorerFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/JdbcJobExplorerFactoryBean.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.FactoryBean;
  * @author Mahmoud Ben Hassine
  * @since 6.0
  */
+@SuppressWarnings("removal")
 public class JdbcJobExplorerFactoryBean extends JobExplorerFactoryBean {
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/SimpleJobExplorer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/SimpleJobExplorer.java
@@ -91,6 +91,7 @@ public class SimpleJobExplorer implements JobExplorer {
 	 * ===================================================================================
 	 */
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
@@ -101,16 +102,18 @@ public class SimpleJobExplorer implements JobExplorer {
 	 * @deprecated since v6.0 and scheduled for removal in v6.2. Use
 	 * {@link #getJobInstances(String, int, int)} instead.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "6.0", forRemoval = true)
 	@Override
 	public List<JobInstance> findJobInstancesByJobName(String jobName, int start, int count) {
 		return getJobInstances(jobName, start, count);
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	@Deprecated(since = "6.0", forRemoval = true)
 	public List<JobInstance> findJobInstancesByName(String jobName, int start, int count) {
-		return this.jobInstanceDao.findJobInstancesByName(jobName, start, count);
+		return getJobInstances(jobName, start, count);
 	}
 
 	@Nullable
@@ -172,6 +175,7 @@ public class SimpleJobExplorer implements JobExplorer {
 		return lastJobExecution;
 	}
 
+	@SuppressWarnings("removal")
 	@Deprecated(since = "6.0", forRemoval = true)
 	@Override
 	public List<JobExecution> findJobExecutions(JobInstance jobInstance) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBean.java
@@ -44,12 +44,14 @@ import java.nio.charset.Charset;
  * @author Mahmoud Ben Hassine
  * @since 6.0
  */
+@SuppressWarnings("removal")
 public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 
 	/**
 	 * @param type a value from the {@link java.sql.Types} class to indicate the type to
 	 * use for a CLOB
 	 */
+	@Override
 	public void setClobType(int type) {
 		super.setClobType(type);
 	}
@@ -61,6 +63,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * {@link org.springframework.batch.item.ExecutionContext}
 	 * @see ExecutionContextSerializer
 	 */
+	@Override
 	public void setSerializer(ExecutionContextSerializer serializer) {
 		super.setSerializer(serializer);
 	}
@@ -77,6 +80,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * characters) than the declaration of the column length in the DDL for the tables.
 	 * @param maxVarCharLength the exitMessageLength to set
 	 */
+	@Override
 	public void setMaxVarCharLength(int maxVarCharLength) {
 		super.setMaxVarCharLength(maxVarCharLength);
 	}
@@ -90,6 +94,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * @param maxVarCharLengthForShortContext the short context length to set
 	 * @since 5.1
 	 */
+	@Override
 	public void setMaxVarCharLengthForShortContext(int maxVarCharLengthForShortContext) {
 		super.setMaxVarCharLengthForShortContext(maxVarCharLengthForShortContext);
 	}
@@ -104,6 +109,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * @param maxVarCharLengthForExitMessage the exitMessageLength to set
 	 * @since 5.1
 	 */
+	@Override
 	public void setMaxVarCharLengthForExitMessage(int maxVarCharLengthForExitMessage) {
 		super.setMaxVarCharLengthForExitMessage(maxVarCharLengthForExitMessage);
 	}
@@ -112,6 +118,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * Public setter for the {@link DataSource}.
 	 * @param dataSource a {@link DataSource}
 	 */
+	@Override
 	public void setDataSource(DataSource dataSource) {
 		super.setDataSource(dataSource);
 	}
@@ -122,6 +129,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * DataSource by default.
 	 * @param jdbcOperations a {@link JdbcOperations}
 	 */
+	@Override
 	public void setJdbcOperations(JdbcOperations jdbcOperations) {
 		super.setJdbcOperations(jdbcOperations);
 	}
@@ -130,6 +138,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * Sets the database type.
 	 * @param dbType as specified by {@link DefaultDataFieldMaxValueIncrementerFactory}
 	 */
+	@Override
 	public void setDatabaseType(String dbType) {
 		super.setDatabaseType(dbType);
 	}
@@ -138,10 +147,12 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * Sets the table prefix for all the batch meta-data tables.
 	 * @param tablePrefix prefix prepended to batch meta-data tables
 	 */
+	@Override
 	public void setTablePrefix(String tablePrefix) {
 		super.setTablePrefix(tablePrefix);
 	}
 
+	@Override
 	public void setIncrementerFactory(DataFieldMaxValueIncrementerFactory incrementerFactory) {
 		super.setIncrementerFactory(incrementerFactory);
 	}
@@ -153,6 +164,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * @see JdbcExecutionContextDao#setCharset(Charset)
 	 * @since 5.0
 	 */
+	@Override
 	public void setCharset(@NonNull Charset charset) {
 		super.setCharset(charset);
 	}
@@ -163,6 +175,7 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	 * @param conversionService the conversion service to use
 	 * @since 5.0
 	 */
+	@Override
 	public void setConversionService(@NonNull ConfigurableConversionService conversionService) {
 		super.setConversionService(conversionService);
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
@@ -49,6 +49,7 @@ public class ResourcelessJobRepository implements JobRepository {
 
 	private JobExecution jobExecution;
 
+	@SuppressWarnings("removal")
 	@Override
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 		return false;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/BatchScopeSupport.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/BatchScopeSupport.java
@@ -185,8 +185,8 @@ public abstract class BatchScopeSupport implements Scope, BeanFactoryPostProcess
 
 			BeanDefinition definition = null;
 			String beanName = null;
-			if (value instanceof BeanDefinition) {
-				definition = (BeanDefinition) value;
+			if (value instanceof BeanDefinition beanDefinition) {
+				definition = beanDefinition;
 				beanName = BeanDefinitionReaderUtils.generateBeanName(definition, registry);
 			}
 			else if (value instanceof BeanDefinitionHolder holder) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/JobContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/JobContext.java
@@ -161,8 +161,8 @@ public class JobContext extends SynchronizedAttributeAccessor {
 		}
 
 		Exception error = errors.get(0);
-		if (error instanceof RuntimeException) {
-			throw (RuntimeException) error;
+		if (error instanceof RuntimeException runtimeException) {
+			throw runtimeException;
 		}
 		else {
 			throw new UnexpectedJobExecutionException(

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/JobSynchronizationManager.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/JobSynchronizationManager.java
@@ -60,12 +60,12 @@ public class JobSynchronizationManager {
 	 * Register a context with the current thread - always put a matching {@link #close()}
 	 * call in a finally block to ensure that the correct context is available in the
 	 * enclosing block.
-	 * @param JobExecution the step context to register
+	 * @param jobExecution the step context to register
 	 * @return a new {@link JobContext} or the current one if it has the same
 	 * {@link JobExecution}
 	 */
-	public static JobContext register(JobExecution JobExecution) {
-		return manager.register(JobExecution);
+	public static JobContext register(JobExecution jobExecution) {
+		return manager.register(jobExecution);
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/scope/context/StepContext.java
@@ -197,8 +197,8 @@ public class StepContext extends SynchronizedAttributeAccessor {
 		}
 
 		Exception error = errors.get(0);
-		if (error instanceof RuntimeException) {
-			throw (RuntimeException) error;
+		if (error instanceof RuntimeException runtimeException) {
+			throw runtimeException;
 		}
 		else {
 			throw new UnexpectedJobExecutionException(

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
@@ -81,6 +81,7 @@ public abstract class AbstractStep implements Step, InitializingBean, BeanNameAw
 
 	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
+	@SuppressWarnings("unused")
 	private MeterRegistry meterRegistry = Metrics.globalRegistry;
 
 	private BatchStepObservationConvention observationConvention = new DefaultBatchStepObservationConvention();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/AbstractTaskletStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/AbstractTaskletStepBuilder.java
@@ -146,8 +146,8 @@ public abstract class AbstractTaskletStepBuilder<B extends AbstractTaskletStepBu
 
 	protected void registerStepListenerAsChunkListener() {
 		for (StepExecutionListener stepExecutionListener : properties.getStepExecutionListeners()) {
-			if (stepExecutionListener instanceof ChunkListener) {
-				listener((ChunkListener) stepExecutionListener);
+			if (stepExecutionListener instanceof ChunkListener chunkListener) {
+				listener(chunkListener);
 			}
 		}
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -574,11 +574,10 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 	protected BatchRetryTemplate createRetryOperations() {
 
 		RetryPolicy retryPolicy = this.retryPolicy;
-		SimpleRetryPolicy simpleRetryPolicy = null;
 
 		Map<Class<? extends Throwable>, Boolean> map = new HashMap<>(retryableExceptionClasses);
 		map.put(ForceRollbackForWriteSkipException.class, true);
-		simpleRetryPolicy = new SimpleRetryPolicy(retryLimit, map);
+		SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy(retryLimit, map);
 
 		if (retryPolicy == null) {
 			Assert.state(!(retryableExceptionClasses.isEmpty() && retryLimit > 0),
@@ -601,10 +600,10 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 
 		// Coordinate the retry policy with the exception handler:
 		RepeatOperations stepOperations = getStepOperations();
-		if (stepOperations instanceof RepeatTemplate) {
+		if (stepOperations instanceof RepeatTemplate repeatTemplate) {
 			SimpleRetryExceptionHandler exceptionHandler = new SimpleRetryExceptionHandler(retryPolicyWrapper,
 					getExceptionHandler(), nonRetryableExceptionClasses);
-			((RepeatTemplate) stepOperations).setExceptionHandler(exceptionHandler);
+			repeatTemplate.setExceptionHandler(exceptionHandler);
 		}
 
 		if (retryContextCache != null) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/SimpleStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/SimpleStepBuilder.java
@@ -383,16 +383,16 @@ public class SimpleStepBuilder<I, O> extends AbstractTaskletStepBuilder<SimpleSt
 	protected void registerAsStreamsAndListeners(ItemReader<? extends I> itemReader,
 			ItemProcessor<? super I, ? extends O> itemProcessor, ItemWriter<? super O> itemWriter) {
 		for (Object itemHandler : new Object[] { itemReader, itemWriter, itemProcessor }) {
-			if (itemHandler instanceof ItemStream) {
-				stream((ItemStream) itemHandler);
+			if (itemHandler instanceof ItemStream itemStream) {
+				stream(itemStream);
 			}
 			if (StepListenerFactoryBean.isListener(itemHandler)) {
 				StepListener listener = StepListenerFactoryBean.getListener(itemHandler);
-				if (listener instanceof StepExecutionListener) {
-					listener((StepExecutionListener) listener);
+				if (listener instanceof StepExecutionListener stepExecutionListener) {
+					listener(stepExecutionListener);
 				}
-				if (listener instanceof ChunkListener) {
-					listener((ChunkListener) listener);
+				if (listener instanceof ChunkListener chunkListener) {
+					listener(chunkListener);
 				}
 				if (listener instanceof ItemReadListener<?> || listener instanceof ItemProcessListener<?, ?>
 						|| listener instanceof ItemWriteListener<?>) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/factory/SimpleStepFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/factory/SimpleStepFactoryBean.java
@@ -107,7 +107,8 @@ public class SimpleStepFactoryBean<T, S> implements FactoryBean<Step>, BeanNameA
 
 	private CompletionPolicy chunkCompletionPolicy;
 
-	private int throttleLimit = TaskExecutorRepeatTemplate.DEFAULT_THROTTLE_LIMIT;
+	@SuppressWarnings("unused")
+	private final int throttleLimit = TaskExecutorRepeatTemplate.DEFAULT_THROTTLE_LIMIT;
 
 	private boolean isReaderTransactionalQueue = false;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkMonitor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkMonitor.java
@@ -58,7 +58,7 @@ public class ChunkMonitor extends ItemStreamSupport {
 
 	private final CompositeItemStream stream = new CompositeItemStream();
 
-	private final ThreadLocal<ChunkMonitorData> holder = new ThreadLocal<>();
+	private static final ThreadLocal<ChunkMonitorData> holder = new ThreadLocal<>();
 
 	private ItemReader<?> reader;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/FaultTolerantChunkProcessor.java
@@ -82,17 +82,17 @@ public class FaultTolerantChunkProcessor<I, O> extends SimpleChunkProcessor<I, O
 	}
 
 	/**
-	 * @param SkipPolicy the {@link SkipPolicy} for item processing
+	 * @param skipPolicy the {@link SkipPolicy} for item processing
 	 */
-	public void setProcessSkipPolicy(SkipPolicy SkipPolicy) {
-		this.itemProcessSkipPolicy = SkipPolicy;
+	public void setProcessSkipPolicy(SkipPolicy skipPolicy) {
+		this.itemProcessSkipPolicy = skipPolicy;
 	}
 
 	/**
-	 * @param SkipPolicy the {@link SkipPolicy} for item writing
+	 * @param skipPolicy the {@link SkipPolicy} for item writing
 	 */
-	public void setWriteSkipPolicy(SkipPolicy SkipPolicy) {
-		this.itemWriteSkipPolicy = SkipPolicy;
+	public void setWriteSkipPolicy(SkipPolicy skipPolicy) {
+		this.itemWriteSkipPolicy = skipPolicy;
 	}
 
 	/**
@@ -489,7 +489,7 @@ public class FaultTolerantChunkProcessor<I, O> extends SimpleChunkProcessor<I, O
 			throw ex;
 		}
 		catch (RuntimeException ex) {
-			throw new SkipListenerFailedException("Fatal exception in SkipPolicy.", ex, e);
+			throw new SkipListenerFailedException("Fatal exception in skipPolicy.", ex, e);
 		}
 	}
 
@@ -526,11 +526,11 @@ public class FaultTolerantChunkProcessor<I, O> extends SimpleChunkProcessor<I, O
 				throw new RetryException("Non-skippable exception in recoverer", e);
 			}
 			else {
-				if (e instanceof Exception) {
-					throw (Exception) e;
+				if (e instanceof Exception exception) {
+					throw exception;
 				}
-				else if (e instanceof Error) {
-					throw (Error) e;
+				else if (e instanceof Error error) {
+					throw error;
 				}
 				else {
 					throw new RetryException("Non-skippable throwable in recoverer", e);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/skip/SkipPolicy.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/skip/SkipPolicy.java
@@ -28,9 +28,9 @@ public interface SkipPolicy {
 
 	/**
 	 * Returns true or false, indicating whether or not processing should continue with
-	 * the given throwable. Clients may use {@code skipCount&lt;0} to probe for exception
+	 * the given throwable. Clients may use {@code skipCount < 0} to probe for exception
 	 * types that are skippable, so implementations should be able to handle gracefully
-	 * the case where {@code skipCount&lt;0}. Implementations should avoid throwing any
+	 * the case where {@code skipCount < 0}. Implementations should avoid throwing any
 	 * undeclared exceptions.
 	 * @param t exception encountered while processing
 	 * @param skipCount currently running count of skips

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/MethodInvokingTaskletAdapter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/MethodInvokingTaskletAdapter.java
@@ -59,8 +59,8 @@ public class MethodInvokingTaskletAdapter extends AbstractMethodInvokingDelegato
 	 * @return an {@link ExitStatus} consistent with the result
 	 */
 	protected ExitStatus mapResult(Object result) {
-		if (result instanceof ExitStatus) {
-			return (ExitStatus) result;
+		if (result instanceof ExitStatus exitStatus) {
+			return exitStatus;
 		}
 		return ExitStatus.COMPLETED;
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -142,8 +142,8 @@ public class TaskletStep extends AbstractStep {
 	 */
 	public void setTasklet(Tasklet tasklet) {
 		this.tasklet = tasklet;
-		if (tasklet instanceof StepExecutionListener) {
-			registerStepExecutionListener((StepExecutionListener) tasklet);
+		if (tasklet instanceof StepExecutionListener stepExecutionListener) {
+			registerStepExecutionListener(stepExecutionListener);
 		}
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
@@ -291,11 +291,11 @@ class BatchRegistrarTests {
 		}
 
 		@Bean
-		public JobKeyGenerator jobKeyGenerator() {
+		public JobKeyGenerator<Object> jobKeyGenerator() {
 			return new TestCustomJobKeyGenerator();
 		}
 
-		private class TestCustomJobKeyGenerator implements JobKeyGenerator {
+		private static class TestCustomJobKeyGenerator implements JobKeyGenerator<Object> {
 
 			@Override
 			public String generateKey(Object source) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/ApplicationContextJobFactoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/ApplicationContextJobFactoryTests.java
@@ -69,8 +69,8 @@ class ApplicationContextJobFactoryTests {
 
 		@Override
 		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-			if (bean instanceof JobSupport) {
-				((JobSupport) bean).setName("bar");
+			if (bean instanceof JobSupport jobSupport) {
+				jobSupport.setName("bar");
 			}
 			return bean;
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/AutomaticJobRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/AutomaticJobRegistrarTests.java
@@ -17,6 +17,7 @@ package org.springframework.batch.core.configuration.support;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,7 +59,7 @@ class AutomaticJobRegistrarTests {
 	@Test
 	void testOrderedImplemented() {
 
-		assertTrue(registrar instanceof Ordered);
+		assertInstanceOf(Ordered.class, registrar);
 		assertEquals(Ordered.LOWEST_PRECEDENCE, registrar.getOrder());
 		registrar.setOrder(1);
 		assertEquals(1, registrar.getOrder());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingletonTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingletonTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
  * @author Henning Pöttker
  * @author Mahmoud Ben Hassine
  */
+@SuppressWarnings("removal")
 class JobRegistrySmartInitializingSingletonTests {
 
 	private final JobRegistry jobRegistry = new MapJobRegistry();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/DummyJobRepository.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/xml/DummyJobRepository.java
@@ -81,6 +81,7 @@ public class DummyJobRepository implements JobRepository, BeanNameAware {
 		return 0;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 		return false;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.mock;
  * @author Mahmoud Ben Hassine
  *
  */
+@SuppressWarnings("removal")
 class JobExplorerFactoryBeanTests {
 
 	private JobExplorerFactoryBean factory;
@@ -147,7 +148,7 @@ class JobExplorerFactoryBeanTests {
 		Assertions.assertEquals(CustomJobKeyGenerator.class, jobKeyGenerator.getClass());
 	}
 
-	class CustomJobKeyGenerator implements JobKeyGenerator<String> {
+	static class CustomJobKeyGenerator implements JobKeyGenerator<String> {
 
 		@Override
 		public String generateKey(String source) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/SimpleJobExplorerIntegrationTests.java
@@ -90,6 +90,7 @@ class SimpleJobExplorerIntegrationTests {
 			return jobExplorerFactoryBean().getObject();
 		}
 
+		@SuppressWarnings("removal")
 		@Bean
 		public JobExplorerFactoryBean jobExplorerFactoryBean() {
 			JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/SimpleJobTests.java
@@ -95,6 +95,7 @@ class SimpleJobTests {
 
 	private SimpleJob job;
 
+	@SuppressWarnings("removal")
 	@BeforeEach
 	void setUp() throws Exception {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()
@@ -178,7 +179,7 @@ class SimpleJobTests {
 		Step testStep = new Step() {
 
 			@Override
-			public void execute(StepExecution stepExecution) throws JobInterruptedException {
+			public void execute(StepExecution stepExecution) {
 				stepExecution.setExitStatus(customStatus);
 			}
 
@@ -192,10 +193,6 @@ class SimpleJobTests {
 				return 1;
 			}
 
-			@Override
-			public boolean isAllowStartIfComplete() {
-				return false;
-			}
 		};
 		List<Step> steps = new ArrayList<>();
 		steps.add(testStep);
@@ -496,8 +493,8 @@ class SimpleJobTests {
 
 		List<JobExecution> jobExecutionList = jobExplorer.getJobExecutions(jobexecution.getJobInstance());
 
-		assertEquals(jobExecutionList.size(), 1);
-		assertEquals(jobExecutionList.get(0).getJobParameters().getString("JobExecutionParameter"), "first");
+		assertEquals(1, jobExecutionList.size());
+		assertEquals("first", jobExecutionList.get(0).getJobParameters().getString("JobExecutionParameter"));
 
 		JobParameters secondJobParameters = new JobParametersBuilder()
 			.addString("JobExecutionParameter", "second", false)
@@ -507,9 +504,9 @@ class SimpleJobTests {
 
 		jobExecutionList = jobExplorer.getJobExecutions(jobexecution.getJobInstance());
 
-		assertEquals(jobExecutionList.size(), 2);
-		assertEquals(jobExecutionList.get(0).getJobParameters().getString("JobExecutionParameter"), "second");
-		assertEquals(jobExecutionList.get(1).getJobParameters().getString("JobExecutionParameter"), "first");
+		assertEquals(2, jobExecutionList.size());
+		assertEquals("second", jobExecutionList.get(0).getJobParameters().getString("JobExecutionParameter"));
+		assertEquals("first", jobExecutionList.get(1).getJobParameters().getString("JobExecutionParameter"));
 
 	}
 
@@ -570,11 +567,11 @@ class SimpleJobTests {
 			jobRepository.update(stepExecution);
 			jobRepository.updateExecutionContext(stepExecution);
 
-			if (exception instanceof JobInterruptedException) {
+			if (exception instanceof JobInterruptedException jobInterruptedException) {
 				stepExecution.setExitStatus(ExitStatus.FAILED);
-				stepExecution.setStatus(((JobInterruptedException) exception).getStatus());
+				stepExecution.setStatus(jobInterruptedException.getStatus());
 				stepExecution.addFailureException(exception);
-				throw (JobInterruptedException) exception;
+				throw jobInterruptedException;
 			}
 			if (exception instanceof RuntimeException) {
 				stepExecution.setExitStatus(ExitStatus.FAILED);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowBuilderTests.java
@@ -57,7 +57,7 @@ class FlowBuilderTests {
 			.start(new JobFlowExecutor(jobRepository, new SimpleStepHandler(jobRepository), execution));
 
 		Iterator<StepExecution> stepExecutions = execution.getStepExecutions().iterator();
-		assertEquals(stepExecutions.next().getStepName(), "stepA");
+		assertEquals("stepA", stepExecutions.next().getStepName());
 		assertFalse(stepExecutions.hasNext());
 	}
 
@@ -74,9 +74,9 @@ class FlowBuilderTests {
 			.start(new JobFlowExecutor(jobRepository, new SimpleStepHandler(jobRepository), execution));
 
 		Iterator<StepExecution> stepExecutions = execution.getStepExecutions().iterator();
-		assertEquals(stepExecutions.next().getStepName(), "stepA");
-		assertEquals(stepExecutions.next().getStepName(), "stepB");
-		assertEquals(stepExecutions.next().getStepName(), "stepC");
+		assertEquals("stepA", stepExecutions.next().getStepName());
+		assertEquals("stepB", stepExecutions.next().getStepName());
+		assertEquals("stepC", stepExecutions.next().getStepName());
 		assertFalse(stepExecutions.hasNext());
 	}
 
@@ -91,7 +91,7 @@ class FlowBuilderTests {
 			.start(new JobFlowExecutor(jobRepository, new SimpleStepHandler(jobRepository), execution));
 
 		Iterator<StepExecution> stepExecutions = execution.getStepExecutions().iterator();
-		assertEquals(stepExecutions.next().getStepName(), "stepA");
+		assertEquals("stepA", stepExecutions.next().getStepName());
 		assertFalse(stepExecutions.hasNext());
 	}
 
@@ -106,7 +106,7 @@ class FlowBuilderTests {
 			.start(new JobFlowExecutor(jobRepository, new SimpleStepHandler(jobRepository), execution));
 
 		Iterator<StepExecution> stepExecutions = execution.getStepExecutions().iterator();
-		assertEquals(stepExecutions.next().getStepName(), "stepA");
+		assertEquals("stepA", stepExecutions.next().getStepName());
 		assertFalse(stepExecutions.hasNext());
 	}
 
@@ -118,23 +118,20 @@ class FlowBuilderTests {
 
 		StepSupport stepA = new StepSupport("stepA") {
 			@Override
-			public void execute(StepExecution stepExecution)
-					throws JobInterruptedException, UnexpectedJobExecutionException {
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
 				stepExecution.setExitStatus(ExitStatus.FAILED);
 			}
 		};
 
 		StepSupport stepB = new StepSupport("stepB") {
 			@Override
-			public void execute(StepExecution stepExecution)
-					throws JobInterruptedException, UnexpectedJobExecutionException {
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
 			}
 		};
 
 		StepSupport stepC = new StepSupport("stepC") {
 			@Override
-			public void execute(StepExecution stepExecution)
-					throws JobInterruptedException, UnexpectedJobExecutionException {
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
 			}
 		};
 
@@ -148,16 +145,15 @@ class FlowBuilderTests {
 			.start(new JobFlowExecutor(jobRepository, new SimpleStepHandler(jobRepository), execution));
 
 		Iterator<StepExecution> stepExecutions = execution.getStepExecutions().iterator();
-		assertEquals(stepExecutions.next().getStepName(), "stepA");
-		assertEquals(stepExecutions.next().getStepName(), "stepC");
+		assertEquals("stepA", stepExecutions.next().getStepName());
+		assertEquals("stepC", stepExecutions.next().getStepName());
 		assertFalse(stepExecutions.hasNext());
 	}
 
 	private static StepSupport createCompleteStep(String name) {
 		return new StepSupport(name) {
 			@Override
-			public void execute(StepExecution stepExecution)
-					throws JobInterruptedException, UnexpectedJobExecutionException {
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
 				stepExecution.upgradeStatus(BatchStatus.COMPLETED);
 				stepExecution.setExitStatus(ExitStatus.COMPLETED);
 			}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowJobTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/flow/FlowJobTests.java
@@ -70,6 +70,7 @@ public class FlowJobTests {
 
 	private boolean fail = false;
 
+	@SuppressWarnings("removal")
 	@BeforeEach
 	void setUp() throws Exception {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobLauncherIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/JobLauncherIntegrationTests.java
@@ -66,7 +66,6 @@ public class JobLauncherIntegrationTests {
 
 		if (start) {
 
-			Calendar c = Calendar.getInstance();
 			JobParametersBuilder builder = new JobParametersBuilder();
 			builder.addString("name", "foo");
 			JobParameters jobParameters = builder.toJobParameters();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobRunnerTests.java
@@ -138,8 +138,8 @@ class CommandLineJobRunnerTests {
 		assertEquals(1, StubSystemExiter.status);
 		String errorMessage = CommandLineJobRunner.getErrorMessage();
 		assertTrue(
-				(errorMessage.contains("No bean named 'no-such-job' is defined")
-						|| (errorMessage.contains("No bean named 'no-such-job' available"))),
+				errorMessage.contains("No bean named 'no-such-job' is defined")
+						|| errorMessage.contains("No bean named 'no-such-job' available"),
 				"Wrong error message: " + errorMessage);
 	}
 
@@ -217,7 +217,7 @@ class CommandLineJobRunnerTests {
 	void testWithStdinParameters() throws Throwable {
 		String[] args = new String[] { jobPath, jobName };
 		System.setIn(new InputStream() {
-			final char[] input = ("foo=bar\nspam=bucket").toCharArray();
+			final char[] input = "foo=bar\nspam=bucket".toCharArray();
 
 			int index = 0;
 
@@ -248,7 +248,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testStop() throws Throwable {
 		String[] args = new String[] { jobPath, "-stop", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(3L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(3L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 	}
@@ -256,7 +256,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testStopFailed() throws Throwable {
 		String[] args = new String[] { jobPath, "-stop", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(0L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(0L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 	}
@@ -264,7 +264,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testStopFailedAndRestarted() throws Throwable {
 		String[] args = new String[] { jobPath, "-stop", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(5L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(5L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 	}
@@ -273,7 +273,7 @@ class CommandLineJobRunnerTests {
 	void testStopRestarted() throws Throwable {
 		String[] args = new String[] { jobPath, "-stop", jobName };
 		JobInstance jobInstance = new JobInstance(3L, jobName);
-		StubJobExplorer.jobInstances = Arrays.asList(jobInstance);
+		StubJobExplorer.jobInstances = List.of(jobInstance);
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 	}
@@ -281,7 +281,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testAbandon() throws Throwable {
 		String[] args = new String[] { jobPath, "-abandon", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(2L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(2L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(0, StubSystemExiter.status);
 	}
@@ -289,7 +289,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testAbandonRunning() throws Throwable {
 		String[] args = new String[] { jobPath, "-abandon", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(3L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(3L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 	}
@@ -297,7 +297,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testAbandonAbandoned() throws Throwable {
 		String[] args = new String[] { jobPath, "-abandon", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(4L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(4L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 	}
@@ -307,7 +307,7 @@ class CommandLineJobRunnerTests {
 		String[] args = new String[] { jobPath, "-restart", jobName };
 		JobParameters jobParameters = new JobParametersBuilder().addString("foo", "bar").toJobParameters();
 		JobInstance jobInstance = new JobInstance(0L, jobName);
-		StubJobExplorer.jobInstances = Arrays.asList(jobInstance);
+		StubJobExplorer.jobInstances = List.of(jobInstance);
 		StubJobExplorer.jobParameters = jobParameters;
 		CommandLineJobRunner.main(args);
 		assertEquals(0, StubSystemExiter.status);
@@ -342,7 +342,7 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testRestartNotFailed() throws Throwable {
 		String[] args = new String[] { jobPath, "-restart", jobName };
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(123L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(123L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(1, StubSystemExiter.status);
 		String errorMessage = CommandLineJobRunner.getErrorMessage();
@@ -353,13 +353,12 @@ class CommandLineJobRunnerTests {
 	@Test
 	void testNext() throws Throwable {
 		String[] args = new String[] { jobPath, "-next", jobName, "bar=foo" };
-		JobParameters jobParameters = new JobParametersBuilder().addString("foo", "bar")
-			.addString("bar", "foo")
-			.toJobParameters();
-		StubJobExplorer.jobInstances = Arrays.asList(new JobInstance(2L, jobName));
+		StubJobExplorer.jobInstances = List.of(new JobInstance(2L, jobName));
 		CommandLineJobRunner.main(args);
 		assertEquals(0, StubSystemExiter.status);
-		jobParameters = new JobParametersBuilder().addString("foo", "spam").addString("bar", "foo").toJobParameters();
+		JobParameters jobParameters = new JobParametersBuilder().addString("foo", "spam")
+			.addString("bar", "foo")
+			.toJobParameters();
 		assertEquals(jobParameters, StubJobLauncher.jobParameters);
 	}
 
@@ -482,25 +481,25 @@ class CommandLineJobRunnerTests {
 		@Override
 		public List<JobExecution> getJobExecutions(JobInstance jobInstance) {
 			if (jobInstance.getId() == 0) {
-				return Arrays.asList(createJobExecution(jobInstance, BatchStatus.FAILED));
+				return List.of(createJobExecution(jobInstance, BatchStatus.FAILED));
 			}
 			if (jobInstance.getId() == 1) {
 				return null;
 			}
 			if (jobInstance.getId() == 2) {
-				return Arrays.asList(createJobExecution(jobInstance, BatchStatus.STOPPED));
+				return List.of(createJobExecution(jobInstance, BatchStatus.STOPPED));
 			}
 			if (jobInstance.getId() == 3) {
-				return Arrays.asList(createJobExecution(jobInstance, BatchStatus.STARTED));
+				return List.of(createJobExecution(jobInstance, BatchStatus.STARTED));
 			}
 			if (jobInstance.getId() == 4) {
-				return Arrays.asList(createJobExecution(jobInstance, BatchStatus.ABANDONED));
+				return List.of(createJobExecution(jobInstance, BatchStatus.ABANDONED));
 			}
 			if (jobInstance.getId() == 5) {
 				return Arrays.asList(createJobExecution(jobInstance, BatchStatus.STARTED),
 						createJobExecution(jobInstance, BatchStatus.FAILED));
 			}
-			return Arrays.asList(createJobExecution(jobInstance, BatchStatus.COMPLETED));
+			return List.of(createJobExecution(jobInstance, BatchStatus.COMPLETED));
 		}
 
 		private JobExecution createJobExecution(JobInstance jobInstance, BatchStatus status) {
@@ -558,6 +557,7 @@ class CommandLineJobRunnerTests {
 			throw new UnsupportedOperationException();
 		}
 
+		@SuppressWarnings("removal")
 		@Override
 		public List<JobInstance> findJobInstancesByJobName(String jobName, int start, int count) {
 			throw new UnsupportedOperationException();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperatorTests.java
@@ -72,6 +72,7 @@ import static org.mockito.Mockito.when;
  * @author Jinwoo Bae
  *
  */
+@SuppressWarnings("removal")
 class TaskExecutorJobOperatorTests {
 
 	private TaskExecutorJobOperator jobOperator;
@@ -177,8 +178,8 @@ class TaskExecutorJobOperatorTests {
 		Properties properties = new Properties();
 		properties.setProperty("a", "b");
 		jobParameters = new JobParameters();
-		when(jobRepository.isJobInstanceExists("foo", jobParameters)).thenReturn(true);
-		jobRepository.isJobInstanceExists("foo", jobParameters);
+		JobInstance jobInstance = new JobInstance(123L, "foo");
+		when(jobRepository.getJobInstance("foo", jobParameters)).thenReturn(jobInstance);
 		assertThrows(JobInstanceAlreadyExistsException.class, () -> jobOperator.start("foo", properties));
 	}
 
@@ -340,10 +341,7 @@ class TaskExecutorJobOperatorTests {
 		job.taskletStep = taskletStep;
 
 		JobRegistry jobRegistry = mock();
-		TaskletStep step = mock();
 
-		when(step.getTasklet()).thenReturn(tasklet);
-		when(step.getName()).thenReturn("test_job.step1");
 		when(jobRegistry.getJob(any(String.class))).thenReturn(job);
 		when(jobRepository.getJobExecution(111L)).thenReturn(jobExecution);
 
@@ -358,18 +356,14 @@ class TaskExecutorJobOperatorTests {
 	void testStopTaskletWhenJobNotRegistered() throws Exception {
 		JobInstance jobInstance = new JobInstance(123L, job.getName());
 		JobExecution jobExecution = new JobExecution(jobInstance, 111L, jobParameters);
-		StoppableTasklet tasklet = mock();
 		JobRegistry jobRegistry = mock();
-		TaskletStep step = mock();
 
-		when(step.getTasklet()).thenReturn(tasklet);
 		when(jobRegistry.getJob(job.getName())).thenThrow(new NoSuchJobException("Unable to find job"));
 		when(jobRepository.getJobExecution(111L)).thenReturn(jobExecution);
 
 		jobOperator.setJobRegistry(jobRegistry);
 		jobOperator.stop(111L);
 		assertEquals(BatchStatus.STOPPING, jobExecution.getStatus());
-		verify(tasklet, never()).stop();
 	}
 
 	@Test
@@ -395,10 +389,7 @@ class TaskExecutorJobOperatorTests {
 		job.taskletStep = taskletStep;
 
 		JobRegistry jobRegistry = mock();
-		TaskletStep step = mock();
 
-		when(step.getTasklet()).thenReturn(tasklet);
-		when(step.getName()).thenReturn("test_job.step1");
 		when(jobRegistry.getJob(any(String.class))).thenReturn(job);
 		when(jobRepository.getJobExecution(111L)).thenReturn(jobExecution);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemReadListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemReadListenerTests.java
@@ -17,7 +17,7 @@ package org.springframework.batch.core.listener;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,11 +67,7 @@ class CompositeItemReadListenerTests {
 
 	@Test
 	void testSetListeners() {
-		compositeListener.setListeners(new ArrayList<>() {
-			{
-				add(listener);
-			}
-		});
+		compositeListener.setListeners(List.of(listener));
 		listener.beforeRead();
 		compositeListener.beforeRead();
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemWriteListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/CompositeItemWriteListenerTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.core.listener;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,11 +69,7 @@ class CompositeItemWriteListenerTests {
 
 	@Test
 	void testSetListeners() {
-		compositeListener.setListeners(new ArrayList<>() {
-			{
-				add(listener);
-			}
-		});
+		compositeListener.setListeners(List.of(listener));
 		Chunk<Object> item = Chunk.of(new Object());
 		listener.beforeWrite(item);
 		compositeListener.beforeWrite(item);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/MulticasterBatchListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/MulticasterBatchListenerTests.java
@@ -16,6 +16,7 @@
 package org.springframework.batch.core.listener;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -459,7 +460,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, multicast::beforeRead);
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -471,7 +472,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.afterRead(null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -483,7 +484,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.beforeProcess(null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -495,7 +496,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.afterProcess(null, null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -507,7 +508,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.beforeWrite(null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -519,7 +520,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.afterWrite(null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -531,7 +532,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.beforeChunk(null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 
@@ -543,7 +544,7 @@ class MulticasterBatchListenerTests {
 		Exception exception = assertThrows(StepListenerFailedException.class, () -> multicast.afterChunk(null));
 		Throwable cause = exception.getCause();
 		String message = cause.getMessage();
-		assertTrue(cause instanceof IllegalStateException);
+		assertInstanceOf(IllegalStateException.class, cause);
 		assertEquals("listener error", message, "Wrong message: " + message);
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/StepListenerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/StepListenerFactoryBeanTests.java
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.batch.core.listener.StepListenerMetaData.AFTER_STEP;
@@ -156,7 +157,7 @@ class StepListenerFactoryBeanTests {
 		MultipleAfterStep delegate = new MultipleAfterStep();
 		factoryBean.setDelegate(delegate);
 		Object listener = factoryBean.getObject();
-		assertTrue(listener instanceof StepExecutionListener);
+		assertInstanceOf(StepExecutionListener.class, listener);
 		((StepExecutionListener) listener).beforeStep(stepExecution);
 		assertEquals(1, delegate.callcount);
 	}
@@ -167,7 +168,7 @@ class StepListenerFactoryBeanTests {
 		ProxyFactory factory = new ProxyFactory(delegate);
 		factoryBean.setDelegate(factory.getProxy());
 		Object listener = factoryBean.getObject();
-		assertTrue(listener instanceof StepExecutionListener);
+		assertInstanceOf(StepExecutionListener.class, listener);
 		((StepExecutionListener) listener).beforeStep(stepExecution);
 		assertEquals(1, delegate.callcount);
 	}
@@ -176,7 +177,7 @@ class StepListenerFactoryBeanTests {
 	void testFactoryMethod() {
 		MultipleAfterStep delegate = new MultipleAfterStep();
 		Object listener = StepListenerFactoryBean.getListener(delegate);
-		assertTrue(listener instanceof StepExecutionListener);
+		assertInstanceOf(StepExecutionListener.class, listener);
 		assertFalse(listener instanceof ChunkListener);
 		((StepExecutionListener) listener).beforeStep(stepExecution);
 		assertEquals(1, delegate.callcount);
@@ -186,7 +187,7 @@ class StepListenerFactoryBeanTests {
 	void testAnnotationsWithOrdered() {
 		Object delegate = new Ordered() {
 			@BeforeStep
-			public void foo(StepExecution execution) {
+			public void foo(@SuppressWarnings("unused") StepExecution execution) {
 			}
 
 			@Override
@@ -195,7 +196,7 @@ class StepListenerFactoryBeanTests {
 			}
 		};
 		StepListener listener = StepListenerFactoryBean.getListener(delegate);
-		assertTrue(listener instanceof Ordered, "Listener is not of correct type");
+		assertInstanceOf(Ordered.class, listener, "Listener is not of correct type");
 		assertEquals(3, ((Ordered) listener).getOrder());
 	}
 
@@ -203,15 +204,15 @@ class StepListenerFactoryBeanTests {
 	void testProxiedAnnotationsFactoryMethod() {
 		Object delegate = new InitializingBean() {
 			@BeforeStep
-			public void foo(StepExecution execution) {
+			public void foo(@SuppressWarnings("unused") StepExecution execution) {
 			}
 
 			@Override
-			public void afterPropertiesSet() throws Exception {
+			public void afterPropertiesSet() {
 			}
 		};
 		ProxyFactory factory = new ProxyFactory(delegate);
-		assertTrue(StepListenerFactoryBean.getListener(factory.getProxy()) instanceof StepExecutionListener,
+		assertInstanceOf(StepExecutionListener.class, StepListenerFactoryBean.getListener(factory.getProxy()),
 				"Listener is not of correct type");
 	}
 
@@ -224,7 +225,7 @@ class StepListenerFactoryBeanTests {
 	void testAnnotationsIsListener() {
 		assertTrue(StepListenerFactoryBean.isListener(new Object() {
 			@BeforeStep
-			public void foo(StepExecution execution) {
+			public void foo(@SuppressWarnings("unused") StepExecution execution) {
 			}
 		}));
 	}
@@ -242,11 +243,11 @@ class StepListenerFactoryBeanTests {
 	void testProxiedAnnotationsIsListener() {
 		Object delegate = new InitializingBean() {
 			@BeforeStep
-			public void foo(StepExecution execution) {
+			public void foo(@SuppressWarnings("unused") StepExecution execution) {
 			}
 
 			@Override
-			public void afterPropertiesSet() throws Exception {
+			public void afterPropertiesSet() {
 			}
 		};
 		ProxyFactory factory = new ProxyFactory(delegate);
@@ -264,7 +265,7 @@ class StepListenerFactoryBeanTests {
 	void testNonListener() {
 		Object delegate = new Object();
 		factoryBean.setDelegate(delegate);
-		assertTrue(factoryBean.getObject() instanceof StepListener);
+		assertInstanceOf(StepListener.class, factoryBean.getObject());
 	}
 
 	@Test
@@ -303,7 +304,7 @@ class StepListenerFactoryBeanTests {
 	void testWrongSignatureAnnotation() {
 		AbstractTestComponent delegate = new AbstractTestComponent() {
 			@AfterWrite
-			public void aMethod(Integer item) {
+			public void aMethod(@SuppressWarnings("unused") Integer item) {
 				executed = true;
 			}
 		};

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/partition/MinMaxPartitioner.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/partition/MinMaxPartitioner.java
@@ -34,7 +34,7 @@ public class MinMaxPartitioner extends SimplePartitioner {
 		int range = total / gridSize;
 		int i = 0;
 		for (ExecutionContext context : partition.values()) {
-			int min = (i++) * range;
+			int min = i++ * range;
 			int max = Math.min(total, i * range);
 			context.putInt("min", min);
 			context.putInt("max", max);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/RemoteStepExecutionAggregatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/partition/support/RemoteStepExecutionAggregatorTests.java
@@ -48,6 +48,7 @@ class RemoteStepExecutionAggregatorTests {
 
 	private StepExecution stepExecution2;
 
+	@SuppressWarnings("removal")
 	@BeforeEach
 	void init() throws Exception {
 		EmbeddedDatabase embeddedDatabase = new EmbeddedDatabaseBuilder()

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobDaoTests.java
@@ -52,7 +52,7 @@ public abstract class AbstractJobDaoTests {
 	protected JobExecutionDao jobExecutionDao;
 
 	protected JobParameters jobParameters = new JobParametersBuilder().addString("job.key", "jobKey")
-		.addLong("long", (long) 1)
+		.addLong("long", 1L)
 		.addDouble("double", 7.7)
 		.toJobParameters();
 
@@ -191,7 +191,7 @@ public abstract class AbstractJobDaoTests {
 	void testUpdateInvalidJobExecution() {
 
 		// id is invalid
-		JobExecution execution = new JobExecution(jobInstance, (long) 29432, jobParameters);
+		JobExecution execution = new JobExecution(jobInstance, 29432L, jobParameters);
 		execution.incrementVersion();
 		assertThrows(NoSuchObjectException.class, () -> jobExecutionDao.updateJobExecution(execution));
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobInstanceDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobInstanceDaoTests.java
@@ -239,7 +239,7 @@ public abstract class AbstractJobInstanceDaoTests {
 	@Test
 	void testCreationAddsVersion() {
 
-		JobInstance jobInstance = new JobInstance((long) 1, "testVersionAndId");
+		JobInstance jobInstance = new JobInstance(1L, "testVersionAndId");
 
 		assertNull(jobInstance.getVersion());
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractStepExecutionDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractStepExecutionDaoTests.java
@@ -224,7 +224,7 @@ public abstract class AbstractStepExecutionDaoTests extends AbstractTransactiona
 	@Transactional
 	@Test
 	void testGetForNotExistingJobExecution() {
-		assertNull(dao.getStepExecution(new JobExecution(jobInstance, (long) 777, new JobParameters()), 11L));
+		assertNull(dao.getStepExecution(new JobExecution(jobInstance, 777L, new JobParameters()), 11L));
 	}
 
 	/**
@@ -233,7 +233,7 @@ public abstract class AbstractStepExecutionDaoTests extends AbstractTransactiona
 	@Transactional
 	@Test
 	void testSaveExecutionWithIdAlreadySet() {
-		stepExecution.setId((long) 7);
+		stepExecution.setId(7L);
 		assertThrows(IllegalArgumentException.class, () -> dao.saveStepExecution(stepExecution));
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/OptimisticLockingFailureTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/OptimisticLockingFailureTests.java
@@ -47,6 +47,7 @@ class OptimisticLockingFailureTests {
 	private static final Set<BatchStatus> END_STATUSES = EnumSet.of(BatchStatus.COMPLETED, BatchStatus.FAILED,
 			BatchStatus.STOPPED);
 
+	@SuppressWarnings("removal")
 	@Test
 	void testAsyncStopOfStartingJob() throws Exception {
 		ApplicationContext applicationContext = new ClassPathXmlApplicationContext(

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDaoTests.java
@@ -98,7 +98,7 @@ public class JdbcJobInstanceDaoTests extends AbstractJobInstanceDaoTests {
 		dao.createJobInstance("anotherJob", new JobParameters());
 		dao.createJobInstance("someJob", new JobParameters());
 
-		List<JobInstance> jobInstances = dao.findJobInstancesByName("*Job", 0, 2);
+		List<JobInstance> jobInstances = dao.getJobInstances("*Job", 0, 2);
 		assertEquals(2, jobInstances.size());
 
 		for (JobInstance instance : jobInstances) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
@@ -62,8 +62,10 @@ import static org.mockito.Mockito.when;
  * @author Mahmoud Ben Hassine
  *
  */
+@SuppressWarnings("removal")
 class JobRepositoryFactoryBeanTests {
 
+	@SuppressWarnings("removal")
 	private JobRepositoryFactoryBean factory;
 
 	private DataFieldMaxValueIncrementerFactory incrementerFactory;
@@ -311,8 +313,7 @@ class JobRepositoryFactoryBeanTests {
 		Advisor[] advisors = target.getAdvisors();
 		for (Advisor advisor : advisors) {
 			if (advisor.getAdvice() instanceof TransactionInterceptor transactionInterceptor) {
-				Assertions.assertEquals(transactionAttributeSource,
-						transactionInterceptor.getTransactionAttributeSource());
+				assertEquals(transactionAttributeSource, transactionInterceptor.getTransactionAttributeSource());
 			}
 		}
 	}
@@ -334,19 +335,21 @@ class JobRepositoryFactoryBeanTests {
 	@Test
 	public void testDefaultJobKeyGenerator() throws Exception {
 		testCreateRepository();
-		JobKeyGenerator jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
-		Assertions.assertEquals(DefaultJobKeyGenerator.class, jobKeyGenerator.getClass());
+		@SuppressWarnings("rawtypes")
+		JobKeyGenerator<?> jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
+		assertEquals(DefaultJobKeyGenerator.class, jobKeyGenerator.getClass());
 	}
 
 	@Test
 	public void testCustomJobKeyGenerator() throws Exception {
 		factory.setJobKeyGenerator(new CustomJobKeyGenerator());
 		testCreateRepository();
-		JobKeyGenerator jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
-		Assertions.assertEquals(CustomJobKeyGenerator.class, jobKeyGenerator.getClass());
+		@SuppressWarnings("rawtypes")
+		JobKeyGenerator<?> jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
+		assertEquals(CustomJobKeyGenerator.class, jobKeyGenerator.getClass());
 	}
 
-	class CustomJobKeyGenerator implements JobKeyGenerator<String> {
+	static class CustomJobKeyGenerator implements JobKeyGenerator<String> {
 
 		@Override
 		public String generateKey(String source) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryIntegrationTests.java
@@ -50,6 +50,7 @@ public class MongoDBJobRepositoryIntegrationTests {
 	@Autowired
 	private MongoTemplate mongoTemplate;
 
+	@SuppressWarnings("removal")
 	@BeforeEach
 	public void setUp() {
 		// collections

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryIntegrationTests.java
@@ -258,7 +258,7 @@ class SimpleJobRepositoryIntegrationTests {
 
 		jobRepository.deleteJobInstance(jobExecution.getJobInstance());
 
-		assertEquals(0, jobRepository.findJobInstancesByName(job.getName(), 0, 1).size());
+		assertEquals(0, jobRepository.getJobInstances(job.getName(), 0, 1).size());
 		assertNull(jobRepository.getLastJobExecution(job.getName(), jobParameters));
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
@@ -17,6 +17,7 @@
 package org.springframework.batch.core.repository.support;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -140,6 +141,7 @@ class SimpleJobRepositoryTests {
 		verify(this.jobInstanceDao).getJobNames();
 	}
 
+	@SuppressWarnings("removal")
 	@Test
 	void testFindJobInstancesByName() {
 		// given
@@ -151,9 +153,10 @@ class SimpleJobRepositoryTests {
 		this.jobRepository.findJobInstancesByName(jobName, start, count);
 
 		// then
-		verify(this.jobInstanceDao).findJobInstancesByName(jobName, start, count);
+		verify(this.jobInstanceDao).getJobInstances(jobName, start, count);
 	}
 
+	@SuppressWarnings("removal")
 	@Test
 	void testFindJobExecutions() {
 		// when
@@ -253,14 +256,14 @@ class SimpleJobRepositoryTests {
 	@Test
 	void testIsJobInstanceFalse() {
 		jobInstanceDao.getJobInstance("foo", new JobParameters());
-		assertFalse(jobRepository.isJobInstanceExists("foo", new JobParameters()));
+		assertNull(jobRepository.getJobInstance("foo", new JobParameters()));
 	}
 
 	@Test
 	void testIsJobInstanceTrue() {
 		when(jobInstanceDao.getJobInstance("foo", new JobParameters())).thenReturn(jobInstance);
 		jobInstanceDao.getJobInstance("foo", new JobParameters());
-		assertTrue(jobRepository.isJobInstanceExists("foo", new JobParameters()));
+		assertNotNull(jobRepository.getJobInstance("foo", new JobParameters()));
 	}
 
 	@Test

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/JobRepositorySupport.java
@@ -71,6 +71,7 @@ public class JobRepositorySupport implements JobRepository {
 	public void updateExecutionContext(StepExecution stepExecution) {
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 		return false;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/StepLocatorStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/StepLocatorStepFactoryBeanTests.java
@@ -74,7 +74,7 @@ class StepLocatorStepFactoryBeanTests {
 
 	@Test
 	void testGetObjectType() {
-		assertTrue((new StepLocatorStepFactoryBean()).getObjectType().isAssignableFrom(Step.class));
+		assertTrue(new StepLocatorStepFactoryBean().getObjectType().isAssignableFrom(Step.class));
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/AbstractExceptionThrowingItemHandlerStub.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/AbstractExceptionThrowingItemHandlerStub.java
@@ -66,11 +66,11 @@ public abstract class AbstractExceptionThrowingItemHandlerStub<T> {
 	protected void checkFailure(T item) throws Exception {
 		if (isFailure(item)) {
 			Throwable t = getException("Intended Failure: " + item);
-			if (t instanceof Exception) {
-				throw (Exception) t;
+			if (t instanceof Exception e) {
+				throw e;
 			}
-			if (t instanceof Error) {
-				throw (Error) t;
+			if (t instanceof Error error) {
+				throw error;
 			}
 			throw new IllegalStateException("Unexpected non-Error Throwable");
 		}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantChunkProviderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantChunkProviderTests.java
@@ -54,12 +54,8 @@ class FaultTolerantChunkProviderTests {
 
 	@Test
 	void testProvideWithOverflow() throws Exception {
-		provider = new FaultTolerantChunkProvider<>(new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() throws Exception, UnexpectedInputException, ParseException {
-				throw new RuntimeException("Planned");
-			}
+		provider = new FaultTolerantChunkProvider<>(() -> {
+			throw new RuntimeException("Planned");
 		}, new RepeatTemplate());
 		provider.setSkipPolicy(new LimitCheckingItemSkipPolicy(Integer.MAX_VALUE,
 				Collections.<Class<? extends Throwable>, Boolean>singletonMap(Exception.class, Boolean.TRUE)));

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanNonBufferingTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanNonBufferingTests.java
@@ -87,7 +87,6 @@ class FaultTolerantStepFactoryBeanNonBufferingTests {
 	 */
 	@Test
 	void testSkip() throws Exception {
-		@SuppressWarnings("unchecked")
 		SkipListener<Integer, String> skipListener = mock();
 		skipListener.onSkipInWrite("3", exception);
 		skipListener.onSkipInWrite("4", exception);
@@ -142,7 +141,7 @@ class FaultTolerantStepFactoryBeanNonBufferingTests {
 		}
 
 		@Override
-		public void write(Chunk<? extends String> items) throws Exception {
+		public void write(Chunk<? extends String> items) {
 			logger.debug("Writing: " + items);
 			for (String item : items) {
 				if (failures.contains(item)) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/FaultTolerantStepFactoryBeanRetryTests.java
@@ -661,19 +661,15 @@ class FaultTolerantStepFactoryBeanRetryTests {
 		factory.setSkipLimit(10);
 		// set the cache limit stupidly low
 		factory.setRetryContextCache(new MapRetryContextCache(0));
-		ItemReader<String> provider = new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() {
-				String item = String.valueOf(count);
-				provided.add(item);
-				count++;
-				if (count >= 10) {
-					// prevent infinite loop in worst case scenario
-					return null;
-				}
-				return item;
+		ItemReader<String> provider = () -> {
+			String item = String.valueOf(count);
+			provided.add(item);
+			count++;
+			if (count >= 10) {
+				// prevent infinite loop in worst case scenario
+				return null;
 			}
+			return item;
 		};
 		ItemWriter<String> itemWriter = chunk -> {
 			processed.addAll(chunk.getItems());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleChunkProviderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleChunkProviderTests.java
@@ -49,14 +49,12 @@ class SimpleChunkProviderTests {
 	void testProvideWithOverflow() throws Exception {
 		provider = new SimpleChunkProvider<>(new ListItemReader<>(Arrays.asList("foo", "bar")), new RepeatTemplate()) {
 			@Override
-			protected String read(StepContribution contribution, Chunk<String> chunk)
-					throws SkipOverflowException, Exception {
+			protected String read(StepContribution contribution, Chunk<String> chunk) {
 				chunk.skip(new RuntimeException("Planned"));
 				throw new SkipOverflowException("Overflow");
 			}
 		};
-		Chunk<String> chunk = null;
-		chunk = provider.provide(contribution);
+		Chunk<String> chunk = provider.provide(contribution);
 		assertNotNull(chunk);
 		assertEquals(0, chunk.getItems().size());
 		assertEquals(1, chunk.getErrors().size());

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -538,6 +538,7 @@ class TaskletStepExceptionTests {
 			return 0;
 		}
 
+		@SuppressWarnings("removal")
 		@Override
 		public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 			return false;

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/ConfigurableSystemProcessExitCodeMapperTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/ConfigurableSystemProcessExitCodeMapperTests.java
@@ -36,16 +36,13 @@ class ConfigurableSystemProcessExitCodeMapperTests {
 	 */
 	@Test
 	void testMapping() {
-		Map<Object, ExitStatus> mappings = new HashMap<>() {
-			{
-				put(0, ExitStatus.COMPLETED);
-				put(1, ExitStatus.FAILED);
-				put(2, ExitStatus.EXECUTING);
-				put(3, ExitStatus.NOOP);
-				put(4, ExitStatus.UNKNOWN);
-				put(ConfigurableSystemProcessExitCodeMapper.ELSE_KEY, ExitStatus.UNKNOWN);
-			}
-		};
+		Map<Object, ExitStatus> mappings = Map.of( //
+				0, ExitStatus.COMPLETED, //
+				1, ExitStatus.FAILED, //
+				2, ExitStatus.EXECUTING, //
+				3, ExitStatus.NOOP, //
+				4, ExitStatus.UNKNOWN, //
+				ConfigurableSystemProcessExitCodeMapper.ELSE_KEY, ExitStatus.UNKNOWN);
 
 		mapper.setMappings(mappings);
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/StepExecutorInterruptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/StepExecutorInterruptionTests.java
@@ -103,22 +103,18 @@ class StepExecutorInterruptionTests {
 		RepeatTemplate template = new RepeatTemplate();
 		// N.B, If we don't set the completion policy it might run forever
 		template.setCompletionPolicy(new SimpleCompletionPolicy(2));
-		step.setTasklet(new TestingChunkOrientedTasklet<>(new ItemReader<>() {
-			@Nullable
-			@Override
-			public Object read() throws Exception {
-				// do something non-trivial (and not Thread.sleep())
-				double foo = 1;
-				for (int i = 2; i < 250; i++) {
-					foo = foo * i;
-				}
+		step.setTasklet(new TestingChunkOrientedTasklet<>(() -> {
+			// do something non-trivial (and not Thread.sleep())
+			double foo = 1;
+			for (int i = 2; i < 250; i++) {
+				foo = foo * i;
+			}
 
-				if (foo != 1) {
-					return foo;
-				}
-				else {
-					return null;
-				}
+			if (foo != 1) {
+				return foo;
+			}
+			else {
+				return null;
 			}
 		}, itemWriter, template));
 
@@ -166,13 +162,7 @@ class StepExecutorInterruptionTests {
 
 		Thread processingThread = createThread(stepExecution);
 
-		step.setTasklet(new TestingChunkOrientedTasklet<>(new ItemReader<>() {
-			@Nullable
-			@Override
-			public Object read() throws Exception {
-				return null;
-			}
-		}, itemWriter));
+		step.setTasklet(new TestingChunkOrientedTasklet<>(() -> null, itemWriter));
 
 		processingThread.start();
 		Thread.sleep(100);
@@ -212,12 +202,8 @@ class StepExecutorInterruptionTests {
 			}
 		});
 
-		step.setTasklet(new TestingChunkOrientedTasklet<>(new ItemReader<>() {
-			@Nullable
-			@Override
-			public Object read() throws Exception {
-				throw new RuntimeException("Planned!");
-			}
+		step.setTasklet(new TestingChunkOrientedTasklet<>(() -> {
+			throw new RuntimeException("Planned!");
 		}, itemWriter));
 
 		jobRepository.add(stepExecution);

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/SystemCommandTaskletIntegrationTests.java
@@ -184,7 +184,7 @@ class SystemCommandTaskletIntegrationTests {
 	 * Command Runner is required to be set.
 	 */
 	@Test
-	public void testCommandRunnerNotSet() throws Exception {
+	public void testCommandRunnerNotSet() {
 		tasklet.setCommandRunner(null);
 		assertThrows(IllegalStateException.class, tasklet::afterPropertiesSet);
 	}
@@ -194,7 +194,10 @@ class SystemCommandTaskletIntegrationTests {
 	 */
 	@Test
 	void testCommandNotSet() {
-		tasklet.setCommand(null);
+		tasklet.setCommand();
+		assertThrows(IllegalStateException.class, tasklet::afterPropertiesSet);
+
+		tasklet.setCommand((String[]) null);
 		assertThrows(IllegalStateException.class, tasklet::afterPropertiesSet);
 
 		tasklet.setCommand("");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/tasklet/TaskletStepTests.java
@@ -242,14 +242,8 @@ class TaskletStepTests {
 	@Test
 	void testIncrementRollbackCount() {
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				throw new RuntimeException();
-			}
-
+		ItemReader<String> itemReader = () -> {
+			throw new RuntimeException();
 		};
 
 		step.setTasklet(new TestingChunkOrientedTasklet<>(itemReader, itemWriter));
@@ -268,14 +262,8 @@ class TaskletStepTests {
 	@Test
 	void testExitCodeDefaultClassification() {
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				throw new RuntimeException();
-
-			}
+		ItemReader<String> itemReader = () -> {
+			throw new RuntimeException();
 
 		};
 
@@ -295,14 +283,8 @@ class TaskletStepTests {
 	@Test
 	void testExitCodeCustomClassification() {
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				throw new RuntimeException();
-
-			}
+		ItemReader<String> itemReader = () -> {
+			throw new RuntimeException();
 
 		};
 
@@ -407,13 +389,7 @@ class TaskletStepTests {
 	 */
 	@Test
 	void testRestartJobOnNonRestartableTasklet() throws Exception {
-		step.setTasklet(new TestingChunkOrientedTasklet<>(new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				return "foo";
-			}
-		}, itemWriter));
+		step.setTasklet(new TestingChunkOrientedTasklet<>(() -> "foo", itemWriter));
 		JobExecution jobExecution = new JobExecution(jobInstance, jobParameters);
 		StepExecution stepExecution = new StepExecution(step.getName(), jobExecution);
 
@@ -599,14 +575,8 @@ class TaskletStepTests {
 
 		step.setInterruptionPolicy(interruptionPolicy);
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				throw new RuntimeException();
-
-			}
+		ItemReader<String> itemReader = () -> {
+			throw new RuntimeException();
 
 		};
 
@@ -627,13 +597,9 @@ class TaskletStepTests {
 	@Test
 	void testStatusForNormalFailure() throws Exception {
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				// Trigger a rollback
-				throw new RuntimeException("Foo");
-			}
+		ItemReader<String> itemReader = () -> {
+			// Trigger a rollback
+			throw new RuntimeException("Foo");
 		};
 		step.setTasklet(new TestingChunkOrientedTasklet<>(itemReader, itemWriter));
 
@@ -652,13 +618,9 @@ class TaskletStepTests {
 	@Test
 	void testStatusForErrorFailure() throws Exception {
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				// Trigger a rollback
-				throw new Error("Foo");
-			}
+		ItemReader<String> itemReader = () -> {
+			// Trigger a rollback
+			throw new Error("Foo");
 		};
 		step.setTasklet(new TestingChunkOrientedTasklet<>(itemReader, itemWriter));
 
@@ -678,13 +640,9 @@ class TaskletStepTests {
 	@Test
 	void testStatusForResetFailedException() throws Exception {
 
-		ItemReader<String> itemReader = new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() throws Exception {
-				// Trigger a rollback
-				throw new RuntimeException("Foo");
-			}
+		ItemReader<String> itemReader = () -> {
+			// Trigger a rollback
+			throw new RuntimeException("Foo");
 		};
 		step.setTasklet(new TestingChunkOrientedTasklet<>(itemReader, itemWriter));
 		step.setTransactionManager(new ResourcelessTransactionManager() {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/MySQLJdbcJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/test/repository/MySQLJdbcJobRepositoryIntegrationTests.java
@@ -101,6 +101,7 @@ class MySQLJdbcJobRepositoryIntegrationTests {
 	 * Note the issue does not happen if the parameter is of type Long (when using
 	 * addLong("date", date.getTime()) for instance).
 	 */
+	@SuppressWarnings("removal")
 	@Test
 	void testDateMillisecondPrecision() throws Exception {
 		// given

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 /**
  * Encapsulation of a list of items to be processed and possibly a list of failed items to
- * be skipped. To mark an item as skipped clients should iterate over the chunk using the
+ * be skipped. To mark an item as skipped, clients should iterate over the chunk using the
  * {@link #iterator()} method, and if there is a failure call
  * {@link Chunk.ChunkIterator#remove()} on the iterator. The skipped items are then
  * available through the chunk.
@@ -130,7 +130,7 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 	}
 
 	/**
-	 * @return true if there are no items in the chunk
+	 * @return {@code true} if there are no items in the chunk
 	 */
 	public boolean isEmpty() {
 		return items.isEmpty();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
@@ -29,9 +29,9 @@ import org.springframework.util.MethodInvoker;
 import org.springframework.util.StringUtils;
 
 /**
- * Superclass for delegating classes which dynamically call a custom method of injected
- * object. Provides convenient API for dynamic method invocation shielding subclasses from
- * low-level details and exception handling.
+ * Superclass for delegating classes which dynamically call a custom method of an injected
+ * object. Provides a convenient API for dynamic method invocation shielding subclasses
+ * from low-level details and exception handling.
  * <p>
  * {@link Exception}s thrown by a successfully invoked delegate method are re-thrown
  * without wrapping. In case the delegate method throws a {@link Throwable} that doesn't
@@ -164,7 +164,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 						if (arguments[j] == null) {
 							continue;
 						}
-						if (!(ClassUtils.isAssignableValue(params[j], arguments[j]))) {
+						if (!ClassUtils.isAssignableValue(params[j], arguments[j])) {
 							argumentsMatchParameters = false;
 						}
 					}
@@ -205,7 +205,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * will be supplied at runtime.
 	 */
 	public void setArguments(Object[] arguments) {
-		this.arguments = arguments == null ? null : Arrays.asList(arguments).toArray();
+		this.arguments = arguments == null ? null : arguments.clone();
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemWriter.java
@@ -77,8 +77,7 @@ public class PropertyExtractingDelegatingItemWriter<T> extends AbstractMethodInv
 	 * e.g. <code>address.city</code>
 	 */
 	public void setFieldsUsedAsTargetMethodArguments(String[] fieldsUsedAsMethodArguments) {
-		this.fieldsUsedAsTargetMethodArguments = Arrays.asList(fieldsUsedAsMethodArguments)
-			.toArray(new String[fieldsUsedAsMethodArguments.length]);
+		this.fieldsUsedAsTargetMethodArguments = fieldsUsedAsMethodArguments.clone();
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
@@ -44,7 +44,7 @@ import org.springframework.util.StringUtils;
 /**
  * <p>
  * A {@link org.springframework.batch.item.ItemReader} that reads records utilizing a
- * {@link org.springframework.data.repository.PagingAndSortingRepository}.
+ * {@link PagingAndSortingRepository}.
  * </p>
  *
  * <p>
@@ -54,9 +54,8 @@ import org.springframework.util.StringUtils;
  * </p>
  *
  * <p>
- * The reader must be configured with a
- * {@link org.springframework.data.repository.PagingAndSortingRepository}, a
- * {@link org.springframework.data.domain.Sort}, and a pageSize greater than 0.
+ * The reader must be configured with a {@link PagingAndSortingRepository}, a
+ * {@link Sort}, and a pageSize greater than 0.
  * </p>
  *
  * <p>
@@ -134,8 +133,7 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 	}
 
 	/**
-	 * The {@link org.springframework.data.repository.PagingAndSortingRepository}
-	 * implementation used to read input from.
+	 * The {@link PagingAndSortingRepository} implementation used to read input from.
 	 * @param repository underlying repository for input to be read from.
 	 */
 	public void setRepository(PagingAndSortingRepository<?, ?> repository) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
@@ -400,8 +400,8 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 			this.con.setAutoCommit(this.initialConnectionAutoCommit);
 		}
 
-		if (useSharedExtendedConnection && dataSource instanceof ExtendedConnectionDataSourceProxy) {
-			((ExtendedConnectionDataSourceProxy) dataSource).stopCloseSuppression(this.con);
+		if (useSharedExtendedConnection && dataSource instanceof ExtendedConnectionDataSourceProxy dataSourceProxy) {
+			dataSourceProxy.stopCloseSuppression(this.con);
 			if (!TransactionSynchronizationManager.isActualTransactionActive()) {
 				DataSourceUtils.releaseConnection(con, dataSource);
 			}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -146,7 +146,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	/**
 	 * A Map&lt;String, Boolean&gt; of sort columns as the key and boolean for
 	 * ascending/descending (ascending = true).
-	 * @return sortKey key to use to sort and limit page content
+	 * @return keys to use to sort and limit page content
 	 */
 	@Override
 	public Map<String, Order> getSortKeys() {
@@ -214,7 +214,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 
 	/**
 	 * Method generating the query string to be used for retrieving the pages following
-	 * the first page. This method must be implemented in sub classes.
+	 * the first page. This method must be implemented in subclasses.
 	 * @param pageSize number of rows to read per page
 	 * @return query string
 	 */

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Db2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/Db2PagingQueryProvider.java
@@ -45,7 +45,7 @@ public class Db2PagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("FETCH FIRST ").append(pageSize).append(" ROWS ONLY").toString();
+		return "FETCH FIRST " + pageSize + " ROWS ONLY";
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/DerbyPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/DerbyPagingQueryProvider.java
@@ -46,7 +46,7 @@ public class DerbyPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder("FETCH FIRST ").append(pageSize).append(" ROWS ONLY").toString();
+		return "FETCH FIRST " + pageSize + " ROWS ONLY";
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/H2PagingQueryProvider.java
@@ -38,7 +38,7 @@ public class H2PagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("FETCH NEXT ").append(pageSize).append(" ROWS ONLY").toString();
+		return "FETCH NEXT " + pageSize + " ROWS ONLY";
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HanaPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HanaPagingQueryProvider.java
@@ -44,7 +44,7 @@ public class HanaPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HsqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/HsqlPagingQueryProvider.java
@@ -46,7 +46,7 @@ public class HsqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+		return "TOP " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MariaDBPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MariaDBPagingQueryProvider.java
@@ -44,7 +44,7 @@ public class MariaDBPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MySqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/MySqlPagingQueryProvider.java
@@ -45,7 +45,7 @@ public class MySqlPagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/OraclePagingQueryProvider.java
@@ -38,7 +38,7 @@ public class OraclePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildRowNumClause(int pageSize) {
-		return new StringBuilder().append("ROWNUM <= ").append(pageSize).toString();
+		return "ROWNUM <= " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/PostgresPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/PostgresPagingQueryProvider.java
@@ -50,7 +50,7 @@ public class PostgresPagingQueryProvider extends AbstractSqlPagingQueryProvider 
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlServerPagingQueryProvider.java
@@ -46,7 +46,7 @@ public class SqlServerPagingQueryProvider extends AbstractSqlPagingQueryProvider
 	}
 
 	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+		return "TOP " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlitePagingQueryProvider.java
@@ -45,7 +45,7 @@ public class SqlitePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildLimitClause(int pageSize) {
-		return new StringBuilder().append("LIMIT ").append(pageSize).toString();
+		return "LIMIT " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SybasePagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SybasePagingQueryProvider.java
@@ -46,7 +46,7 @@ public class SybasePagingQueryProvider extends AbstractSqlPagingQueryProvider {
 	}
 
 	private String buildTopClause(int pageSize) {
-		return new StringBuilder().append("TOP ").append(pageSize).toString();
+		return "TOP " + pageSize;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemReader.java
@@ -141,8 +141,8 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 
 	private T readFromDelegate() throws Exception {
 		T item = delegate.read();
-		if (item instanceof ResourceAware) {
-			((ResourceAware) item).setResource(resources[currentResource]);
+		if (item instanceof ResourceAware resourceAware) {
+			resourceAware.setResource(resources[currentResource]);
 		}
 		return item;
 	}
@@ -222,7 +222,7 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	}
 
 	/**
-	 * Set the boolean indicating whether or not state should be saved in the provided
+	 * Set the boolean indicating whether state should be saved in the provided
 	 * {@link ExecutionContext} during the {@link ItemStream} call to update.
 	 * @param saveState true to update ExecutionContext. False do not update
 	 * ExecutionContext.
@@ -244,7 +244,7 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	 */
 	public void setResources(Resource[] resources) {
 		Assert.notNull(resources, "The resources must not be null");
-		this.resources = Arrays.asList(resources).toArray(new Resource[resources.length]);
+		this.resources = resources.clone();
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactory.java
@@ -53,7 +53,7 @@ public class SimpleBinaryBufferedReaderFactory implements BufferedReaderFactory 
 	}
 
 	@Override
-	public BufferedReader create(Resource resource, String encoding) throws UnsupportedEncodingException, IOException {
+	public BufferedReader create(Resource resource, String encoding) throws IOException {
 		return new BinaryBufferedReader(new InputStreamReader(resource.getInputStream(), encoding), lineEnding);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapper.java
@@ -291,7 +291,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 		// looking for a match.
 		if (index > 0) {
 			prefix = key.substring(0, index);
-			suffix = key.substring(index + 1, key.length());
+			suffix = key.substring(index + 1);
 			String nestedName = findPropertyName(bean, prefix);
 			if (nestedName == null) {
 				return null;
@@ -424,9 +424,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 			}
 			else if (!cls.equals(other.cls))
 				return false;
-			if (distance != other.distance)
-				return false;
-			return true;
+			return distance == other.distance;
 		}
 
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/AbstractLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/AbstractLineTokenizer.java
@@ -96,7 +96,7 @@ public abstract class AbstractLineTokenizer implements LineTokenizer {
 	}
 
 	/**
-	 * @return <code>true</code> if column names have been specified
+	 * @return {@code true} if column names have been specified
 	 * @see #setNames(String[])
 	 */
 	public boolean hasNames() {
@@ -121,7 +121,7 @@ public abstract class AbstractLineTokenizer implements LineTokenizer {
 		List<String> tokens = new ArrayList<>(doTokenize(line));
 
 		// if names are set and strict flag is false
-		if ((names.length != 0) && (!strict)) {
+		if (names.length != 0 && !strict) {
 			adjustTokenCountIfNecessary(tokens);
 		}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
@@ -41,12 +41,9 @@ public class BeanWrapperFieldExtractor<T> implements FieldExtractor<T>, Initiali
 	 */
 	public void setNames(String[] names) {
 		Assert.notNull(names, "Names must be non-null");
-		this.names = Arrays.asList(names).toArray(new String[names.length]);
+		this.names = names.clone();
 	}
 
-	/**
-	 * @see org.springframework.batch.item.file.transform.FieldExtractor#extract(java.lang.Object)
-	 */
 	@Override
 	public Object[] extract(T item) {
 		List<Object> values = new ArrayList<>();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/ConversionException.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/ConversionException.java
@@ -20,6 +20,7 @@ package org.springframework.batch.item.file.transform;
  * @author Mahmoud Ben Hassine
  *
  */
+@SuppressWarnings("unused") // FIXME no usage - should it be deprecated for removal?
 public class ConversionException extends RuntimeException {
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSet.java
@@ -67,9 +67,9 @@ public class DefaultFieldSet implements FieldSet {
 	 */
 	public final void setNumberFormat(NumberFormat numberFormat) {
 		this.numberFormat = numberFormat;
-		if (numberFormat instanceof DecimalFormat) {
-			grouping = String.valueOf(((DecimalFormat) numberFormat).getDecimalFormatSymbols().getGroupingSeparator());
-			decimal = String.valueOf(((DecimalFormat) numberFormat).getDecimalFormatSymbols().getDecimalSeparator());
+		if (numberFormat instanceof DecimalFormat decimalFormat) {
+			grouping = String.valueOf(decimalFormat.getDecimalFormatSymbols().getGroupingSeparator());
+			decimal = String.valueOf(decimalFormat.getDecimalFormatSymbols().getDecimalSeparator());
 		}
 	}
 
@@ -533,8 +533,8 @@ public class DefaultFieldSet implements FieldSet {
 		}
 		catch (ParseException e) {
 			String pattern;
-			if (dateFormat instanceof SimpleDateFormat) {
-				pattern = ((SimpleDateFormat) dateFormat).toPattern();
+			if (dateFormat instanceof SimpleDateFormat simpleDateFormat) {
+				pattern = simpleDateFormat.toPattern();
 			}
 			else {
 				pattern = dateFormat.toString();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
@@ -168,7 +168,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 
 				fieldCount++;
 
-				if (isEnd && (isDelimiter)) {
+				if (isEnd && isDelimiter) {
 					if (includedFields == null || includedFields.contains(fieldCount)) {
 						tokens.add("");
 					}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PassThroughFieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PassThroughFieldExtractor.java
@@ -59,8 +59,8 @@ public class PassThroughFieldExtractor<T> implements FieldExtractor<T> {
 			return ((Map<?, ?>) item).values().toArray();
 		}
 
-		if (item instanceof FieldSet) {
-			return ((FieldSet) item).getValues();
+		if (item instanceof FieldSet fieldSet) {
+			return fieldSet.getValues();
 		}
 
 		return new Object[] { item };

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditor.java
@@ -76,12 +76,12 @@ public class RangeArrayPropertyEditor extends PropertyEditorSupport {
 			int min;
 			int max;
 
-			if ((range.length == 1) && (StringUtils.hasText(range[0]))) {
+			if (range.length == 1 && StringUtils.hasText(range[0])) {
 				min = Integer.parseInt(range[0].trim());
 				// correct max value will be assigned later
 				ranges[i] = new Range(min);
 			}
-			else if ((range.length == 2) && (StringUtils.hasText(range[0])) && (StringUtils.hasText(range[1]))) {
+			else if (range.length == 2 && StringUtils.hasText(range[0]) && StringUtils.hasText(range[1])) {
 				min = Integer.parseInt(range[0].trim());
 				max = Integer.parseInt(range[1].trim());
 				ranges[i] = new Range(min, max);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsMethodArgumentsKeyGenerator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsMethodArgumentsKeyGenerator.java
@@ -43,9 +43,9 @@ public class JmsMethodArgumentsKeyGenerator implements MethodArgumentsKeyGenerat
 	@Override
 	public Object getKey(Object[] items) {
 		for (Object item : items) {
-			if (item instanceof Message) {
+			if (item instanceof Message message) {
 				try {
-					return ((Message) item).getJMSMessageID();
+					return message.getJMSMessageID();
 				}
 				catch (JMSException e) {
 					throw new UnexpectedInputException("Could not extract message ID", e);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsMethodInvocationRecoverer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsMethodInvocationRecoverer.java
@@ -43,11 +43,10 @@ public class JmsMethodInvocationRecoverer<T> implements MethodInvocationRecovere
 	}
 
 	/**
-	 * Send one message per item in the arguments list using the default destination of
-	 * the jms template. If the recovery is successful {@code null} is returned.
+	 * Send one message per item in the argument list using the default destination of the
+	 * jms template. If the recovery is successful {@code null} is returned.
 	 *
-	 * @see org.springframework.retry.interceptor.MethodInvocationRecoverer#recover(Object[],
-	 * Throwable)
+	 * @see MethodInvocationRecoverer#recover(Object[], Throwable)
 	 */
 	@Override
 	@Nullable

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsNewMethodArgumentsIdentifier.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsNewMethodArgumentsIdentifier.java
@@ -42,9 +42,9 @@ public class JmsNewMethodArgumentsIdentifier<T> implements NewMethodArgumentsIde
 	public boolean isNew(Object[] args) {
 
 		for (Object item : args) {
-			if (item instanceof Message) {
+			if (item instanceof Message message) {
 				try {
-					return !((Message) item).getJMSRedelivered();
+					return !message.getJMSRedelivered();
 				}
 				catch (JMSException e) {
 					throw new UnexpectedInputException("Could not extract message ID", e);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
@@ -404,14 +404,12 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		 * @throws IOException If unable to get the offset position
 		 */
 		public long position() throws IOException {
-			long pos = 0;
-
 			if (fileChannel == null) {
 				return 0;
 			}
 
 			outputBufferedWriter.flush();
-			pos = fileChannel.position();
+			long pos = fileChannel.position();
 			if (transactional) {
 				pos += ((TransactionAwareBufferedWriter) outputBufferedWriter).getBufferSize();
 			}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.java
@@ -91,8 +91,8 @@ public abstract class AbstractItemCountingItemStreamItemReader<T> extends Abstra
 		}
 		currentItemCount++;
 		T item = doRead();
-		if (item instanceof ItemCountAware) {
-			((ItemCountAware) item).setItemCount(currentItemCount);
+		if (item instanceof ItemCountAware itemCountAware) {
+			itemCountAware.setItemCount(currentItemCount);
 		}
 		return item;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
@@ -116,9 +116,9 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 		List<Exception> exceptions = new ArrayList<>();
 
 		for (ItemWriter<? super T> writer : delegates) {
-			if (!ignoreItemStream && (writer instanceof ItemStream)) {
+			if (!ignoreItemStream && (writer instanceof ItemStream itemStream)) {
 				try {
-					((ItemStream) writer).close();
+					itemStream.close();
 				}
 				catch (Exception e) {
 					exceptions.add(e);
@@ -137,8 +137,8 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		for (ItemWriter<? super T> writer : delegates) {
-			if (!ignoreItemStream && (writer instanceof ItemStream)) {
-				((ItemStream) writer).open(executionContext);
+			if (!ignoreItemStream && (writer instanceof ItemStream itemStream)) {
+				itemStream.open(executionContext);
 			}
 		}
 	}
@@ -146,8 +146,8 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		for (ItemWriter<? super T> writer : delegates) {
-			if (!ignoreItemStream && (writer instanceof ItemStream)) {
-				((ItemStream) writer).update(executionContext);
+			if (!ignoreItemStream && (writer instanceof ItemStream itemStream)) {
+				itemStream.update(executionContext);
 			}
 		}
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
@@ -138,11 +138,11 @@ public class ScriptItemProcessor<I, O> implements ItemProcessor<I, O>, Initializ
 		Assert.state(scriptSource == null || script == null,
 				"Either a script source or script file must be provided, not both");
 
-		if (scriptSource != null && scriptEvaluator instanceof StandardScriptEvaluator) {
+		if (scriptSource != null && scriptEvaluator instanceof StandardScriptEvaluator standardScriptEvaluator) {
 			Assert.state(StringUtils.hasLength(language),
 					"Language must be provided when using the default ScriptEvaluator and raw source code");
 
-			((StandardScriptEvaluator) scriptEvaluator).setLanguage(language);
+			standardScriptEvaluator.setLanguage(language);
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SingleItemPeekableItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SingleItemPeekableItemReader.java
@@ -101,10 +101,10 @@ public class SingleItemPeekableItemReader<T> implements ItemStreamReader<T>, Pee
 	@Override
 	public void close() throws ItemStreamException {
 		next = null;
-		if (delegate instanceof ItemStream) {
-			((ItemStream) delegate).close();
+		if (delegate instanceof ItemStream itemStream) {
+			itemStream.close();
 		}
-		executionContext = new ExecutionContext();
+		this.executionContext = new ExecutionContext();
 	}
 
 	/**
@@ -117,10 +117,10 @@ public class SingleItemPeekableItemReader<T> implements ItemStreamReader<T>, Pee
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		next = null;
-		if (delegate instanceof ItemStream) {
-			((ItemStream) delegate).open(executionContext);
+		if (delegate instanceof ItemStream itemStream) {
+			itemStream.open(executionContext);
 		}
-		executionContext = new ExecutionContext();
+		this.executionContext = new ExecutionContext();
 	}
 
 	/**
@@ -144,8 +144,8 @@ public class SingleItemPeekableItemReader<T> implements ItemStreamReader<T>, Pee
 	}
 
 	private void updateDelegate(ExecutionContext executionContext) {
-		if (delegate instanceof ItemStream) {
-			((ItemStream) delegate).update(executionContext);
+		if (delegate instanceof ItemStream itemStream) {
+			itemStream.update(executionContext);
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java
@@ -115,15 +115,14 @@ public class StaxEventItemReader<T> extends AbstractItemCountingItemStreamItemRe
 	}
 
 	/**
-	 * @param fragmentRootElementName name of the root element of the fragment
+	 * @param fragmentRootElementName the name of the fragment's root element
 	 */
 	public void setFragmentRootElementName(String fragmentRootElementName) {
 		setFragmentRootElementNames(new String[] { fragmentRootElementName });
 	}
 
 	/**
-	 * @param fragmentRootElementNames list of the names of the root element of the
-	 * fragment
+	 * @param fragmentRootElementNames the names of the fragment's root element
 	 */
 	public void setFragmentRootElementNames(String[] fragmentRootElementNames) {
 		this.fragmentRootElementNames = new ArrayList<>();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -813,8 +813,8 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 		try {
 			eventWriter.flush();
 			position = channel.position();
-			if (bufferedWriter instanceof TransactionAwareBufferedWriter) {
-				position += ((TransactionAwareBufferedWriter) bufferedWriter).getBufferSize();
+			if (bufferedWriter instanceof TransactionAwareBufferedWriter transactionAwareBufferedWriter) {
+				position += transactionAwareBufferedWriter.getBufferSize();
 			}
 		}
 		catch (Exception e) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/NoStartEndDocumentStreamWriter.java
@@ -35,7 +35,7 @@ public class NoStartEndDocumentStreamWriter extends AbstractEventWriterWrapper {
 
 	@Override
 	public void add(XMLEvent event) throws XMLStreamException {
-		if ((!event.isStartDocument()) && (!event.isEndDocument())) {
+		if (!event.isStartDocument() && !event.isEndDocument()) {
 			wrappedEventWriter.add(event);
 		}
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
@@ -53,11 +53,11 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 			return true;
 		}
 		AttributeAccessorSupport that;
-		if (other instanceof SynchronizedAttributeAccessor) {
-			that = ((SynchronizedAttributeAccessor) other).support;
+		if (other instanceof SynchronizedAttributeAccessor synchronizedAttributeAccessor) {
+			that = synchronizedAttributeAccessor.support;
 		}
-		else if (other instanceof AttributeAccessorSupport) {
-			that = (AttributeAccessorSupport) other;
+		else if (other instanceof AttributeAccessorSupport attributeAccessorSupport) {
+			that = attributeAccessorSupport;
 		}
 		else {
 			return false;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/interceptor/RepeatOperationsInterceptor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/interceptor/RepeatOperationsInterceptor.java
@@ -74,9 +74,9 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 			repeatOperations.iterate(context -> {
 				try {
 
-					MethodInvocation clone = invocation;
-					if (invocation instanceof ProxyMethodInvocation) {
-						clone = ((ProxyMethodInvocation) invocation).invocableClone();
+					MethodInvocation clone;
+					if (invocation instanceof ProxyMethodInvocation proxyMethodInvocation) {
+						clone = proxyMethodInvocation.invocableClone();
 					}
 					else {
 						throw new IllegalStateException(
@@ -97,12 +97,12 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 						return RepeatStatus.FINISHED;
 					}
 				}
-				catch (Throwable e) {
-					if (e instanceof Exception) {
-						throw (Exception) e;
+				catch (Throwable t) {
+					if (t instanceof Exception e) {
+						throw e;
 					}
 					else {
-						throw new RepeatOperationsInterceptorException("Unexpected error in batch interceptor", e);
+						throw new RepeatOperationsInterceptorException("Unexpected error in batch interceptor", t);
 					}
 				}
 			});
@@ -122,7 +122,7 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 	}
 
 	private boolean isComplete(Object result) {
-		return result == null || (result instanceof Boolean) && !(Boolean) result;
+		return (result == null) || ((result instanceof Boolean b) && !b);
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/CompletionPolicySupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/CompletionPolicySupport.java
@@ -73,8 +73,8 @@ public class CompletionPolicySupport implements CompletionPolicy {
 	 */
 	@Override
 	public void update(RepeatContext context) {
-		if (context instanceof RepeatContextSupport) {
-			((RepeatContextSupport) context).increment();
+		if (context instanceof RepeatContextSupport repeatContextSupport) {
+			repeatContextSupport.increment();
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/RepeatTemplate.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/RepeatTemplate.java
@@ -309,11 +309,11 @@ public class RepeatTemplate implements RepeatOperations {
 	 * {@link RepeatException}.
 	 */
 	private static void rethrow(Throwable throwable) throws RuntimeException {
-		if (throwable instanceof Error) {
-			throw (Error) throwable;
+		if (throwable instanceof Error error) {
+			throw error;
 		}
-		else if (throwable instanceof RuntimeException) {
-			throw (RuntimeException) throwable;
+		else if (throwable instanceof RuntimeException runtimeException) {
+			throw runtimeException;
 		}
 		else {
 			throw new RepeatException("Exception in batch process", throwable);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ResultHolderResultQueue.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ResultHolderResultQueue.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Semaphore;
  * @author Mahmoud Ben Hassine
  * @deprecated since 5.0 with no replacement. Scheduled for removal in 6.0.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "5.0", forRemoval = true)
 public class ResultHolderResultQueue implements ResultQueue<ResultHolder> {
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplate.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplate.java
@@ -77,6 +77,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 	 * need to synchronize access.
 	 *
 	 */
+	@SuppressWarnings("removal")
 	@Override
 	protected RepeatStatus getNextResult(RepeatContext context, RepeatCallback callback, RepeatInternalState state)
 			throws Throwable {
@@ -134,6 +135,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 	 *
 	 * @see org.springframework.batch.repeat.support.RepeatTemplate#waitForResults(org.springframework.batch.repeat.support.RepeatInternalState)
 	 */
+	@SuppressWarnings("removal")
 	@Override
 	protected boolean waitForResults(RepeatInternalState state) {
 
@@ -185,6 +187,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 	 * @author Dave Syer
 	 *
 	 */
+	@SuppressWarnings("removal")
 	private class ExecutingRunnable implements Runnable, ResultHolder {
 
 		private final RepeatCallback callback;
@@ -288,6 +291,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 	 * @author Dave Syer
 	 *
 	 */
+	@SuppressWarnings("removal")
 	private static class ResultQueueInternalState extends RepeatInternalStateSupport {
 
 		private final ResultQueue<ResultHolder> results;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueue.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueue.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Semaphore;
  * @author Mahmoud Ben Hassine
  * @deprecated since 5.0 with no replacement. Scheduled for removal in 6.0.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "5.0", forRemoval = true)
 public class ThrottleLimitResultQueue<T> implements ResultQueue<T> {
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodInvokerUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodInvokerUtils.java
@@ -116,7 +116,7 @@ public abstract class MethodInvokerUtils {
 	public static MethodInvoker getMethodInvokerByAnnotation(final Class<? extends Annotation> annotationType,
 			final Object target, final Class<?>... expectedParamTypes) {
 		MethodInvoker mi = MethodInvokerUtils.getMethodInvokerByAnnotation(annotationType, target);
-		final Class<?> targetClass = (target instanceof Advised) ? ((Advised) target).getTargetSource().getTargetClass()
+		final Class<?> targetClass = (target instanceof Advised advised) ? advised.getTargetSource().getTargetClass()
 				: target.getClass();
 		if (mi != null) {
 			ReflectionUtils.doWithMethods(targetClass, method -> {
@@ -156,7 +156,7 @@ public abstract class MethodInvokerUtils {
 		Assert.isTrue(
 				ObjectUtils.containsElement(annotationType.getAnnotation(Target.class).value(), ElementType.METHOD),
 				"Annotation [" + annotationType + "] is not a Method-level annotation.");
-		final Class<?> targetClass = (target instanceof Advised) ? ((Advised) target).getTargetSource().getTargetClass()
+		final Class<?> targetClass = (target instanceof Advised advised) ? advised.getTargetSource().getTargetClass()
 				: target.getClass();
 		if (targetClass == null) {
 			// Proxy with no target cannot have annotations

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/PatternMatcher.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/PatternMatcher.java
@@ -46,8 +46,8 @@ public class PatternMatcher<S> {
 	}
 
 	/**
-	 * Lifted from AntPathMatcher in Spring Core. Tests whether or not a string matches
-	 * against a pattern. The pattern may contain two special characters:<br>
+	 * Lifted from AntPathMatcher in Spring Core. Tests whether a string matches against a
+	 * pattern. The pattern may contain two special characters:<br>
 	 * '*' means zero or more characters<br>
 	 * '?' means one and only one character
 	 * @param pattern pattern to match against. Must not be <code>null</code>.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/SimpleMethodInvoker.java
@@ -135,7 +135,7 @@ public class SimpleMethodInvoker implements MethodInvoker {
 		if (obj == this) {
 			return true;
 		}
-		return (rhs.method.equals(this.method)) && (rhs.object.equals(this.object));
+		return rhs.method.equals(this.method) && rhs.object.equals(this.object);
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
@@ -86,26 +86,26 @@ public class TransactionAwareProxyFactory<T> {
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected final T begin(T target) {
-		// Unfortunately in Java 5 this method has to synchronized
+		// Unfortunately in Java 5 this method has to be synchronized
 		// (works OK without in Java 6).
 		synchronized (target) {
-			if (target instanceof List) {
+			if (target instanceof List list) {
 				if (appendOnly) {
 					return (T) new ArrayList();
 				}
-				return (T) new ArrayList((List) target);
+				return (T) new ArrayList(list);
 			}
-			else if (target instanceof Set) {
+			else if (target instanceof Set set) {
 				if (appendOnly) {
 					return (T) new HashSet();
 				}
-				return (T) new HashSet((Set) target);
+				return (T) new HashSet(set);
 			}
-			else if (target instanceof Map) {
+			else if (target instanceof Map map) {
 				if (appendOnly) {
 					return (T) new HashMap();
 				}
-				return (T) new HashMap((Map) target);
+				return (T) new HashMap(map);
 			}
 			else {
 				throw new UnsupportedOperationException("Cannot copy target for this type: " + target.getClass());
@@ -124,11 +124,11 @@ public class TransactionAwareProxyFactory<T> {
 		// Unfortunately in Java 5 this method has to be synchronized
 		// (works OK without in Java 6).
 		synchronized (target) {
-			if (target instanceof Collection) {
+			if (target instanceof Collection collection) {
 				if (!appendOnly) {
-					((Collection) target).clear();
+					collection.clear();
 				}
-				((Collection) target).addAll((Collection) copy);
+				collection.addAll((Collection) copy);
 			}
 			else {
 				if (!appendOnly) {
@@ -239,11 +239,11 @@ public class TransactionAwareProxyFactory<T> {
 
 			if (appendOnly) {
 				String methodName = invocation.getMethod().getName();
-				if ((result == null && methodName.equals("get"))
-						|| (Boolean.FALSE.equals(result) && (methodName.startsWith("contains"))
+				if (((result == null) && methodName.equals("get"))
+						|| ((Boolean.FALSE.equals(result) && methodName.startsWith("contains"))
 								|| (Boolean.TRUE.equals(result) && methodName.startsWith("isEmpty")))) {
-					// In appendOnly mode the result of a get might not be
-					// in the cache...
+					// In appendOnly mode, the result of a get might not be in the
+					// cache...
 					return invocation.proceed();
 				}
 				if (result instanceof Collection<?>) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainer.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainer.java
@@ -103,15 +103,15 @@ public class BatchMessageListenerContainer extends DefaultMessageListenerContain
 			return;
 		}
 		logger.debug("Re-throwing exception in container.");
-		if (ex instanceof RuntimeException) {
+		if (ex instanceof RuntimeException runtimeException) {
 			// We need to re-throw so that an enclosing non-JMS transaction can
 			// rollback...
-			throw (RuntimeException) ex;
+			throw runtimeException;
 		}
-		else if (ex instanceof Error) {
-			// Just re-throw Error instances because otherwise unit tests just
-			// swallow exceptions from EasyMock and JUnit.
-			throw (Error) ex;
+		else if (ex instanceof Error error) {
+			// Just re-throw Error instances because otherwise unit tests just swallow
+			// exceptions from EasyMock and JUnit.
+			throw error;
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainerTests.java
@@ -121,8 +121,7 @@ class BatchMessageListenerContainerTests {
 	private BatchMessageListenerContainer getContainer(RepeatTemplate template) {
 		ConnectionFactory connectionFactory = mock();
 		// Yuck: we need to turn these method in base class to no-ops because the invoker
-		// is a private class
-		// we can't create for test purposes...
+		// is a private class we can't create for test purposes...
 		BatchMessageListenerContainer container = new BatchMessageListenerContainer() {
 			@Override
 			protected void messageReceived(Object invoker, Session session) {
@@ -141,12 +140,12 @@ class BatchMessageListenerContainerTests {
 		return container;
 	}
 
-	private boolean doTestWithException(final Throwable t, boolean expectRollback, int expectGetTransactionCount)
+	private boolean doTestWithException(Throwable t, boolean expectRollback, int expectGetTransactionCount)
 			throws JMSException, IllegalAccessException {
 		container.setAcceptMessagesWhileStopping(true);
 		container.setMessageListener((MessageListener) arg0 -> {
-			if (t instanceof RuntimeException)
-				throw (RuntimeException) t;
+			if (t instanceof RuntimeException runtimeException)
+				throw runtimeException;
 			else
 				throw (Error) t;
 		});
@@ -159,16 +158,14 @@ class BatchMessageListenerContainerTests {
 			when(session.getTransacted()).thenReturn(true);
 		}
 
-		// Expect only one call to consumer (chunk size is 2, but first one
-		// rolls back terminating batch)...
+		// Expect only one call to consumer (chunk size is 2, but first one rolls back
+		// terminating batch)...
 		when(consumer.receive(1000)).thenReturn(message);
 		if (expectRollback) {
 			session.rollback();
 		}
 
-		boolean received = doExecute(session, consumer);
-
-		return received;
+		return doExecute(session, consumer);
 	}
 
 	private boolean doExecute(Session session, MessageConsumer consumer) throws IllegalAccessException {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/example/AvroTestUtils.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/example/AvroTestUtils.java
@@ -42,6 +42,7 @@ class AvroTestUtils {
 			createTestData();
 		}
 		catch (Exception e) {
+			// ignored
 		}
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/example/User.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/example/User.java
@@ -119,15 +119,18 @@ public class User extends org.apache.avro.specific.SpecificRecordBase
 		this.favorite_color = favorite_color;
 	}
 
+	@Override
 	public SpecificData getSpecificData() {
 		return MODEL$;
 	}
 
+	@Override
 	public org.apache.avro.Schema getSchema() {
 		return SCHEMA$;
 	}
 
 	// Used by DatumWriter. Applications should not call.
+	@Override
 	public Object get(int field$) {
 		return switch (field$) {
 			case 0 -> name;
@@ -138,7 +141,7 @@ public class User extends org.apache.avro.specific.SpecificRecordBase
 	}
 
 	// Used by DatumReader. Applications should not call.
-	@SuppressWarnings(value = "unchecked")
+	@Override
 	public void put(int field$, Object value$) {
 		switch (field$) {
 			case 0 -> name = (CharSequence) value$;
@@ -476,7 +479,7 @@ public class User extends org.apache.avro.specific.SpecificRecordBase
 	public void customDecode(org.apache.avro.io.ResolvingDecoder in) throws java.io.IOException {
 		org.apache.avro.Schema.Field[] fieldOrder = in.readFieldOrderIfDiff();
 		if (fieldOrder == null) {
-			this.name = in.readString(this.name instanceof Utf8 ? (Utf8) this.name : null);
+			this.name = in.readString(this.name instanceof Utf8 utf8 ? utf8 : null);
 
 			if (in.readIndex() != 0) {
 				in.readNull();
@@ -491,15 +494,14 @@ public class User extends org.apache.avro.specific.SpecificRecordBase
 				this.favorite_color = null;
 			}
 			else {
-				this.favorite_color = in
-					.readString(this.favorite_color instanceof Utf8 ? (Utf8) this.favorite_color : null);
+				this.favorite_color = in.readString(this.favorite_color instanceof Utf8 utf8 ? utf8 : null);
 			}
 
 		}
 		else {
 			for (int i = 0; i < 3; i++) {
 				switch (fieldOrder[i].pos()) {
-					case 0 -> this.name = in.readString(this.name instanceof Utf8 ? (Utf8) this.name : null);
+					case 0 -> this.name = in.readString(this.name instanceof Utf8 utf8 ? utf8 : null);
 					case 1 -> {
 						if (in.readIndex() != 0) {
 							in.readNull();
@@ -515,8 +517,7 @@ public class User extends org.apache.avro.specific.SpecificRecordBase
 							this.favorite_color = null;
 						}
 						else {
-							this.favorite_color = in
-								.readString(this.favorite_color instanceof Utf8 ? (Utf8) this.favorite_color : null);
+							this.favorite_color = in.readString(this.favorite_color instanceof Utf8 utf8 ? utf8 : null);
 						}
 					}
 					default -> throw new java.io.IOException("Corrupt ResolvingDecoder.");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoCursorItemReaderTest.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/MongoCursorItemReaderTest.java
@@ -204,7 +204,7 @@ class MongoCursorItemReaderTest {
 
 	@Test
 	void testQueryWithMaxTime() throws Exception {
-		reader.setMaxTime(Duration.ofMillis(3000));
+		reader.setMaxTime(Duration.ofSeconds(3));
 		ArgumentCaptor<Query> queryContainer = ArgumentCaptor.forClass(Query.class);
 
 		when(template.stream(queryContainer.capture(), eq(String.class))).thenReturn(Stream.of());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilderTests.java
@@ -45,7 +45,7 @@ public class MongoCursorItemReaderBuilderTests {
 		Map<String, Sort.Direction> sorts = mock();
 		int batchSize = 100;
 		int limit = 10000;
-		Duration maxTime = Duration.ofMillis(1000);
+		Duration maxTime = Duration.ofSeconds(1);
 
 		// when
 		MongoCursorItemReader<String> reader = new MongoCursorItemReaderBuilder<String>().name("reader")

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/ExtendedConnectionDataSourceProxyTests.java
@@ -278,38 +278,38 @@ class ExtendedConnectionDataSourceProxyTests {
 		private static final String UNWRAP_ERROR_MESSAGE = "supplied type is not implemented by this class";
 
 		@Override
-		public Connection getConnection() throws SQLException {
+		public Connection getConnection() {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public Connection getConnection(String username, String password) throws SQLException {
+		public Connection getConnection(String username, String password) {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public PrintWriter getLogWriter() throws SQLException {
+		public PrintWriter getLogWriter() {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public int getLoginTimeout() throws SQLException {
+		public int getLoginTimeout() {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void setLogWriter(PrintWriter out) throws SQLException {
+		public void setLogWriter(PrintWriter out) {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public void setLoginTimeout(int seconds) throws SQLException {
+		public void setLoginTimeout(int seconds) {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public boolean isWrapperFor(Class<?> iface) throws SQLException {
-			if (iface.equals(Supported.class) || (iface.equals(DataSource.class))) {
+		public boolean isWrapperFor(Class<?> iface) {
+			if (iface.equals(Supported.class) || iface.equals(DataSource.class)) {
 				return true;
 			}
 			return false;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaNativeQueryProviderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JpaNativeQueryProviderIntegrationTests.java
@@ -71,7 +71,7 @@ public class JpaNativeQueryProviderIntegrationTests {
 		@SuppressWarnings("unchecked")
 		List<Foo> actualFoos = query.getResultList();
 
-		assertEquals(actualFoos, expectedFoos);
+		assertEquals(expectedFoos, actualFoos);
 	}
 
 	@Test
@@ -96,7 +96,7 @@ public class JpaNativeQueryProviderIntegrationTests {
 		@SuppressWarnings("unchecked")
 		List<Foo> actualFoos = query.getResultList();
 
-		assertEquals(actualFoos, expectedFoos);
+		assertEquals(expectedFoos, actualFoos);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactoryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactoryTests.java
@@ -93,7 +93,7 @@ class SimpleBinaryBufferedReaderFactoryTests {
 		SimpleBinaryBufferedReaderFactory factory = new SimpleBinaryBufferedReaderFactory();
 		factory.setLineEnding("#@");
 		@SuppressWarnings("resource")
-		BufferedReader reader = factory.create(new ByteArrayResource(("a##@").getBytes()), "UTF-8");
+		BufferedReader reader = factory.create(new ByteArrayResource("a##@".getBytes()), "UTF-8");
 		assertEquals("a#", reader.readLine());
 		assertNull(reader.readLine());
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -44,6 +44,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -579,15 +580,16 @@ class FlatFileItemReaderBuilderTests {
 		// then
 		Object lineMapper = ReflectionTestUtils.getField(reader, "lineMapper");
 		assertNotNull(lineMapper);
-		assertTrue(lineMapper instanceof DefaultLineMapper);
+		assertInstanceOf(DefaultLineMapper.class, lineMapper);
 		Object fieldSetMapper = ReflectionTestUtils.getField(lineMapper, "fieldSetMapper");
 		assertNotNull(fieldSetMapper);
-		assertTrue(fieldSetMapper instanceof RecordFieldSetMapper);
+		assertInstanceOf(RecordFieldSetMapper.class, fieldSetMapper);
 	}
 
 	@Test
 	void testSetupWithClassTargetType() {
 		// given
+		@SuppressWarnings("unused")
 		class Person {
 
 			int id;
@@ -607,10 +609,10 @@ class FlatFileItemReaderBuilderTests {
 		// then
 		Object lineMapper = ReflectionTestUtils.getField(reader, "lineMapper");
 		assertNotNull(lineMapper);
-		assertTrue(lineMapper instanceof DefaultLineMapper);
+		assertInstanceOf(DefaultLineMapper.class, lineMapper);
 		Object fieldSetMapper = ReflectionTestUtils.getField(lineMapper, "fieldSetMapper");
 		assertNotNull(fieldSetMapper);
-		assertTrue(fieldSetMapper instanceof BeanWrapperFieldSetMapper);
+		assertInstanceOf(BeanWrapperFieldSetMapper.class, fieldSetMapper);
 	}
 
 	private Resource getResource(String contents) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilderTests.java
@@ -38,6 +38,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -347,16 +348,18 @@ class FlatFileItemWriterBuilderTests {
 		// then
 		Object lineAggregator = ReflectionTestUtils.getField(writer, "lineAggregator");
 		assertNotNull(lineAggregator);
-		assertTrue(lineAggregator instanceof DelimitedLineAggregator);
+		assertInstanceOf(DelimitedLineAggregator.class, lineAggregator);
 		Object fieldExtractor = ReflectionTestUtils.getField(lineAggregator, "fieldExtractor");
 		assertNotNull(fieldExtractor);
-		assertTrue(fieldExtractor instanceof RecordFieldExtractor);
+		assertInstanceOf(RecordFieldExtractor.class, fieldExtractor);
 	}
 
 	@Test
 	void testSetupDelimitedLineAggregatorWithClassItemType() throws IOException {
 		// given
 		WritableResource output = new FileSystemResource(File.createTempFile("foo", "txt"));
+
+		@SuppressWarnings("unused")
 		class Person {
 
 			int id;
@@ -376,10 +379,10 @@ class FlatFileItemWriterBuilderTests {
 		// then
 		Object lineAggregator = ReflectionTestUtils.getField(writer, "lineAggregator");
 		assertNotNull(lineAggregator);
-		assertTrue(lineAggregator instanceof DelimitedLineAggregator);
+		assertInstanceOf(DelimitedLineAggregator.class, lineAggregator);
 		Object fieldExtractor = ReflectionTestUtils.getField(lineAggregator, "fieldExtractor");
 		assertNotNull(fieldExtractor);
-		assertTrue(fieldExtractor instanceof BeanWrapperFieldExtractor);
+		assertInstanceOf(BeanWrapperFieldExtractor.class, fieldExtractor);
 	}
 
 	@Test
@@ -388,7 +391,7 @@ class FlatFileItemWriterBuilderTests {
 		WritableResource output = new FileSystemResource(File.createTempFile("foo", "txt"));
 
 		// when
-		FlatFileItemWriter writer = new FlatFileItemWriterBuilder<>().name("personWriter")
+		FlatFileItemWriter<Object> writer = new FlatFileItemWriterBuilder<>().name("personWriter")
 			.resource(output)
 			.delimited()
 			.names("id", "name")
@@ -397,10 +400,10 @@ class FlatFileItemWriterBuilderTests {
 		// then
 		Object lineAggregator = ReflectionTestUtils.getField(writer, "lineAggregator");
 		assertNotNull(lineAggregator);
-		assertTrue(lineAggregator instanceof DelimitedLineAggregator);
+		assertInstanceOf(DelimitedLineAggregator.class, lineAggregator);
 		Object fieldExtractor = ReflectionTestUtils.getField(lineAggregator, "fieldExtractor");
 		assertNotNull(fieldExtractor);
-		assertTrue(fieldExtractor instanceof BeanWrapperFieldExtractor);
+		assertInstanceOf(BeanWrapperFieldExtractor.class, fieldExtractor);
 	}
 
 	@Test
@@ -422,16 +425,18 @@ class FlatFileItemWriterBuilderTests {
 		// then
 		Object lineAggregator = ReflectionTestUtils.getField(writer, "lineAggregator");
 		assertNotNull(lineAggregator);
-		assertTrue(lineAggregator instanceof FormatterLineAggregator);
+		assertInstanceOf(FormatterLineAggregator.class, lineAggregator);
 		Object fieldExtractor = ReflectionTestUtils.getField(lineAggregator, "fieldExtractor");
 		assertNotNull(fieldExtractor);
-		assertTrue(fieldExtractor instanceof RecordFieldExtractor);
+		assertInstanceOf(RecordFieldExtractor.class, fieldExtractor);
 	}
 
 	@Test
 	void testSetupFormatterLineAggregatorWithClassItemType() throws IOException {
 		// given
 		WritableResource output = new FileSystemResource(File.createTempFile("foo", "txt"));
+
+		@SuppressWarnings("unused")
 		class Person {
 
 			int id;
@@ -452,10 +457,10 @@ class FlatFileItemWriterBuilderTests {
 		// then
 		Object lineAggregator = ReflectionTestUtils.getField(writer, "lineAggregator");
 		assertNotNull(lineAggregator);
-		assertTrue(lineAggregator instanceof FormatterLineAggregator);
+		assertInstanceOf(FormatterLineAggregator.class, lineAggregator);
 		Object fieldExtractor = ReflectionTestUtils.getField(lineAggregator, "fieldExtractor");
 		assertNotNull(fieldExtractor);
-		assertTrue(fieldExtractor instanceof BeanWrapperFieldExtractor);
+		assertInstanceOf(BeanWrapperFieldExtractor.class, fieldExtractor);
 	}
 
 	@Test
@@ -474,10 +479,10 @@ class FlatFileItemWriterBuilderTests {
 		// then
 		Object lineAggregator = ReflectionTestUtils.getField(writer, "lineAggregator");
 		assertNotNull(lineAggregator);
-		assertTrue(lineAggregator instanceof FormatterLineAggregator);
+		assertInstanceOf(FormatterLineAggregator.class, lineAggregator);
 		Object fieldExtractor = ReflectionTestUtils.getField(lineAggregator, "fieldExtractor");
 		assertNotNull(fieldExtractor);
-		assertTrue(fieldExtractor instanceof BeanWrapperFieldExtractor);
+		assertInstanceOf(BeanWrapperFieldExtractor.class, fieldExtractor);
 	}
 
 	private void validateBuilderFlags(FlatFileItemWriter<Foo> writer, String encoding) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/function/PredicateFilteringItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/function/PredicateFilteringItemProcessorTests.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.batch.item.function;
 
-import java.util.function.Predicate;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +25,6 @@ import org.junit.jupiter.api.Test;
  */
 class PredicateFilteringItemProcessorTests {
 
-	private final Predicate<String> foos = item -> item.startsWith("foo");
-
 	@Test
 	void testMandatoryPredicate() {
 		Assertions.assertThrows(IllegalArgumentException.class, () -> new PredicateFilteringItemProcessor<String>(null),
@@ -38,7 +34,8 @@ class PredicateFilteringItemProcessorTests {
 	@Test
 	void testProcess() throws Exception {
 		// given
-		PredicateFilteringItemProcessor<String> processor = new PredicateFilteringItemProcessor<>(this.foos);
+		PredicateFilteringItemProcessor<String> processor = new PredicateFilteringItemProcessor<>(
+				item -> item.startsWith("foo"));
 
 		// when & then
 		Assertions.assertNull(processor.process("foo1"));

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -700,8 +700,7 @@ class StaxEventItemReaderTests {
 			List<XMLEvent> events = new ArrayList<>();
 			do {
 				eventInsideFragment = eventReader.peek();
-				if (eventInsideFragment instanceof EndElement
-						&& fragmentName.equals(((EndElement) eventInsideFragment).getName())) {
+				if (eventInsideFragment instanceof EndElement endElement && fragmentName.equals(endElement.getName())) {
 					break;
 				}
 				events.add(eventReader.nextEvent());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemWriterTests.java
@@ -387,7 +387,7 @@ class StaxEventItemWriterTests {
 		writer.open(executionContext);
 		writer.write(items);
 		String content = getOutputFileContent();
-		assertTrue(content.contains(("<header/>")), "Wrong content: " + content);
+		assertTrue(content.contains("<header/>"), "Wrong content: " + content);
 		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
 	}
 
@@ -612,10 +612,10 @@ class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue(content.contains(("<root xmlns=\"https://www.springframework.org/test\">")),
+		assertTrue(content.contains("<root xmlns=\"https://www.springframework.org/test\">"),
 				"Wrong content: " + content);
 		assertTrue(content.contains(TEST_STRING), "Wrong content: " + content);
-		assertTrue(content.contains(("</root>")), "Wrong content: " + content);
+		assertTrue(content.contains("</root>"), "Wrong content: " + content);
 	}
 
 	/**
@@ -631,11 +631,11 @@ class StaxEventItemWriterTests {
 		writer.write(items);
 		writer.close();
 		String content = getOutputFileContent();
-		assertTrue(content.contains(("<ns:root xmlns:ns=\"https://www.springframework.org/test\">")),
+		assertTrue(content.contains("<ns:root xmlns:ns=\"https://www.springframework.org/test\">"),
 				"Wrong content: " + content);
 		assertTrue(content.contains(NS_TEST_STRING), "Wrong content: " + content);
-		assertTrue(content.contains(("</ns:root>")), "Wrong content: " + content);
-		assertTrue(content.contains(("<ns:root")), "Wrong content: " + content);
+		assertTrue(content.contains("</ns:root>"), "Wrong content: " + content);
+		assertTrue(content.contains("<ns:root"), "Wrong content: " + content);
 	}
 
 	/**
@@ -653,11 +653,11 @@ class StaxEventItemWriterTests {
 		writer.close();
 		String content = getOutputFileContent();
 		assertTrue(content.contains(
-				("<ns:root xmlns:ns=\"https://www.springframework.org/test\" " + "xmlns:foo=\"urn:org.test.foo\">")),
+				"<ns:root xmlns:ns=\"https://www.springframework.org/test\" " + "xmlns:foo=\"urn:org.test.foo\">"),
 				"Wrong content: " + content);
 		assertTrue(content.contains(FOO_TEST_STRING), "Wrong content: " + content);
-		assertTrue(content.contains(("</ns:root>")), "Wrong content: " + content);
-		assertTrue(content.contains(("<ns:root")), "Wrong content: " + content);
+		assertTrue(content.contains("</ns:root>"), "Wrong content: " + content);
+		assertTrue(content.contains("<ns:root"), "Wrong content: " + content);
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/TransactionalStaxEventItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/TransactionalStaxEventItemWriterTests.java
@@ -138,7 +138,7 @@ class TransactionalStaxEventItemWriterTests {
 		});
 		writer.close();
 		String content = outputFileContent();
-		assertEquals(1, StringUtils.countOccurrencesOf(content, ("<header/>")), "Wrong content: " + content);
+		assertEquals(1, StringUtils.countOccurrencesOf(content, "<header/>"), "Wrong content: " + content);
 		assertEquals(1, StringUtils.countOccurrencesOf(content, TEST_STRING), "Wrong content: " + content);
 	}
 
@@ -183,7 +183,7 @@ class TransactionalStaxEventItemWriterTests {
 				}));
 		writer.close();
 		String content = outputFileContent();
-		assertEquals(1, StringUtils.countOccurrencesOf(content, ("<header/>")), "Wrong content: " + content);
+		assertEquals(1, StringUtils.countOccurrencesOf(content, "<header/>"), "Wrong content: " + content);
 		assertEquals(1, StringUtils.countOccurrencesOf(content, TEST_STRING), "Wrong content: " + content);
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/jms/ExternalRetryInBatchTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/jms/ExternalRetryInBatchTests.java
@@ -70,14 +70,10 @@ class ExternalRetryInBatchTests {
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "T_BARS");
 		jmsTemplate.convertAndSend("queue", "foo");
 		jmsTemplate.convertAndSend("queue", "bar");
-		provider = new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() {
-				String text = (String) jmsTemplate.receiveAndConvert("queue");
-				list.add(text);
-				return text;
-			}
+		provider = () -> {
+			String text = (String) jmsTemplate.receiveAndConvert("queue");
+			list.add(text);
+			return text;
 		};
 		retryTemplate = new RetryTemplate();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandlerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandlerTests.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -152,19 +154,14 @@ class SimpleLimitExceptionHandlerTests {
 		handler.setLimit(EXCEPTION_LIMIT);
 		handler.afterPropertiesSet();
 
-		@SuppressWarnings("serial")
-		List<Throwable> throwables = new ArrayList<>() {
-			{
-				for (int i = 0; i < (EXCEPTION_LIMIT); i++) {
-					add(new RuntimeException("below exception limit"));
-				}
-			}
-		};
+		List<RuntimeException> exceptions = IntStream.range(0, EXCEPTION_LIMIT)
+			.mapToObj(__ -> new RuntimeException("below exception limit"))
+			.toList();
 
 		RepeatContextSupport context = new RepeatContextSupport(null);
 
-		for (Throwable throwable : throwables) {
-			assertDoesNotThrow(() -> handler.handleException(context, throwable));
+		for (RuntimeException exception : exceptions) {
+			assertDoesNotThrow(() -> handler.handleException(context, exception));
 		}
 
 	}
@@ -180,22 +177,17 @@ class SimpleLimitExceptionHandlerTests {
 		handler.setLimit(EXCEPTION_LIMIT);
 		handler.afterPropertiesSet();
 
-		@SuppressWarnings("serial")
-		List<Throwable> throwables = new ArrayList<>() {
-			{
-				for (int i = 0; i < (EXCEPTION_LIMIT); i++) {
-					add(new RuntimeException("below exception limit"));
-				}
-			}
-		};
+		List<RuntimeException> exceptions = IntStream.range(0, EXCEPTION_LIMIT)
+			.mapToObj(__ -> new RuntimeException("below exception limit"))
+			.collect(Collectors.toCollection(ArrayList::new));
 
-		throwables.add(new RuntimeException("above exception limit"));
+		exceptions.add(new RuntimeException("above exception limit"));
 
 		RepeatContextSupport context = new RepeatContextSupport(null);
 
 		Exception expected = assertThrows(RuntimeException.class, () -> {
-			for (Throwable throwable : throwables) {
-				handler.handleException(context, throwable);
+			for (Throwable exception : exceptions) {
+				handler.handleException(context, exception);
 			}
 		});
 		assertEquals("above exception limit", expected.getMessage());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ResultHolderResultQueueTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ResultHolderResultQueueTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatStatus;
 
+@SuppressWarnings("removal")
 class ResultHolderResultQueueTests {
 
 	private final ResultHolderResultQueue queue = new ResultHolderResultQueue(10);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueueTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ThrottleLimitResultQueueTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
  * @author Mahmoud Ben Hassine
  *
  */
+@SuppressWarnings("removal")
 class ThrottleLimitResultQueueTests {
 
 	private final ThrottleLimitResultQueue<String> queue = new ThrottleLimitResultQueue<>(1);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/ExternalRetryTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/retry/jms/ExternalRetryTests.java
@@ -62,14 +62,10 @@ class ExternalRetryTests {
 		getMessages(); // drain queue
 		JdbcTestUtils.deleteFromTables(jdbcTemplate, "T_BARS");
 		jmsTemplate.convertAndSend("queue", "foo");
-		provider = new ItemReader<>() {
-			@Nullable
-			@Override
-			public String read() {
-				String text = (String) jmsTemplate.receiveAndConvert("queue");
-				list.add(text);
-				return text;
-			}
+		provider = () -> {
+			String text = (String) jmsTemplate.receiveAndConvert("queue");
+			list.add(text);
+			return text;
 		};
 		retryTemplate = new RetryTemplate();
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ConcurrentTransactionAwareProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ConcurrentTransactionAwareProxyTests.java
@@ -108,7 +108,7 @@ class ConcurrentTransactionAwareProxyTests {
 	@Test
 	void testTransactionalContains() {
 		final Map<Long, Map<String, String>> map = TransactionAwareProxyFactory.createAppendOnlyTransactionalMap();
-		boolean result = new TransactionTemplate(transactionManager).execute(status -> map.containsKey("foo"));
+		boolean result = new TransactionTemplate(transactionManager).execute(status -> map.containsKey(0L));
 		assertFalse(result);
 	}
 
@@ -177,7 +177,7 @@ class ConcurrentTransactionAwareProxyTests {
 		for (int i = 0; i < outerMax; i++) {
 
 			for (int j = 0; j < numberOfKeys; j++) {
-				final long id = j * 1000 + 123L + i;
+				final long id = j * 1000L + 123L + i;
 
 				completionService.submit(() -> {
 					List<String> list = new ArrayList<>();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -75,10 +75,10 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>>, Initiali
 			catch (ExecutionException e) {
 				Throwable cause = e.getCause();
 
-				if (cause instanceof Exception) {
+				if (cause instanceof Exception exception) {
 					logger.debug("An exception was thrown while processing an item", e);
 
-					throw (Exception) cause;
+					throw exception;
 				}
 				else {
 					throw e;

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkMessageChannelItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkMessageChannelItemWriter.java
@@ -260,11 +260,11 @@ public class ChunkMessageChannelItemWriter<T>
 	 * {@link AsynchronousFailureException}.
 	 */
 	protected static AsynchronousFailureException wrapIfNecessary(Throwable throwable) {
-		if (throwable instanceof Error) {
-			throw (Error) throwable;
+		if (throwable instanceof Error error) {
+			throw error;
 		}
-		else if (throwable instanceof AsynchronousFailureException) {
-			return (AsynchronousFailureException) throwable;
+		else if (throwable instanceof AsynchronousFailureException exception) {
+			return exception;
 		}
 		else {
 			return new AsynchronousFailureException("Exception in remote process", throwable);

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkHandlerFactoryBean.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/RemoteChunkHandlerFactoryBean.java
@@ -139,8 +139,8 @@ public class RemoteChunkHandlerFactoryBean<T> implements FactoryBean<ChunkHandle
 				+ "] because it already has a remote chunk writer.  Use a local writer in the step.");
 
 		replaceChunkProcessor((ChunkOrientedTasklet<?>) tasklet, chunkWriter, stepContributionSource);
-		if (chunkWriter instanceof StepExecutionListener) {
-			step.registerStepExecutionListener((StepExecutionListener) chunkWriter);
+		if (chunkWriter instanceof StepExecutionListener stepExecutionListener) {
+			step.registerStepExecutionListener(stepExecutionListener);
 		}
 
 		ChunkProcessorChunkHandler<T> handler = new ChunkProcessorChunkHandler<>();

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandler.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandler.java
@@ -109,6 +109,7 @@ public class MessageChannelPartitionHandler extends AbstractPartitionHandler imp
 	 */
 	private PollableChannel replyChannel;
 
+	@SuppressWarnings("removal")
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(stepName != null, "A step name must be provided for the remote workers.");

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobRepositorySupport.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/JobRepositorySupport.java
@@ -76,6 +76,7 @@ public class JobRepositorySupport implements JobRepository {
 	public void update(StepExecution stepExecution) {
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	public boolean isJobInstanceExists(String jobName, JobParameters jobParameters) {
 		return false;

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/item/MessagingGatewayIntegrationTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/item/MessagingGatewayIntegrationTests.java
@@ -92,7 +92,7 @@ class MessagingGatewayIntegrationTests {
 			if (input.equals("filter")) {
 				return null;
 			}
-			return input + ": " + (count++);
+			return input + ": " + count++;
 		}
 
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/partition/MessageChannelPartitionHandlerTests.java
@@ -128,7 +128,6 @@ class MessageChannelPartitionHandlerTests {
 
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Test
 	void messageReceiveTimeout() throws Exception {
 		// execute with no default set
@@ -137,12 +136,10 @@ class MessageChannelPartitionHandlerTests {
 		StepExecution managerStepExecution = mock();
 		StepExecutionSplitter stepExecutionSplitter = mock();
 		MessagingTemplate operations = mock();
-		Message message = mock();
 		// when
 		HashSet<StepExecution> stepExecutions = new HashSet<>();
 		stepExecutions.add(new StepExecution("step1", new JobExecution(5L)));
 		when(stepExecutionSplitter.split(any(StepExecution.class), eq(1))).thenReturn(stepExecutions);
-		when(message.getPayload()).thenReturn(Collections.emptyList());
 		// set
 		messageChannelPartitionHandler.setMessagingOperations(operations);
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/chunking/ManagerConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/chunking/ManagerConfiguration.java
@@ -110,7 +110,7 @@ public class ManagerConfiguration {
 	@Bean
 	public TaskletStep managerStep() {
 		return this.managerStepBuilderFactory.get("managerStep")
-			.<Integer, Integer>chunk(3)
+			.chunk(3)
 			.reader(itemReader())
 			.outputChannel(requests())
 			.inputChannel(replies())

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/CustomerCredit.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/trade/CustomerCredit.java
@@ -81,7 +81,7 @@ public class CustomerCredit {
 
 	@Override
 	public boolean equals(Object o) {
-		return (o instanceof CustomerCredit) && ((CustomerCredit) o).id == id;
+		return (o instanceof CustomerCredit customerCredit) && customerCredit.id == id;
 	}
 
 	@Override

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/file/multirecordtype/DelegatingTradeLineAggregator.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/file/multirecordtype/DelegatingTradeLineAggregator.java
@@ -32,11 +32,11 @@ public class DelegatingTradeLineAggregator implements LineAggregator<Object> {
 
 	@Override
 	public String aggregate(Object item) {
-		if (item instanceof Trade) {
-			return this.tradeLineAggregator.aggregate((Trade) item);
+		if (item instanceof Trade trade) {
+			return this.tradeLineAggregator.aggregate(trade);
 		}
-		else if (item instanceof CustomerCredit) {
-			return this.customerLineAggregator.aggregate((CustomerCredit) item);
+		else if (item instanceof CustomerCredit customerCredit) {
+			return this.customerLineAggregator.aggregate(customerCredit);
 		}
 		else {
 			throw new RuntimeException();

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/file/patternmatching/internal/validator/OrderValidator.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/file/patternmatching/internal/validator/OrderValidator.java
@@ -256,8 +256,8 @@ public class OrderValidator implements Validator {
 				errors.rejectValue(prefix + ".zipCode", "error.baddress.zipcode.format");
 			}
 
-			if ((!StringUtils.hasText(address.getState()) && ("United States".equals(address.getCountry()))
-					|| StringUtils.hasText(address.getState()) && address.getState().length() != 2)) {
+			if ((!StringUtils.hasText(address.getState()) && "United States".equals(address.getCountry()))
+					|| (StringUtils.hasText(address.getState()) && (address.getState().length() != 2))) {
 				errors.rejectValue(prefix + ".state", "error.baddress.state.length");
 			}
 

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/misc/quartz/JobLauncherDetails.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/misc/quartz/JobLauncherDetails.java
@@ -92,8 +92,8 @@ public class JobLauncherDetails extends QuartzJobBean {
 		for (Entry<String, Object> entry : jobDataMap.entrySet()) {
 			String key = entry.getKey();
 			Object value = entry.getValue();
-			if (value instanceof String && !key.equals(JOB_NAME)) {
-				builder.addString(key, (String) value);
+			if (value instanceof String s && !key.equals(JOB_NAME)) {
+				builder.addString(key, s);
 			}
 			else if (value instanceof Float || value instanceof Double) {
 				builder.addDouble(key, ((Number) value).doubleValue());
@@ -101,8 +101,8 @@ public class JobLauncherDetails extends QuartzJobBean {
 			else if (value instanceof Integer || value instanceof Long) {
 				builder.addLong(key, ((Number) value).longValue());
 			}
-			else if (value instanceof Date) {
-				builder.addDate(key, (Date) value);
+			else if (value instanceof Date date) {
+				builder.addDate(key, date);
 			}
 			else {
 				log.debug("JobDataMap contains values which are not job parameters (ignoring).");

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/partitioning/remote/BasicPartitioner.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/partitioning/remote/BasicPartitioner.java
@@ -35,7 +35,7 @@ public class BasicPartitioner extends SimplePartitioner {
 		Map<String, ExecutionContext> partitions = super.partition(gridSize);
 		int i = 0;
 		for (ExecutionContext context : partitions.values()) {
-			context.put(PARTITION_KEY, PARTITION_KEY + (i++));
+			context.put(PARTITION_KEY, PARTITION_KEY + i++);
 		}
 		return partitions;
 	}

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/compositewriter/CompositeItemWriterSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/compositewriter/CompositeItemWriterSampleFunctionalTests.java
@@ -74,15 +74,12 @@ class CompositeItemWriterSampleFunctionalTests {
 	}
 
 	private void checkOutputTable(int before) {
-		final List<Trade> trades = new ArrayList<>() {
-			{
-				add(new Trade("UK21341EAH41", 211, new BigDecimal("31.11"), "customer1"));
-				add(new Trade("UK21341EAH42", 212, new BigDecimal("32.11"), "customer2"));
-				add(new Trade("UK21341EAH43", 213, new BigDecimal("33.11"), "customer3"));
-				add(new Trade("UK21341EAH44", 214, new BigDecimal("34.11"), "customer4"));
-				add(new Trade("UK21341EAH45", 215, new BigDecimal("35.11"), "customer5"));
-			}
-		};
+		final List<Trade> trades = List.of( //
+				new Trade("UK21341EAH41", 211, new BigDecimal("31.11"), "customer1"),
+				new Trade("UK21341EAH42", 212, new BigDecimal("32.11"), "customer2"),
+				new Trade("UK21341EAH43", 213, new BigDecimal("33.11"), "customer3"),
+				new Trade("UK21341EAH44", 214, new BigDecimal("34.11"), "customer4"),
+				new Trade("UK21341EAH45", 215, new BigDecimal("35.11"), "customer5"));
 
 		int after = JdbcTestUtils.countRowsInTable(jdbcTemplate, "TRADE");
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/file/patternmatching/PatternMatchingJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/file/patternmatching/PatternMatchingJobFunctionalTests.java
@@ -28,6 +28,8 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
 @SpringJUnitConfig(locations = { "/org/springframework/batch/samples/file/patternmatching/job/multilineOrderJob.xml",
 		"/simple-job-launcher-context.xml" })
 class PatternMatchingJobFunctionalTests {
@@ -44,7 +46,7 @@ class PatternMatchingJobFunctionalTests {
 		this.jobLauncherTestUtils.launchJob();
 		Path expectedFile = new ClassPathResource(EXPECTED).getFile().toPath();
 		Path actualFile = new FileSystemResource(ACTUAL).getFile().toPath();
-		Assertions.assertLinesMatch(Files.lines(expectedFile), Files.lines(actualFile));
+		assertLinesMatch(Files.lines(expectedFile), Files.lines(actualFile));
 	}
 
 }

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/filter/CustomerFilterJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/filter/CustomerFilterJobFunctionalTests.java
@@ -81,8 +81,8 @@ class CustomerFilterJobFunctionalTests {
 	void testFilterJob() throws Exception {
 		JobExecution jobExecution = jobLauncherTestUtils.launchJob();
 
-		customers = Arrays.asList(new Customer("customer1", (credits.get("customer1"))),
-				new Customer("customer2", (credits.get("customer2"))), new Customer("customer3", 100500),
+		customers = Arrays.asList(new Customer("customer1", credits.get("customer1")),
+				new Customer("customer2", credits.get("customer2")), new Customer("customer3", 100500),
 				new Customer("customer4", credits.get("customer4")), new Customer("customer5", 32345),
 				new Customer("customer6", 123456));
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/misc/jmx/RemoteLauncherTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/misc/jmx/RemoteLauncherTests.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Mahmoud Ben Hassine
  *
  */
+@SuppressWarnings("removal")
 class RemoteLauncherTests {
 
 	private static final Log logger = LogFactory.getLog(RemoteLauncherTests.class);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/partition/file/PartitionFileJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/partition/file/PartitionFileJobFunctionalTests.java
@@ -85,7 +85,6 @@ class PartitionFileJobFunctionalTests implements ApplicationContextAware {
 		int itemCount = inputs.size();
 		assertTrue(itemCount > 0, "No entries were available in the input");
 
-		inputs.iterator();
 		for (int i = 0; i < itemCount; i++) {
 			assertEquals(inputs.get(i).getCredit().add(CustomerCreditIncreaseProcessor.FIXED_AMOUNT).intValue(),
 					outputs.get(i).getCredit().intValue());
@@ -110,8 +109,8 @@ class PartitionFileJobFunctionalTests implements ApplicationContextAware {
 	 * Open the reader if applicable.
 	 */
 	private void open(ItemReader<?> reader) {
-		if (reader instanceof ItemStream) {
-			((ItemStream) reader).open(new ExecutionContext());
+		if (reader instanceof ItemStream itemStream) {
+			itemStream.open(new ExecutionContext());
 		}
 	}
 
@@ -119,8 +118,8 @@ class PartitionFileJobFunctionalTests implements ApplicationContextAware {
 	 * Close the reader if applicable.
 	 */
 	private void close(ItemReader<?> reader) {
-		if (reader instanceof ItemStream) {
-			((ItemStream) reader).close();
+		if (reader instanceof ItemStream itemStream) {
+			itemStream.close();
 		}
 	}
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/partition/jdbc/PartitionJdbcJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/partition/jdbc/PartitionJdbcJobFunctionalTests.java
@@ -85,7 +85,6 @@ class PartitionJdbcJobFunctionalTests implements ApplicationContextAware {
 		int itemCount = inputs.size();
 		assertTrue(itemCount > 0, "Input from reader has no entries.");
 
-		inputs.iterator();
 		for (int i = 0; i < itemCount; i++) {
 			assertEquals(inputs.get(i).getCredit().add(CustomerCreditIncreaseProcessor.FIXED_AMOUNT).intValue(),
 					outputs.get(i).getCredit().intValue());
@@ -109,8 +108,8 @@ class PartitionJdbcJobFunctionalTests implements ApplicationContextAware {
 	 * Open the reader if applicable.
 	 */
 	private void open(ItemReader<?> reader) {
-		if (reader instanceof ItemStream) {
-			((ItemStream) reader).open(new ExecutionContext());
+		if (reader instanceof ItemStream itemStream) {
+			itemStream.open(new ExecutionContext());
 		}
 	}
 
@@ -118,8 +117,8 @@ class PartitionJdbcJobFunctionalTests implements ApplicationContextAware {
 	 * Close the reader if applicable.
 	 */
 	private void close(ItemReader<?> reader) {
-		if (reader instanceof ItemStream) {
-			((ItemStream) reader).close();
+		if (reader instanceof ItemStream itemStream) {
+			itemStream.close();
 		}
 	}
 

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/GracefulShutdownFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/GracefulShutdownFunctionalTests.java
@@ -55,6 +55,7 @@ class GracefulShutdownFunctionalTests {
 	@Autowired
 	private JobOperator jobOperator;
 
+	@SuppressWarnings("removal")
 	@Test
 	void testLaunchJob() throws Exception {
 		final JobParameters jobParameters = new JobParametersBuilder().addLong("timestamp", System.currentTimeMillis())

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/JobOperatorFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/JobOperatorFunctionalTests.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("removal")
 @SpringJUnitConfig(locations = { "/org/springframework/batch/samples/restart/stop/stopRestartSample.xml" })
 class JobOperatorFunctionalTests {
 
@@ -49,6 +50,7 @@ class JobOperatorFunctionalTests {
 	@Autowired
 	private Job job;
 
+	@SuppressWarnings("removal")
 	@Test
 	void testStartStopResumeJob() throws Exception {
 		String params = "jobOperatorTestParam=7,java.lang.Long,true";

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/skip/SkipSampleFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/skip/SkipSampleFunctionalTests.java
@@ -312,6 +312,7 @@ class SkipSampleFunctionalTests {
 	 * Launch the entire job, including all steps, in order.
 	 * @return JobExecution, so that the test may validate the exit status
 	 */
+	@SuppressWarnings("removal")
 	public long launchJobWithIncrementer() {
 		SkipCheckingListener.resetProcessSkips();
 		try {

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobRepositoryTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobRepositoryTestUtils.java
@@ -166,16 +166,16 @@ public class JobRepositoryTestUtils {
 		for (String jobName : jobNames) {
 			int start = 0;
 			int count = 100;
-			List<JobInstance> jobInstances = this.jobRepository.findJobInstancesByName(jobName, start, count);
+			List<JobInstance> jobInstances = this.jobRepository.getJobInstances(jobName, start, count);
 			while (!jobInstances.isEmpty()) {
 				for (JobInstance jobInstance : jobInstances) {
-					List<JobExecution> jobExecutions = this.jobRepository.findJobExecutions(jobInstance);
+					List<JobExecution> jobExecutions = this.jobRepository.getJobExecutions(jobInstance);
 					if (jobExecutions != null && !jobExecutions.isEmpty()) {
 						removeJobExecutions(jobExecutions);
 					}
 				}
 				start += count;
-				jobInstances = this.jobRepository.findJobInstancesByName(jobName, start, count);
+				jobInstances = this.jobRepository.getJobInstances(jobName, start, count);
 			}
 		}
 	}


### PR DESCRIPTION
This PR introduces ErrorProne, sets the `maven-compiler-plugin` to fail in case of compiler warnings, and fixes all the warnings.

This is a preparation for:
* #4673