### PR TITLE
Fix inaccurate exception message in TaskExecutorJobLauncher

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
@@ -134,7 +134,7 @@ public class TaskExecutorJobLauncher implements JobLauncher, InitializingBean {
 				for (JobExecution execution : executions) {
 					if (execution.isRunning()) {
 						throw new JobExecutionAlreadyRunningException(
-								"A job execution for this job is already running: " + jobInstance);
+								"A job execution for this job is already running: " + execution);
 					}
 					BatchStatus status = execution.getStatus();
 					if (status == BatchStatus.UNKNOWN) {

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncherTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncherTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.launch.support;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobRepository;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link TaskExecutorJobLauncher}.
+ *
+ * @author Jeongwook Ko
+ */
+@SuppressWarnings("removal")
+class TaskExecutorJobLauncherTests {
+
+	private final JobRepository jobRepository = mock();
+
+	private TaskExecutorJobLauncher jobLauncher;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		jobLauncher = new TaskExecutorJobLauncher();
+		jobLauncher.setJobRepository(jobRepository);
+		jobLauncher.afterPropertiesSet();
+	}
+
+	@Test
+	void testRunWithRunningJobExecution() {
+		// given
+		String jobName = "job";
+		JobParameters jobParameters = new JobParameters();
+		Job job = mock();
+		Mockito.when(job.getName()).thenReturn(jobName);
+		JobInstance jobInstance = new JobInstance(1L, jobName);
+		JobExecution runningJobExecution = new JobExecution(2L, jobInstance, jobParameters);
+		runningJobExecution.setStatus(BatchStatus.STARTED);
+		Mockito.when(jobRepository.getJobInstance(jobName, jobParameters)).thenReturn(jobInstance);
+		Mockito.when(jobRepository.getJobExecutions(jobInstance)).thenReturn(List.of(runningJobExecution));
+
+		// when
+		JobExecutionAlreadyRunningException exception = Assertions
+			.assertThrows(JobExecutionAlreadyRunningException.class, () -> jobLauncher.run(job, jobParameters));
+
+		// then
+		Assertions.assertEquals("A job execution for this job is already running: " + runningJobExecution,
+				exception.getMessage());
+		// the message should report the running job execution, not the job instance
+		Assertions.assertTrue(exception.getMessage().contains("status=" + BatchStatus.STARTED));
+	}
+
+}


### PR DESCRIPTION
The JobExecutionAlreadyRunningException thrown by TaskExecutorJobLauncher currently includes the JobInstance details instead of the running JobExecution details.

This commit updates the exception to pass the running JobExecution.

Resolves #5280

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
* Sign-off commits according to the [Developer Certificate of Origin](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring)

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md