### PR TITLE
GH-4941: Add batchSize option to RedisItemReader for optimizing N+1 problem using Redis MGET

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/builder/RedisItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/builder/RedisItemReaderBuilder.java
@@ -33,6 +33,8 @@ public class RedisItemReaderBuilder<K, V> {
 
 	private ScanOptions scanOptions;
 
+	private int batchSize = 1;
+
 	/**
 	 * Set the {@link RedisTemplate} to use in the reader.
 	 * @param redisTemplate the template to use
@@ -54,11 +56,34 @@ public class RedisItemReaderBuilder<K, V> {
 	}
 
 	/**
+	 * Set the batch size for optimized Redis operations.
+	 *
+	 * <p>When batchSize is 1 (default), the reader operates in single-key mode
+	 * for complete backward compatibility. When batchSize is greater than 1,
+	 * the reader uses Redis MGET to fetch multiple keys in a single operation,
+	 * significantly improving performance by reducing network round-trips.</p>
+	 *
+	 * <p>Higher batch sizes reduce network overhead but may increase memory usage.
+	 * Consider your memory constraints when setting this value.</p>
+	 *
+	 * @param batchSize the number of keys to fetch in each Redis operation (must be > 0)
+	 * @return the current builder instance for fluent chaining
+	 * @throws IllegalArgumentException if batchSize is less than or equal to 0
+	 */
+	public RedisItemReaderBuilder<K, V> batchSize(int batchSize) {
+		if (batchSize <= 0) {
+			throw new IllegalArgumentException("Batch size must be greater than 0");
+		}
+		this.batchSize = batchSize;
+		return this;
+	}
+
+	/**
 	 * Build a new {@link RedisItemReader}.
 	 * @return a new item reader
 	 */
 	public RedisItemReader<K, V> build() {
-		return new RedisItemReader<>(this.redisTemplate, this.scanOptions);
+		return new RedisItemReader<>(this.redisTemplate, this.scanOptions, this.batchSize);
 	}
 
 }


### PR DESCRIPTION
### Summary

This PR introduces a `batchSize` parameter to `RedisItemReader` and its builder to solve the classic N+1 issue faced during batch reads from Redis.  
Currently, `RedisItemReader` executes individual GET commands per Redis key resulting in a significant number of network round-trips and performance bottlenecks.

By enabling batch reading with Redis `MGET` when `batchSize` > 1, this enhancement drastically reduces network calls and improves throughput while maintaining full backward compatibility when `batchSize` is not set (default = 1).

### Key Changes

- Added `batchSize` property with default value `1` in `RedisItemReader` and `RedisItemReaderBuilder`.
- When `batchSize` > 1, the reader fetches multiple keys in batch using Redis `multiGet()` and internally buffers results.
- Existing behavior preserved for `batchSize = 1`, ensuring no breaking changes.
- Added thorough JavaDoc explaining usage, limitations, and batch size considerations.
- Updated unit tests to cover both single and batch modes, verifying correct data retrieval and network call optimization.

### Benefits

- Significant performance improvements through reduced network round-trips during batch processing.
- Configurable batching allowing tuning based on memory and performance requirements.
- Maintains Spring Batch's principle of backward compatibility and progressive enhancement.
- Handles Redis SCAN cursor nature without breaking existing semantics.

### Technical Considerations

- Batch size validated to be greater than 0; recommending values between 1 and 1000 to prevent excessive memory use and large network calls.
- The internal queue buffers values for efficient retrieval during batch reads.
- Users should be aware of Redis SCAN characteristics such as key duplication and lack of ordering; idempotent batch jobs recommended.
- Restartability remains unsupported due to unordered nature of Redis SCAN results.

### Related Issue

Fixes #4941

---
"Terminated by KILL-9 SQUAD 💀"