### PR TITLE
Reset CompositeItemReader iterator on open to support multiple executions

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/support/CompositeItemReader.java
@@ -29,6 +29,7 @@ import org.springframework.batch.item.ItemStreamReader;
  *
  * @author Mahmoud Ben Hassine
  * @author Elimelec Burghelea
+ * @author Andrey Litvitski
  * @param <T> type of objects to read
  * @since 5.2
  */
@@ -36,7 +37,7 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 
 	private final List<ItemStreamReader<? extends T>> delegates;
 
-	private final Iterator<ItemStreamReader<? extends T>> delegatesIterator;
+	private Iterator<ItemStreamReader<? extends T>> delegatesIterator;
 
 	private ItemStreamReader<? extends T> currentDelegate;
 
@@ -46,8 +47,7 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 	 */
 	public CompositeItemReader(List<ItemStreamReader<? extends T>> delegates) {
 		this.delegates = delegates;
-		this.delegatesIterator = this.delegates.iterator();
-		this.currentDelegate = this.delegatesIterator.hasNext() ? this.delegatesIterator.next() : null;
+		initIteratorAndCurrentDelegate();
 	}
 
 	// TODO: check if we need to open/close delegates on the fly in read() to avoid
@@ -57,6 +57,7 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 		for (ItemStreamReader<? extends T> delegate : delegates) {
 			delegate.open(executionContext);
 		}
+		initIteratorAndCurrentDelegate();
 	}
 
 	@Override
@@ -104,6 +105,11 @@ public class CompositeItemReader<T> implements ItemStreamReader<T> {
 			exceptions.forEach(holder::addSuppressed);
 			throw holder;
 		}
+	}
+
+	private void initIteratorAndCurrentDelegate() {
+		this.delegatesIterator = this.delegates.iterator();
+		this.currentDelegate = this.delegatesIterator.hasNext() ? this.delegatesIterator.next() : null;
 	}
 
 }


### PR DESCRIPTION
Reset delegatesIterator and currentDelegate in open() to ensure that CompositeItemReader works correctly on repeated job executions. Without this reset, the reader skips all delegates after the first run.

Closes: gh-4926