### PR TITLE
fix MongoCursorItemReaderBuilder sorts field validation logic

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/ExitStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.io.StringWriter;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author JiWon Seo
  *
  */
 public class ExitStatus implements Serializable, Comparable<ExitStatus> {
@@ -231,7 +232,7 @@ public class ExitStatus implements Serializable, Comparable<ExitStatus> {
 	 * @return {@code true} if the exit code is {@code EXECUTING} or {@code UNKNOWN}.
 	 */
 	public boolean isRunning() {
-		return "EXECUTING".equals(this.exitCode) || "UNKNOWN".equals(this.exitCode);
+		return EXECUTING.exitCode.equals(this.exitCode) || UNKNOWN.exitCode.equals(this.exitCode);
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/ExitStatusTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/ExitStatusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2024 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author JiWon Seo
  *
  */
 class ExitStatusTests {
@@ -153,7 +154,7 @@ class ExitStatusTests {
 	}
 
 	@Test
-	void testAddExitDescriptionWIthStacktrace() {
+	void testAddExitDescriptionWithStacktrace() {
 		ExitStatus status = ExitStatus.EXECUTING.addExitDescription(new RuntimeException("Foo"));
 		assertNotSame(ExitStatus.EXECUTING, status);
 		String description = status.getExitDescription();
@@ -182,8 +183,15 @@ class ExitStatusTests {
 	}
 
 	@Test
-	void testUnknownIsRunning() {
+	void testIsRunning() {
+		// running statuses
+		assertTrue(ExitStatus.EXECUTING.isRunning());
 		assertTrue(ExitStatus.UNKNOWN.isRunning());
+		// non running statuses
+		assertFalse(ExitStatus.COMPLETED.isRunning());
+		assertFalse(ExitStatus.FAILED.isRunning());
+		assertFalse(ExitStatus.STOPPED.isRunning());
+		assertFalse(ExitStatus.NOOP.isRunning());
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilder.java
@@ -280,7 +280,7 @@ public class MongoCursorItemReaderBuilder<T> {
 		Assert.notNull(this.targetType, "targetType is required.");
 		Assert.state(StringUtils.hasText(this.jsonQuery) || this.query != null, "A query is required");
 
-		if (StringUtils.hasText(this.jsonQuery) || this.query != null) {
+		if (StringUtils.hasText(this.jsonQuery) && this.query == null) {
 			Assert.notNull(this.sorts, "sorts map is required.");
 		}
 
@@ -297,7 +297,9 @@ public class MongoCursorItemReaderBuilder<T> {
 		reader.setQuery(this.jsonQuery);
 		reader.setParameterValues(this.parameterValues);
 		reader.setFields(this.fields);
-		reader.setSort(this.sorts);
+		if (this.sorts != null) {
+			reader.setSort(this.sorts);
+		}
 		reader.setHint(this.hint);
 		reader.setBatchSize(this.batchSize);
 		reader.setLimit(this.limit);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilderTests.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Mahmoud Ben Hassine
  */
-public class MongoCursorItemReaderBuilderTests {
+class MongoCursorItemReaderBuilderTests {
 
 	@Test
 	void testBuild() {
@@ -65,6 +65,49 @@ public class MongoCursorItemReaderBuilderTests {
 		Assertions.assertEquals(batchSize, ReflectionTestUtils.getField(reader, "batchSize"));
 		Assertions.assertEquals(limit, ReflectionTestUtils.getField(reader, "limit"));
 		Assertions.assertEquals(maxTime, ReflectionTestUtils.getField(reader, "maxTime"));
+	}
+
+	@Test
+	void testBuildWithQueryNoSorts() {
+		// given
+		MongoTemplate template = mock();
+		Class<String> targetType = String.class;
+		Query query = mock();
+		int batchSize = 100;
+		int limit = 10000;
+		Duration maxTime = Duration.ofSeconds(1);
+
+		// when & then
+		Assertions.assertDoesNotThrow(() -> new MongoCursorItemReaderBuilder<String>().name("reader")
+			.template(template)
+			.targetType(targetType)
+			.query(query)
+			.batchSize(batchSize)
+			.limit(limit)
+			.maxTime(maxTime)
+			.build());
+	}
+
+	@Test
+	void testBuildWithJsonQueryNoSorts() {
+		// given
+		MongoTemplate template = mock();
+		Class<String> targetType = String.class;
+		String jsonQuery = "{ }";
+		int batchSize = 100;
+		int limit = 10000;
+		Duration maxTime = Duration.ofSeconds(1);
+
+		// when & then
+		Assertions.assertThrows(IllegalArgumentException.class,
+				() -> new MongoCursorItemReaderBuilder<String>().name("reader")
+					.template(template)
+					.targetType(targetType)
+					.jsonQuery(jsonQuery)
+					.batchSize(batchSize)
+					.limit(limit)
+					.maxTime(maxTime)
+					.build());
 	}
 
 }


### PR DESCRIPTION
Fixes: #4860

## What is the problem
- Forced Sort Passing via sorts() Method When Building with MongoCursorItemReaderBuilder and Query
## What I Did
- Fix MongoCursorItemReaderBuilder sorts field validation logic
- Add 2 test cases for MongoCursorItemReaderBuilder
- Remove public access modifier from MongoCursorItemReaderBuilderTest