### PR TITLE
GH-5006: Fix database connection leak in queryForStream usage

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcExecutionContextDao.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Stream;
+import java.util.List;
 
 import org.springframework.batch.core.job.JobExecution;
 
@@ -59,6 +59,7 @@ import org.springframework.util.Assert;
  * @author David Turanski
  * @author Mahmoud Ben Hassine
  * @author Yanming Zhou
+ * @author Hyunsang Han
  */
 public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implements ExecutionContextDao {
 
@@ -154,10 +155,9 @@ public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implem
 		Long executionId = jobExecution.getId();
 		Assert.notNull(executionId, "ExecutionId must not be null.");
 
-		try (Stream<ExecutionContext> stream = getJdbcTemplate().queryForStream(getQuery(FIND_JOB_EXECUTION_CONTEXT),
-				new ExecutionContextRowMapper(), executionId)) {
-			return stream.findFirst().orElseGet(ExecutionContext::new);
-		}
+		List<ExecutionContext> results = getJdbcTemplate().query(getQuery(FIND_JOB_EXECUTION_CONTEXT),
+				new ExecutionContextRowMapper(), executionId);
+		return !results.isEmpty() ? results.get(0) : new ExecutionContext();
 	}
 
 	@Override
@@ -165,10 +165,9 @@ public class JdbcExecutionContextDao extends AbstractJdbcBatchMetadataDao implem
 		Long executionId = stepExecution.getId();
 		Assert.notNull(executionId, "ExecutionId must not be null.");
 
-		try (Stream<ExecutionContext> stream = getJdbcTemplate().queryForStream(getQuery(FIND_STEP_EXECUTION_CONTEXT),
-				new ExecutionContextRowMapper(), executionId)) {
-			return stream.findFirst().orElseGet(ExecutionContext::new);
-		}
+		List<ExecutionContext> results = getJdbcTemplate().query(getQuery(FIND_STEP_EXECUTION_CONTEXT),
+				new ExecutionContextRowMapper(), executionId);
+		return !results.isEmpty() ? results.get(0) : new ExecutionContext();
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDao.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.springframework.batch.core.job.DefaultJobKeyGenerator;
 import org.springframework.batch.core.job.JobExecution;
@@ -58,6 +57,7 @@ import org.springframework.util.StringUtils;
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
  * @author Yanming Zhou
+ * @author Hyunsang Han
  */
 public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements JobInstanceDao, InitializingBean {
 
@@ -186,11 +186,14 @@ public class JdbcJobInstanceDao extends AbstractJdbcBatchMetadataDao implements 
 
 		RowMapper<JobInstance> rowMapper = new JobInstanceRowMapper();
 
-		try (Stream<JobInstance> stream = getJdbcTemplate().queryForStream(
+		List<JobInstance> instances = getJdbcTemplate().query(
 				getQuery(StringUtils.hasLength(jobKey) ? FIND_JOBS_WITH_KEY : FIND_JOBS_WITH_EMPTY_KEY), rowMapper,
-				jobName, jobKey)) {
-			return stream.findFirst().orElse(null);
+				jobName, jobKey);
+
+		if (!instances.isEmpty()) {
+			Assert.state(instances.size() == 1, "instance count must be 1 but was " + instances.size());
 		}
+		return instances.isEmpty() ? null : instances.get(0);
 
 	}
 


### PR DESCRIPTION
`JdbcTemplate::queryForStream` used in try-with-resources blocks causes database connections to close prematurely, leading to `DataAccessResourceFailureException: This connection has been closed` when Hibernate transactions are still active.

The `queryForStream()` method sets up an `onClose()` callback that immediately releases the database connection when the Stream is closed, but Hibernate transactions may still need to use the same connection, causing a lifecycle mismatch.

I replaced `queryForStream` with `query` in all affected JDBC DAO classes.

Resolves #5006 