### PR TITLE
Fix MongoJobInstanceDao to comply with JobInstanceDao contract

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobInstanceDao.java
@@ -112,8 +112,10 @@ public class MongoJobInstanceDao implements JobInstanceDao {
 
 	@Override
 	public List<JobInstance> getJobInstances(String jobName, int start, int count) {
-		Query query = query(where("jobName").is(jobName))
-			.with(Sort.by(Sort.Order.desc("jobInstanceId")))
+		if (count == 0) {
+			return Collections.emptyList();
+		}
+		Query query = query(where("jobName").is(jobName)).with(Sort.by(Sort.Order.desc("jobInstanceId")))
 			.skip(start)
 			.limit(count);
 		return this.mongoOperations


### PR DESCRIPTION
Closes gh-5274

`MongoJobInstanceDao` has two issues:

1. `getJobNames()` uses `findAll()` which loads all documents into memory without deduplication or sorting. The `JobInstanceDao` interface contract requires distinct, alphabetically sorted names. Replaced with `findDistinct()` with sorting.

2. `getJobInstances()` fetches all matching documents and paginates in Java. Replaced with MongoDB `skip()` and `limit()`.