### PR TITLE
Fix step name being null when not defined as bean

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
@@ -42,6 +42,7 @@ import org.springframework.batch.infrastructure.support.ReflectionUtils;
  * @author Michael Minella
  * @author Taeik Lim
  * @author Mahmoud Ben Hassine
+ * @author Andrey Litvitski
  * @since 2.2
  */
 // FIXME remove once default constructors (required by the XML namespace) are removed
@@ -137,6 +138,9 @@ public abstract class StepBuilderHelper<B extends StepBuilderHelper<B>> {
 	}
 
 	protected void enhance(AbstractStep step) {
+		if (step.getName() == null) {
+			step.setName(step.getClass().getSimpleName());
+		}
 		step.setJobRepository(properties.getJobRepository());
 
 		ObservationRegistry observationRegistry = properties.getObservationRegistry();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/StepBuilderHelperTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/StepBuilderHelperTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.core.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilderHelper;
+import org.springframework.batch.core.step.job.JobStep;
+
+/**
+ * Tests for {@link StepBuilderHelperTests}.
+ *
+ * @author Andrey Litvitski
+ */
+class StepBuilderHelperTests {
+
+	@Test
+	void enhanceShouldDefaultStepNameToShortClassNameWhenNull() {
+		JobRepository jobRepository = mock(JobRepository.class);
+		TestStepBuilderHelper helper = new TestStepBuilderHelper(jobRepository);
+		JobStep step = new JobStep(jobRepository);
+		helper.enhanceForTest(step);
+		assertThat(step.getName()).isEqualTo(step.getClass().getSimpleName());
+	}
+
+	static class TestStepBuilderHelper extends StepBuilderHelper<TestStepBuilderHelper> {
+
+		public TestStepBuilderHelper(JobRepository jobRepository) {
+			super(jobRepository);
+		}
+
+		@Override
+		protected TestStepBuilderHelper self() {
+			return this;
+		}
+
+		void enhanceForTest(AbstractStep step) {
+			super.enhance(step);
+		}
+
+	}
+
+}


### PR DESCRIPTION
In this commit, if Step is not a bean, we give it a class name, thereby preventing null in the class name, which is prohibited by contract.

Closes: gh-5278
