### PR TITLE
Default event-based item readers to bean name and remove strict name assertions

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/MongoCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/MongoCursorItemReader.java
@@ -28,6 +28,7 @@ import org.bson.codecs.DecoderContext;
 import org.jspecify.annotations.Nullable;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -45,9 +46,11 @@ import org.springframework.util.StringUtils;
  * @author LEE Juchan
  * @author Mahmoud Ben Hassine
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  * @since 5.1
  */
-public class MongoCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements InitializingBean {
+public class MongoCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
+		implements InitializingBean, BeanNameAware {
 
 	private MongoOperations template;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/MongoPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/MongoPagingItemReader.java
@@ -25,6 +25,7 @@ import org.bson.codecs.DecoderContext;
 import org.jspecify.annotations.Nullable;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -79,8 +80,10 @@ import org.springframework.util.StringUtils;
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  */
-public class MongoPagingItemReader<T> extends AbstractPaginatedDataItemReader<T> implements InitializingBean {
+public class MongoPagingItemReader<T> extends AbstractPaginatedDataItemReader<T>
+		implements InitializingBean, BeanNameAware {
 
 	protected MongoOperations template;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/RepositoryItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/RepositoryItemReader.java
@@ -31,6 +31,7 @@ import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.adapter.AbstractMethodInvokingDelegator.InvocationTargetThrowableWrapper;
 import org.springframework.batch.infrastructure.item.adapter.DynamicMethodInvocationException;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -80,9 +81,11 @@ import org.springframework.util.StringUtils;
  * @author Antoine Kapps
  * @author Mahmoud Ben Hassine
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  * @since 2.2
  */
-public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements InitializingBean {
+public class RepositoryItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
+		implements InitializingBean, BeanNameAware {
 
 	protected Log logger = LogFactory.getLog(getClass());
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/MongoCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/MongoCursorItemReaderBuilder.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author LEE Juchan
  * @author Mahmoud Ben Hassine
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 5.1
  * @see MongoCursorItemReader
  */
@@ -278,9 +279,6 @@ public class MongoCursorItemReaderBuilder<T> {
 
 	public MongoCursorItemReader<T> build() {
 		Assert.notNull(this.template, "template is required.");
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
 		Assert.notNull(this.targetType, "targetType is required.");
 		Assert.state(StringUtils.hasText(this.jsonQuery) || this.query != null, "A query is required");
 		Assert.notNull(this.sorts, "sorts map is required.");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/MongoPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/MongoPagingItemReaderBuilder.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Drummond Dawson
  * @author Parikshit Dutta
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 5.1
  */
 public class MongoPagingItemReaderBuilder<T> {
@@ -263,9 +264,6 @@ public class MongoPagingItemReaderBuilder<T> {
 
 	public MongoPagingItemReader<T> build() {
 		Assert.notNull(this.template, "template is required.");
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
 		Assert.notNull(this.targetType, "targetType is required.");
 		Assert.state(StringUtils.hasText(this.jsonQuery) || this.query != null, "A query is required");
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/RepositoryItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/RepositoryItemReaderBuilder.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
  * @author Drummond Dawson
+ * @author Andrey Litvitski
  * @since 4.0
  * @see RepositoryItemReader
  */
@@ -192,9 +193,6 @@ public class RepositoryItemReaderBuilder<T> {
 		Assert.notNull(this.repository, "repository is required.");
 		Assert.isTrue(this.pageSize > 0, "Page size must be greater than 0");
 		Assert.hasText(this.methodName, "methodName is required.");
-		if (this.saveState) {
-			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
-		}
 
 		RepositoryItemReader<T> reader = new RepositoryItemReader<>(this.repository, this.sorts);
 		if (this.arguments != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JdbcCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JdbcCursorItemReader.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 
 import org.jspecify.annotations.Nullable;
@@ -62,8 +63,9 @@ import org.springframework.util.ClassUtils;
  * @author Mahmoud Ben Hassine
  * @author Stefano Cordio
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  */
-public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> {
+public class JdbcCursorItemReader<T> extends AbstractCursorItemReader<T> implements BeanNameAware {
 
 	private @Nullable PreparedStatement preparedStatement;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JdbcPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JdbcPagingItemReader.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -75,9 +76,10 @@ import org.springframework.util.ClassUtils;
  * @author Mahmoud Ben Hassine
  * @author Stefano Cordio
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  * @since 2.0
  */
-public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> implements InitializingBean {
+public class JdbcPagingItemReader<T> extends AbstractPagingItemReader<T> implements InitializingBean, BeanNameAware {
 
 	private static final String START_AFTER_VALUE = "start.after";
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JpaCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JpaCursorItemReader.java
@@ -28,6 +28,7 @@ import org.springframework.batch.infrastructure.item.ItemStreamException;
 import org.springframework.batch.infrastructure.item.ItemStreamReader;
 import org.springframework.batch.infrastructure.item.database.orm.JpaQueryProvider;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.util.Assert;
@@ -46,10 +47,12 @@ import org.springframework.util.StringUtils;
  * @author Jinwoo Bae
  * @author Stefano Cordio
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  * @param <T> type of items to read
  * @since 4.3
  */
-public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> implements InitializingBean {
+public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
+		implements InitializingBean, BeanNameAware {
 
 	private EntityManagerFactory entityManagerFactory;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JpaPagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JpaPagingItemReader.java
@@ -31,6 +31,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.database.orm.JpaQueryProvider;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -83,9 +84,10 @@ import org.springframework.util.StringUtils;
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  * @since 2.0
  */
-public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> {
+public class JpaPagingItemReader<T> extends AbstractPagingItemReader<T> implements BeanNameAware {
 
 	private EntityManagerFactory entityManagerFactory;
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JdbcCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JdbcCursorItemReaderBuilder.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Fabio Molignoni
  * @author Juyoung Kim
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 4.0
  */
 public class JdbcCursorItemReaderBuilder<T> {
@@ -349,10 +350,6 @@ public class JdbcCursorItemReaderBuilder<T> {
 	 * @return a fully constructed {@link JdbcCursorItemReader}
 	 */
 	public JdbcCursorItemReader<T> build() {
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
-
 		Assert.hasText(this.sql, "A query is required");
 		Assert.notNull(this.dataSource, "A datasource is required");
 		Assert.notNull(this.rowMapper, "A rowmapper is required");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JdbcPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JdbcPagingItemReaderBuilder.java
@@ -60,6 +60,7 @@ import org.springframework.util.Assert;
  * @author Minsoo Kim
  * @author Juyoung Kim
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 4.0
  * @see JdbcPagingItemReader
  */
@@ -317,10 +318,6 @@ public class JdbcPagingItemReaderBuilder<T> {
 	public JdbcPagingItemReader<T> build() throws Exception {
 		Assert.isTrue(pageSize > 0, "pageSize must be greater than zero");
 		Assert.notNull(dataSource, "dataSource is required");
-
-		if (saveState) {
-			Assert.hasText(name, "A name is required when saveState is set to true");
-		}
 
 		JdbcPagingItemReader<T> reader = new JdbcPagingItemReader<>(this.dataSource,
 				queryProvider == null ? determineQueryProvider(dataSource) : queryProvider);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JpaCursorItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JpaCursorItemReaderBuilder.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Mahmoud Ben Hassine
  * @author Jinwoo Bae
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 4.3
  */
 public class JpaCursorItemReaderBuilder<T> {
@@ -175,9 +176,6 @@ public class JpaCursorItemReaderBuilder<T> {
 	 */
 	public JpaCursorItemReader<T> build() {
 		Assert.notNull(this.entityManagerFactory, "An EntityManagerFactory is required");
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
 		if (this.queryProvider == null) {
 			Assert.hasLength(this.queryString, "Query string is required when queryProvider is null");
 		}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JpaPagingItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/builder/JpaPagingItemReaderBuilder.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Glenn Renfro
  * @author Jinwoo Bae
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 4.0
  */
 
@@ -210,10 +211,6 @@ public class JpaPagingItemReaderBuilder<T> {
 	public JpaPagingItemReader<T> build() {
 		Assert.isTrue(this.pageSize > 0, "pageSize must be greater than zero");
 		Assert.notNull(this.entityManagerFactory, "An EntityManagerFactory is required");
-
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
 
 		if (this.queryProvider == null) {
 			Assert.hasLength(this.queryString, "Query string is required when queryProvider is null");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/FlatFileItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/FlatFileItemReader.java
@@ -30,6 +30,7 @@ import org.springframework.batch.infrastructure.item.ReaderNotOpenException;
 import org.springframework.batch.infrastructure.item.file.separator.RecordSeparatorPolicy;
 import org.springframework.batch.infrastructure.item.file.separator.SimpleRecordSeparatorPolicy;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -50,12 +51,13 @@ import org.springframework.util.StringUtils;
  * @author Mahmoud Ben Hassine
  * @author Stefano Cordio
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  */
 // FIXME the design of creating a flat file reader with an optional resource (to support
 // the multi-resource case) is broken.
 // FIXME The multi-resource reader should create the delegate with the current resource
 public class FlatFileItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
-		implements ResourceAwareItemReaderItemStream<T> {
+		implements ResourceAwareItemReaderItemStream<T>, BeanNameAware {
 
 	private static final Log logger = LogFactory.getLog(FlatFileItemReader.class);
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/MultiResourceItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/MultiResourceItemReader.java
@@ -28,6 +28,7 @@ import org.springframework.batch.infrastructure.item.ItemStream;
 import org.springframework.batch.infrastructure.item.ItemStreamException;
 import org.springframework.batch.infrastructure.item.ResourceAware;
 import org.springframework.batch.infrastructure.item.support.AbstractItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
@@ -43,8 +44,9 @@ import org.springframework.util.Assert;
  * @author Lucas Ward
  * @author Mahmoud Ben Hassine
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  */
-public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> {
+public class MultiResourceItemReader<T> extends AbstractItemStreamItemReader<T> implements BeanNameAware {
 
 	private static final Log logger = LogFactory.getLog(MultiResourceItemReader.class);
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilder.java
@@ -65,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @author François Martin
  * @author Stefano Cordio
  * @author Daeho Kwon
+ * @author Andrey Litvitski
  * @since 4.0
  * @see FlatFileItemReader
  */
@@ -465,9 +466,6 @@ public class FlatFileItemReaderBuilder<T> {
 	 * @return a {@link FlatFileItemReader}
 	 */
 	public FlatFileItemReader<T> build() {
-		if (this.saveState) {
-			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
-		}
 
 		if (this.resource == null) {
 			logger.debug("The resource is null.  This is only a valid scenario when "

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilder.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * @author Glenn Renfro
  * @author Drummond Dawson
  * @author Stefano Cordio
+ * @author Andrey Litvitski
  * @since 4.0
  * @see MultiResourceItemReader
  */
@@ -137,9 +138,6 @@ public class MultiResourceItemReaderBuilder<T> {
 	public MultiResourceItemReader<T> build() {
 		Assert.notNull(this.resources, "resources array is required.");
 		Assert.notNull(this.delegate, "delegate is required.");
-		if (this.saveState) {
-			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
-		}
 
 		MultiResourceItemReader<T> reader = new MultiResourceItemReader<>(this.delegate);
 		reader.setResources(this.resources);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JsonItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JsonItemReader.java
@@ -24,6 +24,7 @@ import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.ItemStreamReader;
 import org.springframework.batch.infrastructure.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
@@ -48,10 +49,11 @@ import org.springframework.util.Assert;
  * @param <T> the type of json objects to read
  * @author Mahmoud Ben Hassine
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  * @since 4.1
  */
 public class JsonItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
-		implements ResourceAwareItemReaderItemStream<T> {
+		implements ResourceAwareItemReaderItemStream<T>, BeanNameAware {
 
 	private static final Log LOGGER = LogFactory.getLog(JsonItemReader.class);
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/builder/JsonItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/builder/JsonItemReaderBuilder.java
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
  *
  * @param <T> type of the target item
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  * @since 4.1
  */
 public class JsonItemReaderBuilder<T> {
@@ -149,9 +150,6 @@ public class JsonItemReaderBuilder<T> {
 	 */
 	public JsonItemReader<T> build() {
 		Assert.notNull(this.jsonObjectReader, "A json object reader is required.");
-		if (this.saveState) {
-			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
-		}
 
 		if (this.resource == null) {
 			logger.debug("The resource is null. This is only a valid scenario when "

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/KafkaItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/KafkaItemReader.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.support.AbstractItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.util.Assert;
 
 /**
@@ -50,9 +51,10 @@ import org.springframework.util.Assert;
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
  * @author Hyunwoo Jung
+ * @author Andrey Litvitski
  * @since 4.2
  */
-public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> {
+public class KafkaItemReader<K, V> extends AbstractItemStreamItemReader<V> implements BeanNameAware {
 
 	private static final String TOPIC_PARTITION_OFFSETS = "topic.partition.offsets";
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/builder/KafkaItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/builder/KafkaItemReaderBuilder.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  *
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  * @since 4.2
  * @see KafkaItemReader
  */
@@ -155,9 +156,6 @@ public class KafkaItemReaderBuilder<K, V> {
 	}
 
 	public KafkaItemReader<K, V> build() {
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
 		Assert.notNull(consumerProperties, "Consumer properties must not be null");
 		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
 				ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG + " property must be provided");

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/LdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/LdifReader.java
@@ -25,6 +25,7 @@ import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.file.FlatFileItemReader;
 import org.springframework.batch.infrastructure.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
 import org.springframework.ldap.core.LdapAttributes;
@@ -62,10 +63,11 @@ import org.springframework.util.Assert;
  * @author Keith Barlow
  * @author Mahmoud Ben Hassine
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  *
  */
 public class LdifReader extends AbstractItemCountingItemStreamItemReader<LdapAttributes>
-		implements ResourceAwareItemReaderItemStream<LdapAttributes>, InitializingBean {
+		implements ResourceAwareItemReaderItemStream<LdapAttributes>, InitializingBean, BeanNameAware {
 
 	private static final Log LOG = LogFactory.getLog(LdifReader.class);
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/MappingLdifReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/MappingLdifReader.java
@@ -24,6 +24,7 @@ import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.file.FlatFileItemReader;
 import org.springframework.batch.infrastructure.item.file.ResourceAwareItemReaderItemStream;
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
 import org.springframework.ldap.core.LdapAttributes;
@@ -54,10 +55,11 @@ import org.springframework.util.Assert;
  * @author Keith Barlow
  * @author Mahmoud Ben Hassine
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  *
  */
 public class MappingLdifReader<T> extends AbstractItemCountingItemStreamItemReader<T>
-		implements ResourceAwareItemReaderItemStream<T>, InitializingBean {
+		implements ResourceAwareItemReaderItemStream<T>, InitializingBean, BeanNameAware {
 
 	private static final Log LOG = LogFactory.getLog(MappingLdifReader.class);
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/builder/LdifReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/builder/LdifReaderBuilder.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
  * Creates a fully qualified LdifReader.
  *
  * @author Glenn Renfro
+ * @author Andrey Litvitski
  * @since 4.0
  */
 public class LdifReaderBuilder {
@@ -164,9 +165,6 @@ public class LdifReaderBuilder {
 		LdifReader reader = new LdifReader(this.resource);
 		reader.setRecordsToSkip(this.recordsToSkip);
 		reader.setSaveState(this.saveState);
-		if (this.name != null) {
-			reader.setName(this.name);
-		}
 		reader.setCurrentItemCount(this.currentItemCount);
 		reader.setMaxItemCount(this.maxItemCount);
 		if (this.skippedRecordsCallback != null) {

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/builder/MappingLdifReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ldif/builder/MappingLdifReaderBuilder.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * Creates a fully qualified MappingLdifReader.
  *
  * @author Glenn Renfro
+ * @author Andrey Litvitski
  * @since 4.0
  */
 public class MappingLdifReaderBuilder<T> {
@@ -174,9 +175,6 @@ public class MappingLdifReaderBuilder<T> {
 	public MappingLdifReader<T> build() throws Exception {
 		Assert.notNull(this.resource, "Resource is required.");
 		Assert.notNull(this.recordMapper, "RecordMapper is required.");
-		if (this.saveState) {
-			Assert.hasText(this.name, "A name is required when saveState is set to true");
-		}
 		MappingLdifReader<T> reader = new MappingLdifReader<>(this.resource);
 		reader.setRecordsToSkip(this.recordsToSkip);
 		reader.setSaveState(saveState);

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemReader.java
@@ -41,6 +41,7 @@ import org.springframework.batch.infrastructure.item.file.ResourceAwareItemReade
 import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
 import org.springframework.batch.infrastructure.item.xml.stax.DefaultFragmentEventReader;
 import org.springframework.batch.infrastructure.item.xml.stax.FragmentEventReader;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
 import org.springframework.oxm.Unmarshaller;
@@ -61,9 +62,10 @@ import org.springframework.util.xml.StaxUtils;
  * @author Mahmoud Ben Hassine
  * @author Glenn Renfro
  * @author Jimmy Praet
+ * @author Andrey Litvitski
  */
 public class StaxEventItemReader<T> extends AbstractItemCountingItemStreamItemReader<T>
-		implements ResourceAwareItemReaderItemStream<T>, InitializingBean {
+		implements ResourceAwareItemReaderItemStream<T>, InitializingBean, BeanNameAware {
 
 	private static final Log logger = LogFactory.getLog(StaxEventItemReader.class);
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/builder/StaxEventItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/builder/StaxEventItemReaderBuilder.java
@@ -42,6 +42,7 @@ import org.springframework.util.xml.StaxUtils;
  * @author Glenn Renfro
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
+ * @author Andrey Litvitski
  * @since 4.0
  */
 public class StaxEventItemReaderBuilder<T> {
@@ -222,9 +223,6 @@ public class StaxEventItemReaderBuilder<T> {
 		else {
 			logger.debug("The resource is null. This is only a valid scenario when "
 					+ "injecting resource later as in when using the MultiResourceItemReader");
-		}
-		if (this.saveState) {
-			Assert.state(StringUtils.hasText(this.name), "A name is required when saveState is set to true.");
 		}
 
 		Assert.notEmpty(this.fragmentRootElements, "At least one fragment root element is required");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/builder/MongoPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/builder/MongoPagingItemReaderBuilderTests.java
@@ -50,6 +50,7 @@ import static org.springframework.data.mongodb.core.query.Query.query;
  * @author Drummond Dawson
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  */
 @ExtendWith(MockitoExtension.class)
 class MongoPagingItemReaderBuilderTests {
@@ -218,15 +219,6 @@ class MongoPagingItemReaderBuilderTests {
 			.query(query(where("_id").is("10")))
 			.name("mongoReaderTest")
 			.pageSize(50), "sorts map is required.");
-	}
-
-	@Test
-	void testNullName() {
-		validateExceptionMessage(new MongoPagingItemReaderBuilder<String>().template(this.template)
-			.targetType(String.class)
-			.jsonQuery("{ }")
-			.sorts(this.sortOptions)
-			.pageSize(50), "A name is required when saveState is set to true");
 	}
 
 	private void validateExceptionMessage(MongoPagingItemReaderBuilder<String> builder, String message) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/builder/RepositoryItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/builder/RepositoryItemReaderBuilderTests.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.when;
  * @author Glenn Renfro
  * @author Drummond Dawson
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  */
 @MockitoSettings(strictness = Strictness.LENIENT)
 class RepositoryItemReaderBuilderTests {
@@ -134,13 +135,6 @@ class RepositoryItemReaderBuilderTests {
 
 	@Test
 	void testSaveState() {
-		var builder = new RepositoryItemReaderBuilder<>().repository(repository)
-			.methodName("foo")
-			.sorts(sorts)
-			.maxItemCount(5);
-		Exception exception = assertThrows(IllegalStateException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true.", exception.getMessage());
-
 		// No IllegalStateException for a name that is not set, should not be thrown since
 		// saveState was false.
 		new RepositoryItemReaderBuilder<>().repository(repository)

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JdbcCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JdbcCursorItemReaderBuilderTests.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
  * @author Juyoung Kim
+ * @author Andrey Litvitski
  */
 class JdbcCursorItemReaderBuilderTests {
 
@@ -313,12 +314,8 @@ class JdbcCursorItemReaderBuilderTests {
 
 	@Test
 	void testValidation() {
-		var builder = new JdbcCursorItemReaderBuilder<Foo>().saveState(true);
+		var builder = new JdbcCursorItemReaderBuilder<Foo>().saveState(false);
 		Exception exception = assertThrows(IllegalArgumentException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true", exception.getMessage());
-
-		builder = new JdbcCursorItemReaderBuilder<Foo>().saveState(false);
-		exception = assertThrows(IllegalArgumentException.class, builder::build);
 		assertEquals("A query is required", exception.getMessage());
 
 		builder = new JdbcCursorItemReaderBuilder<Foo>().saveState(false).sql("select 1");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JdbcPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JdbcPagingItemReaderBuilderTests.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Drummond Dawson
  * @author Mahmoud Ben Hassine
  * @author Juyoung Kim
+ * @author Andrey Litvitski
  */
 class JdbcPagingItemReaderBuilderTests {
 
@@ -291,10 +292,6 @@ class JdbcPagingItemReaderBuilderTests {
 		builder = new JdbcPagingItemReaderBuilder<Foo>().pageSize(2);
 		exception = assertThrows(IllegalArgumentException.class, builder::build);
 		assertEquals("dataSource is required", exception.getMessage());
-
-		builder = new JdbcPagingItemReaderBuilder<Foo>().pageSize(2).dataSource(this.dataSource);
-		exception = assertThrows(IllegalArgumentException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true", exception.getMessage());
 
 		builder = new JdbcPagingItemReaderBuilder<Foo>().saveState(false).pageSize(2).dataSource(this.dataSource);
 		exception = assertThrows(IllegalArgumentException.class, builder::build);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JpaCursorItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JpaCursorItemReaderBuilderTests.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  */
 class JpaCursorItemReaderBuilderTests {
 
@@ -198,10 +199,6 @@ class JpaCursorItemReaderBuilderTests {
 		var builder = new JpaCursorItemReaderBuilder<Foo>();
 		Exception exception = assertThrows(IllegalArgumentException.class, builder::build);
 		assertEquals("An EntityManagerFactory is required", exception.getMessage());
-
-		builder = new JpaCursorItemReaderBuilder<Foo>().entityManagerFactory(this.entityManagerFactory).saveState(true);
-		exception = assertThrows(IllegalArgumentException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true", exception.getMessage());
 
 		builder = new JpaCursorItemReaderBuilder<Foo>().entityManagerFactory(this.entityManagerFactory)
 			.saveState(false);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JpaPagingItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/JpaPagingItemReaderBuilderTests.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Michael Minella
  * @author Parikshit Dutta
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  */
 class JpaPagingItemReaderBuilderTests {
 
@@ -211,10 +212,6 @@ class JpaPagingItemReaderBuilderTests {
 		builder = new JpaPagingItemReaderBuilder<>();
 		exception = assertThrows(IllegalArgumentException.class, builder::build);
 		assertEquals("An EntityManagerFactory is required", exception.getMessage());
-
-		builder = new JpaPagingItemReaderBuilder<Foo>().entityManagerFactory(this.entityManagerFactory).saveState(true);
-		exception = assertThrows(IllegalArgumentException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true", exception.getMessage());
 
 		builder = new JpaPagingItemReaderBuilder<Foo>().entityManagerFactory(this.entityManagerFactory)
 			.saveState(false);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/StoredProcedureItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/builder/StoredProcedureItemReaderBuilderTests.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  */
 class StoredProcedureItemReaderBuilderTests {
 
@@ -81,12 +82,8 @@ class StoredProcedureItemReaderBuilderTests {
 
 	@Test
 	void testValidation() {
-		var builder = new StoredProcedureItemReaderBuilder<Foo>();
+		var builder = new StoredProcedureItemReaderBuilder<Foo>().saveState(false);
 		Exception exception = assertThrows(IllegalArgumentException.class, builder::build);
-		assertEquals("A name is required when saveSate is set to true", exception.getMessage());
-
-		builder = new StoredProcedureItemReaderBuilder<Foo>().saveState(false);
-		exception = assertThrows(IllegalArgumentException.class, builder::build);
 		assertEquals("The name of the stored procedure must be provided", exception.getMessage());
 
 		builder = new StoredProcedureItemReaderBuilder<Foo>().saveState(false).procedureName("read_foos");

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/FlatFileItemReaderBuilderTests.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Patrick Baumgartner
  * @author François Martin
  * @author Daeho Kwon
+ * @author Andrey Litvitski
  */
 class FlatFileItemReaderBuilderTests {
 
@@ -476,43 +477,6 @@ class FlatFileItemReaderBuilderTests {
 		assertEquals(3, item.getSecond());
 		assertEquals("foo", item.getThird());
 		assertNull(reader.read());
-	}
-
-	@Test
-	void testName() {
-		var builder = new FlatFileItemReaderBuilder<Foo>().resource(getResource("1  2  3"))
-			.fixedLength()
-			.columns(new Range(1, 3), new Range(4, 6), new Range(7))
-			.names("first", "second", "third")
-			.targetType(Foo.class);
-		Exception exception = assertThrows(IllegalStateException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true.", exception.getMessage());
-
-		builder = new FlatFileItemReaderBuilder<Foo>().resource(getResource("1  2  3"))
-			.fixedLength()
-			.columns(new Range(1, 3), new Range(4, 6), new Range(7))
-			.names("first", "second", "third")
-			.targetType(Foo.class)
-			.name(null);
-		exception = assertThrows(IllegalStateException.class, builder::build);
-		assertEquals("A name is required when saveState is set to true.", exception.getMessage());
-
-		assertNotNull(new FlatFileItemReaderBuilder<Foo>().resource(getResource("1  2  3"))
-			.fixedLength()
-			.columns(new Range(1, 3), new Range(4, 6), new Range(7))
-			.names("first", "second", "third")
-			.targetType(Foo.class)
-			.saveState(false)
-			.build(), "builder should return new instance of FlatFileItemReader");
-
-		assertNotNull(new FlatFileItemReaderBuilder<Foo>().resource(getResource("1  2  3"))
-			.fixedLength()
-			.columns(new Range(1, 3), new Range(4, 6), new Range(7))
-			.names("first", "second", "third")
-			.targetType(Foo.class)
-			.name("foobar")
-			.build(), "builder should return new instance of FlatFileItemReader");
-
 	}
 
 	@Test

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/builder/JsonItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/builder/JsonItemReaderBuilderTests.java
@@ -32,6 +32,7 @@ import static org.springframework.test.util.ReflectionTestUtils.getField;
 
 /**
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  */
 @ExtendWith(MockitoExtension.class)
 class JsonItemReaderBuilderTests {
@@ -47,10 +48,6 @@ class JsonItemReaderBuilderTests {
 		Exception exception = assertThrows(IllegalArgumentException.class,
 				() -> new JsonItemReaderBuilder<String>().build());
 		assertEquals("A json object reader is required.", exception.getMessage());
-
-		exception = assertThrows(IllegalStateException.class,
-				() -> new JsonItemReaderBuilder<String>().jsonObjectReader(this.jsonObjectReader).build());
-		assertEquals("A name is required when saveState is set to true.", exception.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
Added `BeanNameAware` to event item readers to use the bean name when no explicit  name is provided. Removed name assertions from the corresponding builders.

I've added a `BeanNameAware` implementation wherever the builders have a name. I believe this is what was meant in #5149. In any case, we can look into it.

Closes: #5149