### PR TITLE
Fix javadoc in JdbcCursorItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
@@ -164,7 +164,7 @@ public class JdbcCursorItemReaderBuilder<T> {
 	}
 
 	/**
-	 * The time in milliseconds for the query to timeout
+	 * The time in seconds for the query to timeout
 	 * @param queryTimeout timeout
 	 * @return this instance for method chaining
 	 * @see JdbcCursorItemReader#setQueryTimeout(int)


### PR DESCRIPTION
  - JdbcCursorItemReaderBuilder's javadoc queryTimeout(int) -> milliseconds
  - but, AbstractCursorItmeReader's javadoc setQueryTimeout(int) -> seconds

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md