### PR TITLE
Fix listener API allowing invalid listeners

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java
@@ -161,6 +161,9 @@ public abstract class JobBuilderHelper<B extends JobBuilderHelper<B>> {
 			factory.setDelegate(listener);
 			properties.addJobExecutionListener((JobExecutionListener) factory.getObject());
 		}
+		else {
+			throw new IllegalArgumentException("Missing @BeforeJob or @AfterJob annotations on Listener.");
+		}
 
 		@SuppressWarnings("unchecked")
 		B result = (B) this;

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
@@ -125,6 +125,9 @@ public abstract class StepBuilderHelper<B extends StepBuilderHelper<B>> {
 			factory.setDelegate(listener);
 			properties.addStepExecutionListener((StepExecutionListener) factory.getObject());
 		}
+		else {
+			throw new IllegalArgumentException("Missing @BeforeStep or @AfterStep annotations on Listener.");
+		}
 
 		return self();
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/JobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/JobBuilderTests.java
@@ -19,6 +19,7 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
 
+import org.mockito.Mockito;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.JobExecution;
@@ -40,6 +41,7 @@ import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mahmoud Ben Hassine
@@ -63,6 +65,16 @@ class JobBuilderTests {
 		assertEquals(1, InterfaceBasedJobExecutionListener.beforeJobCount);
 		assertEquals(1, InterfaceBasedJobExecutionListener.afterJobCount);
 
+	}
+
+	@Test
+	void testInvalidListener() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new JobBuilder("job", Mockito.mock()).listener(new InvalidListener())
+					.start(new StepBuilder("step", Mockito.mock())
+						.tasklet((contribution, chunkContext) -> RepeatStatus.FINISHED, Mockito.mock())
+						.build())
+					.build());
 	}
 
 	@Configuration
@@ -126,6 +138,16 @@ class JobBuilderTests {
 		@AfterJob
 		public void afterJob(JobExecution jobExecution) {
 			afterJobCount++;
+		}
+
+	}
+
+	public static class InvalidListener {
+
+		public void beforeStep() {
+		}
+
+		public void afterStep() {
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/builder/StepBuilderTests.java
@@ -60,6 +60,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Dave Syer
@@ -115,6 +116,13 @@ class StepBuilderTests {
 		assertEquals(1, AnnotationBasedStepExecutionListener.afterStepCount);
 		assertEquals(1, AnnotationBasedStepExecutionListener.beforeChunkCount);
 		assertEquals(1, AnnotationBasedStepExecutionListener.afterChunkCount);
+	}
+
+	@Test
+	void testMissingAnnotationsForListeners() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new StepBuilder("step", jobRepository).listener(new InvalidListener())
+					.tasklet((contribution, chunkContext) -> null, transactionManager));
 	}
 
 	@Test
@@ -461,6 +469,16 @@ class StepBuilderTests {
 		@AfterChunkError
 		public void afterChunkError() {
 			afterChunkErrorCount++;
+		}
+
+	}
+
+	public static class InvalidListener {
+
+		public void beforeStep() {
+		}
+
+		public void afterStep() {
 		}
 
 	}


### PR DESCRIPTION
Before listeners could be created without annotations which then would be ignored during runtime. Now listeners without annotations will throw an IllegalArgumentException

Resolves #4808