### PR TITLE
Polish code block style and fix typo in whatsnew.adoc

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/whatsnew.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/whatsnew.adoc
@@ -119,7 +119,7 @@ public CompositeItemReader<Person> itemReader() {
 [[new-adapters-for-java-util-function-apis]]
 == New adapters for java.util.function APIs
 
-Similar to `FucntionItemProcessor` that adapts a `java.util.function.Function` to an item processor, this release
+Similar to `FunctionItemProcessor` that adapts a `java.util.function.Function` to an item processor, this release
 introduces several new adapters for other `java.util.function` interfaces like `Supplier`, `Consumer` and `Predicate`.
 
 The newly added adapters are: `SupplierItemReader`, `ConsumerItemWriter` and `PredicateFilteringItemProcessor`.

--- a/spring-batch-docs/modules/ROOT/pages/whatsnew.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/whatsnew.adoc
@@ -41,7 +41,8 @@ This implementation requires MongoDB version 4 or later and is based on Spring D
 In order to use this job repository, all you need to do is define a `MongoTemplate` and a
 `MongoTransactionManager` which are required by the newly added `MongoJobRepositoryFactoryBean`:
 
-```
+[source, java]
+----
 @Bean
 public JobRepository jobRepository(MongoTemplate mongoTemplate, MongoTransactionManager transactionManager) throws Exception {
 	MongoJobRepositoryFactoryBean jobRepositoryFactoryBean = new MongoJobRepositoryFactoryBean();
@@ -50,7 +51,7 @@ public JobRepository jobRepository(MongoTemplate mongoTemplate, MongoTransaction
 	jobRepositoryFactoryBean.afterPropertiesSet();
 	return jobRepositoryFactoryBean.getObject();
 }
-```
+----
 
 Once the MongoDB job repository defined, you can inject it in any job or step as a regular job repository.
 You can find a complete example in the https://github.com/spring-projects/spring-batch/blob/main/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryIntegrationTests.java[MongoDBJobRepositoryIntegrationTests].
@@ -85,7 +86,8 @@ over different resources and writing a custom reader is not an option.
 A `CompositeItemReader` works like other composite artifacts, by delegating the reading operation to regular item readers
 in order. Here is a quick example showing a composite reader that reads persons data from a flat file then from a database table:
 
-```
+[source, java]
+----
 @Bean
 public FlatFileItemReader<Person> itemReader1() {
     return new FlatFileItemReaderBuilder<Person>()
@@ -112,7 +114,7 @@ public JdbcCursorItemReader<Person> itemReader2() {
 public CompositeItemReader<Person> itemReader() {
     return new CompositeItemReader<>(Arrays.asList(itemReader1(), itemReader2()));
 }
-```
+----
 
 [[new-adapters-for-java-util-function-apis]]
 == New adapters for java.util.function APIs


### PR DESCRIPTION
- Replaced triple backtick (```) code blocks with `[source,java]` blocks for consistent syntax highlighting
- Corrected minor typos (`fucntion` → `function`)