### PR TITLE
Add project icon for JetBrains products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ derbydb
 derby.log
 com.springsource.sts.config.flow.prefs
 s3.properties
-.idea
+.idea/*
+!/.idea/icon.svg
 *.iml
 *.ipr
 *.iws

--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150.49 156.27"><defs><style>.cls-1{fill:#6db33f;}</style></defs><title>logo-batch</title><path class="cls-1" d="M0,101.29v11.57l75.24,43.41,75.25-43.41V101.29L75.24,144.7ZM0,78.14V89.71l75.24,43.41,75.25-43.41V78.14L75.24,121.55ZM75.24,0,0,43.41V66.56L75.24,110l75.25-43.41V43.41Z"/></svg>


### PR DESCRIPTION
This adds a project icon for JetBrains products, such as IntelliJ IDEA:

![Screenshot 2025-06-29 at 23 06 05](https://github.com/user-attachments/assets/ce9ca75a-2cf7-4dfe-a43a-4ca9d385cc94)

The icon has been downloaded from https://spring.io/img/projects/spring-batch.svg.

See spring-projects/spring-framework#34444.