### PR TITLE
Fix typo in whatsnew.adoc and in integration tests

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkOrientedStepFaultToleranceIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkOrientedStepFaultToleranceIntegrationTests.java
@@ -347,16 +347,16 @@ public class ChunkOrientedStepFaultToleranceIntegrationTests {
 	static class FaultTolerantChunkOrientedStepConfiguration {
 
 		@Bean
-		public Step faulTolerantChunkOrientedStep(JobRepository jobRepository,
+		public Step faultTolerantChunkOrientedStep(JobRepository jobRepository,
 				JdbcTransactionManager transactionManager, ItemReader<Person> itemReader,
 				ItemProcessor<Person, Person> itemProcessor, ItemWriter<Person> itemWriter) {
 			// retry policy configuration
 			int retryLimit = 3;
-			Set<Class<? extends Throwable>> nonRetrybaleExceptions = Set.of(FlatFileParseException.class,
+			Set<Class<? extends Throwable>> nonRetryableExceptions = Set.of(FlatFileParseException.class,
 					DataIntegrityViolationException.class);
 			RetryPolicy retryPolicy = RetryPolicy.builder()
 				.maxRetries(retryLimit)
-				.excludes(nonRetrybaleExceptions)
+				.excludes(nonRetryableExceptions)
 				.build();
 
 			// skip policy configuration

--- a/spring-batch-docs/modules/ROOT/pages/whatsnew.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/whatsnew.adoc
@@ -116,14 +116,14 @@ Here is a quick example of how to use the retry and skip features with the new `
 [source, java]
 ----
 @Bean
-public Step faulTolerantChunkOrientedStep(JobRepository jobRepository, ItemReader<Person> itemReader, ItemWriter<Person> itemWriter) {
+public Step faultTolerantChunkOrientedStep(JobRepository jobRepository, ItemReader<Person> itemReader, ItemWriter<Person> itemWriter) {
 
     // retry policy configuration
     int maxRetries = 10;
-    var retrybaleExceptions = Set.of(TransientException.class);
+    var retryableExceptions = Set.of(TransientException.class);
     RetryPolicy retryPolicy = RetryPolicy.builder()
         .maxRetries(maxRetries)
-        .includes(retrybaleExceptions)
+        .includes(retryableExceptions)
         .build();
 
     // skip policy configuration


### PR DESCRIPTION
Fix misspelling in whatsnew.adoc and in test class.

- `faulTolerantChunkOrientedStep` -> `faultTolerantChunkOrientedStep`
- `nonRetrybaleExceptions` -> `nonRetryableExceptions`