### PR TITLE
Remove redundant assert in StoredProcedureItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/StoredProcedureItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/StoredProcedureItemReader.java
@@ -157,8 +157,6 @@ public class StoredProcedureItemReader<T> extends AbstractCursorItemReader<T> {
 	protected void openCursor(Connection con) {
 		Assert.state(refCursorPosition >= 0, "invalid refCursorPosition specified as " + refCursorPosition
 				+ "; it can't be " + "specified as a negative number.");
-		Assert.state(refCursorPosition == 0 || refCursorPosition > 0, "invalid refCursorPosition specified as "
-				+ refCursorPosition + "; there are " + parameters.length + " parameters defined.");
 
 		CallMetaDataContext callContext = new CallMetaDataContext();
 		callContext.setAccessCallParameterMetaData(false);


### PR DESCRIPTION
PR Description

This PR removes a redundant assertion in StoredProcedureItemReader.

The removed line was:
```java
Assert.state(refCursorPosition == 0 || refCursorPosition > 0, ...);
```
does not provide any real validation.The condition is always true for any non-negative value, and the preceding refCursorPosition >= 0 check already covers the only meaningful case.
The message also hints at parameter-bound validation that never happens.

This assertion was introduced in:
[8f70ed8](https://github.com/spring-projects/spring-batch/commit/8f70ed8a31dc108204baabbc92026c5a0ee36f99)
