### PR TITLE
Clarify Javadoc for FaultTolerantStepBuilder#skipLimit

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/FaultTolerantStepBuilder.java
@@ -305,10 +305,18 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 	}
 
 	/**
-	 * Sets the maximum number of failed items to skip before the step fails. Ignored if
-	 * an explicit {@link #skipPolicy(SkipPolicy)} is provided.
-	 * @param skipLimit the skip limit to set. Default is 10.
-	 * @return this for fluent chaining
+	 * Sets the maximum number of failed items to skip before the step fails.
+	 * The default value is 10.
+	 * <p>
+	 * This limit is enforced using the default
+	 * {@link org.springframework.batch.core.step.skip.LimitCheckingItemSkipPolicy}.
+	 * If a custom {@link SkipPolicy} is provided
+	 * via {@link #skipPolicy(SkipPolicy)},
+	 * this limit will not be enforced by the step directly,
+	 * but it can be implemented to be honored by the custom policy.
+	 * @param skipLimit the maximum number of failed items to skip.
+	 * @return this for fluent chaining.
+	 * @see SkipPolicy
 	 */
 	public FaultTolerantStepBuilder<I, O> skipLimit(int skipLimit) {
 		this.skipLimit = skipLimit;
@@ -341,6 +349,9 @@ public class FaultTolerantStepBuilder<I, O> extends SimpleStepBuilder<I, O> {
 	/**
 	 * Provide an explicit policy for managing skips. A skip policy determines which
 	 * exceptions are skippable and how many times.
+	 * <p>
+	 * Note that setting a custom policy overrides the default limit-checking behavior
+	 * configured via {@link #skipLimit(int)}.
 	 * @param skipPolicy the skip policy
 	 * @return this for fluent chaining
 	 */


### PR DESCRIPTION
Fixes #4963

## Summary

The current Javadoc for the `FaultTolerantStepBuilder#skipLimit` method is misleading. It states that the skip limit is "ignored" when a custom `SkipPolicy` is provided, which can be misinterpreted by users to mean that the value is always irrelevant in such cases.

## Solution

This pull request improves the Javadocs for both `skipLimit()` and the related `skipPolicy()` method to make their relationship and behavior crystal clear. 

Based on valuable community feedback, the updated documentation now provides better context on default behavior and clarifies how setting a custom policy overrides the default settings.

## Key Changes

- **In `skipLimit()`:**
  - The description has been reworded to remove the ambiguous term "ignored".
  - Details about the default behavior have been added, explicitly mentioning the `LimitCheckingItemSkipPolicy` and the default limit value of 10.

- **In `skipPolicy()`:**
  - A new note has been added to its Javadoc, providing a clear cross-reference that it overrides the behavior configured via `skipLimit()`.

- The copyright year in the license header has been updated as per the contributor guidelines.

- Adding a `@see` tag that links to the `SkipPolicy` interface for better context and navigation.