### PR TITLE
Collection prefix support for MongoDB job repository

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchRegistrar.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchRegistrar.java
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  * Batch in a declarative way through {@link EnableBatchProcessing}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Myeongha Shin
  * @since 5.0
  * @see EnableBatchProcessing
  */
@@ -183,6 +184,11 @@ class BatchRegistrar implements ImportBeanDefinitionRegistrar {
 		Isolation isolationLevelForCreate = mongoJobRepositoryAnnotation.isolationLevelForCreate();
 		if (isolationLevelForCreate != null) {
 			beanDefinitionBuilder.addPropertyValue("isolationLevelForCreateEnum", isolationLevelForCreate);
+		}
+
+		String collectionPrefix = mongoJobRepositoryAnnotation.collectionPrefix();
+		if (collectionPrefix != null) {
+			beanDefinitionBuilder.addPropertyValue("collectionPrefix", collectionPrefix);
 		}
 
 		String jobKeyGeneratorRef = mongoJobRepositoryAnnotation.jobKeyGeneratorRef();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableMongoJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableMongoJobRepository.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.configuration.annotation;
 
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -97,5 +98,12 @@ public @interface EnableMongoJobRepository {
 	 * {@literal stepExecutionIncrementer}.
 	 */
 	String stepExecutionIncrementerRef() default "stepExecutionIncrementer";
+
+	/**
+	 * Set the prefix for MongoDB collection names. Defaults to
+	 * {@link AbstractMongoBatchMetadataDao#DEFAULT_COLLECTION_PREFIX}.
+	 * @return the collection prefix to use
+	 */
+	String collectionPrefix() default AbstractMongoBatchMetadataDao.DEFAULT_COLLECTION_PREFIX;
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/MongoDefaultBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/MongoDefaultBatchConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.JobKeyGenerator;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.mongodb.MongoSequenceIncrementer;
 import org.springframework.batch.core.repository.support.MongoJobRepositoryFactoryBean;
 import org.springframework.context.annotation.Bean;
@@ -73,6 +74,7 @@ public class MongoDefaultBatchConfiguration extends DefaultBatchConfiguration {
 		try {
 			jobRepositoryFactoryBean.setMongoOperations(getMongoOperations());
 			jobRepositoryFactoryBean.setTransactionManager(getTransactionManager());
+			jobRepositoryFactoryBean.setCollectionPrefix(getCollectionPrefix());
 			jobRepositoryFactoryBean.setIsolationLevelForCreateEnum(getIsolationLevelForCreate());
 			jobRepositoryFactoryBean.setValidateTransactionState(getValidateTransactionState());
 			jobRepositoryFactoryBean.setJobKeyGenerator(getJobKeyGenerator());
@@ -154,12 +156,22 @@ public class MongoDefaultBatchConfiguration extends DefaultBatchConfiguration {
 	}
 
 	/**
+	 * Return the prefix of Batch meta-data collections. Defaults to
+	 * {@link AbstractMongoBatchMetadataDao#DEFAULT_COLLECTION_PREFIX}.
+	 * @return the prefix of meta-data collections
+	 * @since 6.1
+	 */
+	protected String getCollectionPrefix() {
+		return AbstractMongoBatchMetadataDao.DEFAULT_COLLECTION_PREFIX;
+	}
+
+	/**
 	 * Return the incrementer to be used to generate ids for new job instances.
 	 * @return the incrementer to be used to generate ids for new job instances
 	 * @since 6.0
 	 */
 	protected DataFieldMaxValueIncrementer getJobInstanceIncrementer() {
-		return new MongoSequenceIncrementer(getMongoOperations(), "BATCH_JOB_INSTANCE_SEQ");
+		return new MongoSequenceIncrementer(getMongoOperations(), "JOB_INSTANCE_SEQ", getCollectionPrefix());
 	}
 
 	/**
@@ -168,7 +180,7 @@ public class MongoDefaultBatchConfiguration extends DefaultBatchConfiguration {
 	 * @since 6.0
 	 */
 	protected DataFieldMaxValueIncrementer getJobExecutionIncrementer() {
-		return new MongoSequenceIncrementer(getMongoOperations(), "BATCH_JOB_EXECUTION_SEQ");
+		return new MongoSequenceIncrementer(getMongoOperations(), "JOB_EXECUTION_SEQ", getCollectionPrefix());
 	}
 
 	/**
@@ -177,7 +189,7 @@ public class MongoDefaultBatchConfiguration extends DefaultBatchConfiguration {
 	 * @since 6.0
 	 */
 	protected DataFieldMaxValueIncrementer getStepExecutionIncrementer() {
-		return new MongoSequenceIncrementer(getMongoOperations(), "BATCH_STEP_EXECUTION_SEQ");
+		return new MongoSequenceIncrementer(getMongoOperations(), "STEP_EXECUTION_SEQ", getCollectionPrefix());
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/AbstractMongoBatchMetadataDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/AbstractMongoBatchMetadataDao.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.core.repository.dao;
+
+import org.springframework.util.Assert;
+
+/**
+ * Encapsulates common functionality needed by MongoDB batch metadata DAOs - handles
+ * collection prefixes.
+ *
+ * @author Myeongha Shin
+ * @since 6.1
+ */
+public abstract class AbstractMongoBatchMetadataDao {
+
+	/**
+	 * Default value for the collection prefix property.
+	 */
+	public static final String DEFAULT_COLLECTION_PREFIX = "BATCH_";
+
+	private String collectionPrefix = DEFAULT_COLLECTION_PREFIX;
+
+	protected String getCollectionPrefix() {
+		return this.collectionPrefix;
+	}
+
+	/**
+	 * Public setter for the collection prefix property. This will be prefixed to all the
+	 * collection names before queries are executed. Defaults to
+	 * {@link #DEFAULT_COLLECTION_PREFIX}.
+	 * @param collectionPrefix the collection prefix to set
+	 */
+	public void setCollectionPrefix(String collectionPrefix) {
+		Assert.notNull(collectionPrefix, "Collection prefix must not be null.");
+		this.collectionPrefix = collectionPrefix;
+	}
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoExecutionContextDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoExecutionContextDao.java
@@ -20,29 +20,50 @@ import java.util.Collections;
 
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.ExecutionContextDao;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.util.Assert;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 
 /**
  * @author Mahmoud Ben Hassine
+ * @author Myeongha Shin
  * @since 5.2.0
  */
-public class MongoExecutionContextDao implements ExecutionContextDao {
+public class MongoExecutionContextDao extends AbstractMongoBatchMetadataDao implements ExecutionContextDao {
 
-	private static final String STEP_EXECUTIONS_COLLECTION_NAME = "BATCH_STEP_EXECUTION";
+	private static final String STEP_EXECUTIONS_COLLECTION_NAME = "STEP_EXECUTION";
 
-	private static final String JOB_EXECUTIONS_COLLECTION_NAME = "BATCH_JOB_EXECUTION";
+	private static final String JOB_EXECUTIONS_COLLECTION_NAME = "JOB_EXECUTION";
 
 	private final MongoOperations mongoOperations;
 
+	private String stepExecutionCollectionName;
+
+	private String jobExecutionCollectionName;
+
 	public MongoExecutionContextDao(MongoOperations mongoOperations) {
+		Assert.notNull(mongoOperations, "mongoOperations must not be null.");
 		this.mongoOperations = mongoOperations;
+		setCollectionPrefix(getCollectionPrefix());
+	}
+
+	public MongoExecutionContextDao(MongoOperations mongoOperations, String collectionPrefix) {
+		this(mongoOperations);
+		setCollectionPrefix(collectionPrefix);
+	}
+
+	@Override
+	public void setCollectionPrefix(String collectionPrefix) {
+		super.setCollectionPrefix(collectionPrefix);
+		this.stepExecutionCollectionName = getCollectionPrefix() + STEP_EXECUTIONS_COLLECTION_NAME;
+		this.jobExecutionCollectionName = getCollectionPrefix() + JOB_EXECUTIONS_COLLECTION_NAME;
 	}
 
 	@Override
@@ -50,7 +71,7 @@ public class MongoExecutionContextDao implements ExecutionContextDao {
 		Query query = query(where("jobExecutionId").is(jobExecution.getId()));
 		org.springframework.batch.core.repository.persistence.JobExecution execution = this.mongoOperations.findOne(
 				query, org.springframework.batch.core.repository.persistence.JobExecution.class,
-				JOB_EXECUTIONS_COLLECTION_NAME);
+				jobExecutionCollectionName);
 		if (execution == null) {
 			return new ExecutionContext();
 		}
@@ -62,7 +83,7 @@ public class MongoExecutionContextDao implements ExecutionContextDao {
 		Query query = query(where("stepExecutionId").is(stepExecution.getId()));
 		org.springframework.batch.core.repository.persistence.StepExecution execution = this.mongoOperations.findOne(
 				query, org.springframework.batch.core.repository.persistence.StepExecution.class,
-				STEP_EXECUTIONS_COLLECTION_NAME);
+				stepExecutionCollectionName);
 		if (execution == null) {
 			return new ExecutionContext();
 		}
@@ -78,8 +99,7 @@ public class MongoExecutionContextDao implements ExecutionContextDao {
 				new org.springframework.batch.core.repository.persistence.ExecutionContext(executionContext.toMap(),
 						executionContext.isDirty()));
 		this.mongoOperations.updateFirst(query, update,
-				org.springframework.batch.core.repository.persistence.JobExecution.class,
-				JOB_EXECUTIONS_COLLECTION_NAME);
+				org.springframework.batch.core.repository.persistence.JobExecution.class, jobExecutionCollectionName);
 	}
 
 	@Override
@@ -91,8 +111,7 @@ public class MongoExecutionContextDao implements ExecutionContextDao {
 				new org.springframework.batch.core.repository.persistence.ExecutionContext(executionContext.toMap(),
 						executionContext.isDirty()));
 		this.mongoOperations.updateFirst(query, update,
-				org.springframework.batch.core.repository.persistence.StepExecution.class,
-				STEP_EXECUTIONS_COLLECTION_NAME);
+				org.springframework.batch.core.repository.persistence.StepExecution.class, stepExecutionCollectionName);
 
 	}
 
@@ -119,7 +138,7 @@ public class MongoExecutionContextDao implements ExecutionContextDao {
 		org.springframework.batch.core.repository.persistence.ExecutionContext executionContext = new org.springframework.batch.core.repository.persistence.ExecutionContext(
 				Collections.emptyMap(), false);
 		Update executionContextRemovalUpdate = new Update().set("executionContext", executionContext);
-		this.mongoOperations.updateFirst(query, executionContextRemovalUpdate, JOB_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.updateFirst(query, executionContextRemovalUpdate, this.jobExecutionCollectionName);
 	}
 
 	@Override
@@ -128,7 +147,7 @@ public class MongoExecutionContextDao implements ExecutionContextDao {
 		org.springframework.batch.core.repository.persistence.ExecutionContext executionContext = new org.springframework.batch.core.repository.persistence.ExecutionContext(
 				Collections.emptyMap(), false);
 		Update executionContextRemovalUpdate = new Update().set("executionContext", executionContext);
-		this.mongoOperations.updateFirst(query, executionContextRemovalUpdate, STEP_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.updateFirst(query, executionContextRemovalUpdate, this.stepExecutionCollectionName);
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobExecutionDao.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.JobExecutionDao;
 import org.springframework.batch.core.repository.persistence.JobParameter;
 import org.springframework.batch.core.repository.persistence.converter.JobExecutionConverter;
@@ -37,6 +38,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.Assert;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -44,15 +46,18 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 /**
  * @author Mahmoud Ben Hassine
  * @author Yanming Zhou
+ * @author Myeongha Shin
  * @since 5.2.0
  */
-public class MongoJobExecutionDao implements JobExecutionDao {
+public class MongoJobExecutionDao extends AbstractMongoBatchMetadataDao implements JobExecutionDao {
 
-	private static final String JOB_EXECUTIONS_COLLECTION_NAME = "BATCH_JOB_EXECUTION";
+	private static final String JOB_EXECUTIONS_COLLECTION_NAME = "JOB_EXECUTION";
 
-	private static final String JOB_EXECUTIONS_SEQUENCE_NAME = "BATCH_JOB_EXECUTION_SEQ";
+	private static final String JOB_EXECUTIONS_SEQUENCE_NAME = "JOB_EXECUTION_SEQ";
 
 	private final MongoOperations mongoOperations;
+
+	private String jobExecutionsCollectionName;
 
 	private final JobExecutionConverter jobExecutionConverter = new JobExecutionConverter();
 
@@ -60,17 +65,36 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 
 	private MongoJobInstanceDao jobInstanceDao;
 
+	private boolean useDefaultJobExecutionIncrementer = true;
+
 	public MongoJobExecutionDao(MongoOperations mongoOperations) {
+		Assert.notNull(mongoOperations, "mongoOperations must not be null.");
 		this.mongoOperations = mongoOperations;
-		this.jobExecutionIncrementer = new MongoSequenceIncrementer(mongoOperations, JOB_EXECUTIONS_SEQUENCE_NAME);
+		setCollectionPrefix(getCollectionPrefix());
+	}
+
+	public MongoJobExecutionDao(MongoOperations mongoOperations, String collectionPrefix) {
+		this(mongoOperations);
+		setCollectionPrefix(collectionPrefix);
 	}
 
 	public void setJobExecutionIncrementer(DataFieldMaxValueIncrementer jobExecutionIncrementer) {
+		this.useDefaultJobExecutionIncrementer = false;
 		this.jobExecutionIncrementer = jobExecutionIncrementer;
 	}
 
 	public void setJobInstanceDao(MongoJobInstanceDao jobInstanceDao) {
 		this.jobInstanceDao = jobInstanceDao;
+	}
+
+	@Override
+	public void setCollectionPrefix(String collectionPrefix) {
+		super.setCollectionPrefix(collectionPrefix);
+		this.jobExecutionsCollectionName = getCollectionPrefix() + JOB_EXECUTIONS_COLLECTION_NAME;
+		if (this.useDefaultJobExecutionIncrementer) {
+			this.jobExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations,
+					JOB_EXECUTIONS_SEQUENCE_NAME, getCollectionPrefix());
+		}
 	}
 
 	public JobExecution createJobExecution(JobInstance jobInstance, JobParameters jobParameters) {
@@ -79,7 +103,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 
 		org.springframework.batch.core.repository.persistence.JobExecution jobExecutionToSave = this.jobExecutionConverter
 			.fromJobExecution(jobExecution);
-		this.mongoOperations.insert(jobExecutionToSave, JOB_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.insert(jobExecutionToSave, jobExecutionsCollectionName);
 
 		return jobExecution;
 	}
@@ -89,7 +113,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 		Query query = query(where("jobExecutionId").is(jobExecution.getId()));
 		org.springframework.batch.core.repository.persistence.JobExecution jobExecutionToUpdate = this.jobExecutionConverter
 			.fromJobExecution(jobExecution);
-		this.mongoOperations.findAndReplace(query, jobExecutionToUpdate, JOB_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.findAndReplace(query, jobExecutionToUpdate, jobExecutionsCollectionName);
 	}
 
 	@Override
@@ -98,7 +122,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 			.with(Sort.by(Sort.Direction.DESC, "jobExecutionId"));
 		List<org.springframework.batch.core.repository.persistence.JobExecution> jobExecutions = this.mongoOperations
 			.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
-					JOB_EXECUTIONS_COLLECTION_NAME);
+					jobExecutionsCollectionName);
 		return jobExecutions.stream().map(jobExecution -> convert(jobExecution, jobInstance)).toList();
 	}
 
@@ -108,8 +132,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 		Sort.Order sortOrder = Sort.Order.desc("jobExecutionId");
 		org.springframework.batch.core.repository.persistence.JobExecution jobExecution = this.mongoOperations.findOne(
 				query.with(Sort.by(sortOrder)),
-				org.springframework.batch.core.repository.persistence.JobExecution.class,
-				JOB_EXECUTIONS_COLLECTION_NAME);
+				org.springframework.batch.core.repository.persistence.JobExecution.class, jobExecutionsCollectionName);
 		return jobExecution != null ? convert(jobExecution, jobInstance) : null;
 	}
 
@@ -122,7 +145,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 					where("jobInstanceId").is(jobInstance.getId()).and("status").in("STARTING", "STARTED", "STOPPING"));
 			this.mongoOperations
 				.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
-						JOB_EXECUTIONS_COLLECTION_NAME)
+						jobExecutionsCollectionName)
 				.stream()
 				.map(jobExecution -> convert(jobExecution, jobInstance))
 				.forEach(runningJobExecutions::add);
@@ -135,7 +158,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 		Query jobExecutionQuery = query(where("jobExecutionId").is(executionId));
 		org.springframework.batch.core.repository.persistence.JobExecution jobExecution = this.mongoOperations.findOne(
 				jobExecutionQuery, org.springframework.batch.core.repository.persistence.JobExecution.class,
-				JOB_EXECUTIONS_COLLECTION_NAME);
+				jobExecutionsCollectionName);
 		if (jobExecution == null) {
 			return null;
 		}
