### PR TITLE
Add batchSize option to RedisItemReader for MGET optimization #4941

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
@@ -15,6 +15,11 @@
  */
 package org.springframework.batch.item.redis;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
@@ -29,10 +34,17 @@ import org.springframework.util.Assert;
  * query.
  *
  * <p>
+ * The reader supports batch fetching using Redis MGET operations when batchSize is
+ * greater than 1, which significantly improves performance by reducing network
+ * round-trips.
+ * </p>
+ *
+ * <p>
  * The implementation is not thread-safe and not restartable.
  * </p>
  *
  * @author Mahmoud Ben Hassine
+ * @author Jun Kim
  * @since 5.1
  * @param <K> type of keys
  * @param <V> type of values
@@ -43,13 +55,24 @@ public class RedisItemReader<K, V> implements ItemStreamReader<V> {
 
 	private final ScanOptions scanOptions;
 
+	private final int batchSize;
+
+	private final Queue<V> valueBuffer;
+
 	private Cursor<K> cursor;
 
 	public RedisItemReader(RedisTemplate<K, V> redisTemplate, ScanOptions scanOptions) {
+		this(redisTemplate, scanOptions, 1);
+	}
+
+	public RedisItemReader(RedisTemplate<K, V> redisTemplate, ScanOptions scanOptions, int batchSize) {
 		Assert.notNull(redisTemplate, "redisTemplate must not be null");
 		Assert.notNull(scanOptions, "scanOptions must no be null");
+		Assert.isTrue(batchSize > 0 && batchSize <= 1000, "batchSize must be between 1 and 1000");
 		this.redisTemplate = redisTemplate;
 		this.scanOptions = scanOptions;
+		this.batchSize = batchSize;
+		this.valueBuffer = new LinkedList<>();
 	}
 
 	@Override
@@ -59,13 +82,46 @@ public class RedisItemReader<K, V> implements ItemStreamReader<V> {
 
 	@Override
 	public V read() throws Exception {
-		if (this.cursor.hasNext()) {
-			K nextKey = this.cursor.next();
-			return this.redisTemplate.opsForValue().get(nextKey);
+		// If buffer has values, return from buffer first
+		if (!this.valueBuffer.isEmpty()) {
+			return this.valueBuffer.poll();
 		}
-		else {
+
+		// If batch size is 1, use single GET operation (backward compatibility)
+		if (this.batchSize == 1) {
+			if (this.cursor.hasNext()) {
+				K nextKey = this.cursor.next();
+				return this.redisTemplate.opsForValue().get(nextKey);
+			}
+			else {
+				return null;
+			}
+		}
+
+		// Batch mode: collect keys and use MGET
+		List<K> keysToFetch = new ArrayList<>();
+		while (this.cursor.hasNext() && keysToFetch.size() < this.batchSize) {
+			keysToFetch.add(this.cursor.next());
+		}
+
+		if (keysToFetch.isEmpty()) {
 			return null;
 		}
+
+		// Use multiGet for batch fetching
+		List<V> values = this.redisTemplate.opsForValue().multiGet(keysToFetch);
+
+		if (values != null) {
+			// Filter out null values and add to buffer
+			for (V value : values) {
+				if (value != null) {
+					this.valueBuffer.offer(value);
+				}
+			}
+		}
+
+		// Return first value from buffer or null if empty
+		return this.valueBuffer.poll();
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/RedisItemReader.java
@@ -44,7 +44,6 @@ import org.springframework.util.Assert;
  * </p>
  *
  * @author Mahmoud Ben Hassine
- * @author Jun Kim
  * @since 5.1
  * @param <K> type of keys
  * @param <V> type of values

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/builder/RedisItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/builder/RedisItemReaderBuilder.java
@@ -23,7 +23,6 @@ import org.springframework.data.redis.core.ScanOptions;
  * Builder for {@link RedisItemReader}.
  *
  * @author Mahmoud Ben Hassine
- * @author Jun Kim
  * @since 5.1
  * @param <K> type of keys
  * @param <V> type of values

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/builder/RedisItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/redis/builder/RedisItemReaderBuilder.java
@@ -23,6 +23,7 @@ import org.springframework.data.redis.core.ScanOptions;
  * Builder for {@link RedisItemReader}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Jun Kim
  * @since 5.1
  * @param <K> type of keys
  * @param <V> type of values
@@ -32,6 +33,8 @@ public class RedisItemReaderBuilder<K, V> {
 	private RedisTemplate<K, V> redisTemplate;
 
 	private ScanOptions scanOptions;
+
+	private int batchSize = 1;
 
 	/**
 	 * Set the {@link RedisTemplate} to use in the reader.
@@ -54,11 +57,24 @@ public class RedisItemReaderBuilder<K, V> {
 	}
 
 	/**
+	 * Set the batch size for fetching values from Redis. When set to a value greater than
+	 * 1, the reader will use Redis MGET operations to fetch multiple values in a single
+	 * network round-trip, significantly improving performance.
+	 * @param batchSize the number of keys to fetch in each batch (must be between 1 and
+	 * 1000)
+	 * @return the current builder instance for fluent chaining
+	 */
+	public RedisItemReaderBuilder<K, V> batchSize(int batchSize) {
+		this.batchSize = batchSize;
+		return this;
+	}
+
+	/**
 	 * Build a new {@link RedisItemReader}.
 	 * @return a new item reader
 	 */
 	public RedisItemReader<K, V> build() {
-		return new RedisItemReader<>(this.redisTemplate, this.scanOptions);
+		return new RedisItemReader<>(this.redisTemplate, this.scanOptions, this.batchSize);
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/redis/RedisItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/item/redis/RedisItemReaderTests.java
@@ -15,6 +15,10 @@
  */
 package org.springframework.batch.item.redis;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +64,107 @@ public class RedisItemReaderTests {
 		Assertions.assertEquals("foo", item1);
 		Assertions.assertEquals("bar", item2);
 		Assertions.assertNull(item3);
+	}
+
+	@Test
+	void testReadWithBatchSize() throws Exception {
+		// given
+		int batchSize = 2;
+		Mockito.when(this.redisTemplate.scan(this.scanOptions)).thenReturn(this.cursor);
+		Mockito.when(this.cursor.hasNext()).thenReturn(true, true, true, true, false);
+		Mockito.when(this.cursor.next()).thenReturn("person:1", "person:2", "person:3", "person:4");
+
+		// Setup multiGet - batch of 2 keys each time
+		Mockito.when(this.redisTemplate.opsForValue().multiGet(Mockito.anyList())).thenAnswer(invocation -> {
+			List<String> keys = invocation.getArgument(0);
+			if (keys.size() == 2) {
+				if (keys.get(0).equals("person:1") && keys.get(1).equals("person:2")) {
+					return Arrays.asList("foo", "bar");
+				}
+				if (keys.get(0).equals("person:3") && keys.get(1).equals("person:4")) {
+					return Arrays.asList("baz", "qux");
+				}
+			}
+			return Collections.emptyList();
+		});
+
+		RedisItemReader<String, String> redisItemReader = new RedisItemReader<>(this.redisTemplate, this.scanOptions,
+				batchSize);
+		redisItemReader.open(new ExecutionContext());
+
+		// when
+		String item1 = redisItemReader.read();
+		String item2 = redisItemReader.read();
+		String item3 = redisItemReader.read();
+		String item4 = redisItemReader.read();
+		String item5 = redisItemReader.read();
+
+		// then
+		Assertions.assertEquals("foo", item1);
+		Assertions.assertEquals("bar", item2);
+		Assertions.assertEquals("baz", item3);
+		Assertions.assertEquals("qux", item4);
+		Assertions.assertNull(item5);
+
+		// Verify multiGet was called instead of individual get
+		Mockito.verify(this.redisTemplate.opsForValue(), Mockito.times(2)).multiGet(Mockito.any());
+		Mockito.verify(this.redisTemplate.opsForValue(), Mockito.never()).get(Mockito.any());
+	}
+
+	@Test
+	void testReadWithBatchSizeHandlesNullValues() throws Exception {
+		// given
+		int batchSize = 3;
+		Mockito.when(this.redisTemplate.scan(this.scanOptions)).thenReturn(this.cursor);
+		Mockito.when(this.cursor.hasNext()).thenReturn(true, true, true, false);
+		Mockito.when(this.cursor.next()).thenReturn("person:1", "person:2", "person:3");
+
+		// multiGet returns some null values
+		List<String> keys = Arrays.asList("person:1", "person:2", "person:3");
+		List<String> values = Arrays.asList("foo", null, "baz"); // person:2 is null
+		Mockito.when(this.redisTemplate.opsForValue().multiGet(keys)).thenReturn(values);
+
+		RedisItemReader<String, String> redisItemReader = new RedisItemReader<>(this.redisTemplate, this.scanOptions,
+				batchSize);
+		redisItemReader.open(new ExecutionContext());
+
+		// when
+		String item1 = redisItemReader.read();
+		String item2 = redisItemReader.read();
+		String item3 = redisItemReader.read();
+
+		// then - null values should be filtered out
+		Assertions.assertEquals("foo", item1);
+		Assertions.assertEquals("baz", item2);
+		Assertions.assertNull(item3);
+	}
+
+	@Test
+	void testBackwardCompatibilityWithDefaultBatchSize() throws Exception {
+		// given - using constructor without batchSize (defaults to 1)
+		Mockito.when(this.redisTemplate.scan(this.scanOptions)).thenReturn(this.cursor);
+		Mockito.when(this.cursor.hasNext()).thenReturn(true, true, false);
+		Mockito.when(this.cursor.next()).thenReturn("person:1", "person:2");
+		Mockito.when(this.redisTemplate.opsForValue().get("person:1")).thenReturn("foo");
+		Mockito.when(this.redisTemplate.opsForValue().get("person:2")).thenReturn("bar");
+
+		// Using old constructor
+		RedisItemReader<String, String> redisItemReader = new RedisItemReader<>(this.redisTemplate, this.scanOptions);
+		redisItemReader.open(new ExecutionContext());
+
+		// when
+		String item1 = redisItemReader.read();
+		String item2 = redisItemReader.read();
+		String item3 = redisItemReader.read();
+
+		// then
+		Assertions.assertEquals("foo", item1);
+		Assertions.assertEquals("bar", item2);
+		Assertions.assertNull(item3);
+
+		// Verify individual get was called, not multiGet (backward compatibility)
+		Mockito.verify(this.redisTemplate.opsForValue(), Mockito.times(2)).get(Mockito.any());
+		Mockito.verify(this.redisTemplate.opsForValue(), Mockito.never()).multiGet(Mockito.any());
 	}
 
 }


### PR DESCRIPTION
## Summary
This PR addresses issue #4941 by adding a batchSize option to RedisItemReader that enables batch fetching using Redis MGET operations, significantly improving performance by reducing network round-trips.

## Changes
- Added  parameter to RedisItemReader with default value of 1 (backward compatible)
- Implemented batch fetching logic using Redis MGET when batchSize > 1
- Added internal buffering mechanism using Queue for efficient data handling
- Updated RedisItemReaderBuilder to support batchSize configuration
- Added comprehensive test cases for batch reading functionality

## Performance Impact
- **Before**: N keys require N network round-trips (individual GET operations)
- **After**: N keys require N/batchSize network round-trips (MGET operations)
- Example: 1000 keys with batchSize=100 reduces network calls by 90% (10 vs 1000)

## Backward Compatibility
- Default batchSize = 1 preserves existing behavior (100% backward compatible)
- Existing code continues to work without any changes
- batchSize > 1 enables optimized batch processing

## Testing
- Added test for batch reading with multiple batches
- Added test for handling null values in batch results
- Verified backward compatibility with existing tests
- All existing tests pass without modification

## Usage Example
```java
// Backward compatible (existing behavior)
RedisItemReader<String, Object> reader = new RedisItemReaderBuilder<String, Object>()
    .redisTemplate(template)
    .scanOptions(scanOptions)
    .build(); // Uses batchSize = 1

// Optimized batch processing
RedisItemReader<String, Object> optimizedReader = new RedisItemReaderBuilder<String, Object>()
    .redisTemplate(template)
    .scanOptions(scanOptions)
    .batchSize(100) // Process 100 keys per MGET
    .build();
```

Fixes #4941