### PR TITLE
Migrate `spring-batch-infrastructure` to JSpecify annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,8 @@
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
 		<maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
 		<spring-javaformat-maven-plugin.version>0.0.47</spring-javaformat-maven-plugin.version>
-		<error-prone.version>2.41.0</error-prone.version>
+		<error-prone.version>2.42.0</error-prone.version>
+		<nullaway.version>0.12.10</nullaway.version>
 	</properties>
 
 	<build>
@@ -180,6 +181,14 @@
 						<compilerArg>--should-stop=ifError=FLOW</compilerArg>
 						<compilerArg>
 							-Xplugin:ErrorProne
+							<!-- Check JSpecify annotations -->
+							-Xep:NullAway:ERROR
+							-XepOpt:NullAway:OnlyNullMarked
+							<!-- FIXME Remove once https://github.com/uber/NullAway/pull/1295 is released -->
+							-XepOpt:NullAway:CustomContractAnnotations=org.springframework.lang.Contract
+							-XepOpt:NullAway:SuppressionNameAliases=DataFlowIssue
+							<!-- https://github.com/uber/NullAway/issues/162 -->
+							-XepExcludedPaths:.*/src/test/java/.*
 						</compilerArg>
 					</compilerArgs>
 					<annotationProcessorPaths>
@@ -187,6 +196,11 @@
 							<groupId>com.google.errorprone</groupId>
 							<artifactId>error_prone_core</artifactId>
 							<version>${error-prone.version}</version>