@@ -158,7 +181,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 	@Override
 	public void deleteJobExecution(JobExecution jobExecution) {
 		this.mongoOperations.remove(query(where("jobExecutionId").is(jobExecution.getId())),
-				JOB_EXECUTIONS_COLLECTION_NAME);
+				this.jobExecutionsCollectionName);
 
 	}
 
@@ -166,7 +189,7 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 	public void deleteJobExecutionParameters(JobExecution jobExecution) {
 		Query query = new Query(where("jobExecutionId").is(jobExecution.getId()));
 		Update jobParametersRemovalUpdate = new Update().set("jobParameters", Collections.emptyList());
-		this.mongoOperations.updateFirst(query, jobParametersRemovalUpdate, JOB_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.updateFirst(query, jobParametersRemovalUpdate, this.jobExecutionsCollectionName);
 	}
 
 	private JobExecution convert(org.springframework.batch.core.repository.persistence.JobExecution jobExecution,

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
@@ -24,6 +24,7 @@ import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.JobKeyGenerator;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.launch.NoSuchJobException;
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.JobInstanceDao;
 import org.springframework.batch.core.repository.persistence.converter.JobInstanceConverter;
 import org.springframework.data.domain.Sort;
@@ -38,15 +39,18 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 /**
  * @author Mahmoud Ben Hassine
  * @author Yanming Zhou
+ * @author Myeongha Shin
  * @since 5.2.0
  */
-public class MongoJobInstanceDao implements JobInstanceDao {
+public class MongoJobInstanceDao extends AbstractMongoBatchMetadataDao implements JobInstanceDao {
 
-	private static final String COLLECTION_NAME = "BATCH_JOB_INSTANCE";
+	private static final String COLLECTION_NAME = "JOB_INSTANCE";
 
-	private static final String SEQUENCE_NAME = "BATCH_JOB_INSTANCE_SEQ";
+	private static final String SEQUENCE_NAME = "JOB_INSTANCE_SEQ";
 
 	private final MongoOperations mongoOperations;
+
+	private String collectionName;
 
 	private DataFieldMaxValueIncrementer jobInstanceIncrementer;
 
@@ -54,10 +58,17 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 
 	private final JobInstanceConverter jobInstanceConverter = new JobInstanceConverter();
 
+	private boolean useDefaultJobInstanceIncrementer = true;
+
 	public MongoJobInstanceDao(MongoOperations mongoOperations) {
 		Assert.notNull(mongoOperations, "mongoOperations must not be null.");
 		this.mongoOperations = mongoOperations;
-		this.jobInstanceIncrementer = new MongoSequenceIncrementer(mongoOperations, SEQUENCE_NAME);
+		setCollectionPrefix(getCollectionPrefix());
+	}
+
+	public MongoJobInstanceDao(MongoOperations mongoOperations, String collectionPrefix) {
+		this(mongoOperations);
+		setCollectionPrefix(collectionPrefix);
 	}
 
 	public void setJobKeyGenerator(JobKeyGenerator jobKeyGenerator) {
@@ -65,7 +76,18 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	}
 
 	public void setJobInstanceIncrementer(DataFieldMaxValueIncrementer jobInstanceIncrementer) {
+		this.useDefaultJobInstanceIncrementer = false;
 		this.jobInstanceIncrementer = jobInstanceIncrementer;
+	}
+
+	@Override
+	public void setCollectionPrefix(String collectionPrefix) {
+		super.setCollectionPrefix(collectionPrefix);
+		this.collectionName = getCollectionPrefix() + COLLECTION_NAME;
+		if (this.useDefaultJobInstanceIncrementer) {
+			this.jobInstanceIncrementer = new MongoSequenceIncrementer(this.mongoOperations, SEQUENCE_NAME,
+					getCollectionPrefix());
+		}
 	}
 
 	@Override
@@ -81,7 +103,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 		jobInstanceToSave.setJobKey(key);
 		long instanceId = jobInstanceIncrementer.nextLongValue();
 		jobInstanceToSave.setJobInstanceId(instanceId);
-		this.mongoOperations.insert(jobInstanceToSave, COLLECTION_NAME);
+		this.mongoOperations.insert(jobInstanceToSave, this.collectionName);
 
 		JobInstance jobInstance = new JobInstance(instanceId, jobName);
 		jobInstance.incrementVersion(); // TODO is this needed?
@@ -92,16 +114,16 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	public JobInstance getJobInstance(String jobName, JobParameters jobParameters) {
 		String key = this.jobKeyGenerator.generateKey(jobParameters);
 		Query query = query(where("jobName").is(jobName).and("jobKey").is(key));
-		org.springframework.batch.core.repository.persistence.JobInstance jobInstance = this.mongoOperations
-			.findOne(query, org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME);
+		org.springframework.batch.core.repository.persistence.JobInstance jobInstance = this.mongoOperations.findOne(
+				query, org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName);
 		return jobInstance != null ? this.jobInstanceConverter.toJobInstance(jobInstance) : null;
 	}
 
 	@Override
 	public JobInstance getJobInstance(long instanceId) {
 		Query query = query(where("jobInstanceId").is(instanceId));
-		org.springframework.batch.core.repository.persistence.JobInstance jobInstance = this.mongoOperations
-			.findOne(query, org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME);
+		org.springframework.batch.core.repository.persistence.JobInstance jobInstance = this.mongoOperations.findOne(
+				query, org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName);
 		return jobInstance != null ? this.jobInstanceConverter.toJobInstance(jobInstance) : null;
 	}
 
@@ -116,7 +138,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 		Sort.Order sortOrder = Sort.Order.desc("jobInstanceId");
 		List<org.springframework.batch.core.repository.persistence.JobInstance> jobInstances = this.mongoOperations
 			.find(query.with(Sort.by(sortOrder)),
-					org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME)
+					org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName)
 			.stream()
 			.toList();
 		if (jobInstances.size() <= start) {
@@ -139,7 +161,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	public List<JobInstance> getJobInstances(String jobName) {
 		Query query = query(where("jobName").is(jobName));
 		return this.mongoOperations
-			.find(query, org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME)
+			.find(query, org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName)
 			.stream()
 			.map(this.jobInstanceConverter::toJobInstance)
 			.toList();
@@ -149,7 +171,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	public List<Long> getJobInstanceIds(String jobName) {
 		Query query = query(where("jobName").is(jobName));
 		return this.mongoOperations
-			.find(query, org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME)
+			.find(query, org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName)
 			.stream()
 			.map(org.springframework.batch.core.repository.persistence.JobInstance::getJobInstanceId)
 			.toList();
@@ -158,7 +180,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	public List<JobInstance> findJobInstancesByName(String jobName) {
 		Query query = query(where("jobName").is(jobName));
 		return this.mongoOperations
-			.find(query, org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME)
+			.find(query, org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName)
 			.stream()
 			.map(this.jobInstanceConverter::toJobInstance)
 			.toList();
@@ -170,14 +192,14 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 		Sort.Order sortOrder = Sort.Order.desc("jobInstanceId");
 		org.springframework.batch.core.repository.persistence.JobInstance jobInstance = this.mongoOperations.findOne(
 				query.with(Sort.by(sortOrder)), org.springframework.batch.core.repository.persistence.JobInstance.class,
-				COLLECTION_NAME);
+				this.collectionName);
 		return jobInstance != null ? this.jobInstanceConverter.toJobInstance(jobInstance) : null;
 	}
 
 	@Override
 	public List<String> getJobNames() {
 		return this.mongoOperations
-			.findAll(org.springframework.batch.core.repository.persistence.JobInstance.class, COLLECTION_NAME)
+			.findAll(org.springframework.batch.core.repository.persistence.JobInstance.class, this.collectionName)
 			.stream()
 			.map(org.springframework.batch.core.repository.persistence.JobInstance::getJobName)
 			.toList();
@@ -200,12 +222,12 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 			throw new NoSuchJobException("Job not found " + jobName);
 		}
 		Query query = query(where("jobName").is(jobName));
-		return this.mongoOperations.count(query, COLLECTION_NAME);
+		return this.mongoOperations.count(query, this.collectionName);
 	}
 
 	@Override
 	public void deleteJobInstance(JobInstance jobInstance) {
-		this.mongoOperations.remove(query(where("jobInstanceId").is(jobInstance.getId())), COLLECTION_NAME);
+		this.mongoOperations.remove(query(where("jobInstanceId").is(jobInstance.getId())), this.collectionName);
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoSequenceIncrementer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoSequenceIncrementer.java
@@ -24,8 +24,10 @@ import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
+import org.springframework.util.Assert;
 
 // Based on https://www.mongodb.com/blog/post/generating-globally-unique-identifiers-for-use-with-mongodb
 // Section: Use a single counter document to generate unique identifiers one at a time
@@ -37,6 +39,8 @@ import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer
  * @since 5.2.0
  */
 public class MongoSequenceIncrementer implements DataFieldMaxValueIncrementer {
+
+	private static final String SEQUENCES_COLLECTION_NAME = "SEQUENCES";
 
 	/*
 	 * Retry template to handle errors when incrementing the sequence value
@@ -54,16 +58,26 @@ public class MongoSequenceIncrementer implements DataFieldMaxValueIncrementer {
 
 	private final String sequenceName;
 
+	private final String sequencesCollectionName;
+
 	public MongoSequenceIncrementer(MongoOperations mongoTemplate, String sequenceName) {
+		this(mongoTemplate, sequenceName, AbstractMongoBatchMetadataDao.DEFAULT_COLLECTION_PREFIX);
+	}
+
+	public MongoSequenceIncrementer(MongoOperations mongoTemplate, String sequenceName, String collectionPrefix) {
+		Assert.notNull(mongoTemplate, "mongoTemplate must not be null.");
+		Assert.notNull(sequenceName, "sequenceName must not be null.");
+		Assert.notNull(collectionPrefix, "collectionPrefix must not be null.");
 		this.mongoTemplate = mongoTemplate;
-		this.sequenceName = sequenceName;
+		this.sequencesCollectionName = collectionPrefix + SEQUENCES_COLLECTION_NAME;
+		this.sequenceName = collectionPrefix + sequenceName;
 	}
 
 	@Override
 	public long nextLongValue() throws DataAccessException {
 		try {
 			return retryTemplate
-				.execute(() -> mongoTemplate.execute("BATCH_SEQUENCES", collection -> collection
+				.execute(() -> mongoTemplate.execute(sequencesCollectionName, collection -> collection
 					.findOneAndUpdate(new Document("_id", sequenceName), new Document("$inc", new Document("count", 1)),
 							new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER))
 					.getLong("count")));

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoStepExecutionDao.java
@@ -24,12 +24,14 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.StepExecutionDao;
 import org.springframework.batch.core.repository.persistence.converter.JobExecutionConverter;
 import org.springframework.batch.core.repository.persistence.converter.StepExecutionConverter;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
+import org.springframework.util.Assert;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -37,15 +39,20 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 /**
  * @author Mahmoud Ben Hassine
  * @author Yanming Zhou
+ * @author Myeongha Shin
  * @since 5.2.0
  */
-public class MongoStepExecutionDao implements StepExecutionDao {
+public class MongoStepExecutionDao extends AbstractMongoBatchMetadataDao implements StepExecutionDao {
 
-	private static final String STEP_EXECUTIONS_COLLECTION_NAME = "BATCH_STEP_EXECUTION";
+	private static final String STEP_EXECUTIONS_COLLECTION_NAME = "STEP_EXECUTION";
 
-	private static final String STEP_EXECUTIONS_SEQUENCE_NAME = "BATCH_STEP_EXECUTION_SEQ";
+	private static final String STEP_EXECUTIONS_SEQUENCE_NAME = "STEP_EXECUTION_SEQ";
 
-	private static final String JOB_EXECUTIONS_COLLECTION_NAME = "BATCH_JOB_EXECUTION";
+	private static final String JOB_EXECUTIONS_COLLECTION_NAME = "JOB_EXECUTION";
+
+	private String stepExecutionCollectionName;
+
+	private String jobExecutionCollectionName;
 
 	private final StepExecutionConverter stepExecutionConverter = new StepExecutionConverter();
 
@@ -57,17 +64,37 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 
 	MongoJobExecutionDao jobExecutionDao;
 
+	private boolean useDefaultStepExecutionIncrementer = true;
+
 	public MongoStepExecutionDao(MongoOperations mongoOperations) {
+		Assert.notNull(mongoOperations, "mongoOperations must not be null.");
 		this.mongoOperations = mongoOperations;
-		this.stepExecutionIncrementer = new MongoSequenceIncrementer(mongoOperations, STEP_EXECUTIONS_SEQUENCE_NAME);
+		setCollectionPrefix(getCollectionPrefix());
+	}
+
+	public MongoStepExecutionDao(MongoOperations mongoOperations, String collectionPrefix) {
+		this(mongoOperations);
+		setCollectionPrefix(collectionPrefix);
 	}
 
 	public void setStepExecutionIncrementer(DataFieldMaxValueIncrementer stepExecutionIncrementer) {
+		this.useDefaultStepExecutionIncrementer = false;
 		this.stepExecutionIncrementer = stepExecutionIncrementer;
 	}
 
 	public void setJobExecutionDao(MongoJobExecutionDao jobExecutionDao) {
 		this.jobExecutionDao = jobExecutionDao;
+	}
+
+	@Override
+	public void setCollectionPrefix(String collectionPrefix) {
+		super.setCollectionPrefix(collectionPrefix);
+		this.stepExecutionCollectionName = getCollectionPrefix() + STEP_EXECUTIONS_COLLECTION_NAME;
+		this.jobExecutionCollectionName = getCollectionPrefix() + JOB_EXECUTIONS_COLLECTION_NAME;
+		if (this.useDefaultStepExecutionIncrementer) {
+			this.stepExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations,
+					STEP_EXECUTIONS_SEQUENCE_NAME, getCollectionPrefix());
+		}
 	}
 
 	public StepExecution createStepExecution(String stepName, JobExecution jobExecution) {
@@ -76,7 +103,7 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		StepExecution stepExecution = new StepExecution(id, stepName, jobExecution);
 		org.springframework.batch.core.repository.persistence.StepExecution stepExecutionToSave = this.stepExecutionConverter
 			.fromStepExecution(stepExecution);
-		this.mongoOperations.insert(stepExecutionToSave, STEP_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.insert(stepExecutionToSave, stepExecutionCollectionName);
 
 		return stepExecution;
 	}
@@ -86,7 +113,7 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		Query query = query(where("stepExecutionId").is(stepExecution.getId()));
 		org.springframework.batch.core.repository.persistence.StepExecution stepExecutionToUpdate = this.stepExecutionConverter
 			.fromStepExecution(stepExecution);
-		this.mongoOperations.findAndReplace(query, stepExecutionToUpdate, STEP_EXECUTIONS_COLLECTION_NAME);
+		this.mongoOperations.findAndReplace(query, stepExecutionToUpdate, this.stepExecutionCollectionName);
 	}
 
 	@Nullable
@@ -95,7 +122,7 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		Query query = query(where("stepExecutionId").is(stepExecutionId));
 		org.springframework.batch.core.repository.persistence.StepExecution stepExecution = this.mongoOperations
 			.findOne(query, org.springframework.batch.core.repository.persistence.StepExecution.class,
-					STEP_EXECUTIONS_COLLECTION_NAME);
+					this.stepExecutionCollectionName);
 		return stepExecution != null ? this.stepExecutionConverter.toStepExecution(stepExecution,
 				jobExecutionDao.getJobExecution(stepExecution.getJobExecutionId())) : null;
 	}
@@ -106,7 +133,7 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		Query query = query(where("stepExecutionId").is(stepExecutionId));
 		org.springframework.batch.core.repository.persistence.StepExecution stepExecution = this.mongoOperations
 			.findOne(query, org.springframework.batch.core.repository.persistence.StepExecution.class,
-					STEP_EXECUTIONS_COLLECTION_NAME);
+					stepExecutionCollectionName);
 		return stepExecution != null ? this.stepExecutionConverter.toStepExecution(stepExecution, jobExecution) : null;
 	}
 
@@ -118,12 +145,12 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		Query query = query(where("jobInstanceId").is(jobInstance.getId()));
 		List<org.springframework.batch.core.repository.persistence.JobExecution> jobExecutions = this.mongoOperations
 			.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
-					JOB_EXECUTIONS_COLLECTION_NAME);
+					jobExecutionCollectionName);
 		List<org.springframework.batch.core.repository.persistence.StepExecution> stepExecutions = this.mongoOperations
 			.find(query(where("jobExecutionId").in(jobExecutions.stream()
 				.map(org.springframework.batch.core.repository.persistence.JobExecution::getJobExecutionId)
 				.toList())), org.springframework.batch.core.repository.persistence.StepExecution.class,
-					STEP_EXECUTIONS_COLLECTION_NAME);
+					stepExecutionCollectionName);
 		// sort step executions by creation date then id (see contract) and return the
 		// last one
 		Optional<org.springframework.batch.core.repository.persistence.StepExecution> lastStepExecution = stepExecutions
