### PR TITLE
Improve JobRepositoryTestUtils to mitigate OptimisticLockingFailureException while removing JobExecution

### DIFF
--- a/spring-batch-test/src/main/java/org/springframework/batch/test/JobRepositoryTestUtils.java
+++ b/spring-batch-test/src/main/java/org/springframework/batch/test/JobRepositoryTestUtils.java
@@ -151,7 +151,11 @@ public class JobRepositoryTestUtils {
 	 * @param jobExecution the {@link JobExecution} to delete
 	 */
 	public void removeJobExecution(JobExecution jobExecution) {
-		this.jobRepository.deleteJobExecution(jobExecution);
+		// query latest version of JobExecution to avoid OptimisticLockingFailureException
+		jobExecution = this.jobRepository.getJobExecution(jobExecution.getId());
+		if (jobExecution != null) {
+			this.jobRepository.deleteJobExecution(jobExecution);
+		}
 	}
 
 	/**
@@ -165,7 +169,7 @@ public class JobRepositoryTestUtils {
 			List<JobInstance> jobInstances = this.jobRepository.findJobInstances(jobName);
 			for (JobInstance jobInstance : jobInstances) {
 				List<JobExecution> jobExecutions = this.jobRepository.getJobExecutions(jobInstance);
-				if (jobExecutions != null && !jobExecutions.isEmpty()) {
+				if (!jobExecutions.isEmpty()) {
 					removeJobExecutions(jobExecutions);
 				}
 			}


### PR DESCRIPTION
It's safe to remove stale version of JobExecution for testing purpose, this commit mitigate OptimisticLockingFailureException but cannot avoid since race condition may happen.

Fix GH-5161
