### PR TITLE
Fix outdated Spring Batch Javadoc links in reference docs

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/job/advanced-meta-data.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/job/advanced-meta-data.adoc
@@ -49,7 +49,7 @@ need to populate it manually with the jobs that you want to operate through the 
 
 Most of the methods on `JobOperator` are
 self-explanatory, and you can find more detailed explanations in the
-https://docs.spring.io/spring-batch/docs/current/api/org/springframework/batch/core/launch/JobOperator.html[Javadoc of the interface]. However, the
+https://docs.spring.io/spring-batch/reference/api/org/springframework/batch/core/launch/JobOperator.html[Javadoc of the interface]. However, the
 `startNextInstance` method is worth noting. This
 method always starts a new instance of a `Job`.
 This can be extremely useful if there are serious issues in a

--- a/spring-batch-docs/modules/ROOT/pages/testing.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/testing.adoc
@@ -344,4 +344,4 @@ public void testAfterStep() {
 
 The preceding method for creating a simple `StepExecution` is only one convenience method
 available within the factory. You can find a full method listing in its
-link:$$http://docs.spring.io/spring-batch/apidocs/org/springframework/batch/test/MetaDataInstanceFactory.html$$[Javadoc].
+link:$$https://docs.spring.io/spring-batch/reference/api/org/springframework/batch/test/MetaDataInstanceFactory.html$$[Javadoc].


### PR DESCRIPTION
## What
- Updated outdated Spring Batch Javadoc links in the reference docs:
  - `spring-batch-docs/modules/ROOT/pages/job/advanced-meta-data.adoc`
  - `spring-batch-docs/modules/ROOT/pages/testing.adoc`
- Replaced legacy Javadoc URL patterns with the current Spring Batch 6 API path under `https://docs.spring.io/spring-batch/reference/api/...`. 

Closes #5290 
