### PR TITLE
Fix NullPointerException in MongoSequenceIncrementer

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MongoSequenceIncrementer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/MongoSequenceIncrementer.java
@@ -47,7 +47,7 @@ public class MongoSequenceIncrementer implements DataFieldMaxValueIncrementer {
 		return mongoTemplate.execute("BATCH_SEQUENCES",
 				collection -> collection
 					.findOneAndUpdate(new Document("_id", sequenceName), new Document("$inc", new Document("count", 1)),
-							new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER))
+							new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER).upsert(true))
 					.getLong("count"));
 	}
 


### PR DESCRIPTION
When using a MongoDB repository for the first time, the collections used by MongoSequenceIncrementer don't yet exist, which results in the call to findOneAndUpdate().getLong() to reutrn a null, which then results in an NPE unboxing the Long into a long.

Adding upsert(true) creates the initial document with a count of 0 and immediately increments it to 1.
