### PR TITLE
Rename unique job parameter name to batch.random in test utilities

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobLauncherTestUtils.java
@@ -57,8 +57,8 @@ import org.jspecify.annotations.Nullable;
  * <p>
  * It should be noted that using any of the methods that don't contain
  * {@link JobParameters} in their signature, will result in one being created with a
- * random number of type {@code long} as a parameter. This will ensure restartability when
- * no parameters are provided.
+ * random number of type {@code long} as a parameter with the name {@code batch.random}.
+ * This will ensure restartability when no parameters are provided.
  * </p>
  *
  * @author Lucas Ward
@@ -159,16 +159,18 @@ public class JobLauncherTestUtils {
 	}
 
 	/**
-	 * @return a new JobParameters object containing only a parameter with a random number
-	 * of type {@code long}, to ensure that the job instance will be unique.
+	 * @return a new JobParameters object containing only a parameter named
+	 * {@code batch.random} with a random number of type {@code long}, to ensure that the
+	 * job instance will be unique.
 	 */
 	public JobParameters getUniqueJobParameters() {
-		return new JobParameters(Set.of(new JobParameter<>("random", this.secureRandom.nextLong(), Long.class)));
+		return new JobParameters(Set.of(new JobParameter<>("batch.random", this.secureRandom.nextLong(), Long.class)));
 	}
 
 	/**
-	 * @return a new JobParametersBuilder object containing only a parameter with a random
-	 * number of type {@code long}, to ensure that the job instance will be unique.
+	 * @return a new JobParametersBuilder object containing only a parameter named
+	 * {@code batch.random} with a random number of type {@code long}, to ensure that the
+	 * job instance will be unique.
 	 */
 	public JobParametersBuilder getUniqueJobParametersBuilder() {
 		return new JobParametersBuilder(this.getUniqueJobParameters());

--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobOperatorTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobOperatorTestUtils.java
@@ -61,8 +61,8 @@ import org.springframework.util.Assert;
  * <p>
  * It should be noted that using any of the methods that don't contain
  * {@link JobParameters} in their signature, will result in one being created with a
- * random number of type {@code long} as a parameter. This will ensure restartability when
- * no parameters are provided.
+ * random number of type {@code long} as a parameter with the name {@code batch.random}.
+ * This will ensure restartability when no parameters are provided.
  * </p>
  *
  * @author Mahmoud Ben Hassine
@@ -230,17 +230,18 @@ public class JobOperatorTestUtils extends JobLauncherTestUtils {
 	}
 
 	/**
-	 * @return a new {@link JobParameters} object containing only a parameter with a
-	 * random number of type {@code long}, to ensure that the job instance will be unique.
+	 * @return a new {@link JobParameters} object containing only a parameter named
+	 * {@code batch.random} with a random number of type {@code long}, to ensure that the
+	 * job instance will be unique.
 	 */
 	public JobParameters getUniqueJobParameters() {
 		return super.getUniqueJobParameters();
 	}
 
 	/**
-	 * @return a new {@link JobParametersBuilder} object containing only a parameter with
-	 * a random number of type {@code long}, to ensure that the job instance will be
-	 * unique.
+	 * @return a new {@link JobParametersBuilder} object containing only a parameter named
+	 * {@code batch.random} with a random number of type {@code long}, to ensure that the
+	 * job instance will be unique.
 	 */
 	public JobParametersBuilder getUniqueJobParametersBuilder() {
 		return super.getUniqueJobParametersBuilder();


### PR DESCRIPTION
Fixes #5088

## Summary

This PR addresses a parameter collision issue in the test utilities by prefixing framework-provided parameters with `batch.`. The previous parameter name `random` could conflict with user-defined parameters. Following the framework convention (similar to execution context attributes), framework-provided parameters now use the `batch.` prefix.

## Changes

- Renamed the parameter from `random` to `batch.random` in `getUniqueJobParameters()`
- Updated Javadocs in both `JobLauncherTestUtils` and `JobOperatorTestUtils` to explicitly document the parameter name `batch.random`

**Before:**
```java
public JobParameters getUniqueJobParameters() {
    return new JobParameters(Set.of(
        new JobParameter<>("random", this.secureRandom.nextLong(), Long.class)
    ));
}
```

**After:**
```java
public JobParameters getUniqueJobParameters() {
    return new JobParameters(Set.of(
        new JobParameter<>("batch.random", this.secureRandom.nextLong(), Long.class)
    ));
}
```

## Example

Users can now safely use `random` as their own parameter name without collision:

```java
JobParameters params = jobOperatorTestUtils.getUniqueJobParametersBuilder()
    .addLong("random", 12345L)  // Safe - no collision with batch.random!
    .toJobParameters();
```
