### PR TITLE
Improve javadoc of JobInstanceDao#getJobNames method

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JobInstanceDao.java
@@ -125,11 +125,9 @@ public interface JobInstanceDao {
 	}
 
 	/**
-	 * Retrieve the names of all job instances sorted alphabetically - i.e. jobs that have
-	 * ever been executed.
-	 * @return the names of all job instances
+	 * Retrieve the names of all jobs for which job instances exist, sorted alphabetically.
+	 * @return the names of all jobs with job instances
 	 */
-	// FIXME javadoc: i.e. jobs that have * ever been executed ?
 	List<String> getJobNames();
 
 	/**


### PR DESCRIPTION
Fixed javadoc for `getJobNames()` to clarify it returns job names for which job instances exist.

Removed FIXME comment.