### PR TITLE
Remove usage of `JobFactory` in `JobRegistry`

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/JobRegistry.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/JobRegistry.java
@@ -28,11 +28,11 @@ public interface JobRegistry extends ListableJobLocator {
 
 	/**
 	 * Registers a {@link Job} at runtime.
-	 * @param jobFactory the {@link Job} to be registered
-	 * @throws DuplicateJobException if a factory with the same job name has already been
+	 * @param job the {@link Job} to be registered
+	 * @throws DuplicateJobException if a job with the same name has already been
 	 * registered.
 	 */
-	void register(JobFactory jobFactory) throws DuplicateJobException;
+	void register(Job job) throws DuplicateJobException;
 
 	/**
 	 * Unregisters a previously registered {@link Job}. If it was not previously

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultJobLoader.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/DefaultJobLoader.java
@@ -27,7 +27,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.DuplicateJobException;
-import org.springframework.batch.core.configuration.JobFactory;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.configuration.StepRegistry;
 import org.springframework.batch.core.launch.NoSuchJobException;
@@ -251,8 +250,7 @@ public class DefaultJobLoader implements JobLoader, InitializingBean {
 	 * @throws DuplicateJobException if that job is already registered
 	 */
 	private void doRegister(ConfigurableApplicationContext context, Job job) throws DuplicateJobException {
-		final JobFactory jobFactory = new ReferenceJobFactory(job);
-		jobRegistry.register(jobFactory);
+		jobRegistry.register(job);
 
 		if (stepRegistry != null) {
 			if (!(job instanceof StepLocator)) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobFactoryRegistrationListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobFactoryRegistrationListener.java
@@ -53,7 +53,7 @@ public class JobFactoryRegistrationListener {
 		if (logger.isInfoEnabled()) {
 			logger.info("Binding JobFactory: " + jobFactory.getJobName());
 		}
-		jobRegistry.register(jobFactory);
+		jobRegistry.register(jobFactory.createJob());
 	}
 
 	/**

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingleton.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/JobRegistrySmartInitializingSingleton.java
@@ -143,12 +143,11 @@ public class JobRegistrySmartInitializingSingleton
 				groupName = getGroupName(defaultListableBeanFactory.getBeanDefinition(beanName), job);
 			}
 			job = groupName == null ? job : new GroupAwareJob(groupName, job);
-			ReferenceJobFactory jobFactory = new ReferenceJobFactory(job);
-			String name = jobFactory.getJobName();
+			String name = job.getName();
 			if (logger.isDebugEnabled()) {
 				logger.debug("Registering job: " + name);
 			}
-			jobRegistry.register(jobFactory);
+			jobRegistry.register(job);
 			jobNames.add(name);
 		}
 		catch (DuplicateJobException e) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/MapJobRegistry.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/MapJobRegistry.java
@@ -42,14 +42,14 @@ public class MapJobRegistry implements JobRegistry {
 	 */
 	// The "final" ensures that it is visible and initialized when the constructor
 	// resolves.
-	private final ConcurrentMap<String, JobFactory> map = new ConcurrentHashMap<>();
+	private final ConcurrentMap<String, Job> map = new ConcurrentHashMap<>();
 
 	@Override
-	public void register(JobFactory jobFactory) throws DuplicateJobException {
-		Assert.notNull(jobFactory, "jobFactory is null");
-		String name = jobFactory.getJobName();
+	public void register(Job job) throws DuplicateJobException {
+		Assert.notNull(job, "job is null");
+		String name = job.getName();
 		Assert.notNull(name, "Job configuration must have a name.");
-		JobFactory previousValue = map.putIfAbsent(name, jobFactory);
+		Job previousValue = map.putIfAbsent(name, job);
 		if (previousValue != null) {
 			throw new DuplicateJobException("A job configuration with this name [" + name + "] was already registered");
 		}
@@ -63,12 +63,12 @@ public class MapJobRegistry implements JobRegistry {
 
 	@Override
 	public Job getJob(@Nullable String name) throws NoSuchJobException {
-		JobFactory factory = map.get(name);
-		if (factory == null) {
+		Job job = map.get(name);
+		if (job == null) {
 			throw new NoSuchJobException("No job configuration with the name [" + name + "] was registered");
 		}
 		else {
-			return factory.createJob();
+			return job;
 		}
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobFactoryRegistrationListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/JobFactoryRegistrationListenerTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.configuration.JobFactory;
+import org.springframework.batch.core.job.SimpleJob;
 
 /**
  * @author Dave Syer
@@ -37,7 +38,7 @@ class JobFactoryRegistrationListenerTests {
 		listener.bind(new JobFactory() {
 			@Override
 			public Job createJob() {
-				return null;
+				return new SimpleJob("foo");
 			}
 
 			@Override
@@ -54,7 +55,7 @@ class JobFactoryRegistrationListenerTests {
 		listener.unbind(new JobFactory() {
 			@Override
 			public Job createJob() {
-				return null;
+				return new SimpleJob("foo");
 			}
 
 			@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/MapJobRegistryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/MapJobRegistryTests.java
@@ -18,9 +18,9 @@ package org.springframework.batch.core.configuration.support;
 import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.configuration.DuplicateJobException;
-import org.springframework.batch.core.configuration.JobFactory;
-import org.springframework.batch.core.job.JobSupport;
+import org.springframework.batch.core.job.SimpleJob;
 import org.springframework.batch.core.launch.NoSuchJobException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,7 +38,7 @@ class MapJobRegistryTests {
 
 	@Test
 	void testUnregister() throws Exception {
-		registry.register(new ReferenceJobFactory(new JobSupport("foo")));
+		registry.register(new SimpleJob("foo"));
 		assertNotNull(registry.getJob("foo"));
 		registry.unregister("foo");
 		Exception exception = assertThrows(NoSuchJobException.class, () -> registry.getJob("foo"));
@@ -47,28 +47,26 @@ class MapJobRegistryTests {
 
 	@Test
 	void testReplaceDuplicateConfiguration() throws Exception {
-		registry.register(new ReferenceJobFactory(new JobSupport("foo")));
-		JobFactory jobFactory = new ReferenceJobFactory(new JobSupport("foo"));
-		Exception exception = assertThrows(DuplicateJobException.class, () -> registry.register(jobFactory));
+		registry.register(new SimpleJob("foo"));
+		Exception exception = assertThrows(DuplicateJobException.class, () -> registry.register(new SimpleJob("foo")));
 		assertTrue(exception.getMessage().contains("foo"));
 	}
 
 	@Test
 	void testRealDuplicateConfiguration() throws Exception {
-		JobFactory jobFactory = new ReferenceJobFactory(new JobSupport("foo"));
-		registry.register(jobFactory);
-		Exception exception = assertThrows(DuplicateJobException.class, () -> registry.register(jobFactory));
+		registry.register(new SimpleJob("foo"));
+		Exception exception = assertThrows(DuplicateJobException.class, () -> registry.register(new SimpleJob("foo")));
 		assertTrue(exception.getMessage().contains("foo"));
 	}
 
 	@Test
 	void testGetJobConfigurations() throws Exception {
-		JobFactory jobFactory = new ReferenceJobFactory(new JobSupport("foo"));
-		registry.register(jobFactory);
-		registry.register(new ReferenceJobFactory(new JobSupport("bar")));
+		Job fooJob = new SimpleJob("foo");
+		registry.register(fooJob);
+		registry.register(new SimpleJob("base"));
 		Collection<String> configurations = registry.getJobNames();
 		assertEquals(2, configurations.size());
-		assertTrue(configurations.contains(jobFactory.getJobName()));
+		assertTrue(configurations.contains(fooJob.getName()));
 	}
 
 }


### PR DESCRIPTION
This change is to make it easier to register job not through `JobFactory` but directly.

In the tests I used `SimpleJob` for throwing jobs.

By the way, `SimpleJobRepositoryTests` and `SimpleStepFactoryBeanTests` are crashing now, but this has nothing to do with the current change.

Resolves: #4854