### PR TITLE
Supports to create step execution with context

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
@@ -137,17 +137,15 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter {
 			StepExecution lastStepExecution = jobRepository.getLastStepExecution(jobExecution.getJobInstance(),
 					stepName);
 			if (lastStepExecution == null) { // fresh start
-				StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution);
-				currentStepExecution.setExecutionContext(context.getValue());
-				jobRepository.updateExecutionContext(currentStepExecution);
+				StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution,
+						context.getValue());
 				set.add(currentStepExecution);
 			}
 			else { // restart
 				if (lastStepExecution.getStatus() != BatchStatus.COMPLETED
 						&& shouldStart(allowStartIfComplete, stepExecution, lastStepExecution)) {
-					StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution);
-					currentStepExecution.setExecutionContext(lastStepExecution.getExecutionContext());
-					jobRepository.updateExecutionContext(currentStepExecution);
+					StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution,
+							lastStepExecution.getExecutionContext());
 					set.add(currentStepExecution);
 				}
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/JobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/JobRepository.java
@@ -45,6 +45,7 @@ import java.util.Set;
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
+ * @author Yanming Zhou
  */
 @SuppressWarnings("removal")
 public interface JobRepository extends JobExplorer {
@@ -338,6 +339,21 @@ public interface JobRepository extends JobExplorer {
 	 * @since 6.0
 	 */
 	default StepExecution createStepExecution(String stepName, JobExecution jobExecution) {
+		return createStepExecution(stepName, jobExecution, null);
+	}
+
+	/**
+	 * Create a {@link StepExecution} for a given {@link JobExecution} and step name. The
+	 * {@link JobExecution} must already exist. The returned {@link StepExecution} should
+	 * be associated with the {@link JobExecution} (ie. should be added to the list of
+	 * {@link JobExecution#getStepExecutions()}.
+	 * @param stepName the name of the step
+	 * @param jobExecution the job execution to which the step execution belongs
+	 * @param stepExecutionContext the step execution context
+	 * @return a valid {@link StepExecution} for the arguments provided
+	 */
+	default StepExecution createStepExecution(String stepName, JobExecution jobExecution,
+			@Nullable ExecutionContext stepExecutionContext) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
@@ -48,6 +48,7 @@ import org.springframework.batch.infrastructure.support.transaction.Resourceless
  * @since 5.2.0
  * @author Mahmoud Ben Hassine
  * @author Sanghyuk Jung
+ * @author Yanming Zhou
  */
 public class ResourcelessJobRepository implements JobRepository {
 
@@ -266,6 +267,21 @@ public class ResourcelessJobRepository implements JobRepository {
 		stepExecution.setStatus(BatchStatus.STARTING);
 		stepExecution.setLastUpdated(LocalDateTime.now());
 		stepExecution.incrementVersion();
+		jobExecution.addStepExecution(stepExecution);
+		return stepExecution;
+	}
+
+	@Override
+	public StepExecution createStepExecution(String stepName, JobExecution jobExecution,
+			@Nullable ExecutionContext stepExecutionContext) {
+		StepExecution stepExecution = new StepExecution(++stepExecutionIdIncrementer, stepName, jobExecution);
+		stepExecution.setStartTime(LocalDateTime.now());
+		stepExecution.setStatus(BatchStatus.STARTING);
+		stepExecution.setLastUpdated(LocalDateTime.now());
+		stepExecution.incrementVersion();
+		if (stepExecutionContext != null && !stepExecutionContext.isEmpty()) {
+			stepExecution.setExecutionContext(new ExecutionContext(stepExecutionContext));
+		}
 		jobExecution.addStepExecution(stepExecution);
 		return stepExecution;
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -115,20 +115,15 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 		return jobExecution;
 	}
 
-	/**
-	 * Create a new {@link StepExecution} for the given {@link JobExecution} and step
-	 * name, associate a new {@link ExecutionContext} with the new {@link StepExecution},
-	 * and add the new {@link StepExecution} to the {@link JobExecution}.
-	 * @param stepName the name of the step
-	 * @param jobExecution the job execution to which the step execution belongs
-	 * @return the new step execution
-	 * @since 6.0
-	 */
-	public StepExecution createStepExecution(String stepName, JobExecution jobExecution) {
+	public StepExecution createStepExecution(String stepName, JobExecution jobExecution,
+			@Nullable ExecutionContext stepExecutionContext) {
 		Assert.notNull(jobExecution, "JobExecution must not be null.");
 		Assert.notNull(stepName, "Step name must not be null.");
 
 		StepExecution stepExecution = stepExecutionDao.createStepExecution(stepName, jobExecution);
+		if (stepExecutionContext != null && !stepExecutionContext.isEmpty()) {
+			stepExecution.setExecutionContext(new ExecutionContext(stepExecutionContext));
+		}
 		ecDao.saveExecutionContext(stepExecution);
 		jobExecution.addStepExecution(stepExecution);
 

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/remote/RemoteStep.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/remote/RemoteStep.java
@@ -93,12 +93,8 @@ public class RemoteStep extends AbstractStep {
 	protected void doExecute(StepExecution stepExecution) throws Exception {
 		// create a step execution for the remote worker step
 		JobExecution jobExecution = stepExecution.getJobExecution();
-		StepExecution workerStepExecution = getJobRepository().createStepExecution(this.remoteStepName, jobExecution);
-
-		// pass the same context to the remote worker step
-		workerStepExecution.setExecutionContext(stepExecution.getExecutionContext());
-		getJobRepository().update(workerStepExecution);
-		getJobRepository().updateExecutionContext(workerStepExecution);
+		StepExecution workerStepExecution = getJobRepository().createStepExecution(this.remoteStepName, jobExecution,
+				stepExecution.getExecutionContext());
 
 		// send step execution request and wait for the remote step to finish
 		StepExecutionRequest stepExecutionRequest = new StepExecutionRequest(this.remoteStepName,


### PR DESCRIPTION
After this commit, step execution context can be created with actual context instead of creating empty one then updating it.