### PR TITLE
Support Lambda configuration in FlatFileItem builders

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemWriterBuilder.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -50,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Mahmoud Ben Hassine
  * @author Drummond Dawson
  * @author Stefano Cordio
+ * @author Daeho Kwon
  * @since 4.0
  * @see FlatFileItemWriter
  */
@@ -264,6 +266,29 @@ public class FlatFileItemWriterBuilder<T> {
 	}
 
 	/**
+	 * Configure a {@link DelimitedSpec} using a lambda.
+	 * @return the current builder instance
+	 */
+	public FlatFileItemWriterBuilder<T> delimited(Consumer<DelimitedSpec<T>> config) {
+		DelimitedSpecImpl<T> spec = new DelimitedSpecImpl<>();
+		config.accept(spec);
+
+		DelimitedBuilder<T> b = this.delimited();
+		b.delimiter(spec.delimiter);
+		b.quoteCharacter(spec.quoteCharacter);
+		if (spec.sourceType != null) {
+			b.sourceType(spec.sourceType);
+		}
+		if (spec.fieldExtractor != null) {
+			b.fieldExtractor(spec.fieldExtractor);
+		}
+		if (!spec.names.isEmpty()) {
+			b.names(spec.names.toArray(new String[0]));
+		}
+		return this;
+	}
+
+	/**
 	 * Returns an instance of a {@link FormattedBuilder} for building a
 	 * {@link FormatterLineAggregator}. The {@link FormatterLineAggregator} configured by
 	 * this builder will only be used if one is not explicitly configured via
@@ -274,6 +299,33 @@ public class FlatFileItemWriterBuilder<T> {
 	public FormattedBuilder<T> formatted() {
 		this.formattedBuilder = new FormattedBuilder<>(this);
 		return this.formattedBuilder;
+	}
+
+	/**
+	 * Configure a {@link FormattedSpec} using a lambda.
+	 * @return the current builder instance
+	 */
+	public FlatFileItemWriterBuilder<T> formatted(Consumer<FormattedSpec<T>> config) {
+		FormattedSpecImpl<T> spec = new FormattedSpecImpl<>();
+		config.accept(spec);
+
+		FormattedBuilder<T> b = this.formatted();
+		if (spec.format != null) {
+			b.format(spec.format);
+		}
+		b.locale(spec.locale);
+		b.minimumLength(spec.minimumLength);
+		b.maximumLength(spec.maximumLength);
+		if (spec.sourceType != null) {
+			b.sourceType(spec.sourceType);
+		}
+		if (spec.fieldExtractor != null) {
+			b.fieldExtractor(spec.fieldExtractor);
+		}
+		if (!spec.names.isEmpty()) {
+			b.names(spec.names.toArray(new String[0]));
+		}
+		return this;
 	}
 
 	/**
@@ -587,6 +639,142 @@ public class FlatFileItemWriterBuilder<T> {
 		writer.setTransactional(this.transactional);
 
 		return writer;
+	}
+
+	public interface DelimitedSpec<T> {
+
+		DelimitedSpec<T> delimiter(String delimiter);
+
+		DelimitedSpec<T> quoteCharacter(String quoteCharacter);
+
+		DelimitedSpec<T> names(String... names);
+
+		DelimitedSpec<T> fieldExtractor(FieldExtractor<T> fieldExtractor);
+
+		DelimitedSpec<T> sourceType(Class<T> sourceType);
+
+	}
+
+	public interface FormattedSpec<T> {
+
+		FormattedSpec<T> format(String format);
+
+		FormattedSpec<T> locale(Locale locale);
+
+		FormattedSpec<T> minimumLength(int min);
+
+		FormattedSpec<T> maximumLength(int max);
+
+		FormattedSpec<T> names(String... names);
+
+		FormattedSpec<T> fieldExtractor(FieldExtractor<T> fieldExtractor);
+
+		FormattedSpec<T> sourceType(Class<T> sourceType);
+
+	}
+
+	private static class DelimitedSpecImpl<T> implements DelimitedSpec<T> {
+
+		final List<String> names = new ArrayList<>();
+
+		String delimiter = ",";
+
+		String quoteCharacter = "";
+
+		@Nullable FieldExtractor<T> fieldExtractor;
+
+		@Nullable Class<T> sourceType;
+
+		@Override
+		public DelimitedSpec<T> delimiter(String d) {
+			this.delimiter = d;
+			return this;
+		}
+
+		@Override
+		public DelimitedSpec<T> quoteCharacter(String qc) {
+			this.quoteCharacter = qc;
+			return this;
+		}
+
+		@Override
+		public DelimitedSpec<T> names(String... n) {
+			this.names.addAll(Arrays.asList(n));
+			return this;
+		}
+
+		@Override
+		public DelimitedSpec<T> fieldExtractor(FieldExtractor<T> fe) {
+			this.fieldExtractor = fe;
+			return this;
+		}
+
+		@Override
+		public DelimitedSpec<T> sourceType(Class<T> st) {
+			this.sourceType = st;
+			return this;
+		}
+
+	}
+
+	private static class FormattedSpecImpl<T> implements FormattedSpec<T> {
+
+		@Nullable String format;
+
+		Locale locale = Locale.getDefault();
+
+		int minimumLength = 0;
+
+		int maximumLength = 0;
+
+		final List<String> names = new ArrayList<>();
+
+		@Nullable FieldExtractor<T> fieldExtractor;
+
+		@Nullable Class<T> sourceType;
+
+		@Override
+		public FormattedSpec<T> format(String f) {
+			this.format = f;
+			return this;
+		}
+
+		@Override
+		public FormattedSpec<T> locale(Locale l) {
+			this.locale = l;
+			return this;
+		}
+
+		@Override
+		public FormattedSpec<T> minimumLength(int min) {
+			this.minimumLength = min;
+			return this;
+		}
+
+		@Override
+		public FormattedSpec<T> maximumLength(int max) {
+			this.maximumLength = max;
+			return this;
+		}
+
+		@Override
+		public FormattedSpec<T> names(String... n) {
+			this.names.addAll(Arrays.asList(n));
+			return this;
+		}
+
+		@Override
+		public FormattedSpec<T> fieldExtractor(FieldExtractor<T> fe) {
+			this.fieldExtractor = fe;
+			return this;
+		}
+
+		@Override
+		public FormattedSpec<T> sourceType(Class<T> st) {
+			this.sourceType = st;
+			return this;
+		}
+
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Glenn Renfro
  * @author Patrick Baumgartner
  * @author François Martin
+ * @author Daeho Kwon
  */
 class FlatFileItemReaderBuilderTests {
 
@@ -627,6 +628,39 @@ class FlatFileItemReaderBuilderTests {
 		Object fieldSetMapper = ReflectionTestUtils.getField(lineMapper, "fieldSetMapper");
 		assertNotNull(fieldSetMapper);
 		assertInstanceOf(BeanWrapperFieldSetMapper.class, fieldSetMapper);
+	}
+
+	@Test
+	void testDelimitedBuilderLambda() throws Exception {
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+			.resource(getResource("1,2,3"))
+			.delimited(config -> config.delimiter(",").names("first", "second", "third"))
+			.targetType(Foo.class)
+			.build();
+
+		reader.open(new ExecutionContext());
+		Foo item = reader.read();
+		assertEquals(1, item.getFirst());
+		assertEquals(2, item.getSecond());
+		assertEquals("3", item.getThird());
+		assertNull(reader.read());
+	}
+
+	@Test
+	void testFixedLengthBuilderLambda() throws Exception {
+		FlatFileItemReader<Foo> reader = new FlatFileItemReaderBuilder<Foo>().name("fooReader")
+			.resource(getResource("1  2  3"))
+			.fixedLength(config -> config.columns(new Range(1, 3), new Range(4, 6), new Range(7))
+				.names("first", "second", "third"))
+			.targetType(Foo.class)
+			.build();
+
+		reader.open(new ExecutionContext());
+		Foo item = reader.read();
+		assertEquals(1, item.getFirst());
+		assertEquals(2, item.getSecond());
+		assertEquals("3", item.getThird());
+		assertNull(reader.read());
 	}
 
 	private Resource getResource(String contents) {


### PR DESCRIPTION
### Description
This PR addresses #4818

- Added `DelimitedSpec` / `FixedLengthSpec` interfaces for ` FlatFileItemReaderBuilder`
- Added `DelimitedSpec` / `FormattedSpec` interfaces for `FlatFileItemWriterBuilder`
- Introduced overloaded methods for lambda-style configuration

Closes gh-4818