@@ -157,7 +184,7 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		Query query = query(where("jobExecutionId").is(jobExecution.getId()));
 		return this.mongoOperations
 			.find(query, org.springframework.batch.core.repository.persistence.StepExecution.class,
-					STEP_EXECUTIONS_COLLECTION_NAME)
+					stepExecutionCollectionName)
 			.stream()
 			.map(stepExecution -> this.stepExecutionConverter.toStepExecution(stepExecution, jobExecution))
 			.toList();
@@ -168,7 +195,7 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 		Query query = query(where("jobInstanceId").is(jobInstance.getId()));
 		List<org.springframework.batch.core.repository.persistence.JobExecution> jobExecutions = this.mongoOperations
 			.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
-					JOB_EXECUTIONS_COLLECTION_NAME);
+					jobExecutionCollectionName);
 		return this.mongoOperations.count(
 				query(where("jobExecutionId")
 					.in(jobExecutions.stream()
@@ -176,14 +203,13 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 						.toList())
 					.and("name")
 					.is(stepName)),
-				org.springframework.batch.core.repository.persistence.StepExecution.class,
-				STEP_EXECUTIONS_COLLECTION_NAME);
+				org.springframework.batch.core.repository.persistence.StepExecution.class, stepExecutionCollectionName);
 	}
 
 	@Override
 	public void deleteStepExecution(StepExecution stepExecution) {
 		this.mongoOperations.remove(query(where("stepExecutionId").is(stepExecution.getId())),
-				STEP_EXECUTIONS_COLLECTION_NAME);
+				stepExecutionCollectionName);
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/MongoJobExplorerFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/MongoJobExplorerFactoryBean.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.repository.explore.support;
 
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.ExecutionContextDao;
 import org.springframework.batch.core.repository.dao.JobExecutionDao;
 import org.springframework.batch.core.repository.dao.JobInstanceDao;
