### PR TITLE
Fix SimpleStepExecutionSplitter to restart COMPLETED partitions

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/partition/support/SimpleStepExecutionSplitter.java
@@ -144,8 +144,7 @@ public class SimpleStepExecutionSplitter implements StepExecutionSplitter {
 				set.add(currentStepExecution);
 			}
 			else { // restart
-				if (lastStepExecution.getStatus() != BatchStatus.COMPLETED
-						&& shouldStart(allowStartIfComplete, stepExecution, lastStepExecution)) {
+				if (shouldStart(allowStartIfComplete, stepExecution, lastStepExecution)) {
 					StepExecution currentStepExecution = jobRepository.createStepExecution(stepName, jobExecution);
 					currentStepExecution.setExecutionContext(lastStepExecution.getExecutionContext());
 					jobRepository.updateExecutionContext(currentStepExecution);


### PR DESCRIPTION
## Summary                                                                                                                               
  - Remove redundant BatchStatus.COMPLETED check before shouldStart() in SimpleStepExecutionSplitter.split()                                                                                                                                                                                                    
  - Add test cases for COMPLETED partition restart scenarios                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                
  Resolves #5238