### PR TITLE
GH-4961: Fix @BeforeChunk/@AfterChunk to support Chunk parameter as documented

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/StepListenerMetaData.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/StepListenerMetaData.java
@@ -46,6 +46,7 @@ import org.springframework.lang.Nullable;
  * methods, their interfaces, annotation, and expected arguments.
  *
  * @author Lucas Ward
+ * @author Hyunsang Han
  * @since 2.0
  * @see StepListenerFactoryBean
  */
@@ -53,8 +54,8 @@ public enum StepListenerMetaData implements ListenerMetaData {
 
 	BEFORE_STEP("beforeStep", "before-step-method", BeforeStep.class, StepExecutionListener.class, StepExecution.class),
 	AFTER_STEP("afterStep", "after-step-method", AfterStep.class, StepExecutionListener.class, StepExecution.class),
-	BEFORE_CHUNK("beforeChunk", "before-chunk-method", BeforeChunk.class, ChunkListener.class, ChunkContext.class),
-	AFTER_CHUNK("afterChunk", "after-chunk-method", AfterChunk.class, ChunkListener.class, ChunkContext.class),
+	BEFORE_CHUNK("beforeChunk", "before-chunk-method", BeforeChunk.class, ChunkListener.class, Chunk.class),
+	AFTER_CHUNK("afterChunk", "after-chunk-method", AfterChunk.class, ChunkListener.class, Chunk.class),
 	AFTER_CHUNK_ERROR("afterChunkError", "after-chunk-error-method", AfterChunkError.class, ChunkListener.class,
 			ChunkContext.class),
 	BEFORE_READ("beforeRead", "before-read-method", BeforeRead.class, ItemReadListener.class),


### PR DESCRIPTION
Updated `StepListenerMetaData` parameter types from `ChunkContext` to `Chunk` to match Javadocs specification and resolve issue .

**Breaking change: `ChunkContext` parameters no longer supported.**

I believe that:
- This change is planned to be included in the **6.0.0 major release**, and no backward compatibility for `ChunkContext` is considered.
- Since the javadocs already specify `Chunk` as the expected parameter type, maintaining `ChunkContext` support is unnecessary.

Resolves #4961