+						</path>
+						<path>
+							<groupId>com.uber.nullaway</groupId>
+							<artifactId>nullaway</artifactId>
+							<version>${nullaway.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/Chunk.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.item;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +36,7 @@ import java.util.Objects;
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
+ * @author Stefano Cordio
  * @since 2.0
  */
 public class Chunk<W> implements Iterable<W>, Serializable {
@@ -44,7 +47,7 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 
 	private final List<Exception> errors = new ArrayList<>();
 
-	private Object userData;
+	private @Nullable Object userData;
 
 	private boolean end;
 
@@ -65,8 +68,7 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 	}
 
 	@Deprecated(since = "6.0", forRemoval = true)
-	public Chunk(List<? extends W> items, List<SkipWrapper<W>> skips) {
-		super();
+	public Chunk(@Nullable List<? extends W> items, @Nullable List<SkipWrapper<W>> skips) {
 		if (items != null) {
 			this.items.addAll(items);
 		}
@@ -218,7 +220,7 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 	}
 
 	@Deprecated(since = "6.0", forRemoval = true)
-	public Object getUserData() {
+	public @Nullable Object getUserData() {
 		return userData;
 	}
 
@@ -266,9 +268,9 @@ public class Chunk<W> implements Iterable<W>, Serializable {
 	 */
 	public class ChunkIterator implements Iterator<W> {
 
-		final private Iterator<W> iterator;
+		private final Iterator<W> iterator;
 
-		private W next;
+		private @Nullable W next;
 
 		public ChunkIterator(List<W> items) {
 			iterator = items.iterator();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ExecutionContext.java
@@ -23,7 +23,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Object representing a context for an {@link ItemStream}. It is a thin wrapper for a map
@@ -254,8 +254,7 @@ public class ExecutionContext implements Serializable {
 	 * @return The value represented by the given key or {@code null} if the key is not
 	 * present
 	 */
-	@Nullable
-	public Object get(String key) {
+	public @Nullable Object get(String key) {
 		return this.map.get(key);
 	}
 
@@ -269,8 +268,7 @@ public class ExecutionContext implements Serializable {
 	 * key is not present
 	 * @since 5.1
 	 */
-	@Nullable
-	public <V> V get(String key, Class<V> type) {
+	public <V> @Nullable V get(String key, Class<V> type) {
 		Object value = this.map.get(key);
 		if (value == null) {
 			return null;
@@ -289,8 +287,7 @@ public class ExecutionContext implements Serializable {
 	 * if the key is not present
 	 * @since 5.1
 	 */
-	@Nullable
-	public <V> V get(String key, Class<V> type, @Nullable V defaultValue) {
+	public <V> @Nullable V get(String key, Class<V> type, @Nullable V defaultValue) {
 		Object value = this.map.get(key);
 		if (value == null) {
 			return defaultValue;
@@ -373,8 +370,7 @@ public class ExecutionContext implements Serializable {
 	 *
 	 * @see java.util.Map#remove(Object)
 	 */
-	@Nullable
-	public Object remove(String key) {
+	public @Nullable Object remove(String key) {
 		return this.map.remove(key);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemProcessor.java
@@ -16,8 +16,7 @@
 
 package org.springframework.batch.item;
 
-import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for item transformation. Given an item as input, this interface provides an
@@ -53,7 +52,6 @@ public interface ItemProcessor<I, O> {
 	 * processing of the provided item should not continue.
 	 * @throws Exception thrown if exception occurs during processing.
 	 */
-	@Nullable
-	O process(@NonNull I item) throws Exception;
+	@Nullable O process(I item) throws Exception;
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemReader.java
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Strategy interface for providing the data. <br>
@@ -57,7 +57,6 @@ public interface ItemReader<T> {
 	 * @throws Exception if an there is a non-specific error.
 	 * @return T the item to be processed or {@code null} if the data source is exhausted
 	 */
-	@Nullable
-	T read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException;
+	@Nullable T read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException;
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemStreamException.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemStreamException.java
@@ -15,12 +15,15 @@
  */
 package org.springframework.batch.item;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Exception representing any errors encountered while processing a stream.
  *
  * @author Dave Syer
  * @author Lucas Ward
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public class ItemStreamException extends RuntimeException {
 
@@ -33,11 +36,10 @@ public class ItemStreamException extends RuntimeException {
 
 	/**
 	 * Constructs a new instance with a message and nested exception.
-	 * @param msg the exception message.
+	 * @param msg the exception message (can be {@code null}).
 	 * @param nested the cause of the exception.
-	 *
 	 */
-	public ItemStreamException(String msg, Throwable nested) {
+	public ItemStreamException(@Nullable String msg, Throwable nested) {
 		super(msg, nested);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemStreamSupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemStreamSupport.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.util.ExecutionContextUserSupport;
 
 /**
@@ -23,6 +24,7 @@ import org.springframework.batch.item.util.ExecutionContextUserSupport;
  * @author Dave Syer
  * @author Dean de Bree
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  *
  */
 public abstract class ItemStreamSupport implements ItemStream {
@@ -43,7 +45,7 @@ public abstract class ItemStreamSupport implements ItemStream {
 	 * Get the name of the component
 	 * @return the name of the component
 	 */
-	public String getName() {
+	public @Nullable String getName() {
 		return executionContextUserSupport.getName();
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ItemWriter.java
@@ -16,8 +16,6 @@
 
 package org.springframework.batch.item;
 
-import org.springframework.lang.NonNull;
-
 /**
  * <p>
  * Basic interface for generic output operations. Class implementing this interface will
@@ -48,6 +46,6 @@ public interface ItemWriter<T> {
 	 * @throws Exception if there are errors. The framework will catch the exception and
 	 * convert or rethrow it as appropriate.
 	 */
-	void write(@NonNull Chunk<? extends T> chunk) throws Exception;
+	void write(Chunk<? extends T> chunk) throws Exception;
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/KeyValueItemWriter.java
@@ -12,6 +12,7 @@
  */
 package org.springframework.batch.item;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.util.Assert;
@@ -22,21 +23,20 @@ import org.springframework.util.Assert;
  *
  * @author David Turanski
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 2.2
  *
  */
 public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, InitializingBean {
 
-	protected Converter<V, K> itemKeyMapper;
+	protected @Nullable Converter<V, K> itemKeyMapper;
 
 	protected boolean delete;
 
 	@Override
-	public void write(Chunk<? extends V> items) throws Exception {
-		if (items == null) {
-			return;
-		}
-		for (V item : items) {
+	public void write(Chunk<? extends V> chunk) throws Exception {
+		for (V item : chunk) {
+			@SuppressWarnings("DataFlowIssue")
 			K key = itemKeyMapper.convert(item);
 			writeKeyValue(key, item);
 		}
@@ -55,7 +55,7 @@ public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, Initial
 	 * @param key the key
 	 * @param value the item
 	 */
-	protected abstract void writeKeyValue(K key, V value);
+	protected abstract void writeKeyValue(@Nullable K key, V value);
 
 	/**
 	 * afterPropertiesSet() hook

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/PeekableItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/PeekableItemReader.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.batch.item;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <p>
@@ -45,7 +45,6 @@ public interface PeekableItemReader<T> extends ItemReader<T> {
 	 * @return the next item or {@code null} if the data source is exhausted
 	 * @throws Exception if there is a problem
 	 */
-	@Nullable
-	T peek() throws Exception, UnexpectedInputException, ParseException;
+	@Nullable T peek() throws Exception, UnexpectedInputException, ParseException;
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/SkipWrapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/SkipWrapper.java
@@ -16,21 +16,22 @@
 
 package org.springframework.batch.item;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Wrapper for an item and its exception if it failed processing.
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @deprecated since 6.0 with no replacement. Scheduled for removal in 7.0.
  */
 @Deprecated(since = "6.0", forRemoval = true)
 public class SkipWrapper<T> {
 
-	final private Throwable exception;
+	private final @Nullable Throwable exception;
 
-	final private T item;
+	private final @Nullable T item;
 
 	/**
 	 * @param item the item being wrapped.
@@ -39,7 +40,7 @@ public class SkipWrapper<T> {
 		this(item, null);
 	}
 
-	public SkipWrapper(T item, @Nullable Throwable e) {
+	public SkipWrapper(@Nullable T item, @Nullable Throwable e) {
 		this.item = item;
 		this.exception = e;
 	}
@@ -48,8 +49,7 @@ public class SkipWrapper<T> {
 	 * Public getter for the exception.
 	 * @return the exception
 	 */
-	@Nullable
-	public Throwable getException() {
+	public @Nullable Throwable getException() {
 		return exception;
 	}
 
@@ -57,7 +57,7 @@ public class SkipWrapper<T> {
 	 * Public getter for the item.
 	 * @return the item
 	 */
-	public T getItem() {
+	public @Nullable T getItem() {
 		return item;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/SpELItemKeyMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/SpELItemKeyMapper.java
@@ -12,30 +12,29 @@
  */
 package org.springframework.batch.item;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.expression.Expression;
-import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
  * An implementation of {@link Converter} that uses SpEL to map a Value to a key
  *
  * @author David Turanski
+ * @author Stefano Cordio
  * @since 2.2
  */
 public class SpELItemKeyMapper<K, V> implements Converter<V, K> {
 
-	private final ExpressionParser parser = new SpelExpressionParser();
-
 	private final Expression parsedExpression;
 
 	public SpELItemKeyMapper(String keyExpression) {
-		parsedExpression = parser.parseExpression(keyExpression);
+		parsedExpression = new SpelExpressionParser().parseExpression(keyExpression);
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public K convert(V item) {
+	public @Nullable K convert(V item) {
 		return (K) parsedExpression.getValue(item);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/AbstractMethodInvokingDelegator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -41,21 +42,22 @@ import org.springframework.util.StringUtils;
  * @author Robert Kasanicky
  * @author Mahmoud Ben Hassine
  * @author Glenn Renfro
+ * @author Stefano Cordio
  */
 public abstract class AbstractMethodInvokingDelegator<T> implements InitializingBean {
 
-	private Object targetObject;
+	private @Nullable Object targetObject;
 
-	private String targetMethod;
+	private @Nullable String targetMethod;
 
-	private Object[] arguments;
+	private @Nullable Object @Nullable [] arguments;
 
 	/**
 	 * Invoker the target method with arguments set by {@link #setArguments(Object[])}.
 	 * @return object returned by invoked method
 	 * @throws Exception exception thrown when executing the delegate method.
 	 */
-	protected T invokeDelegateMethod() throws Exception {
+	protected @Nullable T invokeDelegateMethod() throws Exception {
 		MethodInvoker invoker = createMethodInvoker(targetObject, targetMethod);
 		invoker.setArguments(arguments);
 		return doInvoke(invoker);
@@ -67,7 +69,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * @return object returned by target method
 	 * @throws Exception exception thrown when executing the delegate method.
 	 */
-	protected T invokeDelegateMethodWithArgument(Object object) throws Exception {
+	protected @Nullable T invokeDelegateMethodWithArgument(Object object) throws Exception {
 		MethodInvoker invoker = createMethodInvoker(targetObject, targetMethod);
 		invoker.setArguments(object);
 		return doInvoke(invoker);
@@ -79,7 +81,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * @return object returned by invoked method
 	 * @throws Exception exception thrown when executing the delegate method.
 	 */
-	protected T invokeDelegateMethodWithArguments(Object[] args) throws Exception {
+	protected @Nullable T invokeDelegateMethodWithArguments(@Nullable Object[] args) throws Exception {
 		MethodInvoker invoker = createMethodInvoker(targetObject, targetMethod);
 		invoker.setArguments(args);
 		return doInvoke(invoker);
@@ -88,7 +90,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	/**
 	 * Create a new configured instance of {@link MethodInvoker}.
 	 */
-	private MethodInvoker createMethodInvoker(Object targetObject, String targetMethod) {
+	private MethodInvoker createMethodInvoker(@Nullable Object targetObject, @Nullable String targetMethod) {
 		HippyMethodInvoker invoker = new HippyMethodInvoker();
 		invoker.setTargetObject(targetObject);
 		invoker.setTargetMethod(targetMethod);
@@ -102,7 +104,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * @return return value of the invoked method
 	 */
 	@SuppressWarnings("unchecked")
-	private T doInvoke(MethodInvoker invoker) throws Exception {
+	private @Nullable T doInvoke(MethodInvoker invoker) throws Exception {
 		try {
 			invoker.prepare();
 		}
@@ -141,6 +143,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	private boolean targetClassDeclaresTargetMethod() {
 		MethodInvoker invoker = createMethodInvoker(targetObject, targetMethod);
 
+		@SuppressWarnings("DataFlowIssue")
 		Method[] memberMethods = invoker.getTargetClass().getMethods();
 		Method[] declaredMethods = invoker.getTargetClass().getDeclaredMethods();
 
@@ -200,11 +203,11 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * providing explicit argument values.
 	 * <p>
 	 * If arguments are set to not-null value {@link #afterPropertiesSet()} will check the
-	 * values are compatible with target method's signature. In case arguments are null
-	 * (not set) method signature will not be checked and it is assumed correct values
-	 * will be supplied at runtime.
+	 * values are compatible with target method's signature. In case arguments are
+	 * {@code null} (not set), the method signature will not be checked, and it is assumed
+	 * correct values will be supplied at runtime.
 	 */
-	public void setArguments(Object[] arguments) {
+	public void setArguments(Object @Nullable [] arguments) {
 		this.arguments = arguments == null ? null : arguments.clone();
 	}
 
@@ -212,7 +215,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * Return arguments.
 	 * @return arguments
 	 */
-	protected Object[] getArguments() {
+	protected @Nullable Object @Nullable [] getArguments() {
 		return arguments;
 	}
 
@@ -220,7 +223,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * @return the object on which the method will be invoked.
 	 * @since 5.1
 	 */
-	protected Object getTargetObject() {
+	protected @Nullable Object getTargetObject() {
 		return targetObject;
 	}
 
@@ -228,7 +231,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 * @return the name of the method to be invoked.
 	 * @since 5.1
 	 */
-	protected String getTargetMethod() {
+	protected @Nullable String getTargetMethod() {
 		return targetMethod;
 	}
 
@@ -240,7 +243,7 @@ public abstract class AbstractMethodInvokingDelegator<T> implements Initializing
 	 */
 	public static class InvocationTargetThrowableWrapper extends RuntimeException {
 
-		public InvocationTargetThrowableWrapper(Throwable cause) {
+		public InvocationTargetThrowableWrapper(@Nullable Throwable cause) {
 			super(cause);
 		}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/HippyMethodInvoker.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/HippyMethodInvoker.java
@@ -17,14 +17,16 @@ package org.springframework.batch.item.adapter;
 
 import java.lang.reflect.Method;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.MethodInvoker;
 import org.springframework.util.ReflectionUtils;
 
 /**
  * A {@link MethodInvoker} that is a bit relaxed about its arguments. You can give it
- * arguments in the wrong order or you can give it too many arguments and it will try and
- * find a method that matches a subset.
+ * arguments in the wrong order, or you can give it too many arguments, and it will try
+ * and find a method that matches a subset.
  *
  * @author Dave Syer
  * @since 2.1
@@ -32,20 +34,23 @@ import org.springframework.util.ReflectionUtils;
 public class HippyMethodInvoker extends MethodInvoker {
 
 	@Override
-	protected Method findMatchingMethod() {
+	protected @Nullable Method findMatchingMethod() {
 		String targetMethod = getTargetMethod();
-		Object[] arguments = getArguments();
 
-		Method[] candidates = ReflectionUtils.getAllDeclaredMethods(getTargetClass());
+		@Nullable Object[] arguments = getArguments();
+
+		Class<?> targetClass = getTargetClass();
+		Assert.state(targetClass != null, "No target class set");
+		Method[] candidates = ReflectionUtils.getAllDeclaredMethods(targetClass);
 		int minTypeDiffWeight = Integer.MAX_VALUE;
 		Method matchingMethod = null;
 
-		Object[] transformedArguments = null;
+		@Nullable Object[] transformedArguments = null;
 
 		for (Method candidate : candidates) {
 			if (candidate.getName().equals(targetMethod)) {
 				Class<?>[] paramTypes = candidate.getParameterTypes();
-				Object[] candidateArguments = new Object[paramTypes.length];
+				@Nullable Object[] candidateArguments = new Object[paramTypes.length];
 				int assignedParameterCount = 0;
 				for (Object argument : arguments) {
 					for (int i = 0; i < paramTypes.length; i++) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/ItemProcessorAdapter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/ItemProcessorAdapter.java
@@ -16,8 +16,9 @@
 
 package org.springframework.batch.item.adapter;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.lang.Nullable;
 
 /**
  * Invokes a custom method on a delegate plain old Java object which itself processes an
@@ -32,9 +33,8 @@ public class ItemProcessorAdapter<I, O> extends AbstractMethodInvokingDelegator<
 	 *
 	 * @see ItemProcessor#process(Object)
 	 */
-	@Nullable
 	@Override
-	public O process(I item) throws Exception {
+	public @Nullable O process(I item) throws Exception {
 		return invokeDelegateMethodWithArgument(item);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/ItemReaderAdapter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/ItemReaderAdapter.java
@@ -16,8 +16,9 @@
 
 package org.springframework.batch.item.adapter;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ItemReader;
-import org.springframework.lang.Nullable;
 
 /**
  * Invokes a custom method on a delegate plain old Java object which itself provides an
@@ -35,9 +36,8 @@ public class ItemReaderAdapter<T> extends AbstractMethodInvokingDelegator<T> imp
 	/**
 	 * @return return value of the target method.
 	 */
-	@Nullable
 	@Override
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		return invokeDelegateMethod();
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/PropertyExtractingDelegatingItemWriter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.item.adapter;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.BeanWrapper;
@@ -39,12 +41,13 @@ import org.springframework.util.ObjectUtils;
 public class PropertyExtractingDelegatingItemWriter<T> extends AbstractMethodInvokingDelegator<T>
 		implements ItemWriter<T> {
 
-	private String[] fieldsUsedAsTargetMethodArguments;
+	private @Nullable String @Nullable [] fieldsUsedAsTargetMethodArguments;
 
 	/**
 	 * Extracts values from item's fields named in fieldsUsedAsTargetMethodArguments and
 	 * passes them as arguments to the delegate method.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 		for (T item : items) {
@@ -52,7 +55,8 @@ public class PropertyExtractingDelegatingItemWriter<T> extends AbstractMethodInv
 			// helper for extracting property values from a bean
 			BeanWrapper beanWrapper = new BeanWrapperImpl(item);
 
-			Object[] methodArguments = new Object[fieldsUsedAsTargetMethodArguments.length];
+			@Nullable Object[] methodArguments = new Object[fieldsUsedAsTargetMethodArguments.length];
+
 			for (int i = 0; i < fieldsUsedAsTargetMethodArguments.length; i++) {
 				methodArguments[i] = beanWrapper.getPropertyValue(fieldsUsedAsTargetMethodArguments[i]);
 			}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/adapter/package-info.java
@@ -3,7 +3,7 @@
  * Adapters for Plain Old Java Objects.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.adapter;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/AmqpItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/AmqpItemReader.java
@@ -16,10 +16,11 @@
 
 package org.springframework.batch.item.amqp;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -35,27 +36,27 @@ import org.springframework.util.Assert;
  *
  * @author Chris Schaefer
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public class AmqpItemReader<T> implements ItemReader<T> {
 
 	private final AmqpTemplate amqpTemplate;
 
-	private Class<? extends T> itemType;
+	private @Nullable Class<? extends T> itemType;
 
 	/**
 	 * Initialize the AmqpItemReader.
 	 * @param amqpTemplate the template to be used. Must not be null.
 	 */
-	public AmqpItemReader(final AmqpTemplate amqpTemplate) {
+	public AmqpItemReader(AmqpTemplate amqpTemplate) {
 		Assert.notNull(amqpTemplate, "AmqpTemplate must not be null");
 
 		this.amqpTemplate = amqpTemplate;
 	}
 
-	@Nullable
 	@Override
 	@SuppressWarnings("unchecked")
-	public T read() {
+	public @Nullable T read() {
 		if (itemType != null && itemType.isAssignableFrom(Message.class)) {
 			return (T) amqpTemplate.receive();
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/AmqpItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/AmqpItemWriter.java
@@ -45,14 +45,14 @@ public class AmqpItemWriter<T> implements ItemWriter<T> {
 
 	private final Log log = LogFactory.getLog(getClass());
 
-	public AmqpItemWriter(final AmqpTemplate amqpTemplate) {
+	public AmqpItemWriter(AmqpTemplate amqpTemplate) {
 		Assert.notNull(amqpTemplate, "AmqpTemplate must not be null");
 
 		this.amqpTemplate = amqpTemplate;
 	}
 
 	@Override
-	public void write(final Chunk<? extends T> items) throws Exception {
+	public void write(Chunk<? extends T> items) throws Exception {
 		if (log.isDebugEnabled()) {
 			log.debug("Writing to AMQP with " + items.size() + " items.");
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.amqp.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.batch.item.amqp.AmqpItemReader;
 import org.springframework.util.Assert;
@@ -24,14 +25,15 @@ import org.springframework.util.Assert;
  * A builder implementation for the {@link AmqpItemReader}
  *
  * @author Glenn Renfro
+ * @author Stefano Cordio
  * @since 4.0
  * @see AmqpItemReader
  */
 public class AmqpItemReaderBuilder<T> {
 
-	private AmqpTemplate amqpTemplate;
+	private @Nullable AmqpTemplate amqpTemplate;
 
-	private Class<? extends T> itemType;
+	private @Nullable Class<? extends T> itemType;
 
 	/**
 	 * Establish the amqpTemplate to be used by the AmqpItemReader.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/builder/AmqpItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/builder/AmqpItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.amqp.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.batch.item.amqp.AmqpItemWriter;
 import org.springframework.util.Assert;
@@ -24,12 +25,13 @@ import org.springframework.util.Assert;
  * A builder implementation for the {@link AmqpItemWriter}
  *
  * @author Glenn Renfro
+ * @author Stefano Cordio
  * @since 4.0
  * @see AmqpItemWriter
  */
 public class AmqpItemWriterBuilder<T> {
 
-	private AmqpTemplate amqpTemplate;
+	private @Nullable AmqpTemplate amqpTemplate;
 
 	/**
 	 * Establish the amqpTemplate to be used by the AmqpItemWriter.
@@ -50,9 +52,7 @@ public class AmqpItemWriterBuilder<T> {
 	public AmqpItemWriter<T> build() {
 		Assert.notNull(this.amqpTemplate, "amqpTemplate is required.");
 
-		AmqpItemWriter<T> writer = new AmqpItemWriter<>(this.amqpTemplate);
-
-		return writer;
+		return new AmqpItemWriter<>(this.amqpTemplate);
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/builder/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
  * Builders for AMQP item reader and writer.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.amqp.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/amqp/package-info.java
@@ -3,8 +3,9 @@
  *
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.amqp;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/AvroItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/AvroItemReader.java
@@ -28,12 +28,12 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecordBase;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -54,9 +54,9 @@ public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 
 	private boolean embeddedSchema = true;
 
-	private InputStreamReader<T> inputStreamReader;
+	private @Nullable InputStreamReader<T> inputStreamReader;
 
-	private DataFileStream<T> dataFileReader;
+	private @Nullable DataFileStream<T> dataFileReader;
 
 	private final InputStream inputStream;
 
@@ -104,15 +104,16 @@ public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 
 	/**
 	 * Disable or enable reading an embedded Avro schema. True by default.
-	 * @param embeddedSchema set to false to if the input does not embed an Avro schema.
+	 * @param embeddedSchema set to {@code false} if the input does not embed an Avro
+	 * schema.
 	 */
 	public void setEmbeddedSchema(boolean embeddedSchema) {
 		this.embeddedSchema = embeddedSchema;
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 		if (this.inputStreamReader != null) {
 			return this.inputStreamReader.read();
 		}
@@ -124,6 +125,7 @@ public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 		initializeReader();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doClose() throws Exception {
 		if (this.inputStreamReader != null) {
@@ -171,7 +173,7 @@ public class AvroItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 			this.binaryDecoder = DecoderFactory.get().binaryDecoder(inputStream, null);
 		}
 
-		private T read() throws Exception {
+		private @Nullable T read() throws Exception {
 			if (!this.binaryDecoder.isEnd()) {
 				return this.datumReader.read(null, this.binaryDecoder);
 			}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/AvroItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/AvroItemWriter.java
@@ -30,6 +30,7 @@ import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecordBase;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -54,13 +55,13 @@ import org.springframework.util.Assert;
  */
 public class AvroItemWriter<T> extends AbstractItemStreamItemWriter<T> {
 
-	private DataFileWriter<T> dataFileWriter;
+	private @Nullable DataFileWriter<T> dataFileWriter;
 
-	private OutputStreamWriter<T> outputStreamWriter;
+	private @Nullable OutputStreamWriter<T> outputStreamWriter;
 
 	private final WritableResource resource;
 
-	private final Resource schemaResource;
+	private final @Nullable Resource schemaResource;
 
 	private final Class<T> clazz;
 
@@ -71,7 +72,7 @@ public class AvroItemWriter<T> extends AbstractItemStreamItemWriter<T> {
 	 * @param schema a {@link Resource} containing the Avro schema.
 	 * @param clazz the data type to be serialized.
 	 */
-	public AvroItemWriter(WritableResource resource, Resource schema, Class<T> clazz) {
+	public AvroItemWriter(WritableResource resource, @Nullable Resource schema, Class<T> clazz) {
 		this.schemaResource = schema;
 		this.resource = resource;
 		this.clazz = clazz;
@@ -87,6 +88,7 @@ public class AvroItemWriter<T> extends AbstractItemStreamItemWriter<T> {
 		embedSchema = false;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 		items.forEach(item -> {
@@ -118,6 +120,7 @@ public class AvroItemWriter<T> extends AbstractItemStreamItemWriter<T> {
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() {
 		try {
@@ -155,7 +158,6 @@ public class AvroItemWriter<T> extends AbstractItemStreamItemWriter<T> {
 			this.outputStreamWriter = createOutputStreamWriter(this.resource.getOutputStream(),
 					datumWriterForClass(this.clazz));
 		}
-
 	}
 
 	private static <T> DatumWriter<T> datumWriterForClass(Class<T> clazz) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemReaderBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.avro.builder;
 
 import org.apache.avro.Schema;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.avro.AvroItemReader;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -29,6 +30,7 @@ import org.springframework.util.StringUtils;
  *
  * @author David Turanski
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 4.2
  */
 public class AvroItemReaderBuilder<T> {
@@ -41,11 +43,11 @@ public class AvroItemReaderBuilder<T> {
 
 	private int currentItemCount;
 
-	private Resource schema;
+	private @Nullable Resource schema;
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private Class<T> type;
+	private @Nullable Class<T> type;
 
 	private boolean embeddedSchema = true;
 
@@ -162,10 +164,12 @@ public class AvroItemReaderBuilder<T> {
 		Assert.notNull(this.resource, "A 'resource' is required.");
 
 		if (this.type != null) {
-			avroItemReader = buildForType();
+			Assert.isNull(this.schema, "You cannot specify a schema and 'type'.");
+			avroItemReader = new AvroItemReader<>(this.resource, this.type);
 		}
 		else {
-			avroItemReader = buildForSchema();
+			Assert.notNull(this.schema, "'schema' is required.");
+			avroItemReader = new AvroItemReader<>(this.resource, this.schema);
 		}
 
 		avroItemReader.setSaveState(this.saveState);
@@ -180,16 +184,6 @@ public class AvroItemReaderBuilder<T> {
 		avroItemReader.setEmbeddedSchema(this.embeddedSchema);
 
 		return avroItemReader;
-	}
-
-	private AvroItemReader<T> buildForType() {
-		Assert.isNull(this.schema, "You cannot specify a schema and 'type'.");
-		return new AvroItemReader<>(this.resource, this.type);
-	}
-
-	private AvroItemReader<T> buildForSchema() {
-		Assert.notNull(this.schema, "'schema' is required.");
-		return new AvroItemReader<>(this.resource, this.schema);
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/AvroItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.avro.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.avro.AvroItemWriter;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -27,15 +28,16 @@ import org.springframework.util.Assert;
  *
  * @author David Turanski
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 4.2
  */
 public class AvroItemWriterBuilder<T> {
 
-	private Class<T> type;
+	private @Nullable Class<T> type;
 
-	private WritableResource resource;
+	private @Nullable WritableResource resource;
 
-	private Resource schema;
+	private @Nullable Resource schema;
 
 	private String name = AvroItemWriter.class.getSimpleName();
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/builder/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.batch.support;
-
-import org.jspecify.annotations.Nullable;
-
 /**
- * A strategy interface for invoking a method. Typically used by adapters.
+ * Builders for Avro item reader and writer.
  *
- * @author Mark Fisher
- * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-public interface MethodInvoker {
+@NullMarked
+package org.springframework.batch.item.avro.builder;
 
-	@Nullable Object invokeMethod(Object... args);
-
-}
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/avro/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Avro related reader and writer.
+ *
+ * @author Stefano Cordio
+ */
+@NullMarked
+package org.springframework.batch.item.avro;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractPaginatedDataItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/AbstractPaginatedDataItemReader.java
@@ -18,12 +18,13 @@ package org.springframework.batch.item.data;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import java.util.Iterator;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * A base class that handles basic reading logic based on the paginated semantics of
@@ -35,6 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Michael Minella
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 2.2
  * @param <T> Type of item to be read
  */
@@ -44,7 +46,7 @@ public abstract class AbstractPaginatedDataItemReader<T> extends AbstractItemCou
 
 	protected int pageSize = 10;
 
-	protected Iterator<T> results;
+	protected @Nullable Iterator<T> results;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -57,9 +59,8 @@ public abstract class AbstractPaginatedDataItemReader<T> extends AbstractItemCou
 		this.pageSize = pageSize;
 	}
 
-	@Nullable
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 
 		this.lock.lock();
 		try {
@@ -69,17 +70,12 @@ public abstract class AbstractPaginatedDataItemReader<T> extends AbstractItemCou
 
 				page++;
 
-				if (results == null || !results.hasNext()) {
+				if (!results.hasNext()) {
 					return null;
 				}
 			}
 
-			if (results.hasNext()) {
-				return results.next();
-			}
-			else {
-				return null;
-			}
+			return results.next();
 		}
 		finally {
 			this.lock.unlock();
@@ -91,8 +87,8 @@ public abstract class AbstractPaginatedDataItemReader<T> extends AbstractItemCou
 	 * page. Each time this method is called, the resulting {@link Iterator} should
 	 * contain the items read within the next page. <br>
 	 * <br>
-	 * If the {@link Iterator} is empty or null when it is returned, this
-	 * {@link ItemReader} will assume that the input has been exhausted.
+	 * If the {@link Iterator} is empty when it is returned, this {@link ItemReader} will
+	 * assume that the input has been exhausted.
 	 * @return an {@link Iterator} containing the items within a page.
 	 */
 	protected abstract Iterator<T> doPageRead();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/MongoPagingItemReader.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.bson.Document;
 import org.bson.codecs.DecoderContext;
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.InitializingBean;
@@ -80,26 +81,25 @@ import org.springframework.util.StringUtils;
  */
 public class MongoPagingItemReader<T> extends AbstractPaginatedDataItemReader<T> implements InitializingBean {
 
-	protected MongoOperations template;
+	protected @Nullable MongoOperations template;
 
-	protected Query query;
+	protected @Nullable Query query;
 
-	protected String queryString;
+	protected @Nullable String queryString;
 
-	protected Class<? extends T> type;
+	protected @Nullable Class<? extends T> type;
 
-	protected Sort sort;
+	protected @Nullable Sort sort;
 
-	protected String hint;
+	protected @Nullable String hint;
 
-	protected String fields;
+	protected @Nullable String fields;
 
-	protected String collection;
+	protected @Nullable String collection;
 
 	protected List<Object> parameterValues = new ArrayList<>();
 
 	public MongoPagingItemReader() {
-		super();
 		setName(ClassUtils.getShortName(MongoPagingItemReader.class));
 	}
 
@@ -183,8 +183,8 @@ public class MongoPagingItemReader<T> extends AbstractPaginatedDataItemReader<T>
 		this.hint = hint;
 	}
 
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	@Override
-	@SuppressWarnings("unchecked")
 	protected Iterator<T> doPageRead() {
 		if (queryString != null) {
 			Pageable pageRequest = PageRequest.of(page, pageSize, sort);
@@ -206,24 +206,18 @@ public class MongoPagingItemReader<T> extends AbstractPaginatedDataItemReader<T>
 				mongoQuery.withHint(hint);
 			}
 
-			if (StringUtils.hasText(collection)) {
-				return (Iterator<T>) template.find(mongoQuery, type, collection).iterator();
-			}
-			else {
-				return (Iterator<T>) template.find(mongoQuery, type).iterator();
-			}
+			return StringUtils.hasText(collection) //
+					? (Iterator<T>) template.find(mongoQuery, type, collection).iterator()
+					: (Iterator<T>) template.find(mongoQuery, type).iterator();
 
 		}
 		else {
 			Pageable pageRequest = PageRequest.of(page, pageSize);
 			query.with(pageRequest);
 
-			if (StringUtils.hasText(collection)) {
-				return (Iterator<T>) template.find(query, type, collection).iterator();
-			}
-			else {
-				return (Iterator<T>) template.find(query, type).iterator();
-			}
+			return StringUtils.hasText(collection) //
+					? (Iterator<T>) template.find(query, type, collection).iterator()
+					: (Iterator<T>) template.find(query, type).iterator();
 		}
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemReader.java
@@ -24,6 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.adapter.AbstractMethodInvokingDelegator.InvocationTargetThrowableWrapper;
@@ -35,7 +36,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.MethodInvoker;
@@ -85,9 +85,9 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 
 	protected Log logger = LogFactory.getLog(getClass());
 
-	private PagingAndSortingRepository<?, ?> repository;
+	private @Nullable PagingAndSortingRepository<?, ?> repository;
 
-	private Sort sort;
+	private @Nullable Sort sort;
 
 	private volatile int page = 0;
 
@@ -95,13 +95,13 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 
 	private volatile int current = 0;
 
-	private List<?> arguments;
+	private @Nullable List<?> arguments;
 
-	private volatile List<T> results;
+	private volatile @Nullable List<T> results;
 
 	private final Lock lock = new ReentrantLock();
 
-	private String methodName;
+	private @Nullable String methodName;
 
 	public RepositoryItemReader() {
 		setName(ClassUtils.getShortName(RepositoryItemReader.class));
@@ -160,9 +160,8 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 		}
 	}
 
-	@Nullable
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 
 		this.lock.lock();
 		try {
@@ -221,8 +220,10 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 	 */
 	@SuppressWarnings("unchecked")
 	protected List<T> doPageRead() throws Exception {
+		@SuppressWarnings("DataFlowIssue")
 		Pageable pageRequest = PageRequest.of(page, pageSize, sort);
 
+		@SuppressWarnings("DataFlowIssue")
 		MethodInvoker invoker = createMethodInvoker(repository, methodName);
 
 		List<Object> parameters = new ArrayList<>();
@@ -267,6 +268,7 @@ public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemR
 		return Sort.by(sortValues);
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	private Object doInvoke(MethodInvoker invoker) throws Exception {
 		try {
 			invoker.prepare();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/RepositoryItemWriter.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.adapter.AbstractMethodInvokingDelegator.InvocationTargetThrowableWrapper;
@@ -63,9 +64,9 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 
 	protected static final Log logger = LogFactory.getLog(RepositoryItemWriter.class);
 
-	private CrudRepository<T, ?> repository;
+	private @Nullable CrudRepository<T, ?> repository;
 
-	private String methodName;
+	private @Nullable String methodName;
 
 	/**
 	 * Specifies what method on the repository to call. This method must have the type of
@@ -103,6 +104,7 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 	 * @param items the list of items to be persisted.
 	 * @throws Exception thrown if error occurs during writing.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	protected void doWrite(Chunk<? extends T> items) throws Exception {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Writing to the repository with " + items.size() + " items.");
@@ -135,7 +137,7 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 		}
 	}
 
-	private Object doInvoke(MethodInvoker invoker) throws Exception {
+	private void doInvoke(MethodInvoker invoker) throws Exception {
 		try {
 			invoker.prepare();
 		}
@@ -144,7 +146,7 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 		}
 
 		try {
-			return invoker.invoke();
+			invoker.invoke();
 		}
 		catch (InvocationTargetException e) {
 			if (e.getCause() instanceof Exception) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilder.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.data.MongoCursorItemReader;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -31,6 +32,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author LEE Juchan
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 5.1
  * @see MongoCursorItemReader
  */
@@ -38,35 +40,35 @@ public class MongoCursorItemReaderBuilder<T> {
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
 	private int currentItemCount;
 
-	private MongoOperations template;
+	private @Nullable MongoOperations template;
 
-	private Class<? extends T> targetType;
+	private @Nullable Class<? extends T> targetType;
 
-	private String collection;
+	private @Nullable String collection;
 
-	private Query query;
+	private @Nullable Query query;
 
-	private String jsonQuery;
+	private @Nullable String jsonQuery;
 
 	private List<Object> parameterValues = new ArrayList<>();
 
-	private String fields;
+	private @Nullable String fields;
 
-	private Map<String, Sort.Direction> sorts;
+	private @Nullable Map<String, Sort.Direction> sorts;
 
-	private String hint;
+	private @Nullable String hint;
 
 	private int batchSize;
 
 	private int limit;
 
-	private Duration maxTime;
+	private @Nullable Duration maxTime;
 
 	/**
 	 * Configure if the state of the
@@ -279,26 +281,35 @@ public class MongoCursorItemReaderBuilder<T> {
 		}
 		Assert.notNull(this.targetType, "targetType is required.");
 		Assert.state(StringUtils.hasText(this.jsonQuery) || this.query != null, "A query is required");
-
-		if (StringUtils.hasText(this.jsonQuery) || this.query != null) {
-			Assert.notNull(this.sorts, "sorts map is required.");
-		}
+		Assert.notNull(this.sorts, "sorts map is required.");
 
 		MongoCursorItemReader<T> reader = new MongoCursorItemReader<>();
 		reader.setSaveState(this.saveState);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 
 		reader.setTemplate(this.template);
 		reader.setTargetType(this.targetType);
-		reader.setCollection(this.collection);
-		reader.setQuery(this.query);
-		reader.setQuery(this.jsonQuery);
+		if (this.collection != null) {
+			reader.setCollection(this.collection);
+		}
+		if (this.query != null) {
+			reader.setQuery(this.query);
+		}
+		if (StringUtils.hasText(this.jsonQuery)) {
+			reader.setQuery(this.jsonQuery);
+		}
 		reader.setParameterValues(this.parameterValues);
-		reader.setFields(this.fields);
+		if (this.fields != null) {
+			reader.setFields(this.fields);
+		}
 		reader.setSort(this.sorts);
-		reader.setHint(this.hint);
+		if (this.hint != null) {
+			reader.setHint(this.hint);
+		}
 		reader.setBatchSize(this.batchSize);
 		reader.setLimit(this.limit);
 		if (this.maxTime != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoItemWriterBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.data.builder;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.data.MongoItemWriter;
 import org.springframework.batch.item.data.MongoItemWriter.Mode;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -33,9 +34,9 @@ import org.springframework.util.Assert;
  */
 public class MongoItemWriterBuilder<T> {
 
-	private MongoOperations template;
+	private @Nullable MongoOperations template;
 
-	private String collection;
+	private @Nullable String collection;
 
 	private Mode mode = Mode.UPSERT;
 
@@ -49,7 +50,7 @@ public class MongoItemWriterBuilder<T> {
 	 * @see MongoItemWriter#setMode(Mode)
 	 * @since 5.1
 	 */
-	public MongoItemWriterBuilder<T> mode(final Mode mode) {
+	public MongoItemWriterBuilder<T> mode(Mode mode) {
 		this.mode = mode;
 
 		return this;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoPagingItemReaderBuilder.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.data.MongoPagingItemReader;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -35,23 +36,24 @@ import org.springframework.util.StringUtils;
  * @author Mahmoud Ben Hassine
  * @author Drummond Dawson
  * @author Parikshit Dutta
+ * @author Stefano Cordio
  * @since 5.1
  */
 public class MongoPagingItemReaderBuilder<T> {
 
-	protected MongoOperations template;
+	protected @Nullable MongoOperations template;
 
-	protected String jsonQuery;
+	protected @Nullable String jsonQuery;
 
-	protected Class<? extends T> targetType;
+	protected @Nullable Class<? extends T> targetType;
 
-	protected Map<String, Sort.Direction> sorts;
+	protected @Nullable Map<String, Sort.Direction> sorts;
 
-	protected String hint;
+	protected @Nullable String hint;
 
-	protected String fields;
+	protected @Nullable String fields;
 
-	protected String collection;
+	protected @Nullable String collection;
 
 	protected List<Object> parameterValues = new ArrayList<>();
 
@@ -59,13 +61,13 @@ public class MongoPagingItemReaderBuilder<T> {
 
 	protected boolean saveState = true;
 
-	protected String name;
+	protected @Nullable String name;
 
 	protected int maxItemCount = Integer.MAX_VALUE;
 
 	protected int currentItemCount;
 
-	protected Query query;
+	protected @Nullable Query query;
 
 	/**
 	 * Configure if the state of the
@@ -272,16 +274,30 @@ public class MongoPagingItemReaderBuilder<T> {
 		MongoPagingItemReader<T> reader = new MongoPagingItemReader<>();
 		reader.setTemplate(this.template);
 		reader.setTargetType(this.targetType);
-		reader.setQuery(this.jsonQuery);
-		reader.setSort(this.sorts);
-		reader.setHint(this.hint);
-		reader.setFields(this.fields);
-		reader.setCollection(this.collection);
+		if (StringUtils.hasText(this.jsonQuery)) {
+			reader.setQuery(this.jsonQuery);
+		}
+		if (this.sorts != null) {
+			reader.setSort(this.sorts);
+		}
+		if (this.hint != null) {
+			reader.setHint(this.hint);
+		}
+		if (this.fields != null) {
+			reader.setFields(this.fields);
+		}
+		if (this.collection != null) {
+			reader.setCollection(this.collection);
+		}
 		reader.setParameterValues(this.parameterValues);
-		reader.setQuery(this.query);
+		if (this.query != null) {
+			reader.setQuery(this.query);
+		}
 
 		reader.setPageSize(this.pageSize);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		reader.setSaveState(this.saveState);
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/RepositoryItemReaderBuilder.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.data.RepositoryItemReader;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -37,19 +38,19 @@ import org.springframework.util.StringUtils;
  */
 public class RepositoryItemReaderBuilder<T> {
 
-	private PagingAndSortingRepository<?, ?> repository;
+	private @Nullable PagingAndSortingRepository<?, ?> repository;
 
-	private Map<String, Sort.Direction> sorts;
+	private @Nullable Map<String, Sort.Direction> sorts;
 
-	private List<?> arguments;
+	private @Nullable List<?> arguments;
 
 	private int pageSize = 10;
 
-	private String methodName;
+	private @Nullable String methodName;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -194,7 +195,9 @@ public class RepositoryItemReaderBuilder<T> {
 		}
 
 		RepositoryItemReader<T> reader = new RepositoryItemReader<>();
-		reader.setArguments(this.arguments);
+		if (this.arguments != null) {
+			reader.setArguments(this.arguments);
+		}
 		reader.setRepository(this.repository);
 		reader.setMethodName(this.methodName);
 		reader.setPageSize(this.pageSize);
@@ -202,7 +205,9 @@ public class RepositoryItemReaderBuilder<T> {
 		reader.setMaxItemCount(this.maxItemCount);
 		reader.setSaveState(this.saveState);
 		reader.setSort(this.sorts);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		return reader;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/RepositoryItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/RepositoryItemWriterBuilder.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.data.RepositoryItemWriter;
 import org.springframework.cglib.proxy.Enhancer;
@@ -40,11 +41,11 @@ public class RepositoryItemWriterBuilder<T> {
 
 	private static final Log logger = LogFactory.getLog(RepositoryItemWriterBuilder.class.getName());
 
-	private CrudRepository<T, ?> repository;
+	private @Nullable CrudRepository<T, ?> repository;
 
-	private String methodName;
+	private @Nullable String methodName;
 
-	private RepositoryMethodReference repositoryMethodReference;
+	private @Nullable RepositoryMethodReference repositoryMethodReference;
 
 	/**
 	 * Specifies what method on the repository to call. This method must have the type of
@@ -121,27 +122,26 @@ public class RepositoryItemWriterBuilder<T> {
 	}
 
 	/**
-	 * Establishes a proxy that will capture a the Repository and the associated
-	 * methodName that will be used by the writer.
+	 * Establishes a proxy that will capture the Repository and the associated methodName
+	 * that will be used by the writer.
 	 *
 	 * @param <T> The type of repository that will be used by the writer. The class must
 	 * not be final.
 	 */
 	public static class RepositoryMethodReference<T> {
 
-		private final RepositoryMethodInterceptor repositoryInvocationHandler;
+		private final RepositoryMethodInterceptor repositoryInvocationHandler = new RepositoryMethodInterceptor();
 
 		private final CrudRepository<?, ?> repository;
 
 		public RepositoryMethodReference(CrudRepository<?, ?> repository) {
 			this.repository = repository;
-			this.repositoryInvocationHandler = new RepositoryMethodInterceptor();
 		}
 
 		/**
-		 * The proxy returned prevents actual method execution and is only used to gather,
+		 * The proxy returned prevents actual method execution and is only used to gather
 		 * information about the method.
-		 * @return T is a proxy of the object passed in in the constructor
+		 * @return T a proxy of the object passed in the constructor
 		 */
 		@SuppressWarnings("unchecked")
 		public T methodIs() {
@@ -155,6 +155,7 @@ public class RepositoryItemWriterBuilder<T> {
 			return this.repository;
 		}
 
+		@SuppressWarnings("DataFlowIssue")
 		String getMethodName() {
 			return this.repositoryInvocationHandler.getMethodName();
 		}
@@ -163,15 +164,15 @@ public class RepositoryItemWriterBuilder<T> {
 
 	private static class RepositoryMethodInterceptor implements MethodInterceptor {
 
-		private String methodName;
+		private @Nullable String methodName;
 
 		@Override
-		public Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy) throws Throwable {
+		public @Nullable Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy) {
 			this.methodName = method.getName();
 			return null;
 		}
 
-		String getMethodName() {
+		@Nullable String getMethodName() {
 			return this.methodName;
 		}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for Spring Data item readers and writers.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.data.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/package-info.java
@@ -3,8 +3,9 @@
  *
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.data;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractCursorItemReader.java
@@ -27,6 +27,8 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.ReaderNotOpenException;
@@ -42,7 +44,6 @@ import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
-import org.springframework.lang.Nullable;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
@@ -53,10 +54,10 @@ import org.springframework.util.Assert;
  * </p>
  *
  * <p>
- * By default the cursor will be opened using a separate connection. The ResultSet for the
- * cursor is held open regardless of commits or roll backs in a surrounding transaction.
- * Clients of this reader are responsible for buffering the items in the case that they
- * need to be re-presented on a rollback. This buffering is handled by the step
+ * By default, the cursor will be opened using a separate connection. The ResultSet for
+ * the cursor is held open regardless of commits or rollbacks in a surrounding
+ * transaction. Clients of this reader are responsible for buffering the items in the case
+ * that they need to be re-presented on a rollback. This buffering is handled by the step
  * implementations provided and is only a concern for anyone writing their own step
  * implementations.
  * </p>
@@ -111,6 +112,7 @@ import org.springframework.util.Assert;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
 		implements InitializingBean {
@@ -120,11 +122,11 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 
 	public static final int VALUE_NOT_SET = -1;
 
-	private Connection con;
+	private @Nullable Connection con;
 
-	protected ResultSet rs;
+	protected @Nullable ResultSet rs;
 
-	private DataSource dataSource;
+	private @Nullable DataSource dataSource;
 
 	private int fetchSize = VALUE_NOT_SET;
 
@@ -136,7 +138,7 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 
 	private boolean verifyCursorPosition = true;
 
-	private SQLExceptionTranslator exceptionTranslator;
+	private @Nullable SQLExceptionTranslator exceptionTranslator;
 
 	private boolean initialized = false;
 
@@ -144,13 +146,9 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 
 	private boolean useSharedExtendedConnection = false;
 
-	private Boolean connectionAutoCommit;
+	private @Nullable Boolean connectionAutoCommit;
 
 	private boolean initialConnectionAutoCommit;
-
-	public AbstractCursorItemReader() {
-		super();
-	}
 
 	/**
 	 * Assert that mandatory properties are set.
@@ -173,7 +171,7 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	 * Public getter for the data source.
 	 * @return the dataSource
 	 */
-	public DataSource getDataSource() {
+	public @Nullable DataSource getDataSource() {
 		return this.dataSource;
 	}
 
@@ -261,6 +259,7 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	 * traversing the ResultSet.
 	 * @param row The index of the row to move to
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private void moveCursorToRow(int row) {
 		try {
 			int count = 0;
@@ -377,6 +376,7 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	 * Check the result set is in sync with the currentRow attribute. This is important to
 	 * ensure that the user hasn't modified the current row.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private void verifyCursorPosition(long expectedCurrentRow) throws SQLException {
 		if (verifyCursorPosition) {
 			if (expectedCurrentRow != this.rs.getRow()) {
@@ -389,6 +389,7 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	 * Close the cursor and database connection. Make call to cleanupOnClose so sub
 	 * classes can cleanup any resources they have allocated.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doClose() throws Exception {
 		initialized = false;
@@ -421,18 +422,18 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	/**
 	 * Execute the statement to open the cursor.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doOpen() throws Exception {
-
 		Assert.state(!initialized, "Stream is already initialized.  Close before re-opening.");
 		Assert.isNull(rs, "ResultSet still open!  Close before re-opening.");
 
 		initializeConnection();
 		openCursor(con);
 		initialized = true;
-
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	protected void initializeConnection() {
 		Assert.state(getDataSource() != null, "DataSource must not be null.");
 
@@ -468,9 +469,8 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	 * Read next row and map it to item, verify cursor position if
 	 * {@link #setVerifyCursorPosition(boolean)} is true.
 	 */
-	@Nullable
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 		if (rs == null) {
 			throw new ReaderNotOpenException("Reader must be open before it can be read.");
 		}
@@ -497,13 +497,13 @@ public abstract class AbstractCursorItemReader<T> extends AbstractItemCountingIt
 	 * @return the mapped object at the cursor position
 	 * @throws SQLException if interactions with the current result set fail
 	 */
-	@Nullable
-	protected abstract T readCursor(ResultSet rs, int currentRow) throws SQLException;
+	protected abstract @Nullable T readCursor(ResultSet rs, int currentRow) throws SQLException;
 
 	/**
 	 * Use {@link ResultSet#absolute(int)} if possible, otherwise scroll by calling
 	 * {@link ResultSet#next()}.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void jumpToItem(int itemIndex) throws Exception {
 		if (driverSupportsAbsolute) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/AbstractPagingItemReader.java
@@ -21,9 +21,10 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -43,6 +44,7 @@ import org.springframework.util.ClassUtils;
  * @author Thomas Risberg
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 2.0
  */
 public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
@@ -58,7 +60,7 @@ public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingIt
 
 	private volatile int page = 0;
 
-	protected volatile List<T> results;
+	protected volatile @Nullable List<T> results;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -99,9 +101,9 @@ public abstract class AbstractPagingItemReader<T> extends AbstractItemCountingIt
 		Assert.state(pageSize > 0, "pageSize must be greater than zero");
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 
 		this.lock.lock();
 		try {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcBatchItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcBatchItemWriter.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.InitializingBean;
@@ -58,19 +59,20 @@ import org.springframework.util.Assert;
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 2.0
  */
 public class JdbcBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 
 	protected static final Log logger = LogFactory.getLog(JdbcBatchItemWriter.class);
 
-	protected NamedParameterJdbcOperations namedParameterJdbcTemplate;
+	protected @Nullable NamedParameterJdbcOperations namedParameterJdbcTemplate;
 
-	protected ItemPreparedStatementSetter<T> itemPreparedStatementSetter;
+	protected @Nullable ItemPreparedStatementSetter<T> itemPreparedStatementSetter;
 
-	protected ItemSqlParameterSourceProvider<T> itemSqlParameterSourceProvider;
+	protected @Nullable ItemSqlParameterSourceProvider<T> itemSqlParameterSourceProvider;
 
-	protected String sql;
+	protected @Nullable String sql;
 
 	protected boolean assertUpdates = true;
 
@@ -143,7 +145,7 @@ public class JdbcBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 		Assert.state(sql != null, "An SQL statement is required.");
 		List<String> namedParameters = new ArrayList<>();
 		parameterCount = JdbcParameterUtils.countParameterPlaceholders(sql, namedParameters);
-		if (namedParameters.size() > 0) {
+		if (!namedParameters.isEmpty()) {
 			if (parameterCount != namedParameters.size()) {
 				throw new InvalidDataAccessApiUsageException(
 						"You can't use both named parameters and classic \"?\" placeholders: " + sql);
@@ -156,9 +158,9 @@ public class JdbcBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	@Override
-	public void write(final Chunk<? extends T> chunk) throws Exception {
+	public void write(Chunk<? extends T> chunk) throws Exception {
 
 		if (!chunk.isEmpty()) {
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JdbcCursorItemReader.java
@@ -20,11 +20,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Objects;
 
 import org.springframework.jdbc.core.PreparedStatementSetter;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -37,7 +39,7 @@ import org.springframework.util.ClassUtils;
  * <p>
  * The statement used to open the cursor is created with the 'READ_ONLY' option since a
  * non read-only cursor may unnecessarily lock tables or rows. It is also opened with
- * 'TYPE_FORWARD_ONLY' option. By default the cursor will be opened using a separate
+ * 'TYPE_FORWARD_ONLY' option. By default, the cursor will be opened using a separate
  * connection which means that it will not participate in any transactions created as part
  * of the step processing.
  * </p>
@@ -56,19 +58,19 @@ import org.springframework.util.ClassUtils;
  * @author Robert Kasanicky
  * @author Thomas Risberg
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
-	private PreparedStatement preparedStatement;
+	private @Nullable PreparedStatement preparedStatement;
 
-	private PreparedStatementSetter preparedStatementSetter;
+	private @Nullable PreparedStatementSetter preparedStatementSetter;
 
-	private String sql;
+	private @Nullable String sql;
 
-	private RowMapper<T> rowMapper;
+	private @Nullable RowMapper<T> rowMapper;
 
 	public JdbcCursorItemReader() {
-		super();
 		setName(ClassUtils.getShortName(JdbcCursorItemReader.class));
 	}
 
@@ -135,9 +137,9 @@ public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T readCursor(ResultSet rs, int currentRow) throws SQLException {
+	protected @Nullable T readCursor(ResultSet rs, int currentRow) throws SQLException {
 		return rowMapper.mapRow(rs, currentRow);
 	}
 
@@ -153,7 +155,7 @@ public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
 
 	@Override
 	public String getSql() {
-		return this.sql;
+		return Objects.requireNonNull(this.sql);
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaCursorItemReader.java
@@ -22,6 +22,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.database.orm.JpaQueryProvider;
@@ -44,24 +45,25 @@ import org.springframework.util.StringUtils;
  *
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
+ * @author Stefano Cordio
  * @param <T> type of items to read
  * @since 4.3
  */
 public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements InitializingBean {
 
-	private EntityManagerFactory entityManagerFactory;
+	private @Nullable EntityManagerFactory entityManagerFactory;
 
-	private EntityManager entityManager;
+	private @Nullable EntityManager entityManager;
 
-	private String queryString;
+	private @Nullable String queryString;
 
-	private JpaQueryProvider queryProvider;
+	private @Nullable JpaQueryProvider queryProvider;
 
-	private Map<String, Object> parameterValues;
+	private @Nullable Map<String, Object> parameterValues;
 
-	private Map<String, Object> hintValues;
+	private @Nullable Map<String, Object> hintValues;
 
-	private Iterator<T> iterator;
+	private @Nullable Iterator<T> iterator;
 
 	/**
 	 * Create a new {@link JpaCursorItemReader}.
@@ -124,7 +126,7 @@ public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemRe
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	protected void doOpen() throws Exception {
 		this.entityManager = this.entityManagerFactory.createEntityManager();
 		if (this.entityManager == null) {
@@ -144,6 +146,7 @@ public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemRe
 		this.iterator = query.getResultStream().iterator();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	private Query createQuery() {
 		if (this.queryProvider == null) {
 			return this.entityManager.createQuery(this.queryString);
@@ -153,22 +156,23 @@ public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemRe
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T doRead() {
+	protected @Nullable T doRead() {
 		return this.iterator.hasNext() ? this.iterator.next() : null;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		super.update(executionContext);
 		this.entityManager.clear();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doClose() {
-		if (this.entityManager != null) {
-			this.entityManager.close();
-		}
+		this.entityManager.close();
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaItemWriter.java
@@ -22,6 +22,7 @@ import jakarta.persistence.EntityManagerFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.InitializingBean;
@@ -44,13 +45,13 @@ import org.springframework.util.Assert;
  * @author Thomas Risberg
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
- *
+ * @author Stefano Cordio
  */
 public class JpaItemWriter<T> implements ItemWriter<T>, InitializingBean {
 
 	protected static final Log logger = LogFactory.getLog(JpaItemWriter.class);
 
-	private EntityManagerFactory entityManagerFactory;
+	private @Nullable EntityManagerFactory entityManagerFactory;
 
 	private boolean usePersist = false;
 
@@ -98,6 +99,7 @@ public class JpaItemWriter<T> implements ItemWriter<T>, InitializingBean {
 	 */
 	@Override
 	public void write(Chunk<? extends T> items) {
+		@SuppressWarnings("DataFlowIssue")
 		EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
 		if (entityManager == null) {
 			throw new DataAccessResourceFailureException("Unable to obtain a transactional EntityManager");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/JpaPagingItemReader.java
@@ -26,6 +26,7 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Query;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.orm.JpaQueryProvider;
 import org.springframework.dao.DataAccessResourceFailureException;
@@ -85,37 +86,24 @@ import org.springframework.util.StringUtils;
  */
 public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 
-	private EntityManagerFactory entityManagerFactory;
+	private @Nullable EntityManagerFactory entityManagerFactory;
 
-	private EntityManager entityManager;
+	private @Nullable EntityManager entityManager;
 
 	private final Map<String, Object> jpaPropertyMap = new HashMap<>();
 
-	private String queryString;
+	private @Nullable String queryString;
 
-	private JpaQueryProvider queryProvider;
+	private @Nullable JpaQueryProvider queryProvider;
 
-	private Map<String, Object> parameterValues;
+	private @Nullable Map<String, Object> parameterValues;
 
-	private Map<String, Object> hintValues;
+	private @Nullable Map<String, Object> hintValues;
 
 	private boolean transacted = true;// default value
 
 	public JpaPagingItemReader() {
 		setName(ClassUtils.getShortName(JpaPagingItemReader.class));
-	}
-
-	/**
-	 * Create a query using an appropriate query provider (entityManager OR
-	 * queryProvider).
-	 */
-	private Query createQuery() {
-		if (queryProvider == null) {
-			return entityManager.createQuery(queryString);
-		}
-		else {
-			return queryProvider.createQuery();
-		}
 	}
 
 	public void setEntityManagerFactory(EntityManagerFactory entityManagerFactory) {
@@ -178,6 +166,7 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 		this.queryProvider = queryProvider;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doOpen() throws Exception {
 		super.doOpen();
@@ -194,8 +183,8 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 
 	}
 
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	@Override
-	@SuppressWarnings("unchecked")
 	protected void doReadPage() {
 
 		EntityTransaction tx = null;
@@ -240,6 +229,21 @@ public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
 		} // end if
 	}
 
+	/**
+	 * Create a query using an appropriate query provider (entityManager OR
+	 * queryProvider).
+	 */
+	@SuppressWarnings("DataFlowIssue")
+	private Query createQuery() {
+		if (queryProvider == null) {
+			return entityManager.createQuery(queryString);
+		}
+		else {
+			return queryProvider.createQuery();
+		}
+	}
+
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doClose() throws Exception {
 		entityManager.close();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/StoredProcedureItemReader.java
@@ -24,12 +24,13 @@ import java.sql.Types;
 import java.util.Arrays;
 
 import org.springframework.jdbc.core.PreparedStatementSetter;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SqlOutParameter;
 import org.springframework.jdbc.core.SqlParameter;
 import org.springframework.jdbc.core.metadata.CallMetaDataContext;
 import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -64,15 +65,15 @@ import org.springframework.util.ClassUtils;
  */
 public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 
-	private CallableStatement callableStatement;
+	private @Nullable CallableStatement callableStatement;
 
-	private PreparedStatementSetter preparedStatementSetter;
+	private @Nullable PreparedStatementSetter preparedStatementSetter;
 
-	private String procedureName;
+	private @Nullable String procedureName;
 
-	private String callString;
+	private @Nullable String callString;
 
-	private RowMapper<T> rowMapper;
+	private @Nullable RowMapper<T> rowMapper;
 
 	private SqlParameter[] parameters = new SqlParameter[0];
 
@@ -81,7 +82,6 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 	private int refCursorPosition = 0;
 
 	public StoredProcedureItemReader() {
-		super();
 		setName(ClassUtils.getShortName(StoredProcedureItemReader.class));
 	}
 
@@ -97,10 +97,10 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 	 * Set the SQL statement to be used when creating the cursor. This statement should be
 	 * a complete and valid SQL statement, as it will be run directly without any
 	 * modification.
-	 * @param sprocedureName the SQL used to call the statement
+	 * @param procedureName the SQL used to call the statement
 	 */
-	public void setProcedureName(String sprocedureName) {
-		this.procedureName = sprocedureName;
+	public void setProcedureName(String procedureName) {
+		this.procedureName = procedureName;
 	}
 
 	/**
@@ -151,6 +151,7 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 		Assert.state(rowMapper != null, "RowMapper must be provided");
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void openCursor(Connection con) {
 
@@ -228,9 +229,9 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T readCursor(ResultSet rs, int currentRow) throws SQLException {
+	protected @Nullable T readCursor(ResultSet rs, int currentRow) throws SQLException {
 		return rowMapper.mapRow(rs, currentRow);
 	}
 
@@ -246,12 +247,7 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 
 	@Override
 	public String getSql() {
-		if (callString != null) {
-			return this.callString;
-		}
-		else {
-			return "PROCEDURE NAME: " + procedureName;
-		}
+		return callString != null ? callString : "PROCEDURE NAME: " + procedureName;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcBatchItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcBatchItemWriterBuilder.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.util.Map;
 import javax.sql.DataSource;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider;
 import org.springframework.batch.item.database.ItemPreparedStatementSetter;
 import org.springframework.batch.item.database.ItemSqlParameterSourceProvider;
@@ -32,6 +33,7 @@ import org.springframework.util.Assert;
  * A builder implementation for the {@link JdbcBatchItemWriter}.
  *
  * @author Michael Minella
+ * @author Stefano Cordio
  * @since 4.0
  * @see JdbcBatchItemWriter
  */
@@ -39,15 +41,15 @@ public class JdbcBatchItemWriterBuilder<T> {
 
 	private boolean assertUpdates = true;
 
-	private String sql;
+	private @Nullable String sql;
 
-	private ItemPreparedStatementSetter<T> itemPreparedStatementSetter;
+	private @Nullable ItemPreparedStatementSetter<T> itemPreparedStatementSetter;
 
-	private ItemSqlParameterSourceProvider<T> itemSqlParameterSourceProvider;
+	private @Nullable ItemSqlParameterSourceProvider<T> itemSqlParameterSourceProvider;
 
-	private DataSource dataSource;
+	private @Nullable DataSource dataSource;
 
-	private NamedParameterJdbcOperations namedParameterJdbcTemplate;
+	private @Nullable NamedParameterJdbcOperations namedParameterJdbcTemplate;
 
 	private BigInteger mapped = new BigInteger("0");
 
@@ -172,8 +174,12 @@ public class JdbcBatchItemWriterBuilder<T> {
 		JdbcBatchItemWriter<T> writer = new JdbcBatchItemWriter<>();
 		writer.setSql(this.sql);
 		writer.setAssertUpdates(this.assertUpdates);
-		writer.setItemSqlParameterSourceProvider(this.itemSqlParameterSourceProvider);
-		writer.setItemPreparedStatementSetter(this.itemPreparedStatementSetter);
+		if (this.itemSqlParameterSourceProvider != null) {
+			writer.setItemSqlParameterSourceProvider(this.itemSqlParameterSourceProvider);
+		}
+		if (this.itemPreparedStatementSetter != null) {
+			writer.setItemPreparedStatementSetter(this.itemPreparedStatementSetter);
+		}
 
 		if (mappedValue == 1) {
 			((JdbcBatchItemWriter<Map<String, Object>>) writer)
@@ -187,7 +193,9 @@ public class JdbcBatchItemWriterBuilder<T> {
 			this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(this.dataSource);
 		}
 
-		writer.setJdbcTemplate(this.namedParameterJdbcTemplate);
+		if (this.namedParameterJdbcTemplate != null) {
+			writer.setJdbcTemplate(this.namedParameterJdbcTemplate);
+		}
 
 		return writer;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JdbcCursorItemReaderBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.database.builder;
 import java.util.List;
 import javax.sql.DataSource;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.AbstractCursorItemReader;
 import org.springframework.batch.item.database.JdbcCursorItemReader;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
@@ -40,11 +41,12 @@ import org.springframework.util.StringUtils;
  * @author Parikshit Dutta
  * @author Fabio Molignoni
  * @author Juyoung Kim
+ * @author Stefano Cordio
  * @since 4.0
  */
 public class JdbcCursorItemReaderBuilder<T> {
 
-	private DataSource dataSource;
+	private @Nullable DataSource dataSource;
 
 	private int fetchSize = AbstractCursorItemReader.VALUE_NOT_SET;
 
@@ -60,15 +62,15 @@ public class JdbcCursorItemReaderBuilder<T> {
 
 	private boolean useSharedExtendedConnection;
 
-	private PreparedStatementSetter preparedStatementSetter;
+	private @Nullable PreparedStatementSetter preparedStatementSetter;
 
-	private String sql;
+	private @Nullable String sql;
 
-	private RowMapper<T> rowMapper;
+	private @Nullable RowMapper<T> rowMapper;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -360,7 +362,9 @@ public class JdbcCursorItemReaderBuilder<T> {
 		}
 
 		reader.setSaveState(this.saveState);
-		reader.setPreparedStatementSetter(this.preparedStatementSetter);
+		if (this.preparedStatementSetter != null) {
+			reader.setPreparedStatementSetter(this.preparedStatementSetter);
+		}
 		reader.setRowMapper(this.rowMapper);
 		reader.setSql(this.sql);
 		reader.setCurrentItemCount(this.currentItemCount);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaCursorItemReaderBuilder.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import jakarta.persistence.EntityManagerFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamSupport;
 import org.springframework.batch.item.database.JpaCursorItemReader;
@@ -31,23 +32,24 @@ import org.springframework.util.Assert;
  *
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
+ * @author Stefano Cordio
  * @since 4.3
  */
 public class JpaCursorItemReaderBuilder<T> {
 
-	private EntityManagerFactory entityManagerFactory;
+	private @Nullable EntityManagerFactory entityManagerFactory;
 
-	private String queryString;
+	private @Nullable String queryString;
 
-	private JpaQueryProvider queryProvider;
+	private @Nullable JpaQueryProvider queryProvider;
 
-	private Map<String, Object> parameterValues;
+	private @Nullable Map<String, Object> parameterValues;
 
-	private Map<String, Object> hintValues;
+	private @Nullable Map<String, Object> hintValues;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -182,14 +184,24 @@ public class JpaCursorItemReaderBuilder<T> {
 
 		JpaCursorItemReader<T> reader = new JpaCursorItemReader<>();
 		reader.setEntityManagerFactory(this.entityManagerFactory);
-		reader.setQueryProvider(this.queryProvider);
-		reader.setQueryString(this.queryString);
-		reader.setParameterValues(this.parameterValues);
-		reader.setHintValues(this.hintValues);
+		if (this.queryProvider != null) {
+			reader.setQueryProvider(this.queryProvider);
+		}
+		if (this.queryString != null) {
+			reader.setQueryString(this.queryString);
+		}
+		if (this.parameterValues != null) {
+			reader.setParameterValues(this.parameterValues);
+		}
+		if (this.hintValues != null) {
+			reader.setHintValues(this.hintValues);
+		}
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 		reader.setSaveState(this.saveState);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 
 		return reader;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaItemWriterBuilder.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.database.builder;
 
 import jakarta.persistence.EntityManagerFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.util.Assert;
 
@@ -25,12 +26,13 @@ import org.springframework.util.Assert;
  *
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
+ * @author Stefano Cordio
  * @since 4.1
  * @see JpaItemWriter
  */
 public class JpaItemWriterBuilder<T> {
 
-	private EntityManagerFactory entityManagerFactory;
+	private @Nullable EntityManagerFactory entityManagerFactory;
 
 	private boolean usePersist = false;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/JpaPagingItemReaderBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.database.builder;
 import java.util.Map;
 import jakarta.persistence.EntityManagerFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.JpaPagingItemReader;
 import org.springframework.batch.item.database.orm.JpaQueryProvider;
 import org.springframework.util.Assert;
@@ -28,6 +29,7 @@ import org.springframework.util.Assert;
  * @author Michael Minella
  * @author Glenn Renfro
  * @author Jinwoo Bae
+ * @author Stefano Cordio
  * @since 4.0
  */
 
@@ -35,21 +37,21 @@ public class JpaPagingItemReaderBuilder<T> {
 
 	private int pageSize = 10;
 
-	private EntityManagerFactory entityManagerFactory;
+	private @Nullable EntityManagerFactory entityManagerFactory;
 
-	private Map<String, Object> parameterValues;
+	private @Nullable Map<String, Object> parameterValues;
 
-	private Map<String, Object> hintValues;
+	private @Nullable Map<String, Object> hintValues;
 
 	private boolean transacted = true;
 
-	private String queryString;
+	private @Nullable String queryString;
 
-	private JpaQueryProvider queryProvider;
+	private @Nullable JpaQueryProvider queryProvider;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -217,17 +219,27 @@ public class JpaPagingItemReaderBuilder<T> {
 
 		JpaPagingItemReader<T> reader = new JpaPagingItemReader<>();
 
-		reader.setQueryString(this.queryString);
+		if (this.queryString != null) {
+			reader.setQueryString(this.queryString);
+		}
+		if (this.parameterValues != null) {
+			reader.setParameterValues(this.parameterValues);
+		}
+		if (this.hintValues != null) {
+			reader.setHintValues(this.hintValues);
+		}
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		reader.setPageSize(this.pageSize);
-		reader.setParameterValues(this.parameterValues);
-		reader.setHintValues(this.hintValues);
 		reader.setEntityManagerFactory(this.entityManagerFactory);
-		reader.setQueryProvider(this.queryProvider);
+		if (this.queryProvider != null) {
+			reader.setQueryProvider(this.queryProvider);
+		}
 		reader.setTransacted(this.transacted);
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 		reader.setSaveState(this.saveState);
-		reader.setName(this.name);
 
 		return reader;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/StoredProcedureItemReaderBuilder.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.database.builder;
 
 import javax.sql.DataSource;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.AbstractCursorItemReader;
 
 import org.springframework.batch.item.database.StoredProcedureItemReader;
@@ -45,7 +46,7 @@ public class StoredProcedureItemReaderBuilder<T> {
 
 	private boolean saveState = true;
 
-	private DataSource dataSource;
+	private @Nullable DataSource dataSource;
 
 	private int fetchSize = VALUE_NOT_SET;
 
@@ -61,11 +62,11 @@ public class StoredProcedureItemReaderBuilder<T> {
 
 	private boolean useSharedExtendedConnection = false;
 
-	private PreparedStatementSetter preparedStatementSetter;
+	private @Nullable PreparedStatementSetter preparedStatementSetter;
 
-	private RowMapper<T> rowMapper;
+	private @Nullable RowMapper<T> rowMapper;
 
-	private String procedureName;
+	private @Nullable String procedureName;
 
 	private SqlParameter[] parameters = new SqlParameter[0];
 
@@ -73,7 +74,7 @@ public class StoredProcedureItemReaderBuilder<T> {
 
 	private int refCursorPosition = 0;
 
-	private String name;
+	private @Nullable String name;
 
 	/**
 	 * Configure if the state of the
@@ -322,7 +323,9 @@ public class StoredProcedureItemReaderBuilder<T> {
 		itemReader.setProcedureName(this.procedureName);
 		itemReader.setRowMapper(this.rowMapper);
 		itemReader.setParameters(this.parameters);
-		itemReader.setPreparedStatementSetter(this.preparedStatementSetter);
+		if (this.preparedStatementSetter != null) {
+			itemReader.setPreparedStatementSetter(this.preparedStatementSetter);
+		}
 		itemReader.setFunction(this.function);
 		itemReader.setRefCursorPosition(this.refCursorPosition);
 		itemReader.setCurrentItemCount(this.currentItemCount);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/builder/package-info.java
@@ -19,7 +19,7 @@
  *
  * @author Mahmoud Ben Hassine
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.database.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/AbstractJpaQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/AbstractJpaQueryProvider.java
@@ -19,7 +19,9 @@ package org.springframework.batch.item.database.orm;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
 
 /**
  * <p>
@@ -34,7 +36,7 @@ import org.springframework.beans.factory.InitializingBean;
  */
 public abstract class AbstractJpaQueryProvider implements JpaQueryProvider, InitializingBean {
 
-	private EntityManager entityManager;
+	private @Nullable EntityManager entityManager;
 
 	/**
 	 * <p>
@@ -55,8 +57,13 @@ public abstract class AbstractJpaQueryProvider implements JpaQueryProvider, Init
 	 * </p>
 	 * @return entityManager the injected {@link EntityManager}
 	 */
-	protected EntityManager getEntityManager() {
+	protected @Nullable EntityManager getEntityManager() {
 		return entityManager;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.state(entityManager != null, "Entity manager must be set");
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNamedQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNamedQueryProvider.java
@@ -17,25 +17,26 @@ package org.springframework.batch.item.database.orm;
 
 import jakarta.persistence.Query;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * <p>
  * This query provider creates JPA named {@link Query}s.
- * </p>
  *
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
+ * @author Stefano Cordio
  * @since 4.3
  * @param <E> entity returned by executing the query
  */
 public class JpaNamedQueryProvider<E> extends AbstractJpaQueryProvider {
 
-	private Class<E> entityClass;
+	private @Nullable Class<E> entityClass;
 
-	private String namedQuery;
+	private @Nullable String namedQuery;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public Query createQuery() {
 		return getEntityManager().createNamedQuery(this.namedQuery, this.entityClass);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNativeQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaNativeQueryProvider.java
@@ -18,26 +18,28 @@ package org.springframework.batch.item.database.orm;
 
 import jakarta.persistence.Query;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
+ * This query provider creates JPA {@link Query queries} from injected native SQL queries.
  * <p>
- * This query provider creates JPA {@link Query}s from injected native SQL queries. This
- * is useful if there is a need to utilize database-specific features such as query hints,
- * the CONNECT keyword in Oracle, etc.
- * </p>
+ * This is useful if there is a need to utilize database-specific features such as query
+ * hints, the {@code CONNECT} keyword in Oracle, etc.
  *
  * @author Anatoly Polinsky
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @param <E> entity returned by executing the query
  */
 public class JpaNativeQueryProvider<E> extends AbstractJpaQueryProvider {
 
-	private Class<E> entityClass;
+	private @Nullable Class<E> entityClass;
 
-	private String sqlQuery;
+	private @Nullable String sqlQuery;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public Query createQuery() {
 		return getEntityManager().createNativeQuery(sqlQuery, entityClass);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/JpaQueryProvider.java
@@ -22,23 +22,18 @@ import jakarta.persistence.Query;
 import org.springframework.batch.item.ItemReader;
 
 /**
- * <p>
  * Interface defining the functionality to be provided for generating queries for use with
- * JPA {@link ItemReader}s or other custom built artifacts.
- * </p>
+ * JPA {@link ItemReader}s or other custom-built artifacts.
  *
  * @author Anatoly Polinsky
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  * @since 2.1
- *
  */
 public interface JpaQueryProvider {
 
 	/**
-	 * <p>
 	 * Create the query object.
-	 * </p>
 	 * @return created query
 	 */
 	Query createQuery();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/orm/package-info.java
@@ -4,7 +4,7 @@
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.database.orm;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of database based item readers and writers.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.database;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/AbstractSqlPagingQueryProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.JdbcParameterUtils;
 import org.springframework.batch.item.database.Order;
 import org.springframework.batch.item.database.PagingQueryProvider;
@@ -50,19 +51,20 @@ import org.springframework.util.StringUtils;
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  * @author Benjamin Hetz
+ * @author Stefano Cordio
  * @since 2.0
  */
 public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvider {
 
-	private String selectClause;
+	private @Nullable String selectClause;
 
-	private String fromClause;
+	private @Nullable String fromClause;
 
-	private String whereClause;
+	private @Nullable String whereClause;
 
 	private Map<String, Order> sortKeys = new LinkedHashMap<>();
 
-	private String groupClause;
+	private @Nullable String groupClause;
 
 	private int parameterCount;
 
@@ -72,20 +74,15 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	 * The setter for the group by clause
 	 * @param groupClause SQL GROUP BY clause part of the SQL query string
 	 */
-	public void setGroupClause(String groupClause) {
-		if (StringUtils.hasText(groupClause)) {
-			this.groupClause = removeKeyWord("group by", groupClause);
-		}
-		else {
-			this.groupClause = null;
-		}
+	public void setGroupClause(@Nullable String groupClause) {
+		this.groupClause = StringUtils.hasText(groupClause) ? removeKeyWord("group by", groupClause) : null;
 	}
 
 	/**
 	 * The getter for the group by clause
 	 * @return SQL GROUP BY clause part of the SQL query string
 	 */
-	public String getGroupClause() {
+	public @Nullable String getGroupClause() {
 		return this.groupClause;
 	}
 
@@ -99,7 +96,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	/**
 	 * @return SQL SELECT clause part of SQL query string
 	 */
-	protected String getSelectClause() {
+	protected @Nullable String getSelectClause() {
 		return selectClause;
 	}
 
@@ -113,14 +110,14 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	/**
 	 * @return SQL FROM clause part of SQL query string
 	 */
-	protected String getFromClause() {
+	protected @Nullable String getFromClause() {
 		return fromClause;
 	}
 
 	/**
 	 * @param whereClause WHERE clause part of SQL query string
 	 */
-	public void setWhereClause(String whereClause) {
+	public void setWhereClause(@Nullable String whereClause) {
 		if (StringUtils.hasText(whereClause)) {
 			this.whereClause = removeKeyWord("where", whereClause);
 		}
@@ -132,7 +129,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	/**
 	 * @return SQL WHERE clause part of SQL query string
 	 */
-	protected String getWhereClause() {
+	protected @Nullable String getWhereClause() {
 		return whereClause;
 	}
 
@@ -166,7 +163,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 	/**
 	 * The sort key placeholder will vary depending on whether named parameters or
 	 * traditional placeholders are used in query strings.
-	 * @return place holder for sortKey.
+	 * @return placeholder for sortKey.
 	 */
 	@Override
 	public String getSortKeyPlaceHolder(String keyName) {
@@ -205,7 +202,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 
 	/**
 	 * Method generating the query string to be used for retrieving the first page. This
-	 * method must be implemented in sub classes.
+	 * method must be implemented in subclasses.
 	 * @param pageSize number of rows to read per page
 	 * @return query string
 	 */

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBean.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryProviderFactoryBean.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.Order;
 import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.batch.support.DatabaseType;
@@ -56,19 +57,19 @@ import org.springframework.util.StringUtils;
  */
 public class SqlPagingQueryProviderFactoryBean implements FactoryBean<PagingQueryProvider> {
 
-	private DataSource dataSource;
+	private @Nullable DataSource dataSource;
 
-	private String databaseType;
+	private @Nullable String databaseType;
 
-	private String fromClause;
+	private @Nullable String fromClause;
 
-	private String whereClause;
+	private @Nullable String whereClause;
 
-	private String selectClause;
+	private @Nullable String selectClause;
 
-	private String groupClause;
+	private @Nullable String groupClause;
 
-	private Map<String, Order> sortKeys;
+	private @Nullable Map<String, Order> sortKeys;
 
 	private final Map<DatabaseType, AbstractSqlPagingQueryProvider> providers = new HashMap<>();
 
@@ -141,11 +142,7 @@ public class SqlPagingQueryProviderFactoryBean implements FactoryBean<PagingQuer
 
 	public void setSortKey(String key) {
 		Assert.doesNotContain(key, ",", "String setter is valid for a single ASC key only");
-
-		Map<String, Order> keys = new LinkedHashMap<>();
-		keys.put(key, Order.ASCENDING);
-
-		this.sortKeys = keys;
+		this.sortKeys = Map.of(key, Order.ASCENDING);
 	}
 
 	/**
@@ -154,6 +151,7 @@ public class SqlPagingQueryProviderFactoryBean implements FactoryBean<PagingQuer
 	 *
 	 * @see FactoryBean#getObject()
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public PagingQueryProvider getObject() throws Exception {
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlPagingQueryUtils.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.database.Order;
 import org.springframework.util.StringUtils;
 
@@ -155,7 +156,7 @@ public abstract class SqlPagingQueryUtils {
 	 * @param rowNumClause the implementation specific row num clause to be used
 	 * @return the generated query
 	 */
-	public static String generateRowNumSqlQuery(AbstractSqlPagingQueryProvider provider, String selectClause,
+	public static String generateRowNumSqlQuery(AbstractSqlPagingQueryProvider provider, @Nullable String selectClause,
 			boolean remainingPageQuery, String rowNumClause) {
 		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT * FROM (SELECT ").append(selectClause);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/package-info.java
@@ -4,7 +4,7 @@
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.database.support;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/FlatFileItemWriter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.file;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.file.transform.LineAggregator;
 import org.springframework.batch.item.support.AbstractFileItemWriter;
@@ -38,10 +39,11 @@ import org.springframework.util.ClassUtils;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public class FlatFileItemWriter<T> extends AbstractFileItemWriter<T> {
 
-	protected LineAggregator<T> lineAggregator;
+	protected @Nullable LineAggregator<T> lineAggregator;
 
 	public FlatFileItemWriter() {
 		this.setExecutionContextName(ClassUtils.getShortName(FlatFileItemWriter.class));
@@ -69,6 +71,7 @@ public class FlatFileItemWriter<T> extends AbstractFileItemWriter<T> {
 		this.lineAggregator = lineAggregator;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public String doWrite(Chunk<? extends T> items) {
 		StringBuilder lines = new StringBuilder();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemReader.java
@@ -21,6 +21,8 @@ import java.util.Comparator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.ItemStreamException;
@@ -29,7 +31,6 @@ import org.springframework.batch.item.ResourceAware;
 import org.springframework.batch.item.UnexpectedInputException;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -51,9 +52,9 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 
 	private static final String RESOURCE_KEY = "resourceIndex";
 
-	private ResourceAwareItemReaderItemStream<? extends T> delegate;
+	private @Nullable ResourceAwareItemReaderItemStream<? extends T> delegate;
 
-	private Resource[] resources;
+	private Resource @Nullable [] resources;
 
 	private boolean saveState = true;
 
@@ -79,6 +80,7 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 		/**
 		 * Compares resource filenames.
 		 */
+		@SuppressWarnings("DataFlowIssue")
 		@Override
 		public int compare(Resource r1, Resource r2) {
 			return r1.getFilename().compareTo(r2.getFilename());
@@ -93,9 +95,9 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	/**
 	 * Reads the next item, jumping to next resource if necessary.
 	 */
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public T read() throws Exception, UnexpectedInputException, ParseException {
+	public @Nullable T read() throws Exception {
 
 		if (noInput) {
 			return null;
@@ -117,7 +119,8 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	 * exhausted. Items are appended to the buffer.
 	 * @return next item from input
 	 */
-	private T readNextItem() throws Exception {
+	@SuppressWarnings("DataFlowIssue")
+	private @Nullable T readNextItem() throws Exception {
 
 		T item = readFromDelegate();
 
@@ -139,7 +142,8 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 		return item;
 	}
 
-	private T readFromDelegate() throws Exception {
+	@SuppressWarnings("DataFlowIssue")
+	private @Nullable T readFromDelegate() throws Exception {
 		T item = delegate.read();
 		if (item instanceof ResourceAware resourceAware) {
 			resourceAware.setResource(resources[currentResource]);
@@ -151,6 +155,7 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	 * Close the {@link #setDelegate(ResourceAwareItemReaderItemStream)} reader and reset
 	 * instance variable values.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws ItemStreamException {
 		super.close();
@@ -166,6 +171,7 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	 * Figure out which resource to start with in case of restart, open the delegate and
 	 * restore delegate's position in the resource.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		super.open(executionContext);
@@ -205,6 +211,7 @@ public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> 
 	/**
 	 * Store the current resource index and position in the resource.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		super.update(executionContext);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/MultiResourceItemWriter.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.file;
 import java.io.File;
 import java.io.IOException;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -50,9 +51,9 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 
 	final static private String CURRENT_RESOURCE_ITEM_COUNT = "resource.item.count";
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private ResourceAwareItemWriterItemStream<? super T> delegate;
+	private @Nullable ResourceAwareItemWriterItemStream<? super T> delegate;
 
 	private int itemCountLimitPerResource = Integer.MAX_VALUE;
 
@@ -70,6 +71,7 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 		this.setExecutionContextName(ClassUtils.getShortName(MultiResourceItemWriter.class));
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 		int writtenItems = 0;
@@ -144,6 +146,7 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 		this.saveState = saveState;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws ItemStreamException {
 		super.close();
@@ -154,6 +157,7 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		super.open(executionContext);
@@ -177,6 +181,7 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		super.update(executionContext);
@@ -192,6 +197,7 @@ public class MultiResourceItemWriter<T> extends AbstractItemStreamItemWriter<T> 
 	/**
 	 * Create output resource (if necessary) and point the delegate to it.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private File setResourceToDelegate() throws IOException {
 		String path = resource.getFile().getAbsolutePath() + suffixCreator.getSuffix(resourceIndex);
 		File file = new File(path);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/NonTransientFlatFileException.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/NonTransientFlatFileException.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.file;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.NonTransientResourceException;
 
 /**
@@ -25,7 +26,7 @@ import org.springframework.batch.item.NonTransientResourceException;
  */
 public class NonTransientFlatFileException extends NonTransientResourceException {
 
-	private final String input;
+	private final @Nullable String input;
 
 	private int lineNumber;
 
@@ -40,13 +41,13 @@ public class NonTransientFlatFileException extends NonTransientResourceException
 		this.lineNumber = lineNumber;
 	}
 
-	public NonTransientFlatFileException(String message, Throwable cause, String input, int lineNumber) {
+	public NonTransientFlatFileException(String message, Throwable cause, @Nullable String input, int lineNumber) {
 		super(message, cause);
 		this.input = input;
 		this.lineNumber = lineNumber;
 	}
 
-	public String getInput() {
+	public @Nullable String getInput() {
 		return input;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/ResourcesItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/ResourcesItemReader.java
@@ -21,10 +21,11 @@ import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourceArrayPropertyEditor;
-import org.springframework.lang.Nullable;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@link ItemReader} which produces {@link Resource} instances from an array. This can be
@@ -72,8 +73,7 @@ public class ResourcesItemReader extends AbstractItemStreamItemReader<Resource> 
 	 * or {@code null} if none remain.
 	 */
 	@Override
-	@Nullable
-	public synchronized Resource read() throws Exception {
+	public synchronized @Nullable Resource read() throws Exception {
 		int index = counter.incrementAndGet() - 1;
 		if (index >= resources.length) {
 			return null;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/SimpleBinaryBufferedReaderFactory.java
@@ -24,6 +24,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.core.io.Resource;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link BufferedReaderFactory} useful for reading simple binary (or text) files with
  * no line endings, such as those produced by mainframe copy books. The reader splits a
@@ -76,7 +78,7 @@ public class SimpleBinaryBufferedReaderFactory implements BufferedReaderFactory 
 		}
 
 		@Override
-		public String readLine() throws IOException {
+		public @Nullable String readLine() throws IOException {
 
 			StringBuilder buffer;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/MultiResourceItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/MultiResourceItemReaderBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.file.builder;
 
 import java.util.Comparator;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.MultiResourceItemReader;
 import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.core.io.Resource;
@@ -29,22 +30,23 @@ import org.springframework.util.StringUtils;
  *
  * @author Glenn Renfro
  * @author Drummond Dawson
+ * @author Stefano Cordio
  * @since 4.0
  * @see MultiResourceItemReader
  */
 public class MultiResourceItemReaderBuilder<T> {
 
-	private ResourceAwareItemReaderItemStream<? extends T> delegate;
+	private @Nullable ResourceAwareItemReaderItemStream<? extends T> delegate;
 
-	private Resource[] resources;
+	private Resource @Nullable [] resources;
 
 	private boolean strict = false;
 
-	private Comparator<Resource> comparator;
+	private @Nullable Comparator<Resource> comparator;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	/**
 	 * Configure if the state of the

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/MultiResourceItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/MultiResourceItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.file.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.MultiResourceItemWriter;
 import org.springframework.batch.item.file.ResourceAwareItemWriterItemStream;
 import org.springframework.batch.item.file.ResourceSuffixCreator;
@@ -32,17 +33,17 @@ import org.springframework.util.Assert;
  */
 public class MultiResourceItemWriterBuilder<T> {
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private ResourceAwareItemWriterItemStream<? super T> delegate;
+	private @Nullable ResourceAwareItemWriterItemStream<? super T> delegate;
 
 	private int itemCountLimitPerResource = Integer.MAX_VALUE;
 
-	private ResourceSuffixCreator suffixCreator;
+	private @Nullable ResourceSuffixCreator suffixCreator;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	/**
 	 * Configure if the state of the
@@ -142,7 +143,9 @@ public class MultiResourceItemWriterBuilder<T> {
 			writer.setResourceSuffixCreator(this.suffixCreator);
 		}
 		writer.setSaveState(this.saveState);
-		writer.setName(this.name);
+		if (this.name != null) {
+			writer.setName(this.name);
+		}
 
 		return writer;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for file item readers and writers.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.file.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.transform.FieldSet;
 import org.springframework.batch.support.DefaultPropertyEditorRegistrar;
 import org.springframework.beans.BeanWrapperImpl;
@@ -88,16 +89,16 @@ import org.springframework.validation.DataBinder;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
+ * @author Stefano Cordio
  */
 public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 		implements FieldSetMapper<T>, BeanFactoryAware, InitializingBean {
 
-	private String name;
+	private @Nullable String name;
 
-	private Class<? extends T> type;
+	private @Nullable Class<? extends T> type;
 
-	private BeanFactory beanFactory;
+	private @Nullable BeanFactory beanFactory;
 
 	private final ConcurrentMap<DistanceHolder, ConcurrentMap<String, String>> propertiesMatched = new ConcurrentHashMap<>();
 
@@ -105,7 +106,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 
 	private boolean strict = true;
 
-	private ConversionService conversionService;
+	private @Nullable ConversionService conversionService;
 
 	private boolean isCustomEditorsSet;
 
@@ -152,7 +153,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 	 * Check that precisely one of type or prototype bean name is specified.
 	 * @throws IllegalStateException if neither is set or both properties are set.
 	 *
-	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 * @see InitializingBean#afterPropertiesSet()
 	 */
 	@Override
 	public void afterPropertiesSet() throws Exception {
@@ -169,7 +170,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 	 * {@link DataBinder} from {@link #createBinder(Object)} has errors after binding).
 	 * @throws NotWritablePropertyException if the {@link FieldSet} contains a field that
 	 * cannot be mapped to a bean property.
-	 * @see org.springframework.batch.item.file.mapping.FieldSetMapper#mapFieldSet(FieldSet)
+	 * @see FieldSetMapper#mapFieldSet(FieldSet)
 	 */
 	@Override
 	public T mapFieldSet(FieldSet fs) throws BindException {
@@ -215,7 +216,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 	protected void initBinder(DataBinder binder) {
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	private T getBean() {
 		if (name != null) {
 			return (T) beanFactory.getBean(name);
@@ -275,11 +276,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 		return properties;
 	}
 
-	private String findPropertyName(Object bean, String key) {
-
-		if (bean == null) {
-			return null;
-		}
+	private @Nullable String findPropertyName(Object bean, String key) {
 
 		Class<?> cls = bean.getClass();
 
@@ -333,6 +330,7 @@ public class BeanWrapperFieldSetMapper<T> extends DefaultPropertyEditorRegistrar
 		return name;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	private Object getPropertyValue(Object bean, String nestedName) {
 		BeanWrapperImpl wrapper = new BeanWrapperImpl(bean);
 		wrapper.setAutoGrowNestedPaths(true);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/DefaultLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/DefaultLineMapper.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.file.mapping;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.LineMapper;
 import org.springframework.batch.item.file.transform.FieldSet;
 import org.springframework.batch.item.file.transform.LineTokenizer;
@@ -33,10 +34,11 @@ import org.springframework.util.Assert;
  */
 public class DefaultLineMapper<T> implements LineMapper<T>, InitializingBean {
 
-	private LineTokenizer tokenizer;
+	private @Nullable LineTokenizer tokenizer;
 
-	private FieldSetMapper<T> fieldSetMapper;
+	private @Nullable FieldSetMapper<T> fieldSetMapper;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public T mapLine(String line, int lineNumber) throws Exception {
 		return fieldSetMapper.mapFieldSet(tokenizer.tokenize(line));

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/PatternMatchingCompositeLineMapper.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.file.mapping;
 
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.LineMapper;
 import org.springframework.batch.item.file.transform.LineTokenizer;
 import org.springframework.batch.item.file.transform.PatternMatchingCompositeLineTokenizer;
@@ -48,8 +49,9 @@ public class PatternMatchingCompositeLineMapper<T> implements LineMapper<T>, Ini
 
 	private final PatternMatchingCompositeLineTokenizer tokenizer = new PatternMatchingCompositeLineTokenizer();
 
-	private PatternMatcher<FieldSetMapper<T>> patternMatcher;
+	private @Nullable PatternMatcher<FieldSetMapper<T>> patternMatcher;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public T mapLine(String line, int lineNumber) throws Exception {
 		return patternMatcher.match(line).mapFieldSet(this.tokenizer.tokenize(line));

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/RecordFieldSetMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/RecordFieldSetMapper.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.file.mapping;
 
 import java.lang.reflect.Constructor;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.transform.FieldSet;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.SimpleTypeConverter;
@@ -40,9 +41,9 @@ public class RecordFieldSetMapper<T> implements FieldSetMapper<T> {
 
 	private final Constructor<T> mappedConstructor;
 
-	private String[] constructorParameterNames;
+	private final @Nullable String[] constructorParameterNames;
 
-	private Class<?>[] constructorParameterTypes;
+	private final Class<?>[] constructorParameterTypes;
 
 	/**
 	 * Create a new {@link RecordFieldSetMapper}.
@@ -75,14 +76,11 @@ public class RecordFieldSetMapper<T> implements FieldSetMapper<T> {
 		Assert.isTrue(fieldSet.getFieldCount() == this.constructorParameterNames.length,
 				"Fields count must be equal to record components count");
 		Assert.isTrue(fieldSet.hasNames(), "Field names must be specified");
-		Object[] args = new Object[0];
-		if (this.constructorParameterNames != null && this.constructorParameterTypes != null) {
-			args = new Object[this.constructorParameterNames.length];
-			for (int i = 0; i < args.length; i++) {
-				String name = this.constructorParameterNames[i];
-				Class<?> type = this.constructorParameterTypes[i];
-				args[i] = this.typeConverter.convertIfNecessary(fieldSet.readRawString(name), type);
-			}
+		@Nullable Object[] args = new Object[this.constructorParameterNames.length];
+		for (int i = 0; i < args.length; i++) {
+			String name = this.constructorParameterNames[i];
+			Class<?> type = this.constructorParameterTypes[i];
+			args[i] = this.typeConverter.convertIfNecessary(fieldSet.readRawString(name), type);
 		}
 		return BeanUtils.instantiateClass(this.mappedConstructor, args);
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/mapping/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of io file support mapping concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.file.mapping;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of io file concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.file;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/DefaultRecordSeparatorPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/DefaultRecordSeparatorPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.file.separator;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -24,7 +25,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
+ * @author Stefano Cordio
  */
 public class DefaultRecordSeparatorPolicy extends SimpleRecordSeparatorPolicy {
 
@@ -71,7 +72,7 @@ public class DefaultRecordSeparatorPolicy extends SimpleRecordSeparatorPolicy {
 	}
 
 	/**
-	 * Public setter for the continuation. Defaults to back slash.
+	 * Public setter for the continuation. Defaults to backslash.
 	 * @param continuation the continuation to set
 	 */
 	public void setContinuation(String continuation) {
@@ -79,22 +80,22 @@ public class DefaultRecordSeparatorPolicy extends SimpleRecordSeparatorPolicy {
 	}
 
 	/**
-	 * Return true if the line does not have unterminated quotes (delimited by "), and
-	 * does not end with a continuation marker ('\'). The test for the continuation marker
-	 * ignores whitespace at the end of the line.
+	 * Return true if the line does not have unterminated quotes (delimited by {@code "}),
+	 * and does not end with a continuation marker ({@code \}). The test for the
+	 * continuation marker ignores whitespace at the end of the line.
 	 *
-	 * @see org.springframework.batch.item.file.separator.RecordSeparatorPolicy#isEndOfRecord(java.lang.String)
+	 * @see RecordSeparatorPolicy#isEndOfRecord(String)
 	 */
 	@Override
-	public boolean isEndOfRecord(String line) {
+	public boolean isEndOfRecord(@Nullable String line) {
 		return !isQuoteUnterminated(line) && !isContinued(line);
 	}
 
 	/**
-	 * If we are in an unterminated quote, add a line separator. Otherwise remove the
+	 * If we are in an unterminated quote, add a line separator. Otherwise, remove the
 	 * continuation marker (plus whitespace at the end) if it is there.
 	 *
-	 * @see org.springframework.batch.item.file.separator.SimpleRecordSeparatorPolicy#preProcess(java.lang.String)
+	 * @see SimpleRecordSeparatorPolicy#preProcess(String)
 	 */
 	@Override
 	public String preProcess(String line) {
@@ -113,8 +114,8 @@ public class DefaultRecordSeparatorPolicy extends SimpleRecordSeparatorPolicy {
 	 * @param line the line to check
 	 * @return true if the quote is unterminated, false otherwise
 	 */
-	private boolean isQuoteUnterminated(String line) {
-		return StringUtils.countOccurrencesOf(line, quoteCharacter) % 2 != 0;
+	private boolean isQuoteUnterminated(@Nullable String line) {
+		return line != null && StringUtils.countOccurrencesOf(line, quoteCharacter) % 2 != 0;
 	}
 
 	/**
@@ -123,11 +124,8 @@ public class DefaultRecordSeparatorPolicy extends SimpleRecordSeparatorPolicy {
 	 * @param line the line to check
 	 * @return true if the line ends with the continuation marker, false otherwise
 	 */
-	private boolean isContinued(String line) {
-		if (line == null) {
-			return false;
-		}
-		return line.trim().endsWith(continuation);
+	private boolean isContinued(@Nullable String line) {
+		return line != null && line.trim().endsWith(continuation);
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/JsonRecordSeparatorPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/JsonRecordSeparatorPolicy.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.file.separator;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -42,8 +43,8 @@ public class JsonRecordSeparatorPolicy extends SimpleRecordSeparatorPolicy {
 	 * @see RecordSeparatorPolicy#isEndOfRecord(String)
 	 */
 	@Override
-	public boolean isEndOfRecord(String line) {
-		return StringUtils.countOccurrencesOf(line, "{") == StringUtils.countOccurrencesOf(line, "}")
+	public boolean isEndOfRecord(@Nullable String line) {
+		return line != null && StringUtils.countOccurrencesOf(line, "{") == StringUtils.countOccurrencesOf(line, "}")
 				&& line.trim().endsWith("}");
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/RecordSeparatorPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/RecordSeparatorPolicy.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.item.file.separator;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.BufferedReader;
 
 /**
@@ -36,14 +38,14 @@ public interface RecordSeparatorPolicy {
 	 * @param record a String without a newline character at the end.
 	 * @return true if this line is a complete record.
 	 */
-	boolean isEndOfRecord(String record);
+	boolean isEndOfRecord(@Nullable String record);
 
 	/**
 	 * Give the policy a chance to post-process a complete record, e.g. remove a suffix.
 	 * @param record the complete record.
-	 * @return a modified version of the record if desired.
+	 * @return a modified version of the record if desired, potentially null.
 	 */
-	String postProcess(String record);
+	@Nullable String postProcess(String record);
 
 	/**
 	 * Pre-process a record before another line is appended, in the case of a multi-line

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/SimpleRecordSeparatorPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/SimpleRecordSeparatorPolicy.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.item.file.separator;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Simplest possible {@link RecordSeparatorPolicy} - treats all lines as record endings.
  *
@@ -30,7 +32,7 @@ public class SimpleRecordSeparatorPolicy implements RecordSeparatorPolicy {
 	 * @see org.springframework.batch.item.file.separator.RecordSeparatorPolicy#isEndOfRecord(java.lang.String)
 	 */
 	@Override
-	public boolean isEndOfRecord(String line) {
+	public boolean isEndOfRecord(@Nullable String line) {
 		return true;
 	}
 
@@ -39,7 +41,7 @@ public class SimpleRecordSeparatorPolicy implements RecordSeparatorPolicy {
 	 * @see org.springframework.batch.item.file.separator.RecordSeparatorPolicy#postProcess(java.lang.String)
 	 */
 	@Override
-	public String postProcess(String record) {
+	public @Nullable String postProcess(String record) {
 		return record;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/SuffixRecordSeparatorPolicy.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/SuffixRecordSeparatorPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package org.springframework.batch.item.file.separator;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link RecordSeparatorPolicy} that looks for an exact match for a String at the end
  * of a line (e.g. a semicolon).
  *
  * @author Dave Syer
- *
+ * @author Stefano Cordio
  */
 public class SuffixRecordSeparatorPolicy extends DefaultRecordSeparatorPolicy {
 
@@ -52,14 +54,13 @@ public class SuffixRecordSeparatorPolicy extends DefaultRecordSeparatorPolicy {
 	}
 
 	/**
-	 * Return true if the line ends with the specified substring. By default whitespace is
-	 * trimmed before the comparison. Also returns true if the line is null, but not if it
-	 * is empty.
+	 * Return true if the line ends with the specified substring. By default, whitespace
+	 * is trimmed before the comparison.
 	 *
-	 * @see org.springframework.batch.item.file.separator.RecordSeparatorPolicy#isEndOfRecord(java.lang.String)
+	 * @see RecordSeparatorPolicy#isEndOfRecord(String)
 	 */
 	@Override
-	public boolean isEndOfRecord(String line) {
+	public boolean isEndOfRecord(@Nullable String line) {
 		if (line == null) {
 			return true;
 		}
@@ -70,10 +71,10 @@ public class SuffixRecordSeparatorPolicy extends DefaultRecordSeparatorPolicy {
 	/**
 	 * Remove the suffix from the end of the record.
 	 *
-	 * @see org.springframework.batch.item.file.separator.SimpleRecordSeparatorPolicy#postProcess(java.lang.String)
+	 * @see SimpleRecordSeparatorPolicy#postProcess(String)
 	 */
 	@Override
-	public String postProcess(String record) {
+	public @Nullable String postProcess(@Nullable String record) {
 		if (record == null) {
 			return null;
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/separator/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of io file support separator concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.file.separator;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/AbstractLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/AbstractLineTokenizer.java
@@ -17,11 +17,11 @@
 package org.springframework.batch.item.file.transform;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Abstract class handling common concerns of various {@link LineTokenizer}
@@ -32,14 +32,15 @@ import org.springframework.util.StringUtils;
  * @author Lucas Ward
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public abstract class AbstractLineTokenizer implements LineTokenizer {
+
+	private static final String EMPTY_TOKEN = "";
 
 	protected String[] names = new String[0];
 
 	private boolean strict = true;
-
-	private final String emptyToken = "";
 
 	private FieldSetFactory fieldSetFactory = new DefaultFieldSetFactory();
 
@@ -77,21 +78,16 @@ public abstract class AbstractLineTokenizer implements LineTokenizer {
 	 * @param names names of each column
 	 */
 	public void setNames(String... names) {
-		if (names == null) {
-			this.names = null;
+		boolean valid = false;
+		for (String name : names) {
+			if (StringUtils.hasText(name)) {
+				valid = true;
+				break;
+			}
 		}
-		else {
-			boolean valid = false;
-			for (String name : names) {
-				if (StringUtils.hasText(name)) {
-					valid = true;
-					break;
-				}
-			}
 
-			if (valid) {
-				this.names = Arrays.asList(names).toArray(new String[names.length]);
-			}
+		if (valid) {
+			this.names = names.clone();
 		}
 	}
 
@@ -100,10 +96,7 @@ public abstract class AbstractLineTokenizer implements LineTokenizer {
 	 * @see #setNames(String[])
 	 */
 	public boolean hasNames() {
-		if (names != null && names.length > 0) {
-			return true;
-		}
-		return false;
+		return names.length > 0;
 	}
 
 	/**
@@ -125,7 +118,7 @@ public abstract class AbstractLineTokenizer implements LineTokenizer {
 			adjustTokenCountIfNecessary(tokens);
 		}
 
-		String[] values = tokens.toArray(new String[tokens.size()]);
+		String[] values = tokens.toArray(new String[0]);
 
 		if (names.length == 0) {
 			return fieldSetFactory.create(values);
@@ -156,7 +149,7 @@ public abstract class AbstractLineTokenizer implements LineTokenizer {
 				// add empty tokens until the token list size matches
 				// the expected number of tokens
 				for (int i = 0; i < (nameLength - tokensSize); i++) {
-					tokens.add(emptyToken);
+					tokens.add(EMPTY_TOKEN);
 				}
 
 			}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/BeanWrapperFieldExtractor.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.file.transform;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.factory.InitializingBean;
@@ -33,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public class BeanWrapperFieldExtractor<T> implements FieldExtractor<T>, InitializingBean {
 
-	private String[] names;
+	private String @Nullable [] names;
 
 	/**
 	 * @param names field names to be extracted by the {@link #extract(Object)} method.
@@ -43,9 +44,10 @@ public class BeanWrapperFieldExtractor<T> implements FieldExtractor<T>, Initiali
 		this.names = names.clone();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public Object[] extract(T item) {
-		List<Object> values = new ArrayList<>();
+		List<@Nullable Object> values = new ArrayList<>();
 
 		BeanWrapper bw = new BeanWrapperImpl(item);
 		for (String propertyName : this.names) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSetFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DefaultFieldSetFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2024 the original author or authors.
+ * Copyright 2009-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.batch.item.file.transform;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default implementation of {@link FieldSetFactory} with no special knowledge of the
@@ -26,13 +26,13 @@ import org.springframework.lang.Nullable;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
+ * @author Stefano Cordio
  */
 public class DefaultFieldSetFactory implements FieldSetFactory {
 
-	private DateFormat dateFormat;
+	private @Nullable DateFormat dateFormat;
 
-	private NumberFormat numberFormat;
+	private @Nullable NumberFormat numberFormat;
 
 	/**
 	 * Default constructor.
@@ -46,27 +46,29 @@ public class DefaultFieldSetFactory implements FieldSetFactory {
 	 * @param numberFormat the {@link NumberFormat} to use for parsing numbers
 	 * @since 5.2
 	 */
-	public DefaultFieldSetFactory(@Nullable DateFormat dateFormat, @Nullable NumberFormat numberFormat) {
+	public DefaultFieldSetFactory(DateFormat dateFormat, NumberFormat numberFormat) {
 		this.dateFormat = dateFormat;
 		this.numberFormat = numberFormat;
 	}
 
 	/**
-	 * The {@link NumberFormat} to use for parsing numbers. If unset then
-	 * {@link java.util.Locale#US} will be used.
-	 * @param numberFormat the {@link NumberFormat} to use for number parsing
-	 */
-	public void setNumberFormat(NumberFormat numberFormat) {
-		this.numberFormat = numberFormat;
-	}
-
-	/**
-	 * The {@link DateFormat} to use for parsing dates. If unset the default pattern is
-	 * ISO standard <code>yyyy-MM-dd</code>.
+	 * The {@link DateFormat} to use for parsing dates.
+	 * <p>
+	 * If unset the default pattern is ISO standard <code>yyyy-MM-dd</code>.
 	 * @param dateFormat the {@link DateFormat} to use for date parsing
 	 */
 	public void setDateFormat(DateFormat dateFormat) {
 		this.dateFormat = dateFormat;
+	}
+
+	/**
+	 * The {@link NumberFormat} to use for parsing numbers.
+	 * <p>
+	 * If unset, {@link java.util.Locale#US} will be used.
+	 * @param numberFormat the {@link NumberFormat} to use for number parsing
+	 */
+	public void setNumberFormat(NumberFormat numberFormat) {
+		this.numberFormat = numberFormat;
 	}
 
 	/**

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/DelimitedLineTokenizer.java
@@ -17,9 +17,9 @@
 package org.springframework.batch.item.file.transform;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -63,7 +63,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 
 	private String escapedQuoteString;
 
-	private Collection<Integer> includedFields = null;
+	private final Set<Integer> includedFields = new HashSet<>();
 
 	/**
 	 * Create a new instance of the {@link DelimitedLineTokenizer} class for the common
@@ -80,6 +80,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 	 * Create a new instance of the {@link DelimitedLineTokenizer} class.
 	 * @param delimiter the desired delimiter. This is required
 	 */
+	@SuppressWarnings("NullAway")
 	public DelimitedLineTokenizer(String delimiter) {
 		Assert.notNull(delimiter, "A delimiter is required");
 		Assert.state(!delimiter.equals(String.valueOf(DEFAULT_QUOTE_CHARACTER)),
@@ -98,14 +99,16 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 	}
 
 	/**
-	 * The fields to include in the output by position (starting at 0). By default all
+	 * The fields to include in the output by position (starting at 0). By default, all
 	 * fields are included, but this property can be set to pick out only a few fields
 	 * from a larger set. Note that if field names are provided, their number must match
 	 * the number of included fields.
 	 * @param includedFields the included fields to set
 	 */
 	public void setIncludedFields(int... includedFields) {
-		this.includedFields = new HashSet<>();
+		if (!this.includedFields.isEmpty()) {
+			this.includedFields.clear();
+		}
 		for (int i : includedFields) {
 			this.includedFields.add(i);
 		}
@@ -161,7 +164,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 					endPosition = (endPosition - delimiter.length()) + 1;
 				}
 
-				if (includedFields == null || includedFields.contains(fieldCount)) {
+				if (includedFields.isEmpty() || includedFields.contains(fieldCount)) {
 					String value = substringWithTrimmedWhitespaceAndQuotesIfQuotesPresent(line, lastCut, endPosition);
 					tokens.add(value);
 				}
@@ -169,7 +172,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 				fieldCount++;
 
 				if (isEnd && isDelimiter) {
-					if (includedFields == null || includedFields.contains(fieldCount)) {
+					if (includedFields.isEmpty() || includedFields.contains(fieldCount)) {
 						tokens.add("");
 					}
 					fieldCount++;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FieldExtractor.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.item.file.transform;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * This class will convert an object to an array of its parts.
  *
@@ -28,6 +30,6 @@ public interface FieldExtractor<T> {
 	 * @param item the object that contains the information to be extracted.
 	 * @return an array containing item's parts
 	 */
-	Object[] extract(T item);
+	@Nullable Object[] extract(T item);
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FieldSet.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FieldSet.java
@@ -15,6 +15,8 @@
 */
 package org.springframework.batch.item.file.transform;
 
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Date;
@@ -47,7 +49,7 @@ public interface FieldSet {
 	/**
 	 * @return fields wrapped by this '<code>FieldSet</code>' instance as String values.
 	 */
-	String[] getValues();
+	@Nullable String[] getValues();
 
 	/**
 	 * Read the {@link String} value at index '<code>index</code>'.
@@ -55,14 +57,14 @@ public interface FieldSet {
 	 * @return {@link String} containing the value at the index.
 	 * @throws IndexOutOfBoundsException if the {@code index} is out of bounds.
 	 */
-	String readString(int index);
+	@Nullable String readString(int index);
 
 	/**
 	 * Read the {@link String} value from column with given '<code>name</code>'.
 	 * @param name the field {@code name}.
 	 * @return {@link String} containing the value from the specified {@code name}.
 	 */
-	String readString(String name);
+	@Nullable String readString(String name);
 
 	/**
 	 * Read the {@link String} value at index '<code>index</code>' including trailing
@@ -71,7 +73,7 @@ public interface FieldSet {
 	 * @return {@link String} containing the value from the specified {@code index}.
 	 * @throws IndexOutOfBoundsException if the {@code index} is out of bounds.
 	 */
-	String readRawString(int index);
+	@Nullable String readRawString(int index);
 
 	/**
 	 * Read the {@link String} value from column with given '<code>name</code>' including
@@ -79,7 +81,7 @@ public interface FieldSet {
 	 * @param name the field {@code name}.
 	 * @return {@link String} containing the value from the specified {@code name}.
 	 */
-	String readRawString(String name);
+	@Nullable String readRawString(String name);
 
 	/**
 	 * Read the '<code>boolean</code>' value at index '<code>index</code>'.
@@ -105,7 +107,7 @@ public interface FieldSet {
 	 * case-sensitive.
 	 * @return boolean containing the value from the specified {@code index}.
 	 * @throws IndexOutOfBoundsException if the index is out of bounds, or if the supplied
-	 * <code>trueValue</code> is <code>null</code>.
+	 * {@code trueValue} is {@code null}.
 	 */
 	boolean readBoolean(int index, String trueValue);
 
@@ -116,7 +118,7 @@ public interface FieldSet {
 	 * case-sensitive.
 	 * @return boolean containing the value from the specified {@code name}.
 	 * @throws IllegalArgumentException if a column with given {@code name} is not
-	 * defined, or if the supplied <code>trueValue</code> is <code>null</code>.
+	 * defined, or if the supplied {@code trueValue} is {@code null}.
 	 */
 	boolean readBoolean(String name, String trueValue);
 
@@ -285,7 +287,7 @@ public interface FieldSet {
 	 * @return {@link BigDecimal} containing the value from the specified index.
 	 * @throws IndexOutOfBoundsException if the index is out of bounds.
 	 */
-	BigDecimal readBigDecimal(int index);
+	@Nullable BigDecimal readBigDecimal(int index);
 
 	/**
 	 * Read the {@link java.math.BigDecimal} value from column with given
@@ -295,7 +297,7 @@ public interface FieldSet {
 	 * @throws IllegalArgumentException if a column with given {@code name} is not
 	 * defined.
 	 */
-	BigDecimal readBigDecimal(String name);
+	@Nullable BigDecimal readBigDecimal(String name);
 
 	/**
 	 * Read the {@link BigDecimal} value at index '<code>index</code>', returning the
@@ -306,7 +308,7 @@ public interface FieldSet {
 	 * @return {@link BigDecimal} containing the value from the specified index.
 	 * @throws IndexOutOfBoundsException if the index is out of bounds.
 	 */
-	BigDecimal readBigDecimal(int index, BigDecimal defaultValue);
+	@Nullable BigDecimal readBigDecimal(int index, BigDecimal defaultValue);
 
 	/**
 	 * Read the {@link BigDecimal} value from column with given '<code>name</code>,
@@ -318,7 +320,7 @@ public interface FieldSet {
 	 * @throws IllegalArgumentException if a column with given {@code name} is not
 	 * defined.
 	 */
-	BigDecimal readBigDecimal(String name, BigDecimal defaultValue);
+	@Nullable BigDecimal readBigDecimal(String name, BigDecimal defaultValue);
 
 	/**
 	 * Read the <code>java.util.Date</code> value in default format at designated column
@@ -425,7 +427,7 @@ public interface FieldSet {
 	 * Construct name-value pairs from the field names and string values. Null values are
 	 * omitted.
 	 * @return some properties representing the field set.
-	 * @throws IllegalStateException if the field name meta data is not available.
+	 * @throws IllegalStateException if the field name metadata is not available.
 	 */
 	Properties getProperties();
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FixedLengthTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FixedLengthTokenizer.java
@@ -16,6 +16,9 @@
 
 package org.springframework.batch.item.file.transform;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,10 +33,11 @@ import java.util.List;
  * @author Lucas Ward
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public class FixedLengthTokenizer extends AbstractLineTokenizer {
 
-	private Range[] ranges;
+	private Range @Nullable [] ranges;
 
 	private int maxRange = 0;
 
@@ -50,7 +54,7 @@ public class FixedLengthTokenizer extends AbstractLineTokenizer {
 	 * @param ranges the column ranges expected in the input
 	 */
 	public void setColumns(Range... ranges) {
-		this.ranges = Arrays.asList(ranges).toArray(new Range[ranges.length]);
+		this.ranges = ranges.clone();
 		calculateMaxRange(ranges);
 	}
 
@@ -60,7 +64,7 @@ public class FixedLengthTokenizer extends AbstractLineTokenizer {
 	 * always a min and max, such as: "1,4-20, 22"
 	 */
 	private void calculateMaxRange(Range[] ranges) {
-		if (ranges == null || ranges.length == 0) {
+		if (ranges.length == 0) {
 			maxRange = 0;
 			return;
 		}
@@ -95,6 +99,7 @@ public class FixedLengthTokenizer extends AbstractLineTokenizer {
 	 */
 	@Override
 	protected List<String> doTokenize(String line) {
+		Assert.state(ranges != null, "ranges must not be null");
 		List<String> tokens = new ArrayList<>(ranges.length);
 		int lineLength;
 		String token;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FlatFileFormatException.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FlatFileFormatException.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.item.file.transform;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Exception indicating that some type of error has occurred while attempting to parse a
  * line of input into tokens.
@@ -26,7 +28,7 @@ package org.springframework.batch.item.file.transform;
  */
 public class FlatFileFormatException extends RuntimeException {
 
-	private String input;
+	private @Nullable String input;
 
 	/**
 	 * Create a new {@link FlatFileFormatException} based on a message.
@@ -61,7 +63,7 @@ public class FlatFileFormatException extends RuntimeException {
 	 * Retrieve the input that caused this exception.
 	 * @return String containing the input.
 	 */
-	public String getInput() {
+	public @Nullable String getInput() {
 		return input;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FormatterLineAggregator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/FormatterLineAggregator.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.file.transform;
 import java.util.Formatter;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -27,10 +28,11 @@ import org.springframework.util.Assert;
  *
  * @see Formatter
  * @author Dave Syer
+ * @author Stefano Cordio
  */
 public class FormatterLineAggregator<T> extends ExtractorLineAggregator<T> {
 
-	private String format;
+	private @Nullable String format;
 
 	private Locale locale = Locale.getDefault();
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/IncorrectTokenCountException.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/IncorrectTokenCountException.java
@@ -22,6 +22,7 @@ package org.springframework.batch.item.file.transform;
  * @author Lucas Ward
  * @author "Michael Minella"
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 1.1
  */
 public class IncorrectTokenCountException extends FlatFileFormatException {
@@ -30,13 +31,10 @@ public class IncorrectTokenCountException extends FlatFileFormatException {
 
 	private final int expectedCount;
 
-	private String input;
-
 	public IncorrectTokenCountException(String message, int expectedCount, int actualCount, String input) {
-		super(message);
+		super(message, input);
 		this.expectedCount = expectedCount;
 		this.actualCount = actualCount;
-		this.input = input;
 	}
 
 	public IncorrectTokenCountException(String message, int expectedCount, int actualCount) {
@@ -46,10 +44,10 @@ public class IncorrectTokenCountException extends FlatFileFormatException {
 	}
 
 	public IncorrectTokenCountException(int expectedCount, int actualCount, String input) {
-		super("Incorrect number of tokens found in record: expected " + expectedCount + " actual " + actualCount);
+		super("Incorrect number of tokens found in record: expected " + expectedCount + " actual " + actualCount,
+				input);
 		this.expectedCount = expectedCount;
 		this.actualCount = actualCount;
-		this.input = input;
 	}
 
 	public IncorrectTokenCountException(int expectedCount, int actualCount) {
@@ -64,15 +62,6 @@ public class IncorrectTokenCountException extends FlatFileFormatException {
 
 	public int getExpectedCount() {
 		return expectedCount;
-	}
-
-	/**
-	 * @return the line that caused the exception
-	 * @since 2.2.6
-	 */
-	@Override
-	public String getInput() {
-		return input;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/LineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/LineTokenizer.java
@@ -16,7 +16,7 @@
 
 package org.springframework.batch.item.file.transform;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface that is used by framework to split string obtained typically from a file into

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/PatternMatchingCompositeLineTokenizer.java
@@ -19,8 +19,9 @@ package org.springframework.batch.item.file.transform;
 import java.util.Map;
 
 import org.springframework.batch.support.PatternMatcher;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -36,8 +37,9 @@ import org.springframework.util.Assert;
  */
 public class PatternMatchingCompositeLineTokenizer implements LineTokenizer, InitializingBean {
 
-	private PatternMatcher<LineTokenizer> tokenizers = null;
+	private @Nullable PatternMatcher<LineTokenizer> tokenizers;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public FieldSet tokenize(@Nullable String line) {
 		return tokenizers.match(line).tokenize(line);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RangeArrayPropertyEditor.java
@@ -111,7 +111,7 @@ public class RangeArrayPropertyEditor extends PropertyEditorSupport {
 		return sb.toString();
 	}
 
-	private void setMaxValues(final Range[] ranges) {
+	private void setMaxValues(Range[] ranges) {
 
 		// Array of integers to track range values by index
 		Integer[] c = new Integer[ranges.length];

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RecordFieldExtractor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RecordFieldExtractor.java
@@ -21,9 +21,11 @@ import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * This is a field extractor for a Java record. By default, it will extract all record
@@ -66,7 +68,7 @@ public class RecordFieldExtractor<T> implements FieldExtractor<T> {
 	public Object[] extract(T item) {
 		List<Object> values = new ArrayList<>();
 		for (String componentName : this.names) {
-			RecordComponent recordComponent = getRecordComponentByName(componentName);
+			RecordComponent recordComponent = getRecordComponentByName(componentName).orElseThrow();
 			Object value;
 			try {
 				value = recordComponent.getAccessor().invoke(item);
@@ -85,19 +87,17 @@ public class RecordFieldExtractor<T> implements FieldExtractor<T> {
 
 	private void validate(String[] names) {
 		for (String name : names) {
-			if (getRecordComponentByName(name) == null) {
+			if (getRecordComponentByName(name).isEmpty()) {
 				throw new IllegalArgumentException(
 						"Component '" + name + "' is not defined in record " + targetType.getName());
 			}
 		}
 	}
 
-	@Nullable
-	private RecordComponent getRecordComponentByName(String name) {
+	private Optional<RecordComponent> getRecordComponentByName(String name) {
 		return Arrays.stream(this.recordComponents)
 			.filter(recordComponent -> recordComponent.getName().equals(name))
-			.findFirst()
-			.orElse(null);
+			.findFirst();
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RegexLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/RegexLineTokenizer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -46,13 +47,15 @@ import org.springframework.util.Assert;
  *
  * @see Matcher#group(int)
  * @author Costin Leau
+ * @author Stefano Cordio
  */
 public class RegexLineTokenizer extends AbstractLineTokenizer {
 
-	private Pattern pattern;
+	private @Nullable Pattern pattern;
 
 	@Override
 	protected List<String> doTokenize(String line) {
+		Assert.state(pattern != null, "pattern must be initialized");
 		Matcher matcher = pattern.matcher(line);
 		boolean matchFound = matcher.find();
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/transform/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of io file support transform concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.file.transform;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/function/FunctionItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/function/FunctionItemProcessor.java
@@ -18,7 +18,8 @@ package org.springframework.batch.item.function;
 import java.util.function.Function;
 
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.lang.Nullable;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -39,9 +40,8 @@ public class FunctionItemProcessor<I, O> implements ItemProcessor<I, O> {
 		this.function = function;
 	}
 
-	@Nullable
 	@Override
-	public O process(I item) throws Exception {
+	public @Nullable O process(I item) throws Exception {
 		return this.function.apply(item);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/function/PredicateFilteringItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/function/PredicateFilteringItemProcessor.java
@@ -18,6 +18,8 @@ package org.springframework.batch.item.function;
 import java.util.function.Predicate;
 
 import org.springframework.batch.item.ItemProcessor;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -42,7 +44,7 @@ public class PredicateFilteringItemProcessor<T> implements ItemProcessor<T, T> {
 	}
 
 	@Override
-	public T process(T item) throws Exception {
+	public @Nullable T process(T item) throws Exception {
 		return this.predicate.test(item) ? null : item;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/function/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/function/package-info.java
@@ -19,7 +19,7 @@
  *
  * @author Mahmoud Ben Hassine
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.function;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsItemReader.java
@@ -18,11 +18,12 @@ package org.springframework.batch.item.jms;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jms.core.JmsOperations;
 import org.springframework.jms.core.JmsTemplate;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import jakarta.jms.Message;
@@ -43,9 +44,9 @@ public class JmsItemReader<T> implements ItemReader<T>, InitializingBean {
 
 	protected Log logger = LogFactory.getLog(getClass());
 
-	protected Class<? extends T> itemType;
+	protected @Nullable Class<? extends T> itemType;
 
-	protected JmsOperations jmsTemplate;
+	protected @Nullable JmsOperations jmsTemplate;
 
 	/**
 	 * Setter for JMS template.
@@ -72,10 +73,9 @@ public class JmsItemReader<T> implements ItemReader<T>, InitializingBean {
 		this.itemType = itemType;
 	}
 
-	@Nullable
 	@Override
-	@SuppressWarnings("unchecked")
-	public T read() {
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
+	public @Nullable T read() {
 		if (itemType != null && itemType.isAssignableFrom(Message.class)) {
 			return (T) jmsTemplate.receive();
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsItemWriter.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.jms;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.jms.core.JmsOperations;
@@ -41,7 +42,7 @@ public class JmsItemWriter<T> implements ItemWriter<T> {
 
 	protected Log logger = LogFactory.getLog(getClass());
 
-	private JmsOperations jmsTemplate;
+	private @Nullable JmsOperations jmsTemplate;
 
 	/**
 	 * Setter for JMS template.
@@ -60,6 +61,7 @@ public class JmsItemWriter<T> implements ItemWriter<T> {
 	 *
 	 * @see org.springframework.batch.item.ItemWriter#write(Chunk)
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsMethodInvocationRecoverer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/JmsMethodInvocationRecoverer.java
@@ -17,8 +17,8 @@ package org.springframework.batch.item.jms;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
-import org.springframework.lang.Nullable;
 import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 import org.springframework.jms.JmsException;
 import org.springframework.jms.core.JmsOperations;
@@ -32,7 +32,7 @@ public class JmsMethodInvocationRecoverer<T> implements MethodInvocationRecovere
 
 	protected Log logger = LogFactory.getLog(getClass());
 
-	private JmsOperations jmsTemplate;
+	private @Nullable JmsOperations jmsTemplate;
 
 	/**
 	 * Setter for jms template.
@@ -48,9 +48,9 @@ public class JmsMethodInvocationRecoverer<T> implements MethodInvocationRecovere
 	 *
 	 * @see MethodInvocationRecoverer#recover(Object[], Throwable)
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	@Nullable
-	public T recover(Object[] items, Throwable cause) {
+	public @Nullable T recover(Object[] items, Throwable cause) {
 		try {
 			for (Object item : items) {
 				jmsTemplate.convertAndSend(item);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/builder/JmsItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/builder/JmsItemReaderBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.jms.builder;
 
 import jakarta.jms.Message;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.jms.JmsItemReader;
 import org.springframework.jms.core.JmsOperations;
 import org.springframework.util.Assert;
@@ -27,13 +28,14 @@ import org.springframework.util.Assert;
  *
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 4.0
  */
 public class JmsItemReaderBuilder<T> {
 
-	protected Class<? extends T> itemType;
+	protected @Nullable Class<? extends T> itemType;
 
-	protected JmsOperations jmsTemplate;
+	protected @Nullable JmsOperations jmsTemplate;
 
 	/**
 	 * Establish the JMS template that will be used by the JmsItemReader.
@@ -70,7 +72,9 @@ public class JmsItemReaderBuilder<T> {
 		Assert.notNull(this.jmsTemplate, "jmsTemplate is required.");
 		JmsItemReader<T> jmsItemReader = new JmsItemReader<>();
 
-		jmsItemReader.setItemType(this.itemType);
+		if (this.itemType != null) {
+			jmsItemReader.setItemType(this.itemType);
+		}
 		jmsItemReader.setJmsTemplate(this.jmsTemplate);
 		return jmsItemReader;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/builder/JmsItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/builder/JmsItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.jms.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.jms.JmsItemWriter;
 import org.springframework.jms.core.JmsOperations;
 import org.springframework.util.Assert;
@@ -28,7 +29,7 @@ import org.springframework.util.Assert;
  */
 public class JmsItemWriterBuilder<T> {
 
-	private JmsOperations jmsTemplate;
+	private @Nullable JmsOperations jmsTemplate;
 
 	/**
 	 * Establish the JMS template that will be used by the {@link JmsItemWriter}.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for JMS item reader and writer.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.jms.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/jms/package-info.java
@@ -3,8 +3,9 @@
  *
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.jms;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/GsonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/GsonJsonObjectReader.java
@@ -25,10 +25,10 @@ import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.ParseException;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -44,11 +44,11 @@ public class GsonJsonObjectReader<T> implements JsonObjectReader<T> {
 
 	private final Class<? extends T> itemType;
 
-	private JsonReader jsonReader;
-
 	private Gson mapper;
 
-	private InputStream inputStream;
+	private @Nullable JsonReader jsonReader;
+
+	private @Nullable InputStream inputStream;
 
 	/**
 	 * Create a new {@link GsonJsonObjectReader} instance.
@@ -83,9 +83,9 @@ public class GsonJsonObjectReader<T> implements JsonObjectReader<T> {
 		this.jsonReader.beginArray();
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		try {
 			if (this.jsonReader.hasNext()) {
 				return this.mapper.fromJson(this.jsonReader, this.itemType);
@@ -97,12 +97,14 @@ public class GsonJsonObjectReader<T> implements JsonObjectReader<T> {
 		return null;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws Exception {
 		this.inputStream.close();
 		this.jsonReader.close();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void jumpToItem(int itemIndex) throws Exception {
 		for (int i = 0; i < itemIndex; i++) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JacksonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JacksonJsonObjectReader.java
@@ -22,10 +22,10 @@ import java.io.InputStream;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.ParseException;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -41,11 +41,11 @@ public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 
 	private final Class<? extends T> itemType;
 
-	private JsonParser jsonParser;
-
 	private ObjectMapper mapper;
 
-	private InputStream inputStream;
+	private @Nullable JsonParser jsonParser;
+
+	private @Nullable InputStream inputStream;
 
 	/**
 	 * Create a new {@link JacksonJsonObjectReader} instance.
@@ -79,9 +79,9 @@ public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 				"The Json input stream must start with an array of Json objects");
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		try {
 			if (this.jsonParser.nextToken() == JsonToken.START_OBJECT) {
 				return this.mapper.readValue(this.jsonParser, this.itemType);
@@ -93,12 +93,14 @@ public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 		return null;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws Exception {
 		this.inputStream.close();
 		this.jsonParser.close();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void jumpToItem(int itemIndex) throws Exception {
 		for (int i = 0; i < itemIndex; i++) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonFileItemWriter.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.json;
 
 import java.util.Iterator;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.support.AbstractFileItemWriter;
 import org.springframework.core.io.WritableResource;
@@ -56,7 +57,7 @@ public class JsonFileItemWriter<T> extends AbstractFileItemWriter<T> {
 
 	private static final char JSON_ARRAY_STOP = ']';
 
-	private JsonObjectMarshaller<T> jsonObjectMarshaller;
+	private @Nullable JsonObjectMarshaller<T> jsonObjectMarshaller;
 
 	/**
 	 * Create a new {@link JsonFileItemWriter} instance.
@@ -93,6 +94,7 @@ public class JsonFileItemWriter<T> extends AbstractFileItemWriter<T> {
 		this.jsonObjectMarshaller = jsonObjectMarshaller;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public String doWrite(Chunk<? extends T> items) {
 		StringBuilder lines = new StringBuilder();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonItemReader.java
@@ -18,12 +18,12 @@ package org.springframework.batch.item.json;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -55,9 +55,9 @@ public class JsonItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 
 	private static final Log LOGGER = LogFactory.getLog(JsonItemReader.class);
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private JsonObjectReader<T> jsonObjectReader;
+	private @Nullable JsonObjectReader<T> jsonObjectReader;
 
 	private boolean strict = true;
 
@@ -105,9 +105,9 @@ public class JsonItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 		this.resource = resource;
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 		return jsonObjectReader.read();
 	}
 
@@ -132,11 +132,13 @@ public class JsonItemReader<T> extends AbstractItemCountingItemStreamItemReader<
 		this.jsonObjectReader.open(this.resource);
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doClose() throws Exception {
 		this.jsonObjectReader.close();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void jumpToItem(int itemIndex) throws Exception {
 		this.jsonObjectReader.jumpToItem(itemIndex);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/JsonObjectReader.java
@@ -16,8 +16,9 @@
 
 package org.springframework.batch.item.json;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 
 /**
  * Strategy interface for Json readers. Implementations are expected to use a streaming
@@ -44,8 +45,7 @@ public interface JsonObjectReader<T> {
 	 * @return the next object or {@code null} if the resource is exhausted
 	 * @throws Exception if unable to read the next object
 	 */
-	@Nullable
-	T read() throws Exception;
+	@Nullable T read() throws Exception;
 
 	/**
 	 * Close the input resource.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/builder/JsonFileItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/builder/JsonFileItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.json.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.file.FlatFileFooterCallback;
 import org.springframework.batch.item.file.FlatFileHeaderCallback;
 import org.springframework.batch.item.json.JsonFileItemWriter;
@@ -32,15 +33,15 @@ import org.springframework.util.Assert;
  */
 public class JsonFileItemWriterBuilder<T> {
 
-	private WritableResource resource;
+	private @Nullable WritableResource resource;
 
-	private JsonObjectMarshaller<T> jsonObjectMarshaller;
+	private @Nullable JsonObjectMarshaller<T> jsonObjectMarshaller;
 
-	private FlatFileHeaderCallback headerCallback;
+	private @Nullable FlatFileHeaderCallback headerCallback;
 
-	private FlatFileFooterCallback footerCallback;
+	private @Nullable FlatFileFooterCallback footerCallback;
 
-	private String name;
+	private @Nullable String name;
 
 	private String encoding = JsonFileItemWriter.DEFAULT_CHARSET;
 
@@ -237,7 +238,9 @@ public class JsonFileItemWriterBuilder<T> {
 
 		JsonFileItemWriter<T> jsonFileItemWriter = new JsonFileItemWriter<>(this.resource, this.jsonObjectMarshaller);
 
-		jsonFileItemWriter.setName(this.name);
+		if (this.name != null) {
+			jsonFileItemWriter.setName(this.name);
+		}
 		jsonFileItemWriter.setAppendAllowed(this.append);
 		jsonFileItemWriter.setEncoding(this.encoding);
 		if (this.headerCallback != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/builder/JsonItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/builder/JsonItemReaderBuilder.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.json.builder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.json.JsonItemReader;
 import org.springframework.batch.item.json.JsonObjectReader;
 import org.springframework.core.io.Resource;
@@ -36,11 +37,11 @@ public class JsonItemReaderBuilder<T> {
 
 	protected Log logger = LogFactory.getLog(getClass());
 
-	private JsonObjectReader<T> jsonObjectReader;
+	private @Nullable JsonObjectReader<T> jsonObjectReader;
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private String name;
+	private @Nullable String name;
 
 	private boolean strict = true;
 
@@ -149,15 +150,18 @@ public class JsonItemReaderBuilder<T> {
 			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
 		}
 
-		if (this.resource == null) {
+		JsonItemReader<T> reader = new JsonItemReader<>();
+		if (this.resource != null) {
+			reader.setResource(this.resource);
+		}
+		else {
 			logger.debug("The resource is null. This is only a valid scenario when "
 					+ "injecting it later as in when using the MultiResourceItemReader");
 		}
-
-		JsonItemReader<T> reader = new JsonItemReader<>();
-		reader.setResource(this.resource);
 		reader.setJsonObjectReader(this.jsonObjectReader);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		reader.setStrict(this.strict);
 		reader.setSaveState(this.saveState);
 		reader.setMaxItemCount(this.maxItemCount);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for JSON item reader and writer.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.json.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/json/package-info.java
@@ -4,8 +4,9 @@
  * </p>
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.json;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemReader.java
@@ -29,10 +29,10 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.support.AbstractItemStreamItemReader;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -58,13 +58,13 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 
 	private final List<TopicPartition> topicPartitions;
 
-	private Map<TopicPartition, Long> partitionOffsets;
+	private @Nullable Map<TopicPartition, Long> partitionOffsets;
 
-	private KafkaConsumer<K, V> kafkaConsumer;
+	private @Nullable KafkaConsumer<K, V> kafkaConsumer;
 
 	private final Properties consumerProperties;
 
-	private Iterator<ConsumerRecord<K, V>> consumerRecords;
+	private @Nullable Iterator<ConsumerRecord<K, V>> consumerRecords;
 
 	private Duration pollTimeout = Duration.ofSeconds(DEFAULT_POLL_TIMEOUT);
 
@@ -163,7 +163,7 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 		this.partitionOffsets = partitionOffsets;
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	@Override
 	public void open(ExecutionContext executionContext) {
 		this.kafkaConsumer = new KafkaConsumer<>(this.consumerProperties);
@@ -184,9 +184,9 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 		this.partitionOffsets.forEach(this.kafkaConsumer::seek);
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public V read() {
+	public @Nullable V read() {
 		if (this.consumerRecords == null || !this.consumerRecords.hasNext()) {
 			this.consumerRecords = this.kafkaConsumer.poll(this.pollTimeout).iterator();
 		}
@@ -200,6 +200,7 @@ public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) {
 		if (this.saveState) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/KafkaItemWriter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.kafka;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.KeyValueItemWriter;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -39,19 +40,21 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 4.2
  *
  */
 public class KafkaItemWriter<K, T> extends KeyValueItemWriter<K, T> {
 
-	protected KafkaTemplate<K, T> kafkaTemplate;
+	protected @Nullable KafkaTemplate<K, T> kafkaTemplate;
 
 	protected final List<CompletableFuture<SendResult<K, T>>> completableFutures = new ArrayList<>();
 
 	private long timeout = -1;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected void writeKeyValue(K key, T value) {
+	protected void writeKeyValue(@Nullable K key, T value) {
 		if (this.delete) {
 			this.completableFutures.add(this.kafkaTemplate.sendDefault(key, null));
 		}
@@ -60,6 +63,7 @@ public class KafkaItemWriter<K, T> extends KeyValueItemWriter<K, T> {
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void flush() throws Exception {
 		this.kafkaTemplate.flush();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemReaderBuilder.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.kafka.KafkaItemReader;
 import org.springframework.util.Assert;
 
@@ -39,19 +40,19 @@ import org.springframework.util.Assert;
  */
 public class KafkaItemReaderBuilder<K, V> {
 
-	private Properties consumerProperties;
+	private @Nullable Properties consumerProperties;
 
-	private String topic;
+	private @Nullable String topic;
 
 	private List<Integer> partitions = new ArrayList<>();
 
-	private Map<TopicPartition, Long> partitionOffsets;
+	private @Nullable Map<TopicPartition, Long> partitionOffsets;
 
 	private Duration pollTimeout = Duration.ofSeconds(30L);
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	/**
 	 * Configure if the state of the
@@ -174,8 +175,12 @@ public class KafkaItemReaderBuilder<K, V> {
 		KafkaItemReader<K, V> reader = new KafkaItemReader<>(this.consumerProperties, this.topic, this.partitions);
 		reader.setPollTimeout(this.pollTimeout);
 		reader.setSaveState(this.saveState);
-		reader.setName(this.name);
-		reader.setPartitionOffsets(this.partitionOffsets);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
+		if (this.partitionOffsets != null) {
+			reader.setPartitionOffsets(this.partitionOffsets);
+		}
 		return reader;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/KafkaItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.kafka.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.kafka.KafkaItemWriter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -30,9 +31,9 @@ import org.springframework.util.Assert;
  */
 public class KafkaItemWriterBuilder<K, V> {
 
-	private KafkaTemplate<K, V> kafkaTemplate;
+	private @Nullable KafkaTemplate<K, V> kafkaTemplate;
 
-	private Converter<V, K> itemKeyMapper;
+	private @Nullable Converter<V, K> itemKeyMapper;
 
 	private boolean delete;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/builder/package-info.java
@@ -19,7 +19,7 @@
  *
  * @author Mathieu Ouellet
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.kafka.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/kafka/package-info.java
@@ -19,7 +19,7 @@
  *
  * @author Mathieu Ouellet
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.kafka;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/LdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/LdifReader.java
@@ -16,13 +16,13 @@
 
 package org.springframework.batch.item.ldif;
 
+import org.jspecify.annotations.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.ldap.core.LdapAttributes;
 import org.springframework.ldap.ldif.parser.LdifParser;
 import org.springframework.util.Assert;
@@ -68,9 +68,9 @@ public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAtt
 
 	private static final Log LOG = LogFactory.getLog(LdifReader.class);
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private LdifParser ldifParser;
+	private @Nullable LdifParser ldifParser;
 
 	private int recordCount = 0;
 
@@ -78,7 +78,7 @@ public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAtt
 
 	private boolean strict = true;
 
-	private RecordCallbackHandler skippedRecordsCallback;
+	private @Nullable RecordCallbackHandler skippedRecordsCallback;
 
 	public LdifReader() {
 		setName(ClassUtils.getShortName(LdifReader.class));
@@ -122,6 +122,7 @@ public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAtt
 		this.recordCount = 0;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doOpen() throws Exception {
 		if (resource == null)
@@ -147,9 +148,9 @@ public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAtt
 		}
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected LdapAttributes doRead() throws Exception {
+	protected @Nullable LdapAttributes doRead() throws Exception {
 		LdapAttributes attributes = null;
 
 		try {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/MappingLdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/MappingLdifReader.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.batch.item.ldif;
 
+import org.jspecify.annotations.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.batch.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.ldap.core.LdapAttributes;
 import org.springframework.ldap.ldif.parser.LdifParser;
 import org.springframework.util.Assert;
@@ -59,9 +59,9 @@ public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemRead
 
 	private static final Log LOG = LogFactory.getLog(MappingLdifReader.class);
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private LdifParser ldifParser;
+	private @Nullable LdifParser ldifParser;
 
 	private int recordCount = 0;
 
@@ -69,9 +69,9 @@ public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemRead
 
 	private boolean strict = true;
 
-	private RecordCallbackHandler skippedRecordsCallback;
+	private @Nullable RecordCallbackHandler skippedRecordsCallback;
 
-	private RecordMapper<T> recordMapper;
+	private @Nullable RecordMapper<T> recordMapper;
 
 	public MappingLdifReader() {
 		setName(ClassUtils.getShortName(MappingLdifReader.class));
@@ -123,6 +123,7 @@ public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemRead
 		this.recordCount = 0;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doOpen() throws Exception {
 		if (resource == null)
@@ -148,9 +149,9 @@ public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemRead
 		}
 	}
 
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	protected T doRead() throws Exception {
+	protected @Nullable T doRead() throws Exception {
 		LdapAttributes attributes = null;
 
 		try {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/RecordMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/RecordMapper.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.batch.item.ldif;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ldap.core.LdapAttributes;
 
 /**
@@ -34,7 +35,6 @@ public interface RecordMapper<T> {
 	 * @param attributes attributes
 	 * @return object of type T or {@code null} if unable to map the record to an object.
 	 */
-	@Nullable
-	T mapRecord(LdapAttributes attributes);
+	@Nullable T mapRecord(LdapAttributes attributes);
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/builder/LdifReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/builder/LdifReaderBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.ldif.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ldif.LdifReader;
 import org.springframework.batch.item.ldif.RecordCallbackHandler;
 import org.springframework.core.io.Resource;
@@ -29,17 +30,17 @@ import org.springframework.util.Assert;
  */
 public class LdifReaderBuilder {
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
 	private int recordsToSkip = 0;
 
 	private boolean strict = true;
 
-	private RecordCallbackHandler skippedRecordsCallback;
+	private @Nullable RecordCallbackHandler skippedRecordsCallback;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -163,7 +164,9 @@ public class LdifReaderBuilder {
 		reader.setResource(this.resource);
 		reader.setRecordsToSkip(this.recordsToSkip);
 		reader.setSaveState(this.saveState);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 		if (this.skippedRecordsCallback != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/builder/MappingLdifReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/builder/MappingLdifReaderBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.ldif.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ldif.MappingLdifReader;
 import org.springframework.batch.item.ldif.RecordCallbackHandler;
 import org.springframework.batch.item.ldif.RecordMapper;
@@ -30,19 +31,19 @@ import org.springframework.util.Assert;
  */
 public class MappingLdifReaderBuilder<T> {
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
 	private int recordsToSkip = 0;
 
 	private boolean strict = true;
 
-	private RecordCallbackHandler skippedRecordsCallback;
+	private @Nullable RecordCallbackHandler skippedRecordsCallback;
 
-	private RecordMapper<T> recordMapper;
+	private @Nullable RecordMapper<T> recordMapper;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -181,7 +182,9 @@ public class MappingLdifReaderBuilder<T> {
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 		reader.setRecordMapper(this.recordMapper);
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		if (this.skippedRecordsCallback != null) {
 			reader.setSkippedRecordsCallback(this.skippedRecordsCallback);
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for LDIF related components.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.ldif.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/ldif/package-info.java
@@ -5,8 +5,9 @@
  *
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.ldif;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/SimpleMailMessageItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/SimpleMailMessageItemWriter.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.mail;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.InitializingBean;
@@ -56,7 +57,7 @@ import org.springframework.util.Assert;
  */
 public class SimpleMailMessageItemWriter implements ItemWriter<SimpleMailMessage>, InitializingBean {
 
-	private MailSender mailSender;
+	private @Nullable MailSender mailSender;
 
 	private MailErrorHandler mailErrorHandler = new DefaultMailErrorHandler();
 
@@ -91,6 +92,7 @@ public class SimpleMailMessageItemWriter implements ItemWriter<SimpleMailMessage
 	 * @param chunk the chunk of items to send
 	 * @see ItemWriter#write(Chunk)
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends SimpleMailMessage> chunk) throws MailException {
 		try {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/builder/SimpleMailMessageItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/builder/SimpleMailMessageItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.mail.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.mail.DefaultMailErrorHandler;
 import org.springframework.batch.item.mail.MailErrorHandler;
@@ -30,10 +31,9 @@ import org.springframework.util.Assert;
  * @author Mahmoud Ben Hassine
  * @since 4.0
  */
-
 public class SimpleMailMessageItemWriterBuilder {
 
-	private MailSender mailSender;
+	private @Nullable MailSender mailSender;
 
 	private MailErrorHandler mailErrorHandler = new DefaultMailErrorHandler();
 
@@ -69,9 +69,7 @@ public class SimpleMailMessageItemWriterBuilder {
 
 		SimpleMailMessageItemWriter writer = new SimpleMailMessageItemWriter();
 		writer.setMailSender(this.mailSender);
-		if (mailErrorHandler != null) {
-			writer.setMailErrorHandler(this.mailErrorHandler);
-		}
+		writer.setMailErrorHandler(this.mailErrorHandler);
 
 		return writer;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for JavaMail related components.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.mail.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/javamail/MimeMessageItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/javamail/MimeMessageItemWriter.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 
 import jakarta.mail.internet.MimeMessage;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.mail.DefaultMailErrorHandler;
@@ -60,7 +61,7 @@ import org.springframework.util.Assert;
  */
 public class MimeMessageItemWriter implements ItemWriter<MimeMessage> {
 
-	private JavaMailSender mailSender;
+	private @Nullable JavaMailSender mailSender;
 
 	private MailErrorHandler mailErrorHandler = new DefaultMailErrorHandler();
 
@@ -94,6 +95,7 @@ public class MimeMessageItemWriter implements ItemWriter<MimeMessage> {
 	 * @param chunk the chunk of items to send
 	 * @see ItemWriter#write(Chunk)
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends MimeMessage> chunk) throws MailException {
 		try {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/javamail/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/javamail/package-info.java
@@ -18,8 +18,9 @@
  * JavaMail related components.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.mail.javamail;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/mail/package-info.java
@@ -3,8 +3,9 @@
  *
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.mail;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure interfaces and primary dependencies for item concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/queue/BlockingQueueItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/queue/BlockingQueueItemReader.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * This is an {@link ItemReader} that reads items from a {@link BlockingQueue}. It stops
- * reading (ie returns {@code null}) if no items are available in the queue after a
+ * reading (i.e., returns {@code null}) if no items are available in the queue after a
  * configurable timeout.
  *
  * @param <T> type of items to read.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.item.redis;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
@@ -43,7 +45,7 @@ public class RedisItemReader<K, V> implements ItemStreamReader<V> {
 
 	private final ScanOptions scanOptions;
 
-	private Cursor<K> cursor;
+	private @Nullable Cursor<K> cursor;
 
 	public RedisItemReader(RedisTemplate<K, V> redisTemplate, ScanOptions scanOptions) {
 		Assert.notNull(redisTemplate, "redisTemplate must not be null");
@@ -57,8 +59,9 @@ public class RedisItemReader<K, V> implements ItemStreamReader<V> {
 		this.cursor = this.redisTemplate.scan(this.scanOptions);
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public V read() throws Exception {
+	public @Nullable V read() throws Exception {
 		if (this.cursor.hasNext()) {
 			K nextKey = this.cursor.next();
 			return this.redisTemplate.opsForValue().get(nextKey);
@@ -68,6 +71,7 @@ public class RedisItemReader<K, V> implements ItemStreamReader<V> {
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws ItemStreamException {
 		this.cursor.close();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemWriter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.redis;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.KeyValueItemWriter;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -28,12 +29,14 @@ import org.springframework.util.Assert;
  *
  * @author Santiago Molano
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  * @since 5.1
  */
 public class RedisItemWriter<K, T> extends KeyValueItemWriter<K, T> {
 
-	private RedisTemplate<K, T> redisTemplate;
+	private @Nullable RedisTemplate<K, T> redisTemplate;
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void writeKeyValue(K key, T value) {
 		if (this.delete) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.batch.support;
-
-import org.jspecify.annotations.Nullable;
-
 /**
- * A strategy interface for invoking a method. Typically used by adapters.
+ * Redis related readers and writers
  *
- * @author Mark Fisher
- * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-public interface MethodInvoker {
+@NullMarked
+package org.springframework.batch.item.redis;
 
-	@Nullable Object invokeMethod(Object... args);
-
-}
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractFileItemWriter.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStream;
@@ -72,7 +73,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 
 	protected static final Log logger = LogFactory.getLog(AbstractFileItemWriter.class);
 
-	public static final String DEFAULT_LINE_SEPARATOR = System.getProperty("line.separator");
+	public static final String DEFAULT_LINE_SEPARATOR = System.lineSeparator();
 
 	public static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
 
@@ -80,9 +81,9 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 
 	private static final String RESTART_DATA_NAME = "current.count";
 
-	private WritableResource resource;
+	private @Nullable WritableResource resource;
 
-	protected OutputState state = null;
+	protected @Nullable OutputState state;
 
 	private boolean saveState = true;
 
@@ -94,9 +95,9 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 
 	private String encoding = DEFAULT_CHARSET;
 
-	private FlatFileHeaderCallback headerCallback;
+	private @Nullable FlatFileHeaderCallback headerCallback;
 
-	private FlatFileFooterCallback footerCallback;
+	private @Nullable FlatFileFooterCallback footerCallback;
 
 	protected String lineSeparator = DEFAULT_LINE_SEPARATOR;
 
@@ -253,6 +254,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 	/**
 	 * @see ItemStream#close()
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() {
 		super.close();
@@ -298,6 +300,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	private void doOpen(ExecutionContext executionContext) throws ItemStreamException {
 		OutputState outputState = getOutputState();
 		if (executionContext.containsKey(getExecutionContextKey(RESTART_DATA_NAME))) {
@@ -348,6 +351,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 	}
 
 	// Returns object representing state.
+	@SuppressWarnings("DataFlowIssue")
 	protected OutputState getOutputState() {
 		if (state == null) {
 			File file;
@@ -372,12 +376,12 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 	 */
 	protected class OutputState {
 
-		private FileOutputStream os;
+		private @Nullable FileOutputStream os;
 
 		// The bufferedWriter over the file channel that is actually written
-		Writer outputBufferedWriter;
+		@Nullable Writer outputBufferedWriter;
 
-		FileChannel fileChannel;
+		@Nullable FileChannel fileChannel;
 
 		// this represents the charset encoding (if any is needed) for the
 		// output file
@@ -403,6 +407,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		 * @return the byte offset position of the cursor in the output file
 		 * @throws IOException If unable to get the offset position
 		 */
+		@SuppressWarnings("DataFlowIssue")
 		public long position() throws IOException {
 			if (fileChannel == null) {
 				return 0;
@@ -511,6 +516,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		 * @param line String to be written to the file
 		 * @throws IOException If unable to write the String to the file
 		 */
+		@SuppressWarnings("DataFlowIssue")
 		public void write(String line) throws IOException {
 			if (!initialized) {
 				initializeBufferedWriter();
@@ -524,6 +530,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		 * Truncate the output at the last known good point.
 		 * @throws IOException if unable to work with file
 		 */
+		@SuppressWarnings("DataFlowIssue")
 		public void truncate() throws IOException {
 			fileChannel.truncate(lastMarkedByteOffsetPosition);
 			fileChannel.position(lastMarkedByteOffsetPosition);
@@ -534,6 +541,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		 * information.
 		 * @throws IOException if unable to initialize buffer
 		 */
+		@SuppressWarnings("DataFlowIssue")
 		private void initializeBufferedWriter() throws IOException {
 
 			File file = resource.getFile();
@@ -608,6 +616,7 @@ public abstract class AbstractFileItemWriter<T> extends AbstractItemStreamItemWr
 		 * beginning.
 		 * @throws IOException if there is an IO problem
 		 */
+		@SuppressWarnings("DataFlowIssue")
 		private void checkFileSize() throws IOException {
 			long size;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/AbstractItemCountingItemStreamItemReader.java
@@ -16,11 +16,12 @@
 
 package org.springframework.batch.item.support;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemCountAware;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStreamException;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -52,8 +53,7 @@ public abstract class AbstractItemCountingItemStreamItemReader<T> extends Abstra
 	 * @throws Exception Allows subclasses to throw checked exceptions for interpretation
 	 * by the framework
 	 */
-	@Nullable
-	protected abstract T doRead() throws Exception;
+	protected abstract @Nullable T doRead() throws Exception;
 
 	/**
 	 * Open resources necessary to start reading input.
@@ -83,9 +83,8 @@ public abstract class AbstractItemCountingItemStreamItemReader<T> extends Abstra
 		}
 	}
 
-	@Nullable
 	@Override
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		if (currentItemCount >= maxItemCount) {
 			return null;
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ClassifierCompositeItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ClassifierCompositeItemProcessor.java
@@ -16,10 +16,11 @@
 
 package org.springframework.batch.item.support;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.classify.Classifier;
 import org.springframework.classify.ClassifierSupport;
-import org.springframework.lang.Nullable;
 
 /**
  * Calls one of a collection of ItemProcessors, based on a router pattern implemented
@@ -47,9 +48,8 @@ public class ClassifierCompositeItemProcessor<I, O> implements ItemProcessor<I, 
 	 * Delegates to injected {@link ItemProcessor} instances according to the
 	 * classification by the {@link Classifier}.
 	 */
-	@Nullable
 	@Override
-	public O process(I item) throws Exception {
+	public @Nullable O process(I item) throws Exception {
 		return processItem(classifier.classify(item), item);
 	}
 
@@ -60,7 +60,7 @@ public class ClassifierCompositeItemProcessor<I, O> implements ItemProcessor<I, 
 	 * extends O> is not applicable for the arguments (I)
 	 */
 	@SuppressWarnings("unchecked")
-	private <T> O processItem(ItemProcessor<T, ? extends O> processor, I input) throws Exception {
+	private <T> @Nullable O processItem(ItemProcessor<T, ? extends O> processor, I input) throws Exception {
 		return processor.process((T) input);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemProcessor.java
@@ -18,11 +18,12 @@ package org.springframework.batch.item.support;
 
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import java.util.Arrays;
 import java.util.List;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Composite {@link ItemProcessor} that passes the item through a sequence of injected
@@ -37,7 +38,7 @@ import java.util.List;
  */
 public class CompositeItemProcessor<I, O> implements ItemProcessor<I, O>, InitializingBean {
 
-	private List<? extends ItemProcessor<?, ?>> delegates;
+	private @Nullable List<? extends ItemProcessor<?, ?>> delegates;
 
 	/**
 	 * Default constructor
@@ -64,10 +65,9 @@ public class CompositeItemProcessor<I, O> implements ItemProcessor<I, O>, Initia
 		setDelegates(delegates);
 	}
 
-	@Nullable
 	@Override
-	@SuppressWarnings("unchecked")
-	public O process(I item) throws Exception {
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
+	public @Nullable O process(I item) throws Exception {
 		Object result = item;
 
 		for (ItemProcessor<?, ?> delegate : delegates) {
@@ -87,7 +87,7 @@ public class CompositeItemProcessor<I, O> implements ItemProcessor<I, O>, Initia
 	 * not applicable for the arguments (Object)
 	 */
 	@SuppressWarnings("unchecked")
-	private <T> Object processItem(ItemProcessor<T, ?> processor, Object input) throws Exception {
+	private @Nullable <T> Object processItem(ItemProcessor<T, ?> processor, Object input) throws Exception {
 		return processor.process((T) input);
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
@@ -20,6 +20,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.springframework.batch.item.ExecutionContext;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 
@@ -38,7 +40,7 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 
 	private final Iterator<ItemStreamReader<? extends T>> delegatesIterator;
 
-	private ItemStreamReader<? extends T> currentDelegate;
+	private @Nullable ItemStreamReader<? extends T> currentDelegate;
 
 	/**
 	 * Create a new {@link CompositeItemReader}.
@@ -60,7 +62,7 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 	}
 
 	@Override
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		if (this.currentDelegate == null) {
 			return null;
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemWriter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStream;
@@ -42,7 +43,7 @@ import java.util.List;
  */
 public class CompositeItemWriter<T> implements ItemStreamWriter<T>, InitializingBean {
 
-	private List<ItemWriter<? super T>> delegates;
+	private @Nullable List<ItemWriter<? super T>> delegates;
 
 	private boolean ignoreItemStream = false;
 
@@ -82,6 +83,7 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 		this.ignoreItemStream = ignoreItemStream;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> chunk) throws Exception {
 		for (ItemWriter<? super T> writer : delegates) {
@@ -111,6 +113,7 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 	 * exceptions thrown by delegates are added as suppressed exceptions into this one, in
 	 * the same order as delegates were registered.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws ItemStreamException {
 		List<Exception> exceptions = new ArrayList<>();
@@ -134,6 +137,7 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		for (ItemWriter<? super T> writer : delegates) {
@@ -143,6 +147,7 @@ public class CompositeItemWriter<T> implements ItemStreamWriter<T>, Initializing
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		for (ItemWriter<? super T> writer : delegates) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/IteratorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/IteratorItemReader.java
@@ -19,7 +19,8 @@ package org.springframework.batch.item.support;
 import java.util.Iterator;
 
 import org.springframework.batch.item.ItemReader;
-import org.springframework.lang.Nullable;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -62,9 +63,8 @@ public class IteratorItemReader<T> implements ItemReader<T> {
 	 * Implementation of {@link ItemReader#read()} that just iterates over the iterator
 	 * provided.
 	 */
-	@Nullable
 	@Override
-	public T read() {
+	public @Nullable T read() {
 		if (iterator.hasNext())
 			return iterator.next();
 		else

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ListItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ListItemReader.java
@@ -20,8 +20,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.springframework.aop.support.AopUtils;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.lang.Nullable;
 
 /**
  * An {@link ItemReader} that pulls data from a list. Useful for testing.
@@ -50,9 +51,8 @@ public class ListItemReader<T> implements ItemReader<T> {
 		}
 	}
 
-	@Nullable
 	@Override
-	public T read() {
+	public @Nullable T read() {
 		if (!list.isEmpty()) {
 			return list.remove(0);
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/PassThroughItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/PassThroughItemProcessor.java
@@ -16,8 +16,9 @@
 
 package org.springframework.batch.item.support;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.lang.Nullable;
 
 /**
  * Simple {@link ItemProcessor} that does nothing - simply passes its argument through to
@@ -34,9 +35,8 @@ public class PassThroughItemProcessor<T> implements ItemProcessor<T, T> {
 	 * @return the item
 	 * @see ItemProcessor#process(Object)
 	 */
-	@Nullable
 	@Override
-	public T process(T item) throws Exception {
+	public @Nullable T process(T item) throws Exception {
 		return item;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/ScriptItemProcessor.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.batch.item.support;
 
-import org.springframework.lang.Nullable;
 import org.springframework.scripting.support.StaticScriptSource;
 import org.springframework.util.StringUtils;
 import org.springframework.batch.item.ItemProcessor;
@@ -30,17 +29,16 @@ import org.springframework.util.Assert;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * <p>
- * {@link org.springframework.batch.item.ItemProcessor} implementation that passes the
- * current item to process to the provided script. Exposes the current item for processing
- * via the
- * {@link org.springframework.batch.item.support.ScriptItemProcessor#ITEM_BINDING_VARIABLE_NAME}
- * key name ("item"). A custom key name can be set by invoking:
- * {@link org.springframework.batch.item.support.ScriptItemProcessor#setItemBindingVariableName}
- * with the desired key name. The thread safety of this
- * {@link org.springframework.batch.item.ItemProcessor} depends on the implementation of
- * the {@link org.springframework.scripting.ScriptEvaluator} used.
+ * {@link ItemProcessor} implementation that passes the current item to process to the
+ * provided script. Exposes the current item for processing via the
+ * {@link ScriptItemProcessor#ITEM_BINDING_VARIABLE_NAME} key name ("item"). A custom key
+ * name can be set by invoking: {@link ScriptItemProcessor#setItemBindingVariableName}
+ * with the desired key name. The thread safety of this {@link ItemProcessor} depends on
+ * the implementation of the {@link org.springframework.scripting.ScriptEvaluator} used.
  * </p>
  *
  * @author Chris Schaefer
@@ -50,20 +48,19 @@ public class ScriptItemProcessor<I, O> implements ItemProcessor<I, O>, Initializ
 
 	public static final String ITEM_BINDING_VARIABLE_NAME = "item";
 
-	private String language;
+	private @Nullable String language;
 
-	private ScriptSource script;
+	private @Nullable ScriptSource script;
 
-	private ScriptSource scriptSource;
+	private @Nullable ScriptSource scriptSource;
 
-	private ScriptEvaluator scriptEvaluator;
+	private @Nullable ScriptEvaluator scriptEvaluator;
 
 	private String itemBindingVariableName = ITEM_BINDING_VARIABLE_NAME;
 
-	@Nullable
 	@Override
-	@SuppressWarnings("unchecked")
-	public O process(I item) throws Exception {
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
+	public @Nullable O process(I item) throws Exception {
 		Map<String, Object> arguments = new HashMap<>();
 		arguments.put(itemBindingVariableName, item);
 
@@ -103,8 +100,7 @@ public class ScriptItemProcessor<I, O> implements ItemProcessor<I, O>, Initializ
 	 * <p>
 	 * Provides the ability to change the key name that scripts use to obtain the current
 	 * item to process if the variable represented by:
-	 * {@link org.springframework.batch.item.support.ScriptItemProcessor#ITEM_BINDING_VARIABLE_NAME}
-	 * is not suitable ("item").
+	 * {@link ScriptItemProcessor#ITEM_BINDING_VARIABLE_NAME} is not suitable ("item").
 	 * </p>
 	 * @param itemBindingVariableName the desired binding variable name
 	 */

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SingleItemPeekableItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SingleItemPeekableItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2024 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ package org.springframework.batch.item.support;
 import java.util.Map.Entry;
 
 import org.springframework.batch.item.ExecutionContext;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemStream;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.PeekableItemReader;
-import org.springframework.lang.Nullable;
 
 /**
  * <p>
@@ -40,13 +41,12 @@ import org.springframework.lang.Nullable;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
  */
 public class SingleItemPeekableItemReader<T> implements ItemStreamReader<T>, PeekableItemReader<T> {
 
-	private ItemReader<T> delegate;
+	private @Nullable ItemReader<T> delegate;
 
-	private T next;
+	private @Nullable T next;
 
 	private ExecutionContext executionContext = new ExecutionContext();
 
@@ -64,9 +64,9 @@ public class SingleItemPeekableItemReader<T> implements ItemStreamReader<T>, Pee
 	 *
 	 * @see ItemReader#read()
 	 */
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		if (next != null) {
 			T item = next;
 			next = null;
@@ -82,9 +82,9 @@ public class SingleItemPeekableItemReader<T> implements ItemStreamReader<T>, Pee
 	 *
 	 * @see PeekableItemReader#peek()
 	 */
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public T peek() throws Exception {
+	public @Nullable T peek() throws Exception {
 		if (next == null) {
 			updateDelegate(executionContext);
 			next = delegate.read();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemReader.java
@@ -19,7 +19,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.batch.item.ItemReader;
-import org.springframework.lang.Nullable;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -47,8 +48,7 @@ public class SynchronizedItemReader<T> implements ItemReader<T> {
 	 * synchronized with a lock.
 	 */
 	@Override
-	@Nullable
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		this.lock.lock();
 		try {
 			return this.delegate.read();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamReader.java
@@ -19,9 +19,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.batch.item.ExecutionContext;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -29,7 +30,7 @@ import org.springframework.util.Assert;
  * This is a simple ItemStreamReader decorator with a synchronized ItemReader.read()
  * method - which makes a non-thread-safe ItemReader thread-safe.
  * <p>
- * However, if reprocessing an item is problematic then using this will make a job not
+ * However, if reprocessing an item is problematic, then using this will make a job not
  * restartable.
  * <p>
  * Here is the motivation behind this class: https://stackoverflow.com/a/20002493/2910265
@@ -41,7 +42,7 @@ import org.springframework.util.Assert;
  */
 public class SynchronizedItemStreamReader<T> implements ItemStreamReader<T>, InitializingBean {
 
-	private ItemStreamReader<T> delegate;
+	private @Nullable ItemStreamReader<T> delegate;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -52,9 +53,9 @@ public class SynchronizedItemStreamReader<T> implements ItemStreamReader<T>, Ini
 	/**
 	 * This delegates to the read method of the <code>delegate</code>
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	@Nullable
-	public T read() throws Exception {
+	public @Nullable T read() throws Exception {
 		this.lock.lock();
 		try {
 			return this.delegate.read();
@@ -64,16 +65,19 @@ public class SynchronizedItemStreamReader<T> implements ItemStreamReader<T>, Ini
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() {
 		this.delegate.close();
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void open(ExecutionContext executionContext) {
 		this.delegate.open(executionContext);
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) {
 		this.delegate.update(executionContext);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/SynchronizedItemStreamWriter.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.support;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -48,7 +49,7 @@ import org.springframework.util.Assert;
  */
 public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, InitializingBean {
 
-	private ItemStreamWriter<T> delegate;
+	private @Nullable ItemStreamWriter<T> delegate;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -63,6 +64,7 @@ public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, Ini
 	/**
 	 * This method delegates to the {@code write} method of the {@code delegate}.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> items) throws Exception {
 		this.lock.lock();
@@ -74,16 +76,19 @@ public class SynchronizedItemStreamWriter<T> implements ItemStreamWriter<T>, Ini
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		this.delegate.open(executionContext);
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void update(ExecutionContext executionContext) throws ItemStreamException {
 		this.delegate.update(executionContext);
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws ItemStreamException {
 		this.delegate.close();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemProcessorBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemProcessorBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.support.ClassifierCompositeItemProcessor;
 import org.springframework.classify.Classifier;
@@ -29,7 +30,7 @@ import org.springframework.util.Assert;
  */
 public class ClassifierCompositeItemProcessorBuilder<I, O> {
 
-	private Classifier<? super I, ItemProcessor<?, ? extends O>> classifier;
+	private @Nullable Classifier<? super I, ItemProcessor<?, ? extends O>> classifier;
 
 	/**
 	 * Establishes the classifier that will determine which {@link ItemProcessor} to use.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/ClassifierCompositeItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.ClassifierCompositeItemWriter;
 import org.springframework.classify.Classifier;
@@ -30,7 +31,7 @@ import org.springframework.util.Assert;
  */
 public class ClassifierCompositeItemWriterBuilder<T> {
 
-	private Classifier<T, ItemWriter<? super T>> classifier;
+	private @Nullable Classifier<T, ItemWriter<? super T>> classifier;
 
 	/**
 	 * Establish the classifier to be used for the selection of which {@link ItemWriter}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/CompositeItemProcessorBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/CompositeItemProcessorBuilder.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.support.builder;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.support.CompositeItemProcessor;
 import org.springframework.util.Assert;
@@ -32,7 +33,7 @@ import org.springframework.util.Assert;
  */
 public class CompositeItemProcessorBuilder<I, O> {
 
-	private List<? extends ItemProcessor<?, ?>> delegates;
+	private @Nullable List<? extends ItemProcessor<?, ?>> delegates;
 
 	/**
 	 * Establishes the {@link ItemProcessor} delegates that will work on the item to be

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/CompositeItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/CompositeItemWriterBuilder.java
@@ -19,6 +19,7 @@ package org.springframework.batch.item.support.builder;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.CompositeItemWriter;
 import org.springframework.util.Assert;
@@ -33,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public class CompositeItemWriterBuilder<T> {
 
-	private List<ItemWriter<? super T>> delegates;
+	private @Nullable List<ItemWriter<? super T>> delegates;
 
 	private boolean ignoreItemStream = false;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/ScriptItemProcessorBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/ScriptItemProcessorBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.support.ScriptItemProcessor;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -29,13 +30,13 @@ import org.springframework.util.StringUtils;
  */
 public class ScriptItemProcessorBuilder<I, O> {
 
-	private String language;
+	private @Nullable String language;
 
-	private Resource scriptResource;
+	private @Nullable Resource scriptResource;
 
-	private String scriptSource;
+	private @Nullable String scriptSource;
 
-	private String itemBindingVariableName;
+	private @Nullable String itemBindingVariableName;
 
 	/**
 	 * Sets the {@link org.springframework.core.io.Resource} location of the script to
@@ -114,6 +115,7 @@ public class ScriptItemProcessorBuilder<I, O> {
 		}
 
 		if (this.scriptSource != null) {
+			Assert.hasText(language, "Language must contain the script language");
 			processor.setScriptSource(this.scriptSource, this.language);
 		}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SingleItemPeekableItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SingleItemPeekableItemReaderBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.support.SingleItemPeekableItemReader;
 import org.springframework.util.Assert;
@@ -28,7 +29,7 @@ import org.springframework.util.Assert;
  */
 public class SingleItemPeekableItemReaderBuilder<T> {
 
-	private ItemReader<T> delegate;
+	private @Nullable ItemReader<T> delegate;
 
 	/**
 	 * The item reader to use as a delegate. Items are read from the delegate and passed

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemReaderBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.support.SynchronizedItemReader;
 import org.springframework.util.Assert;
@@ -28,7 +29,7 @@ import org.springframework.util.Assert;
  */
 public class SynchronizedItemReaderBuilder<T> {
 
-	private ItemReader<T> delegate;
+	private @Nullable ItemReader<T> delegate;
 
 	/**
 	 * The item reader to use as a delegate.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamReaderBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.support.SynchronizedItemStreamReader;
 import org.springframework.util.Assert;
@@ -28,7 +29,7 @@ import org.springframework.util.Assert;
  */
 public class SynchronizedItemStreamReaderBuilder<T> {
 
-	private ItemStreamReader<T> delegate;
+	private @Nullable ItemStreamReader<T> delegate;
 
 	/**
 	 * The item stream reader to use as a delegate. Items are read from the delegate and

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemStreamWriterBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.batch.item.support.SynchronizedItemStreamWriter;
 import org.springframework.util.Assert;
@@ -27,7 +28,7 @@ import org.springframework.util.Assert;
  */
 public class SynchronizedItemStreamWriterBuilder<T> {
 
-	private ItemStreamWriter<T> delegate;
+	private @Nullable ItemStreamWriter<T> delegate;
 
 	/**
 	 * Set the delegate {@link ItemStreamWriter}.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/SynchronizedItemWriterBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.item.support.builder;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.SynchronizedItemWriter;
 import org.springframework.util.Assert;
@@ -28,7 +29,7 @@ import org.springframework.util.Assert;
  */
 public class SynchronizedItemWriterBuilder<T> {
 
-	private ItemWriter<T> delegate;
+	private @Nullable ItemWriter<T> delegate;
 
 	/**
 	 * The item writer to use as a delegate.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/builder/package-info.java
@@ -19,7 +19,7 @@
  *
  * @author Mahmoud Ben Hassine
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.support.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/package-info.java
@@ -3,7 +3,7 @@
  * Internal support package
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.support;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/ExecutionContextUserSupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/ExecutionContextUserSupport.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.item.util;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.util.Assert;
 
@@ -24,10 +25,11 @@ import org.springframework.util.Assert;
  *
  * @author Robert Kasanicky
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
 public class ExecutionContextUserSupport {
 
-	private String name;
+	private @Nullable String name;
 
 	public ExecutionContextUserSupport() {
 		super();
@@ -41,7 +43,7 @@ public class ExecutionContextUserSupport {
 	/**
 	 * @return name used to uniquely identify this instance's entries in shared context.
 	 */
-	public String getName() {
+	public @Nullable String getName() {
 		return this.name;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/util/package-info.java
@@ -18,8 +18,9 @@
  * Infrastructure utility classes.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.util;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/SpringValidator.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/SpringValidator.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.validator;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -33,11 +34,12 @@ import org.springframework.validation.Errors;
  */
 public class SpringValidator<T> implements Validator<T>, InitializingBean {
 
-	private org.springframework.validation.Validator validator;
+	private org.springframework.validation.@Nullable Validator validator;
 
 	/**
 	 * @see Validator#validate(Object)
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void validate(T item) throws ValidationException {
 
@@ -74,8 +76,7 @@ public class SpringValidator<T> implements Validator<T>, InitializingBean {
 	 */
 	private void appendCollection(Collection<?> collection, StringBuilder builder) {
 		for (Object value : collection) {
-			builder.append("\n");
-			builder.append(value.toString());
+			builder.append("\n").append(value);
 		}
 	}
 
@@ -86,7 +87,6 @@ public class SpringValidator<T> implements Validator<T>, InitializingBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(validator != null, "validator must be set");
-
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/ValidatingItemProcessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/ValidatingItemProcessor.java
@@ -15,9 +15,10 @@
  */
 package org.springframework.batch.item.validator;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -31,7 +32,7 @@ import org.springframework.util.Assert;
  */
 public class ValidatingItemProcessor<T> implements ItemProcessor<T, T>, InitializingBean {
 
-	private Validator<? super T> validator;
+	private @Nullable Validator<? super T> validator;
 
 	private boolean filter = false;
 
@@ -72,9 +73,9 @@ public class ValidatingItemProcessor<T> implements ItemProcessor<T, T>, Initiali
 	 * @return the input item
 	 * @throws ValidationException if validation fails
 	 */
-	@Nullable
+	@SuppressWarnings("DataFlowIssue")
 	@Override
-	public T process(T item) throws ValidationException {
+	public @Nullable T process(T item) throws ValidationException {
 		try {
 			validator.validate(item);
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/validator/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of item validator concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.validator;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemWriter.java
@@ -26,6 +26,7 @@ import java.io.Writer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.xml.namespace.QName;
@@ -39,6 +40,7 @@ import javax.xml.transform.Result;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -90,7 +92,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	public static final String DEFAULT_XML_VERSION = "1.0";
 
 	// default standalone document declaration, value not set
-	public static final Boolean DEFAULT_STANDALONE_DOCUMENT = null;
+	public static final @Nullable Boolean DEFAULT_STANDALONE_DOCUMENT = null;
 
 	// default root tag name
 	public static final String DEFAULT_ROOT_TAG_NAME = "root";
@@ -105,10 +107,10 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	private static final String WRITE_STATISTICS_NAME = "record.count";
 
 	// file system resource
-	private WritableResource resource;
+	private @Nullable WritableResource resource;
 
 	// xml marshaller
-	private Marshaller marshaller;
+	private @Nullable Marshaller marshaller;
 
 	// encoding to be used while reading from the resource
 	private String encoding = DEFAULT_ENCODING;
@@ -117,7 +119,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	private String version = DEFAULT_XML_VERSION;
 
 	// standalone header attribute
-	private Boolean standalone = DEFAULT_STANDALONE_DOCUMENT;
+	private @Nullable Boolean standalone = DEFAULT_STANDALONE_DOCUMENT;
 
 	// name of the root tag
 	private String rootTagName = DEFAULT_ROOT_TAG_NAME;
@@ -129,32 +131,32 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	private String rootTagNamespace = "";
 
 	// root element attributes
-	private Map<String, String> rootElementAttributes = null;
+	private Map<String, String> rootElementAttributes = new HashMap<>();
 
 	// TRUE means, that output file will be overwritten if exists - default is
 	// TRUE
 	private boolean overwriteOutput = true;
 
 	// file channel
-	private FileChannel channel;
+	private @Nullable FileChannel channel;
 
 	// wrapper for XML event writer that swallows StartDocument and EndDocument
 	// events
-	private XMLEventWriter eventWriter;
+	private @Nullable XMLEventWriter eventWriter;
 
 	// XML event writer
-	private XMLEventWriter delegateEventWriter;
+	private @Nullable XMLEventWriter delegateEventWriter;
 
 	// current count of processed records
 	private long currentRecordCount = 0;
 
 	private boolean saveState = true;
 
-	private StaxWriterCallback headerCallback;
+	private @Nullable StaxWriterCallback headerCallback;
 
-	private StaxWriterCallback footerCallback;
+	private @Nullable StaxWriterCallback footerCallback;
 
-	private Writer bufferedWriter;
+	private @Nullable Writer bufferedWriter;
 
 	private boolean transactional = true;
 
@@ -276,7 +278,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 *
 	 * @since 4.3
 	 */
-	public Boolean getStandalone() {
+	public @Nullable Boolean getStandalone() {
 		return standalone;
 	}
 
@@ -287,7 +289,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 *
 	 * @since 4.3
 	 */
-	public void setStandalone(Boolean standalone) {
+	public void setStandalone(@Nullable Boolean standalone) {
 		this.standalone = standalone;
 	}
 
@@ -346,7 +348,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * @param rootElementAttributes attributes of the root element
 	 */
 	public void setRootElementAttributes(Map<String, String> rootElementAttributes) {
-		this.rootElementAttributes = rootElementAttributes;
+		this.rootElementAttributes = new HashMap<>(rootElementAttributes);
 	}
 
 	/**
@@ -386,7 +388,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 *
 	 * @see org.springframework.batch.item.ItemStream#open(ExecutionContext)
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
 	@Override
 	public void open(ExecutionContext executionContext) {
 		super.open(executionContext);
@@ -444,6 +446,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	/**
 	 * Helper method for opening output source at given file position
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private void open(long position) {
 
 		File file;
@@ -548,6 +551,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * Subclasses can override to customize the STAX result.
 	 * @return a result for writing to
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	protected Result createStaxResult() {
 		return StaxUtils.createStaxResult(eventWriter);
 	}
@@ -656,6 +660,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * @param writer XML event writer
 	 * @throws XMLStreamException thrown if error occurs.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	protected void endDocument(XMLEventWriter writer) throws XMLStreamException {
 
 		// writer.writeEndDocument(); <- this doesn't work after restart
@@ -675,6 +680,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 *
 	 * @see org.springframework.batch.item.ItemStream#close()
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() {
 		super.close();
@@ -739,6 +745,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 		this.initialized = false;
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	private void closeStream() {
 		try {
 			channel.close();
@@ -754,6 +761,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * @throws IOException thrown if general error occurs.
 	 * @throws XmlMappingException thrown if error occurs during XML Mapping.
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void write(Chunk<? extends T> items) throws XmlMappingException, IOException {
 
@@ -806,8 +814,8 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 *
 	 * @return byte offset in file channel
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private long getPosition() {
-
 		long position;
 
 		try {
@@ -828,8 +836,8 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * Set the file channel position.
 	 * @param newPosition new file channel position
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private void setPosition(long newPosition) {
-
 		try {
 			channel.truncate(newPosition);
 			channel.position(newPosition);
@@ -837,7 +845,6 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 		catch (IOException e) {
 			throw new ItemStreamException("Unable to write to file resource: [" + resource + "]", e);
 		}
-
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemReaderBuilder.java
@@ -23,10 +23,10 @@ import javax.xml.stream.XMLInputFactory;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.item.xml.StaxEventItemReader;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -47,15 +47,15 @@ public class StaxEventItemReaderBuilder<T> {
 
 	private boolean strict = true;
 
-	private Resource resource;
+	private @Nullable Resource resource;
 
-	private Unmarshaller unmarshaller;
+	private @Nullable Unmarshaller unmarshaller;
 
 	private final List<String> fragmentRootElements = new ArrayList<>();
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	private int maxItemCount = Integer.MAX_VALUE;
 
@@ -63,7 +63,7 @@ public class StaxEventItemReaderBuilder<T> {
 
 	private XMLInputFactory xmlInputFactory = StaxUtils.createDefensiveInputFactory();
 
-	private String encoding = StaxEventItemReader.DEFAULT_ENCODING;
+	private @Nullable String encoding = StaxEventItemReader.DEFAULT_ENCODING;
 
 	/**
 	 * Configure if the state of the
@@ -214,25 +214,29 @@ public class StaxEventItemReaderBuilder<T> {
 	public StaxEventItemReader<T> build() {
 		StaxEventItemReader<T> reader = new StaxEventItemReader<>();
 
-		if (this.resource == null) {
+		if (this.resource != null) {
+			reader.setResource(this.resource);
+		}
+		else {
 			logger.debug("The resource is null. This is only a valid scenario when "
 					+ "injecting resource later as in when using the MultiResourceItemReader");
 		}
-
 		if (this.saveState) {
 			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
 		}
 
 		Assert.notEmpty(this.fragmentRootElements, "At least one fragment root element is required");
 
-		reader.setName(this.name);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
 		reader.setSaveState(this.saveState);
-		reader.setResource(this.resource);
-		reader.setFragmentRootElementNames(
-				this.fragmentRootElements.toArray(new String[this.fragmentRootElements.size()]));
+		reader.setFragmentRootElementNames(this.fragmentRootElements.toArray(new String[0]));
 
 		reader.setStrict(this.strict);
-		reader.setUnmarshaller(this.unmarshaller);
+		if (this.unmarshaller != null) {
+			reader.setUnmarshaller(this.unmarshaller);
+		}
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 		reader.setXmlInputFactory(this.xmlInputFactory);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/StaxEventItemWriterBuilder.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.xml.builder;
 
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.xml.StaxEventItemWriter;
 import org.springframework.batch.item.xml.StaxWriterCallback;
 import org.springframework.core.io.WritableResource;
@@ -34,13 +35,13 @@ import org.springframework.util.Assert;
  */
 public class StaxEventItemWriterBuilder<T> {
 
-	private WritableResource resource;
+	private @Nullable WritableResource resource;
 
-	private Marshaller marshaller;
+	private @Nullable Marshaller marshaller;
 
-	private StaxWriterCallback headerCallback;
+	private @Nullable StaxWriterCallback headerCallback;
 
-	private StaxWriterCallback footerCallback;
+	private @Nullable StaxWriterCallback footerCallback;
 
 	private boolean transactional = true;
 
@@ -52,17 +53,17 @@ public class StaxEventItemWriterBuilder<T> {
 
 	private String version = StaxEventItemWriter.DEFAULT_XML_VERSION;
 
-	private Boolean standalone = StaxEventItemWriter.DEFAULT_STANDALONE_DOCUMENT;
+	private @Nullable Boolean standalone = StaxEventItemWriter.DEFAULT_STANDALONE_DOCUMENT;
 
 	private String rootTagName = StaxEventItemWriter.DEFAULT_ROOT_TAG_NAME;
 
-	private Map<String, String> rootElementAttributes;
+	private @Nullable Map<String, String> rootElementAttributes;
 
 	private boolean overwriteOutput = true;
 
 	private boolean saveState = true;
 
-	private String name;
+	private @Nullable String name;
 
 	/**
 	 * The name used to calculate the key within the
@@ -268,20 +269,32 @@ public class StaxEventItemWriterBuilder<T> {
 		StaxEventItemWriter<T> writer = new StaxEventItemWriter<>();
 
 		writer.setEncoding(this.encoding);
-		writer.setFooterCallback(this.footerCallback);
+		if (this.footerCallback != null) {
+			writer.setFooterCallback(this.footerCallback);
+		}
 		writer.setForceSync(this.forceSync);
-		writer.setHeaderCallback(this.headerCallback);
+		if (this.headerCallback != null) {
+			writer.setHeaderCallback(this.headerCallback);
+		}
 		writer.setMarshaller(this.marshaller);
 		writer.setOverwriteOutput(this.overwriteOutput);
-		writer.setResource(this.resource);
-		writer.setRootElementAttributes(this.rootElementAttributes);
+		if (this.resource != null) {
+			writer.setResource(this.resource);
+		}
+		if (this.rootElementAttributes != null) {
+			writer.setRootElementAttributes(this.rootElementAttributes);
+		}
 		writer.setRootTagName(this.rootTagName);
 		writer.setSaveState(this.saveState);
 		writer.setShouldDeleteIfEmpty(this.shouldDeleteIfEmpty);
 		writer.setTransactional(this.transactional);
 		writer.setVersion(this.version);
-		writer.setName(this.name);
-		writer.setStandalone(this.standalone);
+		if (this.name != null) {
+			writer.setName(this.name);
+		}
+		if (this.standalone != null) {
+			writer.setStandalone(this.standalone);
+		}
 
 		return writer;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/builder/package-info.java
@@ -18,8 +18,9 @@
  * Builders for Stax event item reader and writer.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.xml.builder;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of xml input and output.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.xml;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/AbstractEventReaderWrapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/AbstractEventReaderWrapper.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.item.xml.stax;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
@@ -66,7 +68,7 @@ abstract class AbstractEventReaderWrapper implements XMLEventReader {
 	}
 
 	@Override
-	public XMLEvent peek() throws XMLStreamException {
+	public @Nullable XMLEvent peek() throws XMLStreamException {
 		return wrappedEventReader.peek();
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/DefaultFragmentEventReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/DefaultFragmentEventReader.java
@@ -30,6 +30,8 @@ import javax.xml.stream.events.XMLEvent;
 
 import org.springframework.batch.item.ItemStreamException;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Default implementation of {@link FragmentEventReader}
  *
@@ -56,7 +58,7 @@ public class DefaultFragmentEventReader extends AbstractEventReaderWrapper imple
 
 	// fragment root name is remembered so that the matching closing element can
 	// be identified
-	private QName fragmentRootName = null;
+	private @Nullable QName fragmentRootName;
 
 	// counts the occurrences of current fragmentRootName (increased for
 	// StartElement, decreased for EndElement)
@@ -166,7 +168,7 @@ public class DefaultFragmentEventReader extends AbstractEventReaderWrapper imple
 	}
 
 	@Override
-	public XMLEvent peek() throws XMLStreamException {
+	public @Nullable XMLEvent peek() throws XMLStreamException {
 		if (fakeDocumentEnd) {
 			return null;
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/stax/package-info.java
@@ -18,8 +18,9 @@
  * Item reader and writer based on Stax.
  *
  * @author Mahmoud Ben Hassine
+ * @author Stefano Cordio
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.item.xml.stax;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of . concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/poller/DirectPoller.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/poller/DirectPoller.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.poller;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -24,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * A {@link Poller} that uses the callers thread to poll for a result as soon as it is
  * asked for. This is often appropriate if you expect a result relatively quickly, or if
- * there is only one such result expected (otherwise it is more efficient to use a
+ * there is only one such result expected (otherwise, it is more efficient to use a
  * background thread to do the polling).
  *
  * @author Dave Syer
@@ -57,7 +59,7 @@ public class DirectPoller<S> implements Poller<S> {
 
 		private volatile boolean cancelled;
 
-		private volatile S result = null;
+		private volatile @Nullable S result = null;
 
 		private final long interval;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/poller/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/poller/package-info.java
@@ -19,7 +19,7 @@
  *
  * @author Mahmoud Ben Hassine
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.poller;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/RepeatContext.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/RepeatContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.repeat;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.AttributeAccessor;
 
 /**
@@ -35,7 +36,7 @@ public interface RepeatContext extends AttributeAccessor {
 	 * parent. This is an accessor for the parent if it exists.
 	 * @return the parent context or null if there is none
 	 */
-	RepeatContext getParent();
+	@Nullable RepeatContext getParent();
 
 	/**
 	 * Public access to a counter for the number of operations attempted.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/callback/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/callback/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat callback concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.callback;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/RepeatContextCounter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/RepeatContextCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,35 +28,13 @@ import org.springframework.util.Assert;
  * decision is based on the aggregate of a number of sibling batches.
  *
  * @author Dave Syer
- *
+ * @author Stefano Cordio
  */
 public class RepeatContextCounter {
 
-	final private String countKey;
+	private final String countKey;
 
-	/**
-	 * Flag to indicate whether the count is stored at the level of the parent context, or
-	 * just local to the current context. Default value is false.
-	 */
-	final private boolean useParent;
-
-	final private RepeatContext context;
-
-	/**
-	 * Increment the counter.
-	 * @param delta the amount by which to increment the counter.
-	 */
-	final public void increment(int delta) {
-		AtomicInteger count = getCounter();
-		count.addAndGet(delta);
-	}
-
-	/**
-	 * Increment by 1.
-	 */
-	final public void increment() {
-		increment(1);
-	}
+	private final RepeatContext context;
 
 	/**
 	 * Convenience constructor with useParent=false.
@@ -76,26 +54,16 @@ public class RepeatContextCounter {
 	 * itself.
 	 */
 	public RepeatContextCounter(RepeatContext context, String countKey, boolean useParent) {
-
-		super();
-
 		Assert.notNull(context, "The context must be provided to initialize a counter");
 
 		this.countKey = countKey;
-		this.useParent = useParent;
 
 		RepeatContext parent = context.getParent();
 
-		if (this.useParent && parent != null) {
-			this.context = parent;
-		}
-		else {
-			this.context = context;
-		}
+		this.context = useParent && parent != null ? parent : context;
 		if (!this.context.hasAttribute(countKey)) {
 			this.context.setAttribute(countKey, new AtomicInteger());
 		}
-
 	}
 
 	/**
@@ -105,6 +73,22 @@ public class RepeatContextCounter {
 		return getCounter().intValue();
 	}
 
+	/**
+	 * Increment the counter.
+	 * @param delta the amount by which to increment the counter.
+	 */
+	public final void increment(int delta) {
+		getCounter().addAndGet(delta);
+	}
+
+	/**
+	 * Increment by 1.
+	 */
+	public final void increment() {
+		increment(1);
+	}
+
+	@SuppressWarnings("DataFlowIssue")
 	private AtomicInteger getCounter() {
 		return ((AtomicInteger) context.getAttribute(countKey));
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/RepeatContextSupport.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/RepeatContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ public class RepeatContextSupport extends SynchronizedAttributeAccessor implemen
 	 * @param parent {@link RepeatContext} to be used as the parent context.
 	 */
 	public RepeatContextSupport(RepeatContext parent) {
-		super();
 		this.parent = parent;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/SynchronizedAttributeAccessor.java
@@ -16,9 +16,10 @@
 
 package org.springframework.batch.repeat.context;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.AttributeAccessor;
 import org.springframework.core.AttributeAccessorSupport;
-import org.springframework.lang.Nullable;
 
 /**
  * An {@link AttributeAccessor} that synchronizes on a mutex (not this) before modifying
@@ -68,7 +69,7 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 	}
 
 	@Override
-	public Object getAttribute(String name) {
+	public @Nullable Object getAttribute(String name) {
 		synchronized (support) {
 			return support.getAttribute(name);
 		}
@@ -87,14 +88,14 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 	}
 
 	@Override
-	public Object removeAttribute(String name) {
+	public @Nullable Object removeAttribute(String name) {
 		synchronized (support) {
 			return support.removeAttribute(name);
 		}
 	}
 
 	@Override
-	public void setAttribute(String name, Object value) {
+	public void setAttribute(String name, @Nullable Object value) {
 		synchronized (support) {
 			support.setAttribute(name, value);
 		}
@@ -106,8 +107,7 @@ public class SynchronizedAttributeAccessor implements AttributeAccessor {
 	 * @param value the value of the attribute
 	 * @return null if the attribute was not already set, the existing value otherwise.
 	 */
-	@Nullable
-	public Object setAttributeIfAbsent(String name, Object value) {
+	public @Nullable Object setAttributeIfAbsent(String name, Object value) {
 		synchronized (support) {
 			Object old = getAttribute(name);
 			if (old != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/context/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat context concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.context;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandler.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/SimpleLimitExceptionHandler.java
@@ -116,7 +116,7 @@ public class SimpleLimitExceptionHandler implements ExceptionHandler, Initializi
 	 * rethrown.
 	 * @param limit the limit
 	 */
-	public void setLimit(final int limit) {
+	public void setLimit(int limit) {
 		this.limit = limit;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/exception/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat exception handler concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.exception;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/interceptor/RepeatOperationsInterceptor.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/interceptor/RepeatOperationsInterceptor.java
@@ -18,6 +18,7 @@ package org.springframework.batch.repeat.interceptor;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 import org.springframework.aop.ProxyMethodInvocation;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatException;
@@ -59,7 +60,7 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 	 * @see org.aopalliance.intercept.MethodInterceptor#invoke(org.aopalliance.intercept.MethodInvocation)
 	 */
 	@Override
-	public Object invoke(final MethodInvocation invocation) throws Throwable {
+	public @Nullable Object invoke(MethodInvocation invocation) throws Throwable {
 
 		final ResultHolder result = new ResultHolder();
 		// Cache void return value if intercepted method returns void
@@ -121,7 +122,7 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 				+ ".  The invocation was never called, so maybe there is a problem with the completion policy?");
 	}
 
-	private boolean isComplete(Object result) {
+	private boolean isComplete(@Nullable Object result) {
 		return (result == null) || ((result instanceof Boolean b) && !b);
 	}
 
@@ -148,7 +149,7 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 	 */
 	private static class ResultHolder {
 
-		private Object value = null;
+		private @Nullable Object value;
 
 		private boolean ready = false;
 
@@ -156,12 +157,12 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 		 * Public setter for the Object.
 		 * @param value the value to set
 		 */
-		public void setValue(Object value) {
+		public void setValue(@Nullable Object value) {
 			this.ready = true;
 			this.value = value;
 		}
 
-		public void setFinalValue(Object value) {
+		public void setFinalValue(@Nullable Object value) {
 			if (ready) {
 				// Only set the value the last time if the last time was also
 				// the first time
@@ -174,7 +175,7 @@ public class RepeatOperationsInterceptor implements MethodInterceptor {
 		 * Public getter for the Object.
 		 * @return the value
 		 */
-		public Object getValue() {
+		public @Nullable Object getValue() {
 			return value;
 		}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/interceptor/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/interceptor/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat aop concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.interceptor;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/listener/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/listener/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat interceptor concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.listener;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/policy/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat policy concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.policy;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ResultHolder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/ResultHolder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.repeat.support;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.RepeatContext;
 
@@ -34,14 +35,14 @@ interface ResultHolder {
 	 * yet.
 	 * @return the result, or null if there is none.
 	 */
-	RepeatStatus getResult();
+	@Nullable RepeatStatus getResult();
 
 	/**
 	 * Get the error for client from this holder if any. Does not block if none is
 	 * available yet.
 	 * @return the error, or null if there is none.
 	 */
-	Throwable getError();
+	@Nullable Throwable getError();
 
 	/**
 	 * Get the context in which the result evaluation is executing.

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplate.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/TaskExecutorRepeatTemplate.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.repeat.support;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.repeat.RepeatCallback;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatException;
@@ -24,6 +25,8 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.util.Assert;
+
+import java.util.Objects;
 
 /**
  * Provides {@link RepeatOperations} support including interceptors that can be used to
@@ -44,7 +47,7 @@ import org.springframework.util.Assert;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
+ * @author Stefano Cordio
  */
 public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 
@@ -126,7 +129,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 		if (result.getError() != null) {
 			throw result.getError();
 		}
-		return result.getResult();
+		return Objects.requireNonNull(result.getResult());
 	}
 
 	/**
@@ -196,18 +199,14 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 
 		private final ResultQueue<ResultHolder> queue;
 
-		private volatile RepeatStatus result;
+		private volatile @Nullable RepeatStatus result;
 
-		private volatile Throwable error;
+		private volatile @Nullable Throwable error;
 
 		public ExecutingRunnable(RepeatCallback callback, RepeatContext context, ResultQueue<ResultHolder> queue) {
-
-			super();
-
 			this.callback = callback;
 			this.context = context;
 			this.queue = queue;
-
 		}
 
 		/**
@@ -264,7 +263,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 		 * finish.
 		 */
 		@Override
-		public RepeatStatus getResult() {
+		public @Nullable RepeatStatus getResult() {
 			return result;
 		}
 
@@ -273,7 +272,7 @@ public class TaskExecutorRepeatTemplate extends RepeatTemplate {
 		 * finish.
 		 */
 		@Override
-		public Throwable getError() {
+		public @Nullable Throwable getError() {
 			return error;
 		}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/repeat/support/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of repeat support concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.repeat.support;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/AnnotationMethodResolver.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/AnnotationMethodResolver.java
@@ -23,8 +23,9 @@ import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.springframework.aop.support.AopUtils;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
@@ -61,9 +62,8 @@ public class AnnotationMethodResolver implements MethodResolver {
 	 * @throws IllegalArgumentException if more than one Method has the specified
 	 * annotation
 	 */
-	@Nullable
 	@Override
-	public Method findMethod(Object candidate) {
+	public @Nullable Method findMethod(Object candidate) {
 		Assert.notNull(candidate, "candidate object must not be null");
 		Class<?> targetClass = AopUtils.getTargetClass(candidate);
 		if (targetClass == null) {
@@ -81,9 +81,8 @@ public class AnnotationMethodResolver implements MethodResolver {
 	 * @throws IllegalArgumentException if more than one Method has the specified
 	 * annotation
 	 */
-	@Nullable
 	@Override
-	public Method findMethod(final Class<?> clazz) {
+	public @Nullable Method findMethod(Class<?> clazz) {
 		Assert.notNull(clazz, "class must not be null");
 		final AtomicReference<Method> annotatedMethod = new AtomicReference<>();
 		ReflectionUtils.doWithMethods(clazz, method -> {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DefaultPropertyEditorRegistrar.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/DefaultPropertyEditorRegistrar.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.PropertyEditorRegistrar;
 import org.springframework.beans.PropertyEditorRegistry;
 import org.springframework.beans.factory.config.CustomEditorConfigurer;
@@ -34,11 +35,11 @@ import org.springframework.util.ClassUtils;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
- *
+ * @author Stefano Cordio
  */
 public class DefaultPropertyEditorRegistrar implements PropertyEditorRegistrar {
 
-	private Map<Class<?>, PropertyEditor> customEditors;
+	private final Map<Class<?>, PropertyEditor> customEditors = new HashMap<>();
 
 	/**
 	 * Register the custom editors with the given registry.
@@ -47,10 +48,8 @@ public class DefaultPropertyEditorRegistrar implements PropertyEditorRegistrar {
 	 */
 	@Override
 	public void registerCustomEditors(PropertyEditorRegistry registry) {
-		if (this.customEditors != null) {
-			for (Entry<Class<?>, PropertyEditor> entry : customEditors.entrySet()) {
-				registry.registerCustomEditor(entry.getKey(), entry.getValue());
-			}
+		for (Entry<Class<?>, PropertyEditor> entry : customEditors.entrySet()) {
+			registry.registerCustomEditor(entry.getKey(), entry.getValue());
 		}
 	}
 
@@ -61,7 +60,6 @@ public class DefaultPropertyEditorRegistrar implements PropertyEditorRegistrar {
 	 * @see CustomEditorConfigurer#setCustomEditors(Map)
 	 */
 	public void setCustomEditors(Map<?, ? extends PropertyEditor> customEditors) {
-		this.customEditors = new HashMap<>();
 		for (Entry<?, ? extends PropertyEditor> entry : customEditors.entrySet()) {
 			Object key = entry.getKey();
 			Class<?> requiredType;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodResolver.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/MethodResolver.java
@@ -18,7 +18,7 @@ package org.springframework.batch.support;
 
 import java.lang.reflect.Method;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Strategy interface for detecting a single Method on a Class.
@@ -36,8 +36,7 @@ public interface MethodResolver {
 	 * @throws IllegalArgumentException if more than one Method defined on the given
 	 * candidate's Class matches this resolver's criteria
 	 */
-	@Nullable
-	Method findMethod(Object candidate) throws IllegalArgumentException;
+	@Nullable Method findMethod(Object candidate) throws IllegalArgumentException;
 
 	/**
 	 * Find a <em>single</em> Method on the given Class that matches this resolver's
@@ -48,7 +47,6 @@ public interface MethodResolver {
 	 * @throws IllegalArgumentException if more than one Method defined on the given Class
 	 * matches this resolver's criteria
 	 */
-	@Nullable
-	Method findMethod(Class<?> clazz);
+	@Nullable Method findMethod(Class<?> clazz);
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/PropertiesConverter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/PropertiesConverter.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
+
 import org.springframework.util.StringUtils;
 
 /**
@@ -50,7 +50,7 @@ public final class PropertiesConverter {
 	 * @param stringToParse String to parse. Must not be {@code null}.
 	 * @return Properties parsed from each key=value pair.
 	 */
-	public static Properties stringToProperties(@NonNull String stringToParse) {
+	public static Properties stringToProperties(String stringToParse) {
 		Assert.notNull(stringToParse, "stringToParse must not be null");
 		if (!StringUtils.hasText(stringToParse)) {
 			return new Properties();
@@ -76,7 +76,7 @@ public final class PropertiesConverter {
 	 * {@code null}.
 	 * @return String representation of the properties object
 	 */
-	public static String propertiesToString(@NonNull Properties propertiesToParse) {
+	public static String propertiesToString(Properties propertiesToParse) {
 		Assert.notNull(propertiesToParse, "propertiesToParse must not be null");
 		if (propertiesToParse.isEmpty()) {
 			return "";

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of support concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.support;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/ResourcelessTransactionManager.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/ResourcelessTransactionManager.java
@@ -39,6 +39,7 @@ public class ResourcelessTransactionManager extends AbstractPlatformTransactionM
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected Object doGetTransaction() throws TransactionException {
 		Object transaction = new ResourcelessTransaction();
@@ -63,6 +64,7 @@ public class ResourcelessTransactionManager extends AbstractPlatformTransactionM
 		}
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected boolean isExistingTransaction(Object transaction) throws TransactionException {
 		if (TransactionSynchronizationManager.hasResource(this)) {
@@ -76,6 +78,7 @@ public class ResourcelessTransactionManager extends AbstractPlatformTransactionM
 	protected void doSetRollbackOnly(DefaultTransactionStatus status) throws TransactionException {
 	}
 
+	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doCleanupAfterCompletion(Object transaction) {
 		List<?> resources = (List<?>) TransactionSynchronizationManager.getResource(this);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareBufferedWriter.java
@@ -87,6 +87,7 @@ public class TransactionAwareBufferedWriter extends Writer {
 	/**
 	 * @return the current buffer
 	 */
+	@SuppressWarnings("DataFlowIssue")
 	private StringBuilder getCurrentBuffer() {
 
 		if (!TransactionSynchronizationManager.hasResource(bufferKey)) {
@@ -175,7 +176,7 @@ public class TransactionAwareBufferedWriter extends Writer {
 	@Override
 	public void close() throws IOException {
 		if (transactionActive()) {
-			if (getCurrentBuffer().length() > 0) {
+			if (!getCurrentBuffer().isEmpty()) {
 				TransactionSynchronizationManager.bindResource(closeKey, Boolean.TRUE);
 			}
 			return;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/TransactionAwareProxyFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -217,7 +218,7 @@ public class TransactionAwareProxyFactory<T> {
 	private class TransactionAwareInterceptor implements MethodInterceptor {
 
 		@Override
-		public Object invoke(MethodInvocation invocation) throws Throwable {
+		public @Nullable Object invoke(MethodInvocation invocation) throws Throwable {
 
 			if (!TransactionSynchronizationManager.isActualTransactionActive()) {
 				return invocation.proceed();

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/package-info.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/support/transaction/package-info.java
@@ -3,7 +3,7 @@
  * Infrastructure implementations of support transaction concerns.
  * </p>
  */
-@NonNullApi
+@NullMarked
 package org.springframework.batch.support.transaction;
 
-import org.springframework.lang.NonNullApi;
+import org.jspecify.annotations.NullMarked;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainer.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/container/jms/BatchMessageListenerContainer.java
@@ -121,7 +121,7 @@ public class BatchMessageListenerContainer extends DefaultMessageListenerContain
 	 * jakarta.jms.Session, jakarta.jms.MessageConsumer)
 	 */
 	@Override
-	protected boolean receiveAndExecute(final Object invoker, final Session session, final MessageConsumer consumer)
+	protected boolean receiveAndExecute(Object invoker, final Session session, final MessageConsumer consumer)
 			throws JMSException {
 		return proxy.receiveAndExecute(invoker, session, consumer);
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/support/AvroItemWriterTestSupport.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/avro/support/AvroItemWriterTestSupport.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.batch.item.Chunk;
+
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.avro.AvroItemReader;
 import org.springframework.batch.item.avro.builder.AvroItemReaderBuilder;
@@ -91,17 +93,17 @@ public abstract class AvroItemWriterTestSupport extends AvroTestFixtures {
 		}
 
 		@Override
-		public URL getURL() throws IOException {
+		public @Nullable URL getURL() throws IOException {
 			return null;
 		}
 
 		@Override
-		public URI getURI() throws IOException {
+		public @Nullable URI getURI() throws IOException {
 			return null;
 		}
 
 		@Override
-		public File getFile() throws IOException {
+		public @Nullable File getFile() throws IOException {
 			return null;
 		}
 
@@ -116,12 +118,12 @@ public abstract class AvroItemWriterTestSupport extends AvroTestFixtures {
 		}
 
 		@Override
-		public Resource createRelative(String relativePath) throws IOException {
+		public @Nullable Resource createRelative(String relativePath) throws IOException {
 			return null;
 		}
 
 		@Override
-		public String getFilename() {
+		public @Nullable String getFilename() {
 			return null;
 		}
 
@@ -131,7 +133,7 @@ public abstract class AvroItemWriterTestSupport extends AvroTestFixtures {
 		}
 
 		@Override
-		public InputStream getInputStream() throws IOException {
+		public @Nullable InputStream getInputStream() throws IOException {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractPagingItemReaderParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/AbstractPagingItemReaderParameterTests.java
@@ -48,13 +48,13 @@ abstract class AbstractPagingItemReaderParameterTests {
 
 	@AfterEach
 	void tearDown() {
-		((ItemStream) tested).close();
+		tested.close();
 	}
 
 	@Test
 	void testRead() throws Exception {
 
-		((ItemStream) tested).open(executionContext);
+		tested.open(executionContext);
 
 		Foo foo2 = tested.read();
 		assertEquals(2, foo2.getValue());
@@ -76,7 +76,7 @@ abstract class AbstractPagingItemReaderParameterTests {
 	void testReadAfterJumpFirstPage() throws Exception {
 
 		executionContext.putInt(getName() + ".read.count", 2);
-		((ItemStream) tested).open(executionContext);
+		tested.open(executionContext);
 
 		Foo foo4 = tested.read();
 		assertEquals(4, foo4.getValue());
@@ -92,7 +92,7 @@ abstract class AbstractPagingItemReaderParameterTests {
 	void testReadAfterJumpSecondPage() throws Exception {
 
 		executionContext.putInt(getName() + ".read.count", 3);
-		((ItemStream) tested).open(executionContext);
+		tested.open(executionContext);
 
 		Foo foo5 = tested.read();
 		assertEquals(5, foo5.getValue());

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -184,7 +185,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		assertEquals("ERROR", exception.getMessage());
 	}
 
-	public static SqlParameterSource[] eqSqlParameterSourceArray(SqlParameterSource[] in) {
+	public static @Nullable SqlParameterSource[] eqSqlParameterSourceArray(SqlParameterSource[] in) {
 		argThat(new SqlParameterSourceArrayEquals(in));
 		return null;
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderCommonTests.java
@@ -26,7 +26,10 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 /**
  * @author Dave Syer
@@ -35,6 +38,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Mahmoud Ben Hassine
  */
 @SpringJUnitConfig
+@DirtiesContext(classMode = BEFORE_CLASS)
 public class JdbcPagingItemReaderCommonTests extends AbstractItemStreamItemReaderTests {
 
 	@Autowired

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingItemReaderIntegrationTests.java
@@ -23,38 +23,38 @@ import org.springframework.batch.item.database.support.HsqlPagingQueryProvider;
 import org.springframework.batch.item.sample.Foo;
 
 /**
- * Tests for {@link JpaPagingItemReader}.
+ * Tests for {@link JdbcPagingItemReader}.
  *
  * @author Thomas Risberg
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  */
-public class JdbcPagingItemReaderIntegrationTests extends AbstractGenericDataSourceItemReaderIntegrationTests {
+class JdbcPagingItemReaderIntegrationTests extends AbstractGenericDataSourceItemReaderIntegrationTests {
 
 	@Override
 	protected ItemReader<Foo> createItemReader() throws Exception {
 
-		JdbcPagingItemReader<Foo> inputSource = new JdbcPagingItemReader<>();
-		inputSource.setDataSource(dataSource);
+		JdbcPagingItemReader<Foo> itemReader = new JdbcPagingItemReader<>();
+		itemReader.setDataSource(dataSource);
 		HsqlPagingQueryProvider queryProvider = new HsqlPagingQueryProvider();
 		queryProvider.setSelectClause("select ID, NAME, VALUE");
 		queryProvider.setFromClause("from T_FOOS");
 		Map<String, Order> sortKeys = new LinkedHashMap<>();
 		sortKeys.put("ID", Order.ASCENDING);
 		queryProvider.setSortKeys(sortKeys);
-		inputSource.setQueryProvider(queryProvider);
-		inputSource.setRowMapper((rs, i) -> {
+		itemReader.setQueryProvider(queryProvider);
+		itemReader.setRowMapper((rs, i) -> {
 			Foo foo = new Foo();
 			foo.setId(rs.getInt(1));
 			foo.setName(rs.getString(2));
 			foo.setValue(rs.getInt(3));
 			return foo;
 		});
-		inputSource.setPageSize(3);
-		inputSource.afterPropertiesSet();
-		inputSource.setSaveState(true);
+		itemReader.setPageSize(3);
+		itemReader.afterPropertiesSet();
+		itemReader.setSaveState(true);
 
-		return inputSource;
+		return itemReader;
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingQueryIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcPagingQueryIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.test.jdbc.JdbcTestUtils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 /**
  * @author Dave Syer
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 2.1
  */
 @SpringJUnitConfig(locations = "JdbcPagingItemReaderCommonTests-context.xml")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DirtiesContext(classMode = BEFORE_CLASS)
 class JdbcPagingQueryIntegrationTests {
 
 	private static final Log logger = LogFactory.getLog(JdbcPagingQueryIntegrationTests.class);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/orm/JpaNamedQueryProviderTests.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,6 @@ class JpaNamedQueryProviderTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	void testNamedQueryCreation() throws Exception {
 		// given
 		String namedQuery = "allFoos";
@@ -82,7 +82,7 @@ class JpaNamedQueryProviderTests {
 		Query result = jpaNamedQueryProvider.createQuery();
 
 		// then
-		Assert.notNull(result, "Result query must not be null");
+		assertNotNull(result);
 		verify(entityManager).createNamedQuery(namedQuery, Foo.class);
 	}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryUtilsTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/support/SqlPagingQueryUtilsTests.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.database.Order;
 
@@ -118,12 +119,12 @@ class SqlPagingQueryUtilsTests {
 		}
 
 		@Override
-		public String generateFirstPageQuery(int pageSize) {
+		public @Nullable String generateFirstPageQuery(int pageSize) {
 			return null;
 		}
 
 		@Override
-		public String generateRemainingPagesQuery(int pageSize) {
+		public @Nullable String generateRemainingPagesQuery(int pageSize) {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemReaderTests.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -540,7 +541,7 @@ class FlatFileItemReaderTests {
 		}
 
 		@Override
-		public InputStream getInputStream() throws IOException {
+		public @Nullable InputStream getInputStream() throws IOException {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/FlatFileItemWriterTests.java
@@ -328,7 +328,7 @@ class FlatFileItemWriterTests {
 		writeStringTransactionCheck(TEST_STRING);
 	}
 
-	private void writeStringTransactionCheck(final String expectedInTransaction) {
+	private void writeStringTransactionCheck(String expectedInTransaction) {
 		PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
 
 		writer.open(executionContext);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemReaderIntegrationTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Comparator;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +35,6 @@ import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
-import org.springframework.lang.Nullable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -428,9 +428,9 @@ class MultiResourceItemReaderIntegrationTests {
 
 		private boolean closeCalled = false;
 
-		@Nullable
 		@Override
-		public String read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+		public @Nullable String read()
+				throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterFlatFileTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/MultiResourceItemWriterFlatFileTests.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.file;
 
 import java.io.File;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +50,7 @@ public class MultiResourceItemWriterFlatFileTests extends AbstractMultiResourceI
 		}
 
 		@Override
-		public Void doInTransaction(TransactionStatus status) {
+		public @Nullable Void doInTransaction(TransactionStatus status) {
 			try {
 				tested.write(list);
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/mapping/BeanWrapperFieldSetMapperTests.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,6 @@ import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.lang.Nullable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.DataBinder;
@@ -799,16 +799,15 @@ class BeanWrapperFieldSetMapperTests {
 			return true;
 		}
 
-		@Nullable
 		@Override
 		@SuppressWarnings("unchecked")
-		public <T> T convert(@Nullable Object source, Class<T> targetType) {
+		public <T> @Nullable T convert(@Nullable Object source, Class<T> targetType) {
 			return (T) "CONVERTED";
 		}
 
-		@Nullable
 		@Override
-		public Object convert(@Nullable Object source, @Nullable TypeDescriptor sourceType, TypeDescriptor targetType) {
+		public @Nullable Object convert(@Nullable Object source, @Nullable TypeDescriptor sourceType,
+				TypeDescriptor targetType) {
 			return "CONVERTED";
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DefaultFieldSetTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/file/transform/DefaultFieldSetTests.java
@@ -457,7 +457,7 @@ class DefaultFieldSetTests {
 	@Test
 	void testToStringNullTokens() {
 		fieldSet = new DefaultFieldSet(null);
-		assertEquals("", fieldSet.toString());
+		assertEquals("[]", fieldSet.toString());
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/function/SupplierItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/function/SupplierItemReaderTests.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.function;
 
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,7 @@ class SupplierItemReaderTests {
 		private int count = 1;
 
 		@Override
-		public String get() {
+		public @Nullable String get() {
 			return count <= 2 ? "foo" + count++ : null;
 		}
 	};

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/json/JsonItemReaderTests.java
@@ -18,6 +18,7 @@ package org.springframework.batch.item.json;
 
 import java.io.InputStream;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -114,7 +115,7 @@ class JsonItemReaderTests {
 		}
 
 		@Override
-		public InputStream getInputStream() {
+		public @Nullable InputStream getInputStream() {
 			return null;
 		}
 
@@ -141,7 +142,7 @@ class JsonItemReaderTests {
 		}
 
 		@Override
-		public InputStream getInputStream() {
+		public @Nullable InputStream getInputStream() {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/sample/FooService.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/sample/FooService.java
@@ -18,6 +18,8 @@ package org.springframework.batch.item.sample;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Custom class that contains the logic of providing and processing {@link Foo} objects.
  * It serves the purpose to show how providing/processing logic contained in a custom
@@ -38,7 +40,7 @@ public class FooService {
 
 	private final List<Foo> processedFooNameValuePairs = new ArrayList<>(GENERATION_LIMIT);
 
-	public Foo generateFoo() {
+	public @Nullable Foo generateFoo() {
 		if (counter++ >= GENERATION_LIMIT)
 			return null;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ClassifierCompositeItemProcessorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ClassifierCompositeItemProcessorTests.java
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.classify.PatternMatchingClassifier;
 import org.springframework.classify.SubclassClassifier;
-import org.springframework.lang.Nullable;
 
 /**
  * @author Jimmy Praet
@@ -37,16 +37,16 @@ class ClassifierCompositeItemProcessorTests {
 		ClassifierCompositeItemProcessor<String, String> processor = new ClassifierCompositeItemProcessor<>();
 
 		ItemProcessor<String, String> fooProcessor = new ItemProcessor<>() {
-			@Nullable
+
 			@Override
-			public String process(String item) throws Exception {
+			public @Nullable String process(String item) throws Exception {
 				return "foo: " + item;
 			}
 		};
 		ItemProcessor<String, String> defaultProcessor = new ItemProcessor<>() {
-			@Nullable
+
 			@Override
-			public String process(String item) throws Exception {
+			public @Nullable String process(String item) throws Exception {
 				return item;
 			}
 		};
@@ -70,23 +70,23 @@ class ClassifierCompositeItemProcessorTests {
 		ClassifierCompositeItemProcessor<Number, CharSequence> processor = new ClassifierCompositeItemProcessor<>();
 
 		ItemProcessor<Integer, String> intProcessor = new ItemProcessor<>() {
-			@Nullable
+
 			@Override
-			public String process(Integer item) throws Exception {
+			public @Nullable String process(Integer item) throws Exception {
 				return "int: " + item;
 			}
 		};
 		ItemProcessor<Long, StringBuffer> longProcessor = new ItemProcessor<>() {
-			@Nullable
+
 			@Override
-			public StringBuffer process(Long item) throws Exception {
+			public @Nullable StringBuffer process(Long item) throws Exception {
 				return new StringBuffer("long: " + item);
 			}
 		};
 		ItemProcessor<Number, StringBuilder> defaultProcessor = new ItemProcessor<>() {
-			@Nullable
+
 			@Override
-			public StringBuilder process(Number item) throws Exception {
+			public @Nullable StringBuilder process(Number item) throws Exception {
 				return new StringBuilder("number: " + item);
 			}
 		};

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/ItemCountingItemStreamItemReaderTests.java
@@ -23,10 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.lang.Nullable;
 
 /**
  * @author Dave Syer
@@ -145,9 +145,8 @@ class ItemCountingItemStreamItemReaderTests {
 			openCalled = true;
 		}
 
-		@Nullable
 		@Override
-		protected String doRead() throws Exception {
+		protected @Nullable String doRead() throws Exception {
 			if (!items.hasNext()) {
 				return null;
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SingleItemPeekableItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/support/SingleItemPeekableItemReaderTests.java
@@ -21,9 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.lang.Nullable;
 
 /**
  * @author Dave Syer
@@ -128,9 +128,8 @@ class SingleItemPeekableItemReaderTests {
 			counter = 0;
 		}
 
-		@Nullable
 		@Override
-		protected T doRead() throws Exception {
+		protected @Nullable T doRead() throws Exception {
 			if (counter >= list.size()) {
 				return null;
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/xml/StaxEventItemReaderTests.java
@@ -17,6 +17,7 @@ package org.springframework.batch.item.xml;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -767,7 +768,7 @@ class StaxEventItemReaderTests {
 	private static class ItemCountAwareMockFragmentUnmarshaller extends MockFragmentUnmarshaller {
 
 		@Override
-		public Object unmarshal(Source source) throws XmlMappingException, IOException {
+		public @Nullable Object unmarshal(Source source) throws XmlMappingException, IOException {
 			List<XMLEvent> fragment = (List<XMLEvent>) super.unmarshal(source);
 			if (fragment != null) {
 				return new ItemCountAwareFragment(fragment);
@@ -833,7 +834,7 @@ class StaxEventItemReaderTests {
 		}
 
 		@Override
-		public InputStream getInputStream() throws IOException {
+		public @Nullable InputStream getInputStream() throws IOException {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/poller/DirectPollerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/poller/DirectPollerTests.java
@@ -96,7 +96,7 @@ class DirectPollerTests {
 		assertEquals("Expected", exception.getCause().getMessage());
 	}
 
-	private void sleepAndCreateStringInBackground(final long duration) {
+	private void sleepAndCreateStringInBackground(long duration) {
 		new Thread(() -> {
 			try {
 				Thread.sleep(duration);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/interceptor/RepeatOperationsInterceptorTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/interceptor/RepeatOperationsInterceptorTests.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.framework.Advised;
@@ -236,7 +237,7 @@ class RepeatOperationsInterceptorTests {
 		}
 
 		@Override
-		public Object service() throws Exception {
+		public @Nullable Object service() throws Exception {
 			count++;
 			if (count <= maxService) {
 				return count;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ChunkedRepeatTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ChunkedRepeatTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.batch.repeat.support;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ItemReader;
@@ -25,7 +26,6 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.repeat.callback.NestedRepeatCallback;
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.lang.Nullable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -156,9 +156,8 @@ class ChunkedRepeatTests extends AbstractTradeBatchTests {
 			ItemReader<Trade> truncated = new ItemReader<>() {
 				int count = 0;
 
-				@Nullable
 				@Override
-				public Trade read() throws Exception {
+				public @Nullable Trade read() throws Exception {
 					if (count++ < 2)
 						return provider.read();
 					return null;

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ResultHolderResultQueueTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/repeat/support/ResultHolderResultQueueTests.java
@@ -18,6 +18,7 @@ package org.springframework.batch.repeat.support;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.repeat.RepeatContext;
 import org.springframework.batch.repeat.RepeatStatus;
@@ -61,7 +62,7 @@ class ResultHolderResultQueueTests {
 		}
 
 		@Override
-		public RepeatContext getContext() {
+		public @Nullable RepeatContext getContext() {
 			return null;
 		}
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ConcurrentTransactionAwareProxyTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/support/transaction/ConcurrentTransactionAwareProxyTests.java
@@ -112,7 +112,7 @@ class ConcurrentTransactionAwareProxyTests {
 		assertFalse(result);
 	}
 
-	private void testSet(final Set<String> set) throws Exception {
+	private void testSet(Set<String> set) throws Exception {
 
 		for (int i = 0; i < outerMax; i++) {
 
@@ -138,7 +138,7 @@ class ConcurrentTransactionAwareProxyTests {
 
 	}
 
-	private void testList(final List<String> list, final boolean mutate) throws Exception {
+	private void testList(List<String> list, final boolean mutate) throws Exception {
 
 		for (int i = 0; i < outerMax; i++) {
 
@@ -170,7 +170,7 @@ class ConcurrentTransactionAwareProxyTests {
 
 	}
 
-	private void testMap(final Map<Long, Map<String, String>> map) throws Exception {
+	private void testMap(Map<Long, Map<String, String>> map) throws Exception {
 
 		int numberOfKeys = outerMax;
 
@@ -197,7 +197,7 @@ class ConcurrentTransactionAwareProxyTests {
 
 	}
 
-	private String saveInSetAndAssert(final Set<String> set, final String value) {
+	private String saveInSetAndAssert(Set<String> set, final String value) {
 
 		new TransactionTemplate(transactionManager).execute((TransactionCallback<Void>) status -> {
 			set.add(value);
@@ -210,7 +210,7 @@ class ConcurrentTransactionAwareProxyTests {
 
 	}
 
-	private String saveInListAndAssert(final List<String> list, final String value) {
+	private String saveInListAndAssert(List<String> list, final String value) {
 
 		new TransactionTemplate(transactionManager).execute((TransactionCallback<Void>) status -> {
 			list.add(value);
@@ -223,7 +223,7 @@ class ConcurrentTransactionAwareProxyTests {
 
 	}
 
-	private Map<String, String> saveInMapAndAssert(final Map<Long, Map<String, String>> map, final Long id,
+	private Map<String, String> saveInMapAndAssert(Map<Long, Map<String, String>> map, final Long id,
 			final String value) {
 
 		new TransactionTemplate(transactionManager).execute((TransactionCallback<Void>) status -> {


### PR DESCRIPTION
This PR migrates `spring-batch-infrastructure` to JSpecify annotations and introduces NullAway to verify `@NullMarked` annotated packages (productive code only).

I used the following strategy to handle cases of null-safety mismatch detected by NullAway:
* Whenever possible, I refactored the code to be null-safe
* When refactoring was either not possible or too complex, I annotated the corresponding part with `@SuppressWarnings("DataFlowIssue")`, which is recognized by both [IntelliJ IDEA](https://www.jetbrains.com/help/inspectopedia/DataFlowIssue.html) and [NullAway](https://github.com/uber/NullAway/wiki/Configuration#suppression-name-aliases-version-0128-and-after)

Many classes could benefit from a more aggressive refactoring, where a constructor with parameters could be favored instead of relying on the default constructor + setters + `afterPropertiesSet` implementation. I'll work on a proposal in a separate PR.

* See #4673