### PR TITLE
Enhance RedisItemReader/Writer performance with pipelining

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/redis/builder/RedisItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/redis/builder/RedisItemReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.data.redis.core.ScanOptions;
  * Builder for {@link RedisItemReader}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Hyunwoo Jung
  * @since 5.1
  * @param <K> type of keys
  * @param <V> type of values
@@ -32,6 +33,8 @@ public class RedisItemReaderBuilder<K, V> {
 	private RedisTemplate<K, V> redisTemplate;
 
 	private ScanOptions scanOptions;
+
+	private int fetchSize;
 
 	/**
 	 * Set the {@link RedisTemplate} to use in the reader.
@@ -54,11 +57,21 @@ public class RedisItemReaderBuilder<K, V> {
 	}
 
 	/**
+	 * Set the fetchSize to how many items from Redis in a single round-trip.
+	 * @param fetchSize the number of items to fetch per pipeline execution
+	 * @return the current builder instance for fluent chaining
+	 */
+	public RedisItemReaderBuilder<K, V> fetchSize(int fetchSize) {
+		this.fetchSize = fetchSize;
+		return this;
+	}
+
+	/**
 	 * Build a new {@link RedisItemReader}.
 	 * @return a new item reader
 	 */
 	public RedisItemReader<K, V> build() {
-		return new RedisItemReader<>(this.redisTemplate, this.scanOptions);
+		return new RedisItemReader<>(this.redisTemplate, this.scanOptions, this.fetchSize);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/redis/RedisItemReaderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/redis/RedisItemReaderIntegrationTests.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 @ExtendWith(SpringExtension.class)
 class RedisItemReaderIntegrationTests {
 
-	private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:8.0.3");
+	private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:8.2.2");
 
 	@Container
 	public static RedisContainer redis = new RedisContainer(REDIS_IMAGE);
@@ -82,7 +82,7 @@ class RedisItemReaderIntegrationTests {
 
 		RedisTemplate<String, Person> redisTemplate = setUpRedisTemplate(connectionFactory);
 		ScanOptions scanOptions = ScanOptions.scanOptions().match("person:*").count(10).build();
-		this.reader = new RedisItemReader<>(redisTemplate, scanOptions);
+		this.reader = new RedisItemReader<>(redisTemplate, scanOptions, 10);
 
 		this.reader.open(new ExecutionContext());
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/redis/RedisItemWriterIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/redis/RedisItemWriterIntegrationTests.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(SpringExtension.class)
 class RedisItemWriterIntegrationTests {
 
-	private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:8.0.3");
+	private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:8.2.2");
 
 	@Container
 	public static RedisContainer redis = new RedisContainer(REDIS_IMAGE);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/redis/builder/RedisItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/redis/builder/RedisItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ import static org.mockito.Mockito.mock;
  * Test class for {@link RedisItemReaderBuilder}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Hyunwoo Jung
  */
-public class RedisItemReaderBuilderTests {
+class RedisItemReaderBuilderTests {
 
 	@Test
 	void testRedisItemReaderCreation() {
@@ -44,12 +45,14 @@ public class RedisItemReaderBuilderTests {
 		RedisItemReader<String, String> reader = new RedisItemReaderBuilder<String, String>()
 			.redisTemplate(redisTemplate)
 			.scanOptions(scanOptions)
+			.fetchSize(10)
 			.build();
 
 		// then
 		assertNotNull(reader);
 		assertEquals(redisTemplate, ReflectionTestUtils.getField(reader, "redisTemplate"));
 		assertEquals(scanOptions, ReflectionTestUtils.getField(reader, "scanOptions"));
+		assertEquals(10, ReflectionTestUtils.getField(reader, "fetchSize"));
 	}
 
 }


### PR DESCRIPTION
- RedisItemReader: Retrieves up to `fetchSize` items in a single round-trip.
- RedisItemWriter: Processes each chunk in a single round-trip.

Closes: GH-4939