### PR TITLE
Fix javadoc in JdbcCursorItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
@@ -164,7 +164,7 @@ public class JdbcCursorItemReaderBuilder<T> {
 	}
 
 	/**
-	 * The time in milliseconds for the query to timeout
+	 * The time in seconds for the query to timeout
 	 * @param queryTimeout timeout
 	 * @return this instance for method chaining
 	 * @see JdbcCursorItemReader#setQueryTimeout(int)


### PR DESCRIPTION
  - JdbcCursorItemReaderBuilder.queryTimeout(int) -> milliseconds
  - but, AbstractCursorItemReader.setQueryTimeout(int) -> seconds