### PR TITLE
Refactor JobKeyGenerator to use JobParameters instead of generic type

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/DefaultJobKeyGenerator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/DefaultJobKeyGenerator.java
@@ -36,7 +36,7 @@ import org.springframework.util.DigestUtils;
  * @author Mahmoud Ben Hassine
  * @since 2.2
  */
-public class DefaultJobKeyGenerator implements JobKeyGenerator<JobParameters> {
+public class DefaultJobKeyGenerator implements JobKeyGenerator {
 
 	/**
 	 * Generates the job key to be used based on the {@link JobParameters} instance

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/JobKeyGenerator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/JobKeyGenerator.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.core.job;
 
+import org.springframework.batch.core.job.parameters.JobParameters;
+
 /**
  * Strategy interface for the generation of the key used in identifying unique
  * {@link JobInstance} objects.
@@ -22,11 +24,10 @@ package org.springframework.batch.core.job;
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  * @author Taeik Lim
- * @param <T> The type of the source data used to calculate the key.
  * @since 2.2
  */
 @FunctionalInterface
-public interface JobKeyGenerator<T> {
+public interface JobKeyGenerator {
 
 	/**
 	 * Method to generate the unique key used to identify a job instance.
@@ -34,6 +35,6 @@ public interface JobKeyGenerator<T> {
 	 * {@code null}).
 	 * @return a unique string identifying the job based on the information supplied.
 	 */
-	String generateKey(T source);
+	String generateKey(JobParameters source);
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDao.java
@@ -127,7 +127,7 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 
 	private DataFieldMaxValueIncrementer jobInstanceIncrementer;
 
-	private JobKeyGenerator<JobParameters> jobKeyGenerator = new DefaultJobKeyGenerator();
+	private JobKeyGenerator jobKeyGenerator = new DefaultJobKeyGenerator();
 
 	/**
 	 * In this JDBC implementation a job instance id is obtained by asking the

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
@@ -48,7 +48,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 
 	private DataFieldMaxValueIncrementer jobInstanceIncrementer;
 
-	private JobKeyGenerator<JobParameters> jobKeyGenerator = new DefaultJobKeyGenerator();
+	private JobKeyGenerator jobKeyGenerator = new DefaultJobKeyGenerator();
 
 	private final JobInstanceConverter jobInstanceConverter = new JobInstanceConverter();
 
@@ -58,7 +58,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 		this.jobInstanceIncrementer = new MongoSequenceIncrementer(mongoOperations, SEQUENCE_NAME);
 	}
 
-	public void setJobKeyGenerator(JobKeyGenerator<JobParameters> jobKeyGenerator) {
+	public void setJobKeyGenerator(JobKeyGenerator jobKeyGenerator) {
 		this.jobKeyGenerator = jobKeyGenerator;
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/DefaultJobKeyGeneratorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/DefaultJobKeyGeneratorTests.java
@@ -27,7 +27,7 @@ import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 
 class DefaultJobKeyGeneratorTests {
 
-	private final JobKeyGenerator<JobParameters> jobKeyGenerator = new DefaultJobKeyGenerator();
+	private final JobKeyGenerator jobKeyGenerator = new DefaultJobKeyGenerator();
 
 	@Test
 	void testNullParameters() {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
@@ -30,6 +30,7 @@ import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.converter.DefaultJobParametersConverter;
 import org.springframework.batch.core.converter.JobParametersConverter;
 import org.springframework.batch.core.converter.JsonJobParametersConverter;
+import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.repository.JobRepository;
@@ -291,14 +292,14 @@ class BatchRegistrarTests {
 		}
 
 		@Bean
-		public JobKeyGenerator<Object> jobKeyGenerator() {
+		public JobKeyGenerator jobKeyGenerator() {
 			return new TestCustomJobKeyGenerator();
 		}
 
-		private static class TestCustomJobKeyGenerator implements JobKeyGenerator<Object> {
+		private static class TestCustomJobKeyGenerator implements JobKeyGenerator {
 
 			@Override
-			public String generateKey(Object source) {
+			public String generateKey(JobParameters source) {
 				return "1";
 			}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/explore/support/JobExplorerFactoryBeanTests.java
@@ -17,6 +17,7 @@ package org.springframework.batch.core.explore.support;
 
 import javax.sql.DataSource;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.batch.core.job.DefaultJobKeyGenerator;
 import org.springframework.batch.core.job.JobKeyGenerator;
+import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.repository.explore.JobExplorer;
 import org.springframework.batch.core.repository.explore.support.JobExplorerFactoryBean;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -148,10 +150,10 @@ class JobExplorerFactoryBeanTests {
 		Assertions.assertEquals(CustomJobKeyGenerator.class, jobKeyGenerator.getClass());
 	}
 
-	static class CustomJobKeyGenerator implements JobKeyGenerator<String> {
+	static class CustomJobKeyGenerator implements JobKeyGenerator {
 
 		@Override
-		public String generateKey(String source) {
+		public @NotNull String generateKey(@NotNull JobParameters source) {
 			return "1";
 		}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/jdbc/CustomJobKeyGenerator.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/jdbc/CustomJobKeyGenerator.java
@@ -17,11 +17,12 @@ package org.springframework.batch.core.repository.dao.jdbc;
 
 import org.jetbrains.annotations.NotNull;
 import org.springframework.batch.core.job.JobKeyGenerator;
+import org.springframework.batch.core.job.parameters.JobParameters;
 
-public class CustomJobKeyGenerator implements JobKeyGenerator<String> {
+public class CustomJobKeyGenerator implements JobKeyGenerator {
 
 	@Override
-	public @NotNull String generateKey(@NotNull String source) {
+	public @NotNull String generateKey(@NotNull JobParameters source) {
 		return "1";
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JobRepositoryFactoryBeanTests.java
@@ -334,8 +334,7 @@ class JobRepositoryFactoryBeanTests {
 	@Test
 	public void testDefaultJobKeyGenerator() throws Exception {
 		testCreateRepository();
-		@SuppressWarnings("rawtypes")
-		JobKeyGenerator<?> jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
+		JobKeyGenerator jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
 		assertEquals(DefaultJobKeyGenerator.class, jobKeyGenerator.getClass());
 	}
 
@@ -343,15 +342,14 @@ class JobRepositoryFactoryBeanTests {
 	public void testCustomJobKeyGenerator() throws Exception {
 		factory.setJobKeyGenerator(new CustomJobKeyGenerator());
 		testCreateRepository();
-		@SuppressWarnings("rawtypes")
-		JobKeyGenerator<?> jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
+		JobKeyGenerator jobKeyGenerator = (JobKeyGenerator) ReflectionTestUtils.getField(factory, "jobKeyGenerator");
 		assertEquals(CustomJobKeyGenerator.class, jobKeyGenerator.getClass());
 	}
 
-	static class CustomJobKeyGenerator implements JobKeyGenerator<String> {
+	static class CustomJobKeyGenerator implements JobKeyGenerator {
 
 		@Override
-		public String generateKey(String source) {
+		public String generateKey(JobParameters source) {
 			return "1";
 		}
 


### PR DESCRIPTION
The JobKeyGenerator<T> interface currently uses a generic type parameter <T> to represent the source used to generate a job key. However, in practice, all known implementations and usages of this interface rely specifically on JobParameters as the source type.

resolves #4886 