### PR TITLE
Fix: FlatFileItemWriterBuilder - Ensure names() is respected for RecordFieldExtractor

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/file/builder/FlatFileItemWriterBuilder.java
@@ -392,6 +392,9 @@ public class FlatFileItemWriterBuilder<T> {
 			if (this.fieldExtractor == null) {
 				if (this.sourceType != null && this.sourceType.isRecord()) {
 					this.fieldExtractor = new RecordFieldExtractor<>(this.sourceType);
+					if (!this.names.isEmpty()) {
+						((RecordFieldExtractor<?>) this.fieldExtractor).setNames(this.names.toArray(new String[0]));
+					}
 				}
 				else {
 					BeanWrapperFieldExtractor<T> beanWrapperFieldExtractor = new BeanWrapperFieldExtractor<>();


### PR DESCRIPTION
Description
When using FlatFileItemWriterBuilder with Java Record types, specifying .names() is currently required, but RecordFieldExtractor ignores those names due to a missing .setNames() call. This causes all record components to be extracted regardless of the .names() setting, leading to unexpected behavior.

This patch fixes the issue by invoking .setNames() on RecordFieldExtractor when names are specified, aligning its behavior with BeanWrapperFieldExtractor used for non-record types.

No breaking changes are introduced.

Changes
Added .setNames() call on newly created RecordFieldExtractor if names are provided.

Maintains consistency and backward compatibility in builder API.

Motivation
Enables partial field extraction from Java Records via .names() method, matching the behavior for Java Beans.

Resolves a long-standing inconsistency and confusion reported by users and educators.

Additional Notes
Powerd by KILL-9 💀

Related Issue
This PR addresses issue #4935