### PR TITLE
correct JobOperatorFactoryBean sample code

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/job/configuring-operator.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/job/configuring-operator.adoc
@@ -21,7 +21,7 @@ The following example shows how to configure a `TaskExecutorJobOperator` in Java
 @Bean
 public JobOperatorFactoryBean jobOperator(JobRepository jobRepository) {
 	JobOperatorFactoryBean jobOperatorFactoryBean = new JobOperatorFactoryBean();
-	jobOperator.setJobRepository(jobRepository);
+	jobOperatorFactoryBean.setJobRepository(jobRepository);
 	return jobOperatorFactoryBean;
 }
 ...
@@ -74,8 +74,8 @@ The following Java example configures a `TaskExecutorJobOperator` to return imme
 @Bean
 public JobOperatorFactoryBean jobOperator(JobRepository jobRepository) {
 	JobOperatorFactoryBean jobOperatorFactoryBean = new JobOperatorFactoryBean();
-	jobOperator.setJobRepository(jobRepository);
-	jobOperator.setTaskExecutor(new SimpleAsyncTaskExecutor());
+	jobOperatorFactoryBean.setJobRepository(jobRepository);
+	jobOperatorFactoryBean.setTaskExecutor(new SimpleAsyncTaskExecutor());
 	return jobOperatorFactoryBean;
 }
 ----


### PR DESCRIPTION
Hello, I was reading the Spring Batch 6.0 documentation and noticed a typo, so I’m submitting this fix.
There is a variable name typo in the JobOperator example.