### PR TITLE
Add compile-time safety to FlatFileItemReaderBuilder DSL

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilder.java
@@ -66,6 +66,7 @@ import org.springframework.util.StringUtils;
  * @author François Martin
  * @author Stefano Cordio
  * @author Daeho Kwon
+ * @author snowykte0426
  * @since 4.0
  * @see FlatFileItemReader
  */
@@ -288,12 +289,12 @@ public class FlatFileItemReaderBuilder<T> {
 	/**
 	 * A {@link FieldSetMapper} implementation to be used.
 	 * @param mapper a {@link FieldSetMapper}
-	 * @return The current instance of the builder.
+	 * @return A stage that prevents calling targetType()
 	 * @see DefaultLineMapper#setFieldSetMapper(FieldSetMapper)
 	 */
-	public FlatFileItemReaderBuilder<T> fieldSetMapper(FieldSetMapper<T> mapper) {
+	public FieldSetMapperStage<T> fieldSetMapper(FieldSetMapper<T> mapper) {
 		this.fieldSetMapper = mapper;
-		return this;
+		return new FieldSetMapperStageImpl();
 	}
 
 	/**
@@ -394,12 +395,12 @@ public class FlatFileItemReaderBuilder<T> {
 	 * required, providing your own {@link FieldSetMapper} via {@link #fieldSetMapper} is
 	 * required.
 	 * @param targetType The class to map to
-	 * @return The current instance of the builder.
+	 * @return A stage that prevents calling fieldSetMapper()
 	 * @see BeanWrapperFieldSetMapper#setTargetType(Class)
 	 */
-	public FlatFileItemReaderBuilder<T> targetType(Class<T> targetType) {
+	public TargetTypeStage<T> targetType(Class<T> targetType) {
 		this.targetType = targetType;
-		return this;
+		return new TargetTypeStageImpl();
 	}
 
 	/**
@@ -1063,6 +1064,441 @@ public class FlatFileItemReaderBuilder<T> {
 		public FixedLengthSpec<T> strict(boolean strict) {
 			this.strict = strict;
 			return this;
+		}
+
+	}
+
+	/**
+	 * Stage interface that prevents calling targetType() after fieldSetMapper() has been
+	 * called. This provides compile-time safety to ensure mutual exclusivity between
+	 * these two methods.
+	 */
+	public interface FieldSetMapperStage<T> {
+
+		/**
+		 * Configure if the state of the {@link ItemStreamSupport} should be persisted
+		 * within the {@link ExecutionContext} for restart purposes.
+		 * @param saveState defaults to true
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> saveState(boolean saveState);
+
+		/**
+		 * The name used to calculate the key within the {@link ExecutionContext}.
+		 * Required if {@link #saveState(boolean)} is set to true.
+		 * @param name name of the reader instance
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> name(String name);
+
+		/**
+		 * Configure the max number of items to be read.
+		 * @param maxItemCount the max items to be read
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> maxItemCount(int maxItemCount);
+
+		/**
+		 * Index for the current item. Used on restarts to indicate where to start from.
+		 * @param currentItemCount current index
+		 * @return this instance for method chaining
+		 */
+		FieldSetMapperStage<T> currentItemCount(int currentItemCount);
+
+		/**
+		 * The {@link Resource} to be used as input.
+		 * @param resource the input to the reader.
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> resource(Resource resource);
+
+		/**
+		 * Configure if the reader should be in strict mode (require the input
+		 * {@link Resource} to exist).
+		 * @param strict true if the input file is required to exist.
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> strict(boolean strict);
+
+		/**
+		 * Configure the encoding used by the reader to read the input source.
+		 * @param encoding to use to read the input source.
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> encoding(String encoding);
+
+		/**
+		 * The number of lines to skip at the beginning of reading the file.
+		 * @param linesToSkip number of lines to be skipped.
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> linesToSkip(int linesToSkip);
+
+		/**
+		 * A callback to be called for each line that is skipped.
+		 * @param callback the callback
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> skippedLinesCallback(LineCallbackHandler callback);
+
+		/**
+		 * Configures the comment prefixes for this reader.
+		 * @param comments comment prefixes
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> addComment(String comments);
+
+		/**
+		 * Configures the {@link RecordSeparatorPolicy} for this reader.
+		 * @param policy the policy to be used
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> recordSeparatorPolicy(RecordSeparatorPolicy policy);
+
+		/**
+		 * Configures the {@link BufferedReaderFactory} for this reader.
+		 * @param bufferedReaderFactory the factory to be used
+		 * @return The current instance of the builder.
+		 */
+		FieldSetMapperStage<T> bufferedReaderFactory(BufferedReaderFactory bufferedReaderFactory);
+
+		/**
+		 * Builds the {@link FlatFileItemReader}.
+		 * @return a {@link FlatFileItemReader}
+		 */
+		FlatFileItemReader<T> build();
+
+	}
+
+	/**
+	 * Stage interface that prevents calling fieldSetMapper() after targetType() has been
+	 * called. This provides compile-time safety to ensure mutual exclusivity between
+	 * these two methods.
+	 */
+	public interface TargetTypeStage<T> {
+
+		/**
+		 * Configure if the state of the {@link ItemStreamSupport} should be persisted
+		 * within the {@link ExecutionContext} for restart purposes.
+		 * @param saveState defaults to true
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> saveState(boolean saveState);
+
+		/**
+		 * The name used to calculate the key within the {@link ExecutionContext}.
+		 * Required if {@link #saveState(boolean)} is set to true.
+		 * @param name name of the reader instance
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> name(String name);
+
+		/**
+		 * Configure the max number of items to be read.
+		 * @param maxItemCount the max items to be read
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> maxItemCount(int maxItemCount);
+
+		/**
+		 * Index for the current item. Used on restarts to indicate where to start from.
+		 * @param currentItemCount current index
+		 * @return this instance for method chaining
+		 */
+		TargetTypeStage<T> currentItemCount(int currentItemCount);
+
+		/**
+		 * The {@link Resource} to be used as input.
+		 * @param resource the input to the reader.
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> resource(Resource resource);
+
+		/**
+		 * Configure if the reader should be in strict mode (require the input
+		 * {@link Resource} to exist).
+		 * @param strict true if the input file is required to exist.
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> strict(boolean strict);
+
+		/**
+		 * Configure the encoding used by the reader to read the input source.
+		 * @param encoding to use to read the input source.
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> encoding(String encoding);
+
+		/**
+		 * The number of lines to skip at the beginning of reading the file.
+		 * @param linesToSkip number of lines to be skipped.
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> linesToSkip(int linesToSkip);
+
+		/**
+		 * A callback to be called for each line that is skipped.
+		 * @param callback the callback
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> skippedLinesCallback(LineCallbackHandler callback);
+
+		/**
+		 * Configures the id of a prototype scoped bean to be used as the item returned by
+		 * the reader.
+		 * @param prototypeBeanName the name of a prototype scoped bean
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> prototypeBeanName(String prototypeBeanName);
+
+		/**
+		 * Configures the {@link BeanFactory} used to create the beans that are returned
+		 * as items.
+		 * @param beanFactory a {@link BeanFactory}
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> beanFactory(BeanFactory beanFactory);
+
+		/**
+		 * Register custom type converters for beans being mapped.
+		 * @param customEditors a {@link Map} of editors
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> customEditors(Map<Class<?>, PropertyEditor> customEditors);
+
+		/**
+		 * Configures the maximum tolerance between the actual spelling of a field's name
+		 * and the property's name.
+		 * @param distanceLimit distance limit to set
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> distanceLimit(int distanceLimit);
+
+		/**
+		 * If set to true, mapping will fail if the {@link FieldSet} contains fields that
+		 * cannot be mapped to the bean.
+		 * @param beanMapperStrict defaults to false
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> beanMapperStrict(boolean beanMapperStrict);
+
+		/**
+		 * Configures the comment prefixes for this reader.
+		 * @param comments comment prefixes
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> addComment(String comments);
+
+		/**
+		 * Configures the {@link RecordSeparatorPolicy} for this reader.
+		 * @param policy the policy to be used
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> recordSeparatorPolicy(RecordSeparatorPolicy policy);
+
+		/**
+		 * Configures the {@link BufferedReaderFactory} for this reader.
+		 * @param bufferedReaderFactory the factory to be used
+		 * @return The current instance of the builder.
+		 */
+		TargetTypeStage<T> bufferedReaderFactory(BufferedReaderFactory bufferedReaderFactory);
+
+		/**
+		 * Builds the {@link FlatFileItemReader}.
+		 * @return a {@link FlatFileItemReader}
+		 */
+		FlatFileItemReader<T> build();
+
+	}
+
+	private class FieldSetMapperStageImpl implements FieldSetMapperStage<T> {
+
+		@Override
+		public FieldSetMapperStage<T> saveState(boolean saveState) {
+			FlatFileItemReaderBuilder.this.saveState(saveState);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> name(String name) {
+			FlatFileItemReaderBuilder.this.name(name);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> maxItemCount(int maxItemCount) {
+			FlatFileItemReaderBuilder.this.maxItemCount(maxItemCount);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> currentItemCount(int currentItemCount) {
+			FlatFileItemReaderBuilder.this.currentItemCount(currentItemCount);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> resource(Resource resource) {
+			FlatFileItemReaderBuilder.this.resource(resource);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> strict(boolean strict) {
+			FlatFileItemReaderBuilder.this.strict(strict);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> encoding(String encoding) {
+			FlatFileItemReaderBuilder.this.encoding(encoding);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> linesToSkip(int linesToSkip) {
+			FlatFileItemReaderBuilder.this.linesToSkip(linesToSkip);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> skippedLinesCallback(LineCallbackHandler callback) {
+			FlatFileItemReaderBuilder.this.skippedLinesCallback(callback);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> addComment(String comments) {
+			FlatFileItemReaderBuilder.this.addComment(comments);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> recordSeparatorPolicy(RecordSeparatorPolicy policy) {
+			FlatFileItemReaderBuilder.this.recordSeparatorPolicy(policy);
+			return this;
+		}
+
+		@Override
+		public FieldSetMapperStage<T> bufferedReaderFactory(BufferedReaderFactory bufferedReaderFactory) {
+			FlatFileItemReaderBuilder.this.bufferedReaderFactory(bufferedReaderFactory);
+			return this;
+		}
+
+		@Override
+		public FlatFileItemReader<T> build() {
+			return FlatFileItemReaderBuilder.this.build();
+		}
+
+	}
+
+	private class TargetTypeStageImpl implements TargetTypeStage<T> {
+
+		@Override
+		public TargetTypeStage<T> saveState(boolean saveState) {
+			FlatFileItemReaderBuilder.this.saveState(saveState);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> name(String name) {
+			FlatFileItemReaderBuilder.this.name(name);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> maxItemCount(int maxItemCount) {
+			FlatFileItemReaderBuilder.this.maxItemCount(maxItemCount);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> currentItemCount(int currentItemCount) {
+			FlatFileItemReaderBuilder.this.currentItemCount(currentItemCount);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> resource(Resource resource) {
+			FlatFileItemReaderBuilder.this.resource(resource);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> strict(boolean strict) {
+			FlatFileItemReaderBuilder.this.strict(strict);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> encoding(String encoding) {
+			FlatFileItemReaderBuilder.this.encoding(encoding);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> linesToSkip(int linesToSkip) {
+			FlatFileItemReaderBuilder.this.linesToSkip(linesToSkip);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> skippedLinesCallback(LineCallbackHandler callback) {
+			FlatFileItemReaderBuilder.this.skippedLinesCallback(callback);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> prototypeBeanName(String prototypeBeanName) {
+			FlatFileItemReaderBuilder.this.prototypeBeanName(prototypeBeanName);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> beanFactory(BeanFactory beanFactory) {
+			FlatFileItemReaderBuilder.this.beanFactory(beanFactory);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> customEditors(Map<Class<?>, PropertyEditor> customEditors) {
+			FlatFileItemReaderBuilder.this.customEditors(customEditors);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> distanceLimit(int distanceLimit) {
+			FlatFileItemReaderBuilder.this.distanceLimit(distanceLimit);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> beanMapperStrict(boolean beanMapperStrict) {
+			FlatFileItemReaderBuilder.this.beanMapperStrict(beanMapperStrict);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> addComment(String comments) {
+			FlatFileItemReaderBuilder.this.addComment(comments);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> recordSeparatorPolicy(RecordSeparatorPolicy policy) {
+			FlatFileItemReaderBuilder.this.recordSeparatorPolicy(policy);
+			return this;
+		}
+
+		@Override
+		public TargetTypeStage<T> bufferedReaderFactory(BufferedReaderFactory bufferedReaderFactory) {
+			FlatFileItemReaderBuilder.this.bufferedReaderFactory(bufferedReaderFactory);
+			return this;
+		}
+
+		@Override
+		public FlatFileItemReader<T> build() {
+			return FlatFileItemReaderBuilder.this.build();
 		}
 
 	}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -19,6 +19,7 @@ import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,7 @@ import org.springframework.batch.infrastructure.item.file.FlatFileItemReader;
 import org.springframework.batch.infrastructure.item.file.builder.FlatFileItemReaderBuilder;
 import org.springframework.batch.infrastructure.item.file.mapping.BeanWrapperFieldSetMapper;
 import org.springframework.batch.infrastructure.item.file.mapping.DefaultLineMapper;
+import org.springframework.batch.infrastructure.item.file.mapping.FieldSetMapper;
 import org.springframework.batch.infrastructure.item.file.mapping.RecordFieldSetMapper;
 import org.springframework.batch.infrastructure.item.file.separator.DefaultRecordSeparatorPolicy;
 import org.springframework.batch.infrastructure.item.file.transform.DefaultFieldSet;
@@ -45,6 +47,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -61,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Patrick Baumgartner
  * @author François Martin
  * @author Daeho Kwon
+ * @author snowykte0426
  */
 class FlatFileItemReaderBuilderTests {
 
@@ -568,14 +572,26 @@ class FlatFileItemReaderBuilderTests {
 	}
 
 	@Test
-	void testErrorWhenTargetTypeAndFieldSetMapperIsProvided() {
-		var builder = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
-			.resource(getResource("1;2;3"))
-			.lineTokenizer(line -> new DefaultFieldSet(line.split(";")))
-			.targetType(Foo.class)
-			.fieldSetMapper(fieldSet -> new Foo());
-		var exception = assertThrows(IllegalStateException.class, builder::build);
-		assertEquals("Either a TargetType or FieldSetMapper can be set, can't be both.", exception.getMessage());
+	void testCompileTimeSafety() {
+		// Verify that valid usage patterns work correctly
+		// Pattern 1: Using targetType only (tokenizer configured first)
+		assertDoesNotThrow(() -> {
+			new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+				.resource(getResource("1;2;3"))
+				.delimited()
+				.names("first", "second", "third")
+				.targetType(Foo.class)
+				.build();
+		});
+
+		// Pattern 2: Using fieldSetMapper only
+		assertDoesNotThrow(() -> {
+			new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+				.resource(getResource("1;2;3"))
+				.lineTokenizer(line -> new DefaultFieldSet(line.split(";")))
+				.fieldSetMapper(fieldSet -> new Foo())
+				.build();
+		});
 	}
 
 	@Test
@@ -584,12 +600,12 @@ class FlatFileItemReaderBuilderTests {
 		record Person(int id, String name) {
 		}
 
-		// when
+		// when - tokenizer configured before targetType() for compile-time safety
 		FlatFileItemReader<Person> reader = new FlatFileItemReaderBuilder<Person>().name("personReader")
 			.resource(getResource("1,foo"))
-			.targetType(Person.class)
 			.delimited()
 			.names("id", "name")
+			.targetType(Person.class)
 			.build();
 
 		// then
@@ -613,12 +629,12 @@ class FlatFileItemReaderBuilderTests {
 
 		}
 
-		// when
+		// when - tokenizer configured before targetType() for compile-time safety
 		FlatFileItemReader<Person> reader = new FlatFileItemReaderBuilder<Person>().name("personReader")
 			.resource(getResource("1,foo"))
-			.targetType(Person.class)
 			.delimited()
 			.names("id", "name")
+			.targetType(Person.class)
 			.build();
 
 		// then
@@ -628,6 +644,57 @@ class FlatFileItemReaderBuilderTests {
 		Object fieldSetMapper = ReflectionTestUtils.getField(lineMapper, "fieldSetMapper");
 		assertNotNull(fieldSetMapper);
 		assertInstanceOf(BeanWrapperFieldSetMapper.class, fieldSetMapper);
+	}
+
+	@Test
+	void testFieldSetMapperStageAPI() {
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+			.resource(getResource("1;2;3"))
+			.lineTokenizer(line -> new DefaultFieldSet(line.split(";")))
+			.fieldSetMapper(fieldSet -> {
+				Foo item = new Foo();
+				item.setFirst(Integer.parseInt(fieldSet.readString(0)));
+				item.setSecond(Integer.parseInt(fieldSet.readString(1)));
+				item.setThird(fieldSet.readString(2));
+				return item;
+			})
+			.build();
+
+		assertNotNull(reader);
+	}
+
+	@Test
+	void testTargetTypeStageAPI() {
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+			.resource(getResource("1;2;3"))
+			.delimited()
+			.names("first", "second", "third")
+			.targetType(Foo.class)
+			.beanMapperStrict(true)
+			.build();
+
+		assertNotNull(reader);
+	}
+
+	@Test
+	void testTargetTypeStageMethodsAvailable() {
+		var stage = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+			.resource(getResource("1;2;3"))
+			.delimited()
+			.names("first", "second", "third")
+			.targetType(Foo.class);
+
+		assertDoesNotThrow(() -> stage.beanMapperStrict(true).distanceLimit(2).customEditors(Map.of()).build());
+	}
+
+	@Test
+	void testFieldSetMapperStageMethodsAvailable() {
+		var stage = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+			.resource(getResource("1;2;3"))
+			.lineTokenizer(line -> new DefaultFieldSet(line.split(";")))
+			.fieldSetMapper(fieldSet -> new Foo());
+
+		assertDoesNotThrow(() -> stage.saveState(false).maxItemCount(100).strict(false).encoding("UTF-8").build());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

  This PR enhances the `FlatFileItemReaderBuilder` to prevent mutual
  exclusivity violations between `targetType()` and `fieldSetMapper()`
  methods at compile time rather than runtime, resolving issue #4888.

  ## Changes

  - **Enhanced DSL with Stage Pattern**: Introduced
  `FieldSetMapperStage<T>` and `TargetTypeStage<T>` interfaces
  - **Compile-time Safety**: Prevents incompatible method combinations
  through type system

  ## Implementation Details

  ### Before (Runtime Error)
  ```java
  // This would compile but fail at runtime
  new FlatFileItemReaderBuilder<Foo>()
      .name("fooReader")
      .resource(resource)
      .lineTokenizer(tokenizer)
      .targetType(Foo.class)
      .fieldSetMapper(mapper)  // IllegalStateException at runtime
      .build();
```
  After (Compile-time Safety)
```java
  // This won't compile - IDE shows error immediately
  new FlatFileItemReaderBuilder<Foo>()
      .name("fooReader")
      .resource(resource)
      .lineTokenizer(tokenizer)
      .targetType(Foo.class)
      .fieldSetMapper(mapper)  // Compile error: method not available
      .build();
```
  Usage Patterns
```java
  // Pattern 1: Using targetType() - returns TargetTypeStage<T>
  new FlatFileItemReaderBuilder<Foo>()
      .name("fooReader")
      .resource(resource)
      .delimited()
      .names("field1", "field2")
      .targetType(Foo.class)
      .beanMapperStrict(true)  // targetType-specific methods available
      .build();

  // Pattern 2: Using fieldSetMapper() - returns FieldSetMapperStage<T>
  new FlatFileItemReaderBuilder<Foo>()
      .name("fooReader")
      .resource(resource)
      .lineTokenizer(tokenizer)
      .fieldSetMapper(fieldSet -> new Foo())
      .saveState(false)  // common methods available
      .build();
```
  Fixes
  Issue #4888