### PR TITLE
Proposed addition of various general purpose readers

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/PagingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/PagingItemReader.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.data;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * {@link ItemReader} for reading items using in a paging fashion using the spring data {@link Pageable}
+ * and {@link Page} abstractions.
+ *
+ * @param <T> the type of the items read by the item reader
+ * @author Chirag Tailor
+ * @since 6.0
+ */
+public class PagingItemReader<T> implements ItemReader<T> {
+
+    private final Function<Pageable, Page<T>> pageProvider;
+
+	private final List<T> items = new ArrayList<>();
+
+	private Pageable pageable;
+
+	private boolean isLast = false;
+
+    /**
+	 * Create a new {@link PagingItemReader}.
+	 * @param pageProvider the function to resolve the request for a page of items
+	 * @param pageSize the size of the page to request
+	 */
+	public PagingItemReader(Function<Pageable, Page<T>> pageProvider,
+							int pageSize) {
+        this.pageProvider = pageProvider;
+        this.pageable = Pageable.ofSize(pageSize);
+    }
+
+	@Override
+	public @Nullable T read() throws Exception {
+		if (items.isEmpty() && isLast) {
+			return null;
+		}
+
+		if (items.isEmpty()) {
+			Page<T> page = pageProvider.apply(pageable);
+			items.addAll(page.getContent());
+			isLast = page.isLast();
+		}
+
+		T item = items.remove(0);
+
+		if (items.isEmpty()) {
+			pageable = pageable.next();
+		}
+
+		return item;
+	}
+
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/function/ListSupplierItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/function/ListSupplierItemReader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.infrastructure.item.function;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.data.util.Lazy;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Adapter for a {@link Supplier<List>} to an {@link ItemReader}.
+ *
+ * @param <T> type of items to read
+ * @author Chirag Tailor
+ * @since 6.0
+ */
+public class ListSupplierItemReader<T> implements ItemReader<T> {
+
+	private final Lazy<List<T>> items;
+
+	/**
+	 * Create a new {@link ListSupplierItemReader}.
+	 * @param supplier the supplier to use to read items. Must not be {@code null}.
+	 */
+	public ListSupplierItemReader(Supplier<List<T>> supplier) {
+		Assert.notNull(supplier, "A supplier is required");
+		this.items = Lazy.of(() -> new ArrayList<>(supplier.get()));
+	}
+
+	@Override
+	public @Nullable T read() throws Exception {
+		if (items.get().isEmpty()) {
+			return null;
+		}
+		return items.get().remove(0);
+	}
+
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/FilteringItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/FilteringItemReader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.support;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.infrastructure.item.ItemReader;
+
+import java.util.function.Predicate;
+
+/**
+ * Filters an {@link ItemReader} reading items of type {@link T} by applying a predicate to each item.
+ * <p>
+ * This adapter mimics the behavior of
+ * {@link java.util.stream.Collectors#filtering(java.util.function.Predicate, java.util.stream.Collector)}.
+ *
+ * @param <T> the type of the items read by the upstream item reader
+ * @author Chirag Tailor
+ * @since 6.0
+ */
+public class FilteringItemReader<T> implements ItemReader<T> {
+
+    private final ItemReader<T> upstream;
+
+    private final Predicate<T> predicate;
+
+    /**
+     * Create a new {@link FilteringItemReader}.
+     *
+     * @param upstream  the upstream item reader whose items will have the predicate applied
+     * @param predicate the predicate to apply to the items read from the upstream
+     */
+    public FilteringItemReader(ItemReader<T> upstream, Predicate<T> predicate) {
+        this.upstream = upstream;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public @Nullable T read() throws Exception {
+        return readAndFilter();
+    }
+
+    private @Nullable T readAndFilter() throws Exception {
+        T item = upstream.read();
+        if (item == null) {
+            return null;
+        }
+        if (predicate.test(item)) {
+            return item;
+        }
+        return readAndFilter();
+    }
+
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/FlatMappingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/FlatMappingItemReader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.support;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.infrastructure.item.ItemReader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Adapts an {@link ItemReader} reading items of type {@link T} to one reading items of
+ * type {@link U} by applying a flat mapping function to each item.
+ * <p>
+ * This adapter mimics the behavior of
+ * {@link java.util.stream.Collectors#flatMapping(Function, java.util.stream.Collector)}.
+ *
+ * @param <T> the type of the items read by the upstream item reader
+ * @param <U> type of items
+ * @author Chirag Tailor
+ * @since 6.0
+ */
+public class FlatMappingItemReader<T, U> implements ItemReader<U> {
+
+	private final ItemReader<T> upstream;
+
+	private final Function<T, List<U>> mapper;
+
+	private final List<U> items = new ArrayList<>();
+
+	/**
+	 * Create a new {@link FlatMappingItemReader}.
+	 * @param upstream the upstream item reader whose items will have the mapper applied
+	 * @param mapper the mapping function to apply to the items read from the upstream
+	 */
+	public FlatMappingItemReader(ItemReader<T> upstream, Function<T, List<U>> mapper) {
+		this.upstream = upstream;
+		this.mapper = mapper;
+	}
+
+	@Override
+	public @Nullable U read() throws Exception {
+		while (items.isEmpty()) {
+			T item = upstream.read();
+			if (Objects.isNull(item)) {
+				return null;
+			}
+			items.addAll(mapper.apply(item));
+		}
+		return items.remove(0);
+	}
+
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/MappingItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/MappingItemReader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.support;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.infrastructure.item.ItemReader;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Adapts an {@link ItemReader} reading items of type {@link T} to one reading items of
+ * type {@link U} by applying a mapping function to each item.
+ * <p>
+ * This adapter mimics the behavior of
+ * {@link java.util.stream.Collectors#mapping(Function, java.util.stream.Collector)}.
+ *
+ * @param <T> the type of the items read by the upstream item reader
+ * @param <U> type of items
+ * @author Chirag Tailor
+ * @since 6.0
+ */
+public class MappingItemReader<T, U> implements ItemReader<U> {
+
+	private final ItemReader<T> upstream;
+
+	private final Function<T, U> mapper;
+
+	/**
+	 * Create a new {@link MappingItemReader}.
+	 * @param upstream the upstream item reader whose items will have the mapper applied
+	 * @param mapper the mapping function to apply to the items read from the upstream
+	 */
+	public MappingItemReader(ItemReader<T> upstream, Function<T, U> mapper) {
+		this.upstream = upstream;
+		this.mapper = mapper;
+	}
+
+	@Override
+	public @Nullable U read() throws Exception {
+		T item = upstream.read();
+		if (Objects.isNull(item)) {
+			return null;
+		}
+		return mapper.apply(item);
+	}
+
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/builder/ItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/support/builder/ItemReaderBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.support.builder;
+
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.batch.infrastructure.item.support.FilteringItemReader;
+import org.springframework.batch.infrastructure.item.support.FlatMappingItemReader;
+import org.springframework.batch.infrastructure.item.support.MappingItemReader;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * @author Chirag Tailor
+ * @since 6.0
+ */
+public class ItemReaderBuilder<T> {
+    private final ItemReader<T> itemReader;
+
+    private ItemReaderBuilder(ItemReader<T> itemReader) {
+        this.itemReader = itemReader;
+    }
+
+    public static <T> ItemReaderBuilder<T> from(ItemReader<T> itemReader) {
+        return new ItemReaderBuilder<>(itemReader);
+    }
+
+    public <U> ItemReaderBuilder<U> map(Function<T, U> mapper) {
+        return new ItemReaderBuilder<>(new MappingItemReader<>(itemReader, mapper));
+    }
+
+    public <U> ItemReaderBuilder<U> flatMap(Function<T, List<U>> mapper) {
+        return new ItemReaderBuilder<>(new FlatMappingItemReader<>(itemReader, mapper));
+    }
+
+    public ItemReaderBuilder<T> filter(Predicate<T> predicate) {
+        return new ItemReaderBuilder<>(new FilteringItemReader<>(itemReader, predicate));
+    }
+
+    public ItemReader<T> build() {
+        return itemReader;
+    }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/PagingItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/PagingItemReaderTests.java
@@ -1,0 +1,39 @@
+package org.springframework.batch.infrastructure.item.data;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PagingItemReaderTests {
+    @Test
+    void readsItemsBasedOnPageSize_returningNullWhenThereAreNoRemainingElementsAndNoRemainingPages() throws Exception {
+        int totalItems = 2;
+        int pageSize = 1;
+        PagingItemReader<TestItem> pagingItemReader = new PagingItemReader<>(
+                pageable ->
+                        switch (pageable.getPageNumber()) {
+                            case 0 -> new PageImpl<>(
+                                    List.of(new TestItem(1)),
+                                    PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
+                                    totalItems);
+                            case 1 -> new PageImpl<>(
+                                    List.of(new TestItem(2)),
+                                    PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()),
+                                    totalItems);
+                            default -> throw new IllegalStateException("Unexpected value: " + pageable.getPageNumber());
+                        },
+                pageSize);
+
+        assertThat(Objects.requireNonNull(pagingItemReader.read()).number()).isEqualTo(1);
+        assertThat(Objects.requireNonNull(pagingItemReader.read()).number()).isEqualTo(2);
+        assertThat(pagingItemReader.read()).isNull();
+    }
+
+    private record TestItem(int number) {
+    }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/function/ListSupplierItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/function/ListSupplierItemReaderTests.java
@@ -1,0 +1,43 @@
+package org.springframework.batch.infrastructure.item.function;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListSupplierItemReaderTests {
+    @Test
+    void readsItemsFromSupplierInSequence_returningNullWhenThereAreNoRemainingElements() throws Exception {
+        ListSupplierItemReader<TestItem> listSupplierItemReader = new ListSupplierItemReader<>(() -> List.of(
+                new TestItem(1),
+                new TestItem(2),
+                new TestItem(3)));
+
+        assertThat(Objects.requireNonNull(listSupplierItemReader.read()).number()).isEqualTo(1);
+        assertThat(Objects.requireNonNull(listSupplierItemReader.read()).number()).isEqualTo(2);
+        assertThat(Objects.requireNonNull(listSupplierItemReader.read()).number()).isEqualTo(3);
+        assertThat(listSupplierItemReader.read()).isNull();
+    }
+
+    @Test
+    void callsTheSupplierExactlyOnceDuringTheFirstRead() throws Exception {
+        AtomicInteger callCount = new AtomicInteger();
+        ListSupplierItemReader<TestItem> listSupplierItemReader = new ListSupplierItemReader<>(() -> {
+            callCount.getAndIncrement();
+            return List.of(new TestItem(1), new TestItem(2));
+        });
+
+        assertThat(callCount.get()).isEqualTo(0);
+        assertThat(Objects.requireNonNull(listSupplierItemReader.read()).number()).isEqualTo(1);
+        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(Objects.requireNonNull(listSupplierItemReader.read()).number()).isEqualTo(2);
+        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(listSupplierItemReader.read()).isNull();
+    }
+
+    private record TestItem(int number) {
+    }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/FilteringItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/FilteringItemReaderTests.java
@@ -1,0 +1,29 @@
+package org.springframework.batch.infrastructure.item.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilteringItemReaderTests {
+    @Test
+    void filtersTheItemsReadByTheUpstreamItemReader() throws Exception {
+        ListItemReader<TestItem> upstreamItemReader = new ListItemReader<>(List.of(
+                new TestItem("---keep-1---"),
+                new TestItem("---remove---"),
+                new TestItem("---keep-2---"),
+                new TestItem("---remove---"),
+                new TestItem("---keep-3---")
+        ));
+        FilteringItemReader<TestItem> filteringItemReader = new FilteringItemReader<>(upstreamItemReader, testItem -> testItem.value().contains("keep"));
+        assertThat(Objects.requireNonNull(filteringItemReader.read()).value()).isEqualTo("---keep-1---");
+        assertThat(Objects.requireNonNull(filteringItemReader.read()).value()).isEqualTo("---keep-2---");
+        assertThat(Objects.requireNonNull(filteringItemReader.read()).value()).isEqualTo("---keep-3---");
+        assertThat(filteringItemReader.read()).isNull();
+    }
+
+    private record TestItem(String value) {
+    }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/FlatMappingItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/FlatMappingItemReaderTests.java
@@ -1,0 +1,39 @@
+package org.springframework.batch.infrastructure.item.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlatMappingItemReaderTests {
+    @Test
+    void mapsTheItemsReadByTheUpstreamItemReader_readingTheResultingItemsInSequence() throws Exception {
+        // given
+        ListItemReader<TestUpstreamItem> upstreamItemReader = new ListItemReader<>(List.of(
+                new TestUpstreamItem(2),
+                new TestUpstreamItem(3)
+        ));
+        FlatMappingItemReader<TestUpstreamItem, TestItem> flatMappingItemReader = new FlatMappingItemReader<>(upstreamItemReader,
+                testUpstreamItem -> IntStream.range(0, testUpstreamItem.number())
+                        .mapToObj(n -> new TestItem(testUpstreamItem.number() * 2 + n))
+                        .toList());
+
+        // when
+        // then
+        assertThat(Objects.requireNonNull(flatMappingItemReader.read()).number()).isEqualTo(4);
+        assertThat(Objects.requireNonNull(flatMappingItemReader.read()).number()).isEqualTo(5);
+        assertThat(Objects.requireNonNull(flatMappingItemReader.read()).number()).isEqualTo(6);
+        assertThat(Objects.requireNonNull(flatMappingItemReader.read()).number()).isEqualTo(7);
+        assertThat(Objects.requireNonNull(flatMappingItemReader.read()).number()).isEqualTo(8);
+        assertThat(flatMappingItemReader.read()).isNull();
+    }
+
+    private record TestUpstreamItem(int number) {
+    }
+
+    private record TestItem(int number) {
+    }
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/MappingItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/MappingItemReaderTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Chirag Tailor
+ */
+class MappingItemReaderTests {
+
+	@Test
+	void mapsTheItemsReadByTheUpstreamItemReader() throws Exception {
+		// given
+		ListItemReader<TestUpstreamItem> upstreamItemReader = new ListItemReader<>(List.of(new TestUpstreamItem(3)));
+		MappingItemReader<TestUpstreamItem, TestItem> mappingItemReader = new MappingItemReader<>(upstreamItemReader,
+				testUpstreamItem -> new TestItem(testUpstreamItem.number() * 2));
+
+		// when
+		TestItem testItem = mappingItemReader.read();
+
+		// then
+		assertThat(testItem).isNotNull();
+		assertThat(testItem.number()).isEqualTo(6);
+	}
+
+	@Test
+	void terminatesWhenThereAreNoMoreUpstreamItems() throws Exception {
+		// given
+		ListItemReader<TestUpstreamItem> upstreamItemReader = new ListItemReader<>(List.of());
+		MappingItemReader<TestUpstreamItem, TestItem> mappingItemReader = new MappingItemReader<>(upstreamItemReader,
+				testUpstreamItem -> new TestItem(testUpstreamItem.number() * 2));
+
+		// when
+		TestItem testItem = mappingItemReader.read();
+
+		// then
+		assertThat(testItem).isNull();
+	}
+
+	private record TestUpstreamItem(int number) {
+	}
+
+	private record TestItem(int number) {
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/builder/ItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/support/builder/ItemReaderBuilderTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.support.builder;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.batch.infrastructure.item.support.ListItemReader;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Chirag Tailor
+ */
+class ItemReaderBuilderTests {
+
+    @Test
+    void createsABuilderWithAllOfTheSpecifiedBehaviors() throws Exception {
+        ItemReader<TestItemC> itemReader =
+                ItemReaderBuilder.from(new ListItemReader<>(List.of(new TestItemA(3))))
+//                [3]
+                .flatMap(testItemA -> IntStream.range(0, testItemA.number())
+                        .mapToObj(value -> new TestItemB(testItemA.number() * 3 + value))
+                        .toList())
+//                [9,10,11]
+                .map(testItemB -> new TestItemC(testItemB.number() * 5))
+//                [45,50,55]
+                .filter(testItemC -> testItemC.number() % 2 == 0)
+//                [50]
+                .build();
+
+        assertThat(Objects.requireNonNull(itemReader.read())).isEqualTo(new TestItemC(50));
+        assertThat(itemReader.read()).isNull();
+    }
+
+    private record TestItemA(int number) {
+    }
+
+    private record TestItemB(int number) {
+    }
+
+    private record TestItemC(int number) {
+    }
+}


### PR DESCRIPTION
This PR adds the following general purpose item readers for consideration to be included in the framework, along with an `ItemReaderBuilder` for combining the mapping, flat mapping, and filtering item readers from below.

- `MappingItemReader`
- `FlatMappingItemReader`
- `FilteringItemReader`
- `ListSupplierItemReader`
- `PagingItemReader`

These item readers and builder were originally implemented within a spring batch based project where they proved to be very helpful in declaratively defining item reader beans for various job steps. Given their general applicability, in case other users of the framework may also find them helpful, they are offered here for consideration to be included in the framework.

Please consider this proposal as the start of a discussion. If any of these implementations seem worthwhile to be added to the framework, I would be happy to document them in the [Item Reader and Writer Implementations](https://github.com/spring-projects/spring-batch/blob/main/spring-batch-docs/modules/ROOT/pages/readers-and-writers/item-reader-writer-implementations.adoc) doc along with any other appropriate doc pages.