### PR TITLE
Fix potential NPE in JdbcJobExecutionDao

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobExecutionDao.java
@@ -314,10 +314,10 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 	public JobExecution getLastJobExecution(JobInstance jobInstance) {
 		long jobInstanceId = jobInstance.getId();
 
-		long lastJobExecutionId = getJdbcTemplate().queryForObject(getQuery(GET_LAST_JOB_EXECUTION_ID),
-				(rs, rowNum) -> rs.getLong(1), jobInstanceId, jobInstanceId);
+		Long lastJobExecutionId = getJdbcTemplate().queryForObject(getQuery(GET_LAST_JOB_EXECUTION_ID), Long.class,
+				jobInstanceId, jobInstanceId);
 
-		return getJobExecution(lastJobExecutionId);
+		return lastJobExecutionId != null ? getJobExecution(lastJobExecutionId) : null;
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobDaoTests.java
@@ -254,6 +254,8 @@ public abstract class AbstractJobDaoTests {
 	@Transactional
 	@Test
 	void testGetLastJobExecution() {
+		assertEquals(null, jobExecutionDao.getLastJobExecution(jobInstance));
+
 		JobExecution lastExecution = new JobExecution(1L, jobInstance, jobParameters);
 		lastExecution.setStatus(BatchStatus.STARTED);
 


### PR DESCRIPTION
The result set may be empty then unbox `lastJobExecutionId` will cause NPE.