@@ -38,6 +39,7 @@ import org.springframework.util.Assert;
  * "batch.version")</strong>
  *
  * @author Mahmoud Ben Hassine
+ * @author Myeongha Shin
  * @since 5.2.0
  * @deprecated since 6.0 in favor of {@link MongoJobRepositoryFactoryBean}. Scheduled for
  * removal in 6.2 or later.
@@ -47,28 +49,43 @@ public class MongoJobExplorerFactoryBean extends AbstractJobExplorerFactoryBean 
 
 	private MongoOperations mongoOperations;
 
+	private String collectionPrefix = AbstractMongoBatchMetadataDao.DEFAULT_COLLECTION_PREFIX;
+
 	public void setMongoOperations(MongoOperations mongoOperations) {
 		this.mongoOperations = mongoOperations;
 	}
 
+	public void setCollectionPrefix(String collectionPrefix) {
+		Assert.notNull(collectionPrefix, "Collection prefix must not be null.");
+		this.collectionPrefix = collectionPrefix;
+	}
+
 	@Override
 	protected JobInstanceDao createJobInstanceDao() {
-		return new MongoJobInstanceDao(this.mongoOperations);
+		MongoJobInstanceDao jobInstanceDao = new MongoJobInstanceDao(this.mongoOperations);
+		jobInstanceDao.setCollectionPrefix(this.collectionPrefix);
+		return jobInstanceDao;
 	}
 
 	@Override
 	protected JobExecutionDao createJobExecutionDao() {
-		return new MongoJobExecutionDao(this.mongoOperations);
+		MongoJobExecutionDao jobExecutionDao = new MongoJobExecutionDao(this.mongoOperations);
+		jobExecutionDao.setCollectionPrefix(this.collectionPrefix);
+		return jobExecutionDao;
 	}
 
 	@Override
 	protected StepExecutionDao createStepExecutionDao() {
-		return new MongoStepExecutionDao(this.mongoOperations);
+		MongoStepExecutionDao stepExecutionDao = new MongoStepExecutionDao(this.mongoOperations);
+		stepExecutionDao.setCollectionPrefix(this.collectionPrefix);
+		return stepExecutionDao;
 	}
 
 	@Override
 	protected ExecutionContextDao createExecutionContextDao() {
-		return new MongoExecutionContextDao(this.mongoOperations);
+		MongoExecutionContextDao executionContextDao = new MongoExecutionContextDao(this.mongoOperations);
+		executionContextDao.setCollectionPrefix(this.collectionPrefix);
+		return executionContextDao;
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/MongoJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/MongoJobRepositoryFactoryBean.java
@@ -17,6 +17,7 @@ package org.springframework.batch.core.repository.support;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.batch.core.repository.dao.AbstractMongoBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.mongodb.MongoExecutionContextDao;
 import org.springframework.batch.core.repository.dao.mongodb.MongoJobExecutionDao;
 import org.springframework.batch.core.repository.dao.mongodb.MongoJobInstanceDao;
@@ -37,6 +38,7 @@ import org.springframework.util.Assert;
  * "batch.version")</strong>
  *
  * @author Mahmoud Ben Hassine
