### PR TITLE
Alternative fix for race condition in StepContribution counters

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkOrientedStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkOrientedStepTests.java
@@ -28,6 +28,7 @@ import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.ResourcelessJobRepository;
 import org.springframework.batch.core.step.FatalStepExecutionException;
+import org.springframework.batch.core.step.StepContribution;
 import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.core.step.builder.ChunkOrientedStepBuilder;
 import org.springframework.batch.core.step.builder.StepBuilder;
@@ -257,7 +258,7 @@ public class ChunkOrientedStepTests {
 		step.setItemProcessor(processor);
 		step.setFaultTolerant(true);
 		step.setRetryPolicy(RetryPolicy.withMaxRetries(1)); // retry once (initial + 1
-															// retry)
+		// retry)
 		step.setSkipPolicy(new NeverSkipItemSkipPolicy()); // never skip
 		step.afterPropertiesSet();
 
@@ -364,6 +365,149 @@ public class ChunkOrientedStepTests {
 			return this.updateCount;
 		}
 
+	}
+
+	@Test
+	void testFilterCountAccuracyInConcurrentMode() throws Exception {
+		// given
+		int itemCount = 10;
+		AtomicInteger readCounter = new AtomicInteger(0);
+
+		ItemReader<Integer> reader = () -> {
+			int current = readCounter.incrementAndGet();
+			return current <= itemCount ? current : null;
+		};
+
+		ItemProcessor<Integer, Integer> filteringProcessor = item -> null;
+
+		ItemWriter<Integer> writer = chunk -> {
+		};
+
+		JobRepository jobRepository = new ResourcelessJobRepository();
+		ChunkOrientedStep<Integer, Integer> step = new ChunkOrientedStep<>("step", 100, reader, writer, jobRepository);
+		step.setItemProcessor(filteringProcessor);
+		step.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		step.afterPropertiesSet();
+
+		JobInstance jobInstance = new JobInstance(1L, "job");
+		JobExecution jobExecution = new JobExecution(1L, jobInstance, new JobParameters());
+		StepExecution stepExecution = new StepExecution(1L, "step", jobExecution);
+
+		// when
+		step.execute(stepExecution);
+
+		// then
+		assertEquals(itemCount, stepExecution.getFilterCount(), "Race condition detected! Expected " + itemCount
+				+ " filtered items, but got " + stepExecution.getFilterCount());
+	}
+
+	@Test
+	void testFilterCountAccuracyInSequentialMode() throws Exception {
+		// given
+		int itemCount = 10;
+		AtomicInteger readCounter = new AtomicInteger(0);
+
+		ItemReader<Integer> reader = () -> {
+			int current = readCounter.incrementAndGet();
+			return current <= itemCount ? current : null;
+		};
+
+		ItemProcessor<Integer, Integer> filteringProcessor = item -> null;
+		ItemWriter<Integer> writer = chunk -> {
+		};
+
+		JobRepository jobRepository = new ResourcelessJobRepository();
+		ChunkOrientedStep<Integer, Integer> step = new ChunkOrientedStep<>("step", 100, reader, writer, jobRepository);
+		step.setItemProcessor(filteringProcessor);
+		step.afterPropertiesSet();
+
+		JobInstance jobInstance = new JobInstance(1L, "job");
+		JobExecution jobExecution = new JobExecution(1L, jobInstance, new JobParameters());
+		StepExecution stepExecution = new StepExecution(1L, "step", jobExecution);
+
+		// when
+		step.execute(stepExecution);
+
+		// then
+		assertEquals(itemCount, stepExecution.getFilterCount(), "Sequential mode should have accurate filter count");
+	}
+
+	@Test
+	void testProcessSkipCountAccuracyInConcurrentMode() throws Exception {
+		// given
+		int itemCount = 10;
+		AtomicInteger readCounter = new AtomicInteger(0);
+
+		ItemReader<Integer> reader = () -> {
+			int current = readCounter.incrementAndGet();
+			return current <= itemCount ? current : null;
+		};
+
+		ItemProcessor<Integer, Integer> failingProcessor = item -> {
+			throw new RuntimeException("Simulated processing failure");
+		};
+
+		ItemWriter<Integer> writer = chunk -> {
+		};
+
+		JobRepository jobRepository = new ResourcelessJobRepository();
+		ChunkOrientedStep<Integer, Integer> step = new ChunkOrientedStep<>("step", 100, reader, writer, jobRepository);
+		step.setItemProcessor(failingProcessor);
+		step.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		step.setFaultTolerant(true);
+		step.setRetryPolicy(RetryPolicy.withMaxRetries(1));
+		step.setSkipPolicy((throwable, skipCount) -> throwable instanceof RuntimeException);
+
+		step.afterPropertiesSet();
+
+		JobInstance jobInstance = new JobInstance(1L, "job");
+		JobExecution jobExecution = new JobExecution(1L, jobInstance, new JobParameters());
+		StepExecution stepExecution = new StepExecution(1L, "step", jobExecution);
+
+		// when
+		step.execute(stepExecution);
+
+		// then
+		assertEquals(itemCount, stepExecution.getProcessSkipCount(), "Race condition detected! Expected " + itemCount
+				+ " process skips, but got " + stepExecution.getProcessSkipCount());
+	}
+
+	@Test
+	void testProcessSkipCountAccuracyInSequentialMode() throws Exception {
+		// given
+		int itemCount = 10;
+		AtomicInteger readCounter = new AtomicInteger(0);
+
+		ItemReader<Integer> reader = () -> {
+			int current = readCounter.incrementAndGet();
+			return current <= itemCount ? current : null;
+		};
+
+		ItemProcessor<Integer, Integer> failingProcessor = item -> {
+			throw new RuntimeException("Simulated processing failure");
+		};
+
+		ItemWriter<Integer> writer = chunk -> {
+		};
+
+		JobRepository jobRepository = new ResourcelessJobRepository();
+		ChunkOrientedStep<Integer, Integer> step = new ChunkOrientedStep<>("step", 100, reader, writer, jobRepository);
+		step.setItemProcessor(failingProcessor);
+		step.setFaultTolerant(true);
+		step.setRetryPolicy(RetryPolicy.withMaxRetries(1));
+		step.setSkipPolicy((throwable, skipCount) -> throwable instanceof RuntimeException);
+		step.afterPropertiesSet();
+
+		JobInstance jobInstance = new JobInstance(1L, "job");
+		JobExecution jobExecution = new JobExecution(1L, jobInstance, new JobParameters());
+		StepExecution stepExecution = new StepExecution(1L, "step", jobExecution);
+
+		// when
+		step.execute(stepExecution);
+
+		// then
+		assertEquals(itemCount, stepExecution.getProcessSkipCount(),
+				"Sequential mode should have accurate process skip count");
 	}
 
 }


### PR DESCRIPTION
Use separate StepContribution instances for each worker thread and aggregate them in the main thread after all tasks complete. This approach avoids race conditions  
  without modifying the StepContribution class itself. Resolves #5188