### PR TITLE
Fix dirty flag not cleared in updateExecutionContext

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
@@ -48,6 +48,7 @@ import org.springframework.batch.infrastructure.support.transaction.Resourceless
  * @since 5.2.0
  * @author Mahmoud Ben Hassine
  * @author Sanghyuk Jung
+ * @author Andrey Litvitski
  */
 public class ResourcelessJobRepository implements JobRepository {
 
@@ -244,6 +245,7 @@ public class ResourcelessJobRepository implements JobRepository {
 	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
 		jobExecution.setLastUpdated(LocalDateTime.now());
+		jobExecution.getExecutionContext().clearDirtyFlag();
 	}
 
 	@Override
@@ -336,6 +338,7 @@ public class ResourcelessJobRepository implements JobRepository {
 	@Override
 	public void updateExecutionContext(StepExecution stepExecution) {
 		stepExecution.setLastUpdated(LocalDateTime.now());
+		stepExecution.getExecutionContext().clearDirtyFlag();
 	}
 
 	private boolean isJobKeyEquals(JobParameters jobParameters) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -53,6 +53,7 @@ import java.util.List;
  * @author Parikshit Dutta
  * @author Mark John Moreno
  * @author Yanming Zhou
+ * @author Andrey Litvitski
  * @see JobRepository
  * @see JobInstanceDao
  * @see JobExecutionDao
@@ -185,11 +186,13 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 		validateStepExecution(stepExecution);
 		Assert.notNull(stepExecution.getId(), "StepExecution must already be saved (have an id assigned)");
 		ecDao.updateExecutionContext(stepExecution);
+		stepExecution.getExecutionContext().clearDirtyFlag();
 	}
 
 	@Override
 	public void updateExecutionContext(JobExecution jobExecution) {
 		ecDao.updateExecutionContext(jobExecution);
+		jobExecution.getExecutionContext().clearDirtyFlag();
 	}
 
 	@Override


### PR DESCRIPTION
ExecutionContext#clearDirtyFlag() is now called after persisting the context.

Closes: gh-5249
