### PR TITLE
Fix copy-paste error in JobInstanceAlreadyExistsException javadoc

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobInstanceAlreadyExistsException.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobInstanceAlreadyExistsException.java
@@ -19,7 +19,8 @@ import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.JobExecutionException;
 
 /**
- * Checked exception to indicate that a required {@link Job} is not available.
+ * Checked exception to indicate that a {@link org.springframework.batch.core.JobInstance} 
+ * already exists for the given {@link Job} and identifying parameters.
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine


### PR DESCRIPTION
## Description
This PR fixes a copy-paste error in the JavaDoc of `JobInstanceAlreadyExistsException`.

## Problem
The JavaDoc incorrectly stated:
> Checked exception to indicate that a required Job is not available.

This description actually belongs to `NoSuchJobException`, not `JobInstanceAlreadyExistsException`.

## Solution
Updated the JavaDoc to correctly describe the exception:
> Checked exception to indicate that a JobInstance already exists for the given Job and identifying parameters.

## Changes
- Fixed JavaDoc in `JobInstanceAlreadyExistsException.java`

Resolves #4932