### PR TITLE
Remove ErrorProne exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,45 +189,6 @@
 						<compilerArg>--should-stop=ifError=FLOW</compilerArg>
 						<compilerArg>
 							-Xplugin:ErrorProne
-							-Xep:AlmostJavadoc:OFF
-							-Xep:ByteBufferBackingArray:OFF
-							-Xep:ClassCanBeStatic:OFF
-							-Xep:CollectionUndefinedEquality:OFF
-							-Xep:DefaultCharset:OFF
-							-Xep:DirectInvocationOnMock:OFF
-							-Xep:DoNotCallSuggester:OFF
-							-Xep:EmptyCatch:OFF
-							-Xep:EqualsGetClass:OFF
-							-Xep:Finally:OFF
-							-Xep:FutureReturnValueIgnored:OFF
-							-Xep:HidingField:OFF
-							-Xep:ImmutableEnumChecker:OFF
-							-Xep:InlineMeSuggester:OFF
-							-Xep:InputStreamSlowMultibyteRead:OFF
-							-Xep:JavaTimeDefaultTimeZone:OFF
-							-Xep:JavaUtilDate:OFF
-							-Xep:JdkObsolete:OFF
-							-Xep:MissingSummary:OFF
-							-Xep:MixedMutabilityReturnType:OFF
-							-Xep:MutablePublicArray:OFF
-							-Xep:NonAtomicVolatileUpdate:OFF
-							-Xep:RedundantControlFlow:OFF
-							-Xep:ReferenceEquality:OFF
-							-Xep:StaticAssignmentInConstructor:OFF
-							-Xep:StaticAssignmentOfThrowable:OFF
-							-Xep:StaticMockMember:OFF
-							-Xep:StreamResourceLeak:OFF
-							-Xep:StringCaseLocaleUsage:OFF
-							-Xep:StringSplitter:OFF
-							-Xep:SynchronizeOnNonFinalField:OFF
-							-Xep:ThreadLocalUsage:OFF
-							-Xep:ThreadPriorityCheck:OFF
-							-Xep:TypeParameterUnusedInFormals:OFF
-							-Xep:UndefinedEquals:OFF
-							-Xep:UnnecessaryStringBuilder:OFF
-							-Xep:UnusedMethod:OFF
-							-Xep:UnusedVariable:OFF
-							-Xep:WaitNotInLoop:OFF
 						</compilerArg>
 					</compilerArgs>
 					<annotationProcessorPaths>


### PR DESCRIPTION
As discussed at https://github.com/spring-projects/spring-batch/commit/72694e628d887c18ece95dccda4dedec62c83a1f#commitcomment-159564950, now that ErrorProne doesn't trigger failures in case of warnings, the existing exclusions should be removed.