### PR TITLE
Bump `spring-javaformat-maven-plugin.version` from 0.0.39 to 0.0.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 		<maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
 		<maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
 		<maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-		<spring-javaformat-maven-plugin.version>0.0.39</spring-javaformat-maven-plugin.version>
+		<spring-javaformat-maven-plugin.version>0.0.47</spring-javaformat-maven-plugin.version>
 		<error-prone.version>2.38.0</error-prone.version>
 	</properties>
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/amqp/builder/AmqpItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2025 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ class AmqpItemReaderBuilderTests {
 		when(this.amqpTemplate.receiveAndConvert()).thenReturn("foo");
 
 		final AmqpItemReader<String> amqpItemReader = new AmqpItemReaderBuilder<String>()
-				.amqpTemplate(this.amqpTemplate).build();
+			.amqpTemplate(this.amqpTemplate)
+			.build();
 		assertEquals("foo", amqpItemReader.read());
 	}
 
@@ -52,7 +53,9 @@ class AmqpItemReaderBuilderTests {
 		when(this.amqpTemplate.receiveAndConvert()).thenReturn("foo");
 
 		final AmqpItemReader<String> amqpItemReader = new AmqpItemReaderBuilder<String>()
-				.amqpTemplate(this.amqpTemplate).itemType(String.class).build();
+			.amqpTemplate(this.amqpTemplate)
+			.itemType(String.class)
+			.build();
 
 		assertEquals("foo", amqpItemReader.read());
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/database/JdbcBatchItemWriterNamedParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		when(namedParameterJdbcOperations.batchUpdate(eq(sql),
 				eqSqlParameterSourceArray(
 						new SqlParameterSource[] { new BeanPropertySqlParameterSource(new Foo("bar")) })))
-								.thenReturn(new int[] { 1 });
+			.thenReturn(new int[] { 1 });
 		writer.write(Chunk.of(new Foo("bar")));
 	}
 
@@ -166,7 +166,7 @@ public class JdbcBatchItemWriterNamedParameterTests {
 		when(namedParameterJdbcOperations.batchUpdate(eq(sql),
 				eqSqlParameterSourceArray(
 						new SqlParameterSource[] { new BeanPropertySqlParameterSource(new Foo("bar")) })))
-								.thenReturn(new int[] { 0 });
+			.thenReturn(new int[] { 0 });
 		Exception exception = assertThrows(EmptyResultDataAccessException.class,
 				() -> writer.write(Chunk.of(new Foo("bar"))));
 		String message = exception.getMessage();


### PR DESCRIPTION
This upgrades the Maven plugin of `spring-javaformat` to its [latest version](https://github.com/spring-io/spring-javaformat/releases/tag/v0.0.47).

The latest version includes improvements for formatting JSpecify-based code, making it a pre-step for #4864.