### PR TITLE
Fix duplicated write count in local chunking sample

### DIFF
--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/chunking/local/LocalChunkingJobConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/chunking/local/LocalChunkingJobConfiguration.java
@@ -99,7 +99,6 @@ public class LocalChunkingJobConfiguration {
 		return (chunk, contribution) -> transactionTemplate.executeWithoutResult(transactionStatus -> {
 			try {
 				itemWriter.write(chunk);
-				contribution.incrementWriteCount(chunk.size());
 				contribution.setExitStatus(ExitStatus.COMPLETED);
 			}
 			catch (Exception e) {

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/chunking/local/LocalChunkingJobFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/chunking/local/LocalChunkingJobFunctionalTests.java
@@ -51,6 +51,8 @@ public class LocalChunkingJobFunctionalTests {
 		assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
 		int vetsCount = JdbcTestUtils.countRowsInTable(jdbcTemplate, "vets");
 		assertEquals(6, vetsCount);
+		long writeCount = jobExecution.getStepExecutions().iterator().next().getWriteCount();
+		assertEquals(6, writeCount);
 	}
 
 	@Test
@@ -72,6 +74,8 @@ public class LocalChunkingJobFunctionalTests {
 		assertTrue(jobExecution.getExitStatus().getExitDescription().contains("size limit: 30"));
 		int vetsCount = JdbcTestUtils.countRowsInTable(jdbcTemplate, "vets");
 		assertEquals(4, vetsCount);
+		long writeCount = jobExecution.getStepExecutions().iterator().next().getWriteCount();
+		assertEquals(4, writeCount);
 	}
 
 }


### PR DESCRIPTION
## Summary
- remove manual `contribution.incrementWriteCount(chunk.size())` from `LocalChunkingJobConfiguration`
- rely on framework-managed write count increment in `ChunkOrientedStep`
- add write-count assertions in `LocalChunkingJobFunctionalTests` (success/failure paths)

## Why
`ChunkOrientedStep#writeChunk` already increments write count after a successful write. The sample also incremented it manually, which made the reported write count misleading.

Closes #5302
