### PR TITLE
GH-5285: Clarify JavaDoc of BatchStatus.isLessThanOrEqualTo

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public enum BatchStatus {
 
 	/**
 	 * @param other A status value to which to compare.
-	 * @return {@code true} if this is less than {@code other}.
+	 * @return {@code true} if this is less than or equal to {@code other}.
 	 */
 	public boolean isLessThanOrEqualTo(BatchStatus other) {
 		return this.compareTo(other) <= 0;


### PR DESCRIPTION
The JavaDoc of `BatchStatus.isLessThanOrEqualTo(BatchStatus other)`
was slightly misleading as it only mentioned "less than" while the
method actually performs a "less than or equal to" comparison.

This update clarifies the documentation to accurately reflect the
method behavior.

No functional changes.