### PR TITLE
Fix that `ResourcelessJobRepository::getJobInstanceCount` violate API contract

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
@@ -197,7 +197,7 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 	@Override
 	public long getJobInstanceCount(String jobName) throws NoSuchJobException {
 		if (!getJobNames().contains(jobName)) {
-			throw new NoSuchJobException("Job not found " + jobName);
+			throw new NoSuchJobException("No job instances were found for job name " + jobName);
 		}
 		Query query = query(where("jobName").is(jobName));
 		return this.mongoOperations.count(query, COLLECTION_NAME);

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/ResourcelessJobRepository.java
@@ -27,6 +27,7 @@ import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.JobKeyGenerator;
 import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.core.repository.JobRepository;
@@ -48,6 +49,7 @@ import org.springframework.batch.infrastructure.support.transaction.Resourceless
  * @since 5.2.0
  * @author Mahmoud Ben Hassine
  * @author Sanghyuk Jung
+ * @author Yanming Zhou
  */
 public class ResourcelessJobRepository implements JobRepository {
 
@@ -160,9 +162,9 @@ public class ResourcelessJobRepository implements JobRepository {
 	}
 
 	@Override
-	public long getJobInstanceCount(String jobName) {
-		if (this.jobInstance == null || !this.jobInstance.getJobName().equals(jobName)) {
-			return 0;
+	public long getJobInstanceCount(String jobName) throws NoSuchJobException {
+		if (!getJobNames().contains(jobName)) {
+			throw new NoSuchJobException("No job instances were found for job name " + jobName);
 		}
 		return 1;
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/ResourcelessJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/ResourcelessJobRepositoryTests.java
@@ -21,6 +21,7 @@ import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Mahmoud Ben Hassine
  * @author Sanghyuk Jung
+ * @author Yanming Zhou
  */
 class ResourcelessJobRepositoryTests {
 
@@ -225,21 +227,17 @@ class ResourcelessJobRepositoryTests {
 	}
 
 	@Test
-	void getJobInstanceCountWithDifferentJobName() {
+	void getJobInstanceCountWithDifferentJobName() throws Exception {
 		// given
 		String jobName = "job";
 		JobParameters jobParameters = new JobParameters();
 		jobRepository.createJobInstance(jobName, jobParameters);
 
-		// when
-		long count = jobRepository.getJobInstanceCount("differentJob");
-
-		// then
-		assertEquals(0L, count);
+		assertThrows(NoSuchJobException.class, () -> jobRepository.getJobInstanceCount("differentJob"));
 	}
 
 	@Test
-	void getJobInstanceCountWithCorrectJobName() {
+	void getJobInstanceCountWithCorrectJobName() throws Exception {
 		// given
 		String jobName = "job";
 		JobParameters jobParameters = new JobParameters();


### PR DESCRIPTION
And polish `MongoJobInstanceDao::getJobInstanceCount` to use consistent exception message.

See https://github.com/spring-projects/spring-batch/issues/5124#issuecomment-3749784120
See https://github.com/spring-projects/spring-batch/issues/5252
