### PR TITLE
Fix KafkaItemReader ClassCastException during ExecutionContext deserialization

### DIFF
--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/kafka/KafkaItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/kafka/KafkaItemReaderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @author Mahmoud Ben Hassine
  * @author François Martin
  * @author Patrick Baumgartner
+ * @author Hyunwoo Jung
  */
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(SpringExtension.class)
@@ -267,8 +268,8 @@ class KafkaItemReaderIntegrationTests {
 			future.get();
 		}
 		ExecutionContext executionContext = new ExecutionContext();
-		Map<TopicPartition, Long> offsets = new HashMap<>();
-		offsets.put(new TopicPartition("topic3", 0), 1L);
+		Map<String, Long> offsets = new HashMap<>();
+		offsets.put("0", 1L);
 		executionContext.put("topic.partition.offsets", offsets);
 
 		// topic3-0: val0, val1, val2, val3, val4
@@ -308,9 +309,9 @@ class KafkaItemReaderIntegrationTests {
 		}
 
 		ExecutionContext executionContext = new ExecutionContext();
-		Map<TopicPartition, Long> offsets = new HashMap<>();
-		offsets.put(new TopicPartition("topic4", 0), 1L);
-		offsets.put(new TopicPartition("topic4", 1), 2L);
+		Map<String, Long> offsets = new HashMap<>();
+		offsets.put("0", 1L);
+		offsets.put("1", 2L);
 		executionContext.put("topic.partition.offsets", offsets);
 
 		// topic4-0: val0, val2, val4, val6


### PR DESCRIPTION
Using Jackson2ExecutionContextStringSerializer causes KafkaItemReader to throw a ClassCastException.

Because KafkaItemReader stores a Map<TopicPartition, Long> in the ExecutionContext, the serializer converts all map keys to strings.

To fix this, I changed it to store only the partition number (as a string) instead of the full TopicPartition object.

Resolves: #3797