### PR TITLE
remove JobRegistrySmartInitializingSingleton usage

### DIFF
--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/test-context.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/test-context.xml
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
-
-	<bean
-		class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="registry" />
-	</bean>
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="registry"
 		class="org.springframework.batch.core.configuration.support.MapJobRegistry" />

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/trivial-context-autoregister.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/configuration/support/trivial-context-autoregister.xml
@@ -11,10 +11,6 @@
         </property>
 	</bean>
 
-	<bean class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="jobRegistry" />
-	</bean>
-
 	<bean id="jobRegistry" class="org.springframework.batch.core.configuration.support.MapJobRegistry"/>
 
 </beans>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/support/launcher-with-locator.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/support/launcher-with-locator.xml
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:tx="http://www.springframework.org/schema/tx"
-	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="test-environment.xml" />
 	<import resource="job.xml" />
 	<import resource="job2.xml" />
-	
+
 	<bean id="jobRegistry" class="org.springframework.batch.core.configuration.support.MapJobRegistry"/>
-	
-	<bean class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="jobRegistry"/>
-	</bean>
 
 </beans>

--- a/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/support/test-environment-with-registry-and-auto-register.xml
+++ b/spring-batch-core/src/test/resources/org/springframework/batch/core/launch/support/test-environment-with-registry-and-auto-register.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:p="http://www.springframework.org/schema/p"
+<beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="test-environment-with-registry.xml" />
-
-	<bean class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="jobRegistry"/>
-	</bean>
 
 </beans>

--- a/spring-batch-core/src/test/resources/simple-job-launcher-context.xml
+++ b/spring-batch-core/src/test/resources/simple-job-launcher-context.xml
@@ -6,10 +6,6 @@
 
 	<import resource="classpath:data-source-context.xml" />
 
-	<bean class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="jobRegistry"/>
-	</bean>
-
 	<bean id="jobRepository"
 		class="org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean"
 		p:dataSource-ref="dataSource" p:transactionManager-ref="transactionManager" />

--- a/spring-batch-samples/src/main/resources/org/springframework/batch/samples/restart/stop/stopRestartSample.xml
+++ b/spring-batch-samples/src/main/resources/org/springframework/batch/samples/restart/stop/stopRestartSample.xml
@@ -5,10 +5,6 @@
 
 	<import resource="classpath:data-source-context.xml" />
 
-	<bean class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="jobRegistry"/>
-	</bean>
-
 	<bean id="jobRepository"
 		  class="org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean"
 		  p:dataSource-ref="dataSource" p:transactionManager-ref="transactionManager"/>
@@ -34,13 +30,13 @@
 		<property name="jobRepository" ref="jobRepository" />
 		<property name="restartable" value="true" />
 	</bean>
-	
+
 	<bean id="taskletStep" class="org.springframework.batch.core.step.tasklet.TaskletStep" abstract="true">
 		<property name="transactionManager" ref="transactionManager" />
 		<property name="jobRepository" ref="jobRepository" />
 		<property name="allowStartIfComplete" value="true" />
 	</bean>
-	
+
 	<bean id="simpleStep" class="org.springframework.batch.core.step.factory.FaultTolerantStepFactoryBean" abstract="true">
 		<property name="transactionManager" ref="transactionManager" />
 		<property name="jobRepository" ref="jobRepository" />
@@ -48,7 +44,7 @@
 
 	<bean id="infiniteLoopJob" parent="simpleJob">
 		<property name="jobParametersIncrementer">
-			<bean class="org.springframework.batch.core.launch.support.RunIdIncrementer" />	
+			<bean class="org.springframework.batch.core.launch.support.RunIdIncrementer" />
 		</property>
 		<property name="steps">
 			<bean id="infiniteStep" parent="simpleStep">

--- a/spring-batch-samples/src/main/resources/simple-job-launcher-context.xml
+++ b/spring-batch-samples/src/main/resources/simple-job-launcher-context.xml
@@ -6,10 +6,6 @@
 
 	<import resource="data-source-context.xml" />
 
-	<bean class="org.springframework.batch.core.configuration.support.JobRegistrySmartInitializingSingleton">
-		<property name="jobRegistry" ref="jobRegistry"/>
-	</bean>
-
 	<bean id="jobRepository"
 		class="org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean"
 		p:dataSource-ref="dataSource" p:transactionManager-ref="transactionManager"/>


### PR DESCRIPTION
JobRegistrySmartInitializingSingleton is deprecated and not needed anymore.
Removed it from tests and samples.