### PR TITLE
Implement `ItemStreamWriter` in `MappingItemWriter`

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/readers-and-writers/item-reader-writer-implementations.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/readers-and-writers/item-reader-writer-implementations.adoc
@@ -7,11 +7,9 @@ discussed in the previous sections.
 [[decorators]]
 == Decorators
 
-In some cases, a user needs specialized behavior to be appended to a pre-existing
-`ItemReader`.   Spring Batch offers some out of the box decorators that can add
-additional behavior to to your `ItemReader` and `ItemWriter` implementations.
-
-Spring Batch includes the following decorators:
+In some cases, you might need specialized behavior to be appended to a pre-existing
+`ItemReader` or `ItemWriter` implementation.
+For this purpose, Spring Batch offers the following out-of-the-box decorators:
 
 * xref:readers-and-writers/item-reader-writer-implementations.adoc#synchronizedItemStreamReader[`SynchronizedItemStreamReader`]
 * xref:readers-and-writers/item-reader-writer-implementations.adoc#singleItemPeekableItemReader[`SingleItemPeekableItemReader`]
@@ -113,10 +111,12 @@ through the provided `Classifier`. Spring Batch provides a
 
 The `MappingItemWriter` adapts an `ItemWriter` accepting items of a given type to one accepting
 items of another type by applying a mapping function to each item before writing.
+Thread-safety is guaranteed as long as the downstream item writer is thread-safe, and state
+management is honored with a downstream `ItemStream` item writer.
 
 This item writer is most useful when used in combination with a `CompositeItemWriter`, where the
 mapping function in front of the downstream writer can be a getter of the input item or a more
-complex transformation logic.
+complex transformation logic, effectively allowing deconstruction patterns.
 
 [[messagingReadersAndWriters]]
 == Messaging Readers And Writers

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/MappingItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/MappingItemWriter.java
@@ -17,6 +17,10 @@
 package org.springframework.batch.infrastructure.item.support;
 
 import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemStream;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.batch.infrastructure.item.ItemStreamWriter;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 
 import java.util.function.Function;
@@ -25,10 +29,14 @@ import java.util.function.Function;
  * Adapts an {@link ItemWriter} accepting items of type {@link U} to one accepting items
  * of type {@link T} by applying a mapping function to each item before writing.
  * <p>
- * The {@code MappingItemWriter} is most useful when used in combination with a
+ * Thread-safety is guaranteed as long as the downstream item writer is thread-safe, and
+ * state management is honored with a downstream {@link ItemStream} item writer.
+ * <p>
+ * This adapter is most useful when used in combination with a
  * {@link org.springframework.batch.infrastructure.item.support.CompositeItemWriter},
  * where the mapping function in front of the downstream writer can be a getter of the
- * input item or a more complex transformation logic.
+ * input item or a more complex transformation logic, effectively allowing deconstruction
+ * patterns.
  * <p>
  * This adapter mimics the behavior of
  * {@link java.util.stream.Collectors#mapping(Function, java.util.stream.Collector)}.
@@ -38,7 +46,7 @@ import java.util.function.Function;
  * @author Stefano Cordio
  * @since 6.0
  */
-public class MappingItemWriter<T, U> implements ItemWriter<T> {
+public class MappingItemWriter<T, U> implements ItemStreamWriter<T> {
 
 	private final Function<? super T, ? extends U> mapper;
 
@@ -57,6 +65,27 @@ public class MappingItemWriter<T, U> implements ItemWriter<T> {
 	@Override
 	public void write(Chunk<? extends T> chunk) throws Exception {
 		downstream.write(new Chunk<>(chunk.getItems().stream().map(mapper).toList()));
+	}
+
+	@Override
+	public void open(ExecutionContext executionContext) throws ItemStreamException {
+		if (downstream instanceof ItemStream itemStream) {
+			itemStream.open(executionContext);
+		}
+	}
+
+	@Override
+	public void update(ExecutionContext executionContext) throws ItemStreamException {
+		if (downstream instanceof ItemStream itemStream) {
+			itemStream.update(executionContext);
+		}
+	}
+
+	@Override
+	public void close() throws ItemStreamException {
+		if (downstream instanceof ItemStream itemStream) {
+			itemStream.close();
+		}
 	}
 
 }


### PR DESCRIPTION
This change:
* Adds state management delegation to `MappingItemWriter` by implementing `ItemStreamWriter`
* Enhances the `MappingItemWriter` reference documentation section