### PR TITLE
Fix step execution context is not persisted and restored

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
@@ -45,6 +45,7 @@ import org.springframework.batch.infrastructure.item.ExecutionContext;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  * @since 2.0
  */
 public class SimpleStepExecutionSplitter implements StepExecutionSplitter {
@@ -138,6 +139,7 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter {
 			if (lastStepExecution == null) { // fresh start
 				StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution);
 				currentStepExecution.setExecutionContext(context.getValue());
+				jobRepository.updateExecutionContext(currentStepExecution);
 				set.add(currentStepExecution);
 			}
 			else { // restart
@@ -145,6 +147,7 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter {
 						&& shouldStart(allowStartIfComplete, stepExecution, lastStepExecution)) {
 					StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution);
 					currentStepExecution.setExecutionContext(lastStepExecution.getExecutionContext());
+					jobRepository.updateExecutionContext(currentStepExecution);
 					set.add(currentStepExecution);
 				}
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -52,6 +52,7 @@ import java.util.List;
  * @author Baris Cubukcuoglu
  * @author Parikshit Dutta
  * @author Mark John Moreno
+ * @author Yanming Zhou
  * @see JobRepository
  * @see JobInstanceDao
  * @see JobExecutionDao
@@ -82,7 +83,13 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 	@Nullable
 	@Override
 	public StepExecution getStepExecution(long executionId) {
-		return this.stepExecutionDao.getStepExecution(executionId);
+		StepExecution stepExecution = this.stepExecutionDao.getStepExecution(executionId);
+		if (stepExecution != null) {
+			fillStepExecutionDependencies(stepExecution);
+			ExecutionContext jobExecutionContext = this.ecDao.getExecutionContext(stepExecution.getJobExecution());
+			stepExecution.getJobExecution().setExecutionContext(jobExecutionContext);
+		}
+		return stepExecution;
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryIntegrationTests.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Robert Kasanicky
  * @author Dimitrios Liapis
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  */
 // TODO rename to JdbcJobRepositoryIntegrationTests and update to new domain model
 // TODO should add a mongodb similar test suite
@@ -168,11 +169,17 @@ class SimpleJobRepositoryIntegrationTests {
 		JobExecution jobExec = jobRepository.createJobExecution(jobInstance, jobParameters, new ExecutionContext());
 		jobExec.setStartTime(LocalDateTime.now());
 		jobExec.setExecutionContext(ctx);
+		jobRepository.updateExecutionContext(jobExec);
 		Step step = new StepSupport("step1");
 		StepExecution stepExec = jobRepository.createStepExecution(step.getName(), jobExec);
 		stepExec.setExecutionContext(ctx);
+		jobRepository.updateExecutionContext(stepExec);
 
 		StepExecution retrievedStepExec = jobRepository.getLastStepExecution(jobExec.getJobInstance(), step.getName());
+		assertEquals(stepExec, retrievedStepExec);
+		assertEquals(ctx, retrievedStepExec.getExecutionContext());
+
+		retrievedStepExec = jobRepository.getStepExecution(stepExec.getId());
 		assertEquals(stepExec, retrievedStepExec);
 		assertEquals(ctx, retrievedStepExec.getExecutionContext());
 	}


### PR DESCRIPTION
1. Step execution context is not persisted in `SimpleStepExecutionSplitter::split`
2. Step execution context is not restored in `SimpleJobRepository::getStepExecution`

Closes GH-5138
