### PR TITLE
Fix ID collision in MetaDataInstanceFactory for test scenarios with @SpringBatchTest

### DIFF
--- a/spring-batch-test/src/test/java/org/springframework/batch/test/MetaDataInstanceFactoryTests.java
+++ b/spring-batch-test/src/test/java/org/springframework/batch/test/MetaDataInstanceFactoryTests.java
@@ -16,6 +16,7 @@
 package org.springframework.batch.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
@@ -104,6 +105,20 @@ class MetaDataInstanceFactoryTests {
 	@Test
 	void testCreateJobExecutionWithStepExecutions() {
 		assertNotNull(MetaDataInstanceFactory.createJobExecutionWithStepExecutions(executionId, List.of(stepName)));
+	}
+
+	@Test
+	void testCreateStepExecutionWithJobParametersShouldGenerateUniqueIds() {
+		JobParameters params1 = new JobParametersBuilder().addString("key", "value1").toJobParameters();
+		JobParameters params2 = new JobParametersBuilder().addString("key", "value2").toJobParameters();
+
+		StepExecution step1 = MetaDataInstanceFactory.createStepExecution(params1);
+		StepExecution step2 = MetaDataInstanceFactory.createStepExecution(params2);
+
+		assertNotEquals(step1.getId(), step2.getId());
+		assertNotEquals(step1.getJobExecutionId(), step2.getJobExecutionId());
+
+		assertNotEquals(step1, step2);
 	}
 
 }


### PR DESCRIPTION
## Problem
Tests using `StepScopeTestUtils` with `@SpringBatchTest` failed with `ClassCastException` due to ID collisions. `MetaDataInstanceFactory` always created instances with the same default IDs (123L), causing multiple `StepExecution` instances to be treated as identical in `StepSynchronizationManager`.

## Solution
Added `AtomicLong` counters to generate unique IDs for each `StepExecution` and `JobExecution`. This prevents context collisions while maintaining backward compatibility—the first invocation still uses the original default IDs.

## Changes
- Added `jobExecutionIdCounter` and `stepExecutionIdCounter` static fields
- Updated `createStepExecution(JobParameters)` to use `incrementAndGet()` for unique IDs
- Added test case to verify unique ID generation

Closes #5181