### PR TITLE
Fix stepName filtering in MongoStepExecutionDao.countStepExecutions

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoStepExecutionDao.java
@@ -170,9 +170,12 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 			.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
 					JOB_EXECUTIONS_COLLECTION_NAME);
 		return this.mongoOperations.count(
-				query(where("jobExecutionId").in(jobExecutions.stream()
-					.map(org.springframework.batch.core.repository.persistence.JobExecution::getJobExecutionId)
-					.toList())),
+				query(where("jobExecutionId")
+					.in(jobExecutions.stream()
+						.map(org.springframework.batch.core.repository.persistence.JobExecution::getJobExecutionId)
+						.toList())
+					.and("name")
+					.is(stepName)),
 				org.springframework.batch.core.repository.persistence.StepExecution.class,
 				STEP_EXECUTIONS_COLLECTION_NAME);
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoStepExecutionDaoIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoStepExecutionDaoIntegrationTests.java
@@ -182,15 +182,24 @@ class MongoStepExecutionDaoIntegrationTests extends AbstractMongoDBDaoIntegratio
 	}
 
 	@Test
-	void testCountStepExecutions() {
-		// Given
-		StepExecution stepExecution = dao.createStepExecution("step", jobExecution);
+	void testCountStepExecutionsFiltersByStepName() {
+		// given
+		dao.createStepExecution("stepA", jobExecution);
+		dao.createStepExecution("stepA", jobExecution);
+		dao.createStepExecution("stepB", jobExecution);
+		dao.createStepExecution("stepC", jobExecution);
 
-		// When
-		long result = dao.countStepExecutions(jobInstance, stepExecution.getStepName());
+		// when
+		long countA = dao.countStepExecutions(jobInstance, "stepA");
+		long countB = dao.countStepExecutions(jobInstance, "stepB");
+		long countC = dao.countStepExecutions(jobInstance, "stepC");
+		long countNonExistent = dao.countStepExecutions(jobInstance, "nonExistentStep");
 
-		// Then
-		assertEquals(1, result);
+		// then
+		assertEquals(2, countA);
+		assertEquals(1, countB);
+		assertEquals(1, countC);
+		assertEquals(0, countNonExistent);
 	}
 
 	@Test


### PR DESCRIPTION
The countStepExecutions method was not filtering by stepName parameter, causing it to count all step executions for the job instance instead of only
the specific step. This fix aligns MongoDB implementation with JDBC implementation behavior. Resolves #5220