### PR TITLE
Mark argument to ExitStatus#equals as nullable

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 import java.io.PrintWriter;
@@ -198,7 +199,7 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(@Nullable Object obj) {
 		if (obj == null) {
 			return false;
 		}


### PR DESCRIPTION
I think this commit will fix this question of mine from 5 years ago https://stackoverflow.com/questions/56653315/why-is-kotlin-double-equals-not-finding-a-equals-method