### PR TITLE
GH-4949: Fix intermittently breaking test case - SimpleStepFactoryBeanTests.testSimpleConcurrentJob

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/SimpleStepFactoryBeanTests.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,11 +70,12 @@ class SimpleStepFactoryBeanTests {
 
 	private JobRepository repository;
 
-	private final List<String> written = new ArrayList<>();
+	private final List<String> written = new CopyOnWriteArrayList<>();
 
 	private final ItemWriter<String> writer = data -> written.addAll(data.getItems());
 
-	private ItemReader<String> reader = new ListItemReader<>(Arrays.asList("a", "b", "c"));
+	private ItemReader<String> reader = new ListItemReader<>(
+			new CopyOnWriteArrayList<>(new String[] { "a", "b", "c" }));
 
 	private final SimpleJob job = new SimpleJob();
 


### PR DESCRIPTION
## Summary
This PR fixes #4949.
The test case(SimpleStepFactoryBeanTests.testSimpleConcurrentJob) breaks intermittently.
Because of used collections are not thread safe.

## Changes
- Modify collections that are used in test case to thread safe.