+ * @author Myeongha Shin
  * @since 5.2.0
  */
 public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean implements InitializingBean {
@@ -48,6 +50,8 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 	private @Nullable DataFieldMaxValueIncrementer jobExecutionIncrementer;
 
 	private @Nullable DataFieldMaxValueIncrementer stepExecutionIncrementer;
+
+	private String collectionPrefix = AbstractMongoBatchMetadataDao.DEFAULT_COLLECTION_PREFIX;
 
 	public void setMongoOperations(MongoOperations mongoOperations) {
 		this.mongoOperations = mongoOperations;
@@ -65,6 +69,11 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 		this.stepExecutionIncrementer = stepExecutionIncrementer;
 	}
 
+	public void setCollectionPrefix(String collectionPrefix) {
+		Assert.notNull(collectionPrefix, "Collection prefix must not be null.");
+		this.collectionPrefix = collectionPrefix;
+	}
+
 	@Override
 	protected Object getTarget() throws Exception {
 		MongoJobInstanceDao jobInstanceDao = createJobInstanceDao();
@@ -79,6 +88,7 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 	@Override
 	protected MongoJobInstanceDao createJobInstanceDao() {
 		MongoJobInstanceDao mongoJobInstanceDao = new MongoJobInstanceDao(this.mongoOperations);
+		mongoJobInstanceDao.setCollectionPrefix(this.collectionPrefix);
 		mongoJobInstanceDao.setJobKeyGenerator(this.jobKeyGenerator);
 		mongoJobInstanceDao.setJobInstanceIncrementer(this.jobInstanceIncrementer);
 		return mongoJobInstanceDao;
@@ -87,6 +97,7 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 	@Override
 	protected MongoJobExecutionDao createJobExecutionDao() {
 		MongoJobExecutionDao mongoJobExecutionDao = new MongoJobExecutionDao(this.mongoOperations);
+		mongoJobExecutionDao.setCollectionPrefix(this.collectionPrefix);
 		mongoJobExecutionDao.setJobExecutionIncrementer(this.jobExecutionIncrementer);
 		return mongoJobExecutionDao;
 	}
@@ -94,13 +105,16 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 	@Override
 	protected MongoStepExecutionDao createStepExecutionDao() {
 		MongoStepExecutionDao mongoStepExecutionDao = new MongoStepExecutionDao(this.mongoOperations);
+		mongoStepExecutionDao.setCollectionPrefix(this.collectionPrefix);
 		mongoStepExecutionDao.setStepExecutionIncrementer(this.stepExecutionIncrementer);
 		return mongoStepExecutionDao;
 	}
 
 	@Override
 	protected MongoExecutionContextDao createExecutionContextDao() {
-		return new MongoExecutionContextDao(this.mongoOperations);
+		MongoExecutionContextDao executionContextDao = new MongoExecutionContextDao(this.mongoOperations);
+		executionContextDao.setCollectionPrefix(this.collectionPrefix);
+		return executionContextDao;
 	}
 
 	@Override
@@ -108,15 +122,16 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 		super.afterPropertiesSet();
 		Assert.notNull(this.mongoOperations, "MongoOperations must not be null.");
 		if (this.jobInstanceIncrementer == null) {
-			this.jobInstanceIncrementer = new MongoSequenceIncrementer(this.mongoOperations, "BATCH_JOB_INSTANCE_SEQ");
+			this.jobInstanceIncrementer = new MongoSequenceIncrementer(this.mongoOperations, "JOB_INSTANCE_SEQ",
+					this.collectionPrefix);
 		}
 		if (this.jobExecutionIncrementer == null) {
-			this.jobExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations,
-					"BATCH_JOB_EXECUTION_SEQ");
+			this.jobExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations, "JOB_EXECUTION_SEQ",
+					this.collectionPrefix);
 		}
 		if (this.stepExecutionIncrementer == null) {
-			this.stepExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations,
-					"BATCH_STEP_EXECUTION_SEQ");
+			this.stepExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations, "STEP_EXECUTION_SEQ",
+					this.collectionPrefix);
 		}
 	}
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
@@ -33,6 +33,7 @@ import org.springframework.batch.core.converter.JsonJobParametersConverter;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.dao.mongodb.MongoJobInstanceDao;
 import org.springframework.batch.core.repository.dao.jdbc.JdbcExecutionContextDao;
 import org.springframework.batch.core.repository.dao.jdbc.JdbcJobExecutionDao;
 import org.springframework.batch.core.repository.dao.jdbc.JdbcJobInstanceDao;
@@ -215,6 +216,21 @@ class BatchRegistrarTests {
 		Assertions.assertNotNull(jobRepository);
 	}
 
+	@Test
+	@DisplayName("Mongo collection prefix should be configured successfully with @EnableMongoJobRepository")
+	void testMongoCollectionPrefixConfiguredWithEnableMongoJobRepository() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				MongoJobConfigurationWithCustomCollectionPrefix.class);
+
+		JobRepository jobRepository = context.getBean(JobRepository.class);
+		MongoJobInstanceDao jobInstanceDao = (MongoJobInstanceDao) ReflectionTestUtils.getField(jobRepository,
+				"jobInstanceDao");
+
+		Assertions.assertNotNull(jobRepository);
+		Assertions.assertEquals("TEST_COLLECTION_PREFIX_JOB_INSTANCE",
+				ReflectionTestUtils.getField(jobInstanceDao, "collectionName"));
+	}
+
 	@Configuration
 	@EnableBatchProcessing
 	public static class JobConfigurationWithUserDefinedInfrastructureBeans {
@@ -339,6 +355,23 @@ class BatchRegistrarTests {
 	@EnableBatchProcessing
 	@EnableMongoJobRepository
 	public static class MongoJobConfiguration {
+
+		@Bean
+		public MongoOperations mongoTemplate() {
+			return Mockito.mock(MongoOperations.class);
+		}
+
+		@Bean
+		public MongoTransactionManager transactionManager() {
+			return Mockito.mock(MongoTransactionManager.class);
+		}
+
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	@EnableMongoJobRepository(collectionPrefix = "TEST_COLLECTION_PREFIX_")
+	public static class MongoJobConfigurationWithCustomCollectionPrefix {
 
 		@Bean
 		public MongoOperations mongoTemplate() {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/MongoDefaultBatchConfigurationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/support/MongoDefaultBatchConfigurationTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.configuration.support;
+
+import java.util.Map;
+
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.MongoDBTestInfrastructureConfiguration;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * @author Myeongha Shin
+ */
+@DirtiesContext
+@Testcontainers(disabledWithoutDocker = true)
+@SpringJUnitConfig(MongoDefaultBatchConfigurationTests.MyJobConfiguration.class)
+class MongoDefaultBatchConfigurationTests {
+
+	private static final String COLLECTION_PREFIX = "TEST_COLLECTION_PREFIX_";
+
+	@Autowired
+	private MongoTemplate mongoTemplate;
+
+	@BeforeEach
+	void setUp() {
+		createCollections(this.mongoTemplate);
+	}
+
+	@Test
+	void testCustomCollectionPrefix(@Autowired JobOperator jobOperator, @Autowired Job job) throws Exception {
+		JobExecution jobExecution = jobOperator.start(job, new JobParameters());
+
+		Assertions.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+		Assertions.assertEquals(1, mongoTemplate.getCollection(COLLECTION_PREFIX + "JOB_INSTANCE").countDocuments());
+		Assertions.assertEquals(1, mongoTemplate.getCollection(COLLECTION_PREFIX + "JOB_EXECUTION").countDocuments());
+		Assertions.assertEquals(1, mongoTemplate.getCollection(COLLECTION_PREFIX + "STEP_EXECUTION").countDocuments());
+		Assertions.assertFalse(mongoTemplate.collectionExists("BATCH_JOB_INSTANCE"));
+		Assertions.assertFalse(mongoTemplate.collectionExists("BATCH_JOB_EXECUTION"));
+		Assertions.assertFalse(mongoTemplate.collectionExists("BATCH_STEP_EXECUTION"));
+	}
+
+	private void createCollections(MongoTemplate mongoTemplate) {
+		mongoTemplate.createCollection(COLLECTION_PREFIX + "JOB_INSTANCE");
+		mongoTemplate.createCollection(COLLECTION_PREFIX + "JOB_EXECUTION");
+		mongoTemplate.createCollection(COLLECTION_PREFIX + "STEP_EXECUTION");
+		mongoTemplate.createCollection(COLLECTION_PREFIX + "SEQUENCES");
+		MongoCollection<Document> sequencesCollection = mongoTemplate.getCollection(COLLECTION_PREFIX + "SEQUENCES");
+		sequencesCollection.insertOne(new Document(Map.of("_id", COLLECTION_PREFIX + "JOB_INSTANCE_SEQ", "count", 0L)));
+		sequencesCollection
+			.insertOne(new Document(Map.of("_id", COLLECTION_PREFIX + "JOB_EXECUTION_SEQ", "count", 0L)));
+		sequencesCollection
+			.insertOne(new Document(Map.of("_id", COLLECTION_PREFIX + "STEP_EXECUTION_SEQ", "count", 0L)));
+	}
+
+	@Configuration
+	@Import(MongoDBTestInfrastructureConfiguration.class)
+	static class MyJobConfiguration extends MongoDefaultBatchConfiguration {
+
+		@Bean
+		public Job job(JobRepository jobRepository, MongoTransactionManager transactionManager) {
+			return new JobBuilder("job", jobRepository)
+				.start(new StepBuilder("step1", jobRepository)
+					.tasklet((contribution, chunkContext) -> RepeatStatus.FINISHED, transactionManager)
+					.build())
+				.build();
+		}
+
+		@Override
+		protected String getCollectionPrefix() {
+			return COLLECTION_PREFIX;
+		}
+
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/explore/support/MongoJobExplorerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/explore/support/MongoJobExplorerFactoryBeanTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository.explore.support;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.batch.core.repository.explore.JobExplorer;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * @author Myeongha Shin
+ */
+class MongoJobExplorerFactoryBeanTests {
+
+	@Test
+	@SuppressWarnings("removal")
+	void testDefaultCollectionPrefixMaintainsBackwardCompatibility() throws Exception {
+		MongoJobExplorerFactoryBean factoryBean = new MongoJobExplorerFactoryBean();
+		factoryBean.setMongoOperations(Mockito.mock(MongoOperations.class));
+		factoryBean.setTransactionManager(Mockito.mock(PlatformTransactionManager.class));
+		factoryBean.afterPropertiesSet();
+
+		JobExplorer jobExplorer = factoryBean.getObject();
+
+		Assertions.assertNotNull(jobExplorer);
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBCollectionPrefixTestConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBCollectionPrefixTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,27 +26,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.MongoTransactionManager;
-import org.springframework.data.mongodb.core.MongoTemplate;
 
 /**
- * @author Mahmoud Ben Hassine
- * @author Yanming Zhou
+ * Test configuration for MongoDB collection prefix functionality
+ *
+ * @author Myeongha Shin
  */
 @Configuration
 @Import(MongoDBTestInfrastructureConfiguration.class)
 @EnableBatchProcessing
-@EnableMongoJobRepository
-class MongoDBIntegrationTestConfiguration {
+@EnableMongoJobRepository(collectionPrefix = "TEST_COLLECTION_PREFIX_")
+class MongoDBCollectionPrefixTestConfiguration {
 
-	@Bean
-	public JobRepository jobRepository(MongoTemplate mongoTemplate, MongoTransactionManager transactionManager)
-			throws Exception {
-		MongoJobRepositoryFactoryBean jobRepositoryFactoryBean = new MongoJobRepositoryFactoryBean();
-		jobRepositoryFactoryBean.setMongoOperations(mongoTemplate);
-		jobRepositoryFactoryBean.setTransactionManager(transactionManager);
-		jobRepositoryFactoryBean.afterPropertiesSet();
-		return jobRepositoryFactoryBean.getObject();
-	}
+	static final String COLLECTION_PREFIX = "TEST_COLLECTION_PREFIX_";
 
 	@Bean
 	public Job job(JobRepository jobRepository, MongoTransactionManager transactionManager) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryCollectionPrefixTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBJobRepositoryCollectionPrefixTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository.support;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * Test for MongoDB collection prefix functionality
+ *
+ * @author Myeongha Shin
+ */
+@DirtiesContext
+@Testcontainers(disabledWithoutDocker = true)
+@SpringJUnitConfig(MongoDBCollectionPrefixTestConfiguration.class)
+public class MongoDBJobRepositoryCollectionPrefixTests {
+
+	@Autowired
+	private MongoTemplate mongoTemplate;
+
+	private static final String PREFIX = MongoDBCollectionPrefixTestConfiguration.COLLECTION_PREFIX;
+
+	@BeforeEach
+	public void setUp() {
+		// collections with custom prefix
+		mongoTemplate.createCollection(PREFIX + "JOB_INSTANCE");
+		mongoTemplate.createCollection(PREFIX + "JOB_EXECUTION");
+		mongoTemplate.createCollection(PREFIX + "STEP_EXECUTION");
+		// sequences collection with custom prefix
+		mongoTemplate.createCollection(PREFIX + "SEQUENCES");
+		mongoTemplate.getCollection(PREFIX + "SEQUENCES")
+			.insertOne(new Document(Map.of("_id", PREFIX + "JOB_INSTANCE_SEQ", "count", 0L)));
+		mongoTemplate.getCollection(PREFIX + "SEQUENCES")
+			.insertOne(new Document(Map.of("_id", PREFIX + "JOB_EXECUTION_SEQ", "count", 0L)));
+		mongoTemplate.getCollection(PREFIX + "SEQUENCES")
+			.insertOne(new Document(Map.of("_id", PREFIX + "STEP_EXECUTION_SEQ", "count", 0L)));
+	}
+
+	@Test
+	void testJobExecutionWithCustomPrefix(@Autowired JobOperator jobOperator, @Autowired Job job,
+			@Autowired JobRepository jobRepository) throws Exception {
+		// given
+		JobParameters jobParameters = new JobParametersBuilder().addString("name", "foo")
+			.addLocalDateTime("runtime", LocalDateTime.now())
+			.toJobParameters();
+
+		// when
+		JobExecution jobExecution = jobOperator.start(job, jobParameters);
+
+		// then
+		Assertions.assertNotNull(jobExecution);
+		Assertions.assertEquals(ExitStatus.COMPLETED, jobExecution.getExitStatus());
+
+		// Verify data is stored in collections with custom prefix
+		MongoCollection<Document> jobInstancesCollection = mongoTemplate.getCollection(PREFIX + "JOB_INSTANCE");
+		MongoCollection<Document> jobExecutionsCollection = mongoTemplate.getCollection(PREFIX + "JOB_EXECUTION");
+		MongoCollection<Document> stepExecutionsCollection = mongoTemplate.getCollection(PREFIX + "STEP_EXECUTION");
+
+		Assertions.assertEquals(1, jobInstancesCollection.countDocuments());
+		Assertions.assertEquals(1, jobExecutionsCollection.countDocuments());
+		Assertions.assertEquals(2, stepExecutionsCollection.countDocuments());
+
+		JobExecution actualJobExecution = jobRepository.getJobExecution(jobExecution.getId());
+		StepExecution stepExecution = jobExecution.getStepExecutions().stream().findFirst().orElseThrow();
+		StepExecution actualStepExecution = jobRepository.getStepExecution(jobExecution.getId(), stepExecution.getId());
+
+		Assertions.assertNotNull(actualJobExecution);
+		Assertions.assertEquals(jobExecution.getId(), actualJobExecution.getId());
+		Assertions.assertNotNull(actualStepExecution);
+		Assertions.assertEquals(stepExecution.getId(), actualStepExecution.getId());
+
+		// Verify default collections are empty
+		Assertions.assertFalse(mongoTemplate.collectionExists("BATCH_JOB_INSTANCE"));
+		Assertions.assertFalse(mongoTemplate.collectionExists("BATCH_JOB_EXECUTION"));
+		Assertions.assertFalse(mongoTemplate.collectionExists("BATCH_STEP_EXECUTION"));
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBTestInfrastructureConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoDBTestInfrastructureConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository.support;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.testcontainers.mongodb.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Shared MongoDB test infrastructure.
+ *
+ * @author Myeongha Shin
+ */
+@Configuration
+public class MongoDBTestInfrastructureConfiguration {
+
+	private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:8.0.11");
+
+	@Bean(initMethod = "start")
+	public MongoDBContainer mongoDBContainer() {
+		return new MongoDBContainer(MONGODB_IMAGE).withReplicaSet();
+	}
+
+	@Bean
+	public MongoDatabaseFactory mongoDatabaseFactory(MongoDBContainer mongoDBContainer) {
+		return new SimpleMongoClientDatabaseFactory(mongoDBContainer.getConnectionString() + "/test");
+	}
+
+	@Bean
+	public MongoTemplate mongoTemplate(MongoDatabaseFactory mongoDatabaseFactory) {
+		MongoTemplate template = new MongoTemplate(mongoDatabaseFactory);
+		MappingMongoConverter converter = (MappingMongoConverter) template.getConverter();
+		converter.setMapKeyDotReplacement(".");
+		return template;
+	}
+
+	@Bean
+	public MongoTransactionManager transactionManager(MongoDatabaseFactory mongoDatabaseFactory) {
+		MongoTransactionManager mongoTransactionManager = new MongoTransactionManager();
+		mongoTransactionManager.setDatabaseFactory(mongoDatabaseFactory);
+		mongoTransactionManager.afterPropertiesSet();
+		return mongoTransactionManager;
+	}
+
+}


### PR DESCRIPTION
📝 Description
This PR adds collection prefix support for MongoDB job repository, mirroring the existing tablePrefix functionality in JDBC job repository. This enables multi-application support, environment isolation, and easier management of MongoDB collections in Spring Batch deployments.

🎯 Motivation
Currently, MongoDB job repository uses hardcoded collection names (BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION, etc.), making it difficult to:

Run multiple Spring Batch applications against the same MongoDB database
Isolate different environments (dev, test, prod)
Manage collections with custom naming conventions

🔧 Changes
EnableMongoJobRepository: Add collectionPrefix parameter (defaults to "BATCH_")
MongoJobRepositoryFactoryBean: Add collection prefix support
MongoDB DAO classes: Support configurable collection names via constructor parameters
BatchRegistrar: Pass collection prefix from annotation to factory bean
Tests: Add integration tests for collection prefix functionality

💡 Usage Example
```
@EnableBatchProcessing
@EnableMongoJobRepository(collectionPrefix = "MY_APP_")
public class BatchConfiguration {
    // Configuration
}
```

This will create collections like:
MY_APP_JOB_INSTANCE
MY_APP_JOB_EXECUTION
MY_APP_STEP_EXECUTION

Closes: [collectionPrefix for MongoDB Job repository #4980](https://github.com/spring-projects/spring-batch/issues/4980)