### PR TITLE
Propagate step context to worker threads in multi-threaded ChunkOrientedStep

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkOrientedStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkOrientedStep.java
@@ -398,7 +398,15 @@ public class ChunkOrientedStep<I, O> extends AbstractStep {
 			for (int i = 0; i < this.chunkSize && this.chunkTracker.get().moreItems(); i++) {
 				I item = readItem(contribution);
 				if (item != null) {
-					Future<O> itemProcessingFuture = this.taskExecutor.submit(() -> processItem(item, contribution));
+					Future<O> itemProcessingFuture = this.taskExecutor.submit(() -> {
+						try {
+							StepSynchronizationManager.register(stepExecution);
+							return processItem(item, contribution);
+						}
+						finally {
+							StepSynchronizationManager.close();
+						}
+					});
 					itemProcessingTasks.add(itemProcessingFuture);
 				}
 			}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TestConfiguration.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TestConfiguration.java
@@ -53,6 +53,7 @@ public class TestConfiguration {
 	}
 
 	@Bean
+	@StepScope
 	public ItemProcessor<Person, Person> itemProcessor() {
 		return item -> {
 			if (System.getProperty("fail") != null) {


### PR DESCRIPTION
Fixes #5183

## Summary

- Fix `ScopeNotActiveException` when using `@StepScope` beans in multi-threaded `ChunkOrientedStep`
- Register `StepExecution` to worker threads in `processChunkConcurrently` method
- Add `@StepScope` to `itemProcessor` in integration test to verify the fix

## Context
When a step is configured with a `TaskExecutor` for multi-threaded processing, worker threads do not inherit the `StepContext` from the main thread because `ThreadLocal` does not propagate to child threads.

This causes `@StepScope` proxied beans (like `ItemProcessor`) to throw `ScopeNotActiveException` when accessed from worker threads.

## Solution

In `processChunkConcurrently`, register the `StepExecution` to each worker thread before processing and close it after completion:

```java
Future<O> itemProcessingFuture = this.taskExecutor.submit(() -> {
     try {
          StepSynchronizationManager.register(stepExecution);
          return processItem(item, contribution);
     }
     finally {
          StepSynchronizationManager.close();
     }
});
```

## Test

- Modified TestConfiguration.itemProcessor() to use @StepScope annotation
- All 5 tests in ChunkOrientedStepIntegrationTests pass