### PR TITLE
fix MongoCursorItemReaderBuilder sorts field validation logic

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilder.java
@@ -280,7 +280,7 @@ public class MongoCursorItemReaderBuilder<T> {
 		Assert.notNull(this.targetType, "targetType is required.");
 		Assert.state(StringUtils.hasText(this.jsonQuery) || this.query != null, "A query is required");
 
-		if (StringUtils.hasText(this.jsonQuery) || this.query != null) {
+		if (StringUtils.hasText(this.jsonQuery) && this.query == null) {
 			Assert.notNull(this.sorts, "sorts map is required.");
 		}
 
@@ -297,7 +297,9 @@ public class MongoCursorItemReaderBuilder<T> {
 		reader.setQuery(this.jsonQuery);
 		reader.setParameterValues(this.parameterValues);
 		reader.setFields(this.fields);
-		reader.setSort(this.sorts);
+		if (this.sorts != null) {
+			reader.setSort(this.sorts);
+		}
 		reader.setHint(this.hint);
 		reader.setBatchSize(this.batchSize);
 		reader.setLimit(this.limit);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/data/builder/MongoCursorItemReaderBuilderTests.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Mahmoud Ben Hassine
  */
-public class MongoCursorItemReaderBuilderTests {
+class MongoCursorItemReaderBuilderTests {
 
 	@Test
 	void testBuild() {
@@ -67,4 +67,47 @@ public class MongoCursorItemReaderBuilderTests {
 		Assertions.assertEquals(maxTime, ReflectionTestUtils.getField(reader, "maxTime"));
 	}
 
+
+	@Test
+	void testBuildWithQueryNoSorts() {
+		// given
+		MongoTemplate template = mock();
+		Class<String> targetType = String.class;
+		Query query = mock();
+		int batchSize = 100;
+		int limit = 10000;
+		Duration maxTime = Duration.ofSeconds(1);
+
+		// when & then
+		Assertions.assertDoesNotThrow(() -> new MongoCursorItemReaderBuilder<String>().name("reader")
+																					  .template(template)
+																					  .targetType(targetType)
+																					  .query(query)
+																					  .batchSize(batchSize)
+																					  .limit(limit)
+																					  .maxTime(maxTime)
+																					  .build());
+	}
+
+	@Test
+	void testBuildWithJsonQueryNoSorts() {
+		// given
+		MongoTemplate template = mock();
+		Class<String> targetType = String.class;
+		String jsonQuery = "{ }";
+		int batchSize = 100;
+		int limit = 10000;
+		Duration maxTime = Duration.ofSeconds(1);
+
+		// when & then
+		Assertions.assertThrows(IllegalArgumentException.class,
+				() -> new MongoCursorItemReaderBuilder<String>().name("reader")
+																.template(template)
+																.targetType(targetType)
+																.jsonQuery(jsonQuery)
+																.batchSize(batchSize)
+																.limit(limit)
+																.maxTime(maxTime)
+																.build());
+	}
 }


### PR DESCRIPTION
Fixes: #4860

## What is the problem
- Forced Sort Passing via sorts() Method When Building with MongoCursorItemReaderBuilder and Query
## What I Did
- Fix MongoCursorItemReaderBuilder sorts field validation logic
- Add 2 test cases for MongoCursorItemReaderBuilder
- Remove public access modifier from MongoCursorItemReaderBuilderTest