### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: task"
+  - package-ecosystem: "github-actions"
+    target-branch: "5.2.x"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: task"


### PR DESCRIPTION
This commit configures GitHub to keep GitHub actions up to the latest available version in the form of PRs