### PR TITLE
Incorrect error message in JobOperatorTestUtils constructor

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobOperatorTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobOperatorTestUtils.java
@@ -86,7 +86,7 @@ public class JobOperatorTestUtils extends JobLauncherTestUtils {
 	 * @param jobRepository to use to access job metadata
 	 */
 	public JobOperatorTestUtils(JobOperator jobOperator, JobRepository jobRepository) {
-		Assert.notNull(jobOperator, "JobRepository must not be null");
+		Assert.notNull(jobOperator, "JobOperator must not be null");
 		Assert.notNull(jobRepository, "JobRepository must not be null");
 		this.jobOperator = jobOperator;
 		this.jobRepository = jobRepository;


### PR DESCRIPTION
## What
Fix incorrect error message in `JobOperatorTestUtils` constructor

## Why  
The first `Assert.notNull` statement was incorrectly referencing 'JobRepository' when it should reference 'JobOperator' for the jobOperator parameter validation.

## Changes
- Changed error message from "JobRepository must not be null" to "JobOperator must not be null" in the first assertion

Fixes gh-5051

---

**Checklist:**
- [x] Rebased on latest `main` branch
- [x] All tests pass
- [x] Commits are signed-off (DCO)
- [x] No new unit tests needed (simple error message correction)