### PR TITLE
Add BatchJobLifecycleManager for graceful job execution shutdown

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/BatchJobLifecycleManager.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/BatchJobLifecycleManager.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.launch.support;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.launch.JobExecutionNotRunningException;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link SmartLifecycle} implementation that manages the lifecycle of job executions
+ * during application shutdown. This component tracks active job executions and ensures
+ * they are properly stopped and given time to complete before the JVM shuts down.
+ *
+ * <p>
+ * This manager is designed to prevent issues where job execution metadata cannot be saved
+ * due to database connections closing before job threads complete during shutdown.
+ *
+ * @author Mahmoud Ben Hassine
+ * @since 6.0
+ */
+public class BatchJobLifecycleManager implements SmartLifecycle {
+
+	private static final Log logger = LogFactory.getLog(BatchJobLifecycleManager.class);
+
+	private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
+
+	private final JobOperator jobOperator;
+
+	private final Set<JobExecution> jobExecutions = ConcurrentHashMap.newKeySet();
+
+	private final Duration shutdownTimeout;
+
+	private volatile boolean running = false;
+
+	private int phase = Integer.MAX_VALUE - 1000;
+
+	private boolean autoStartup = true;
+
+	/**
+	 * Create a new {@link BatchJobLifecycleManager}.
+	 * @param jobOperator the job operator to use for stopping job executions
+	 */
+	public BatchJobLifecycleManager(JobOperator jobOperator) {
+		this(jobOperator, DEFAULT_SHUTDOWN_TIMEOUT);
+	}
+
+	/**
+	 * Create a new {@link BatchJobLifecycleManager}.
+	 * @param jobOperator the job operator to use for stopping job executions
+	 * @param shutdownTimeout the maximum time to wait for job executions to complete
+	 * during shutdown
+	 */
+	public BatchJobLifecycleManager(JobOperator jobOperator, Duration shutdownTimeout) {
+		Assert.notNull(jobOperator, "jobOperator must not be null");
+		Assert.notNull(shutdownTimeout, "shutdownTimeout must not be null");
+		this.jobOperator = jobOperator;
+		this.shutdownTimeout = shutdownTimeout;
+	}
+
+	/**
+	 * Track a job execution for lifecycle management.
+	 * @param jobExecution the job execution to track
+	 */
+	public void track(JobExecution jobExecution) {
+		Assert.notNull(jobExecution, "jobExecution must not be null");
+		this.jobExecutions.add(jobExecution);
+		if (logger.isDebugEnabled()) {
+			logger.debug(
+					"Tracking job execution " + jobExecution.getId() + ". Total tracked: " + this.jobExecutions.size());
+		}
+	}
+
+	/**
+	 * Untrack a job execution from lifecycle management.
+	 * @param jobExecution the job execution to untrack
+	 */
+	public void untrack(JobExecution jobExecution) {
+		Assert.notNull(jobExecution, "jobExecution must not be null");
+		this.jobExecutions.remove(jobExecution);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Untracking job execution " + jobExecution.getId() + ". Total tracked: "
+					+ this.jobExecutions.size());
+		}
+	}
+
+	@Override
+	public void start() {
+		this.running = true;
+		if (logger.isInfoEnabled()) {
+			logger.info("BatchJobLifecycleManager started");
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (!this.running) {
+			return;
+		}
+
+		try {
+			stopRunningExecutions();
+			waitForCompletion();
+		}
+		finally {
+			this.running = false;
+		}
+
+		if (logger.isInfoEnabled()) {
+			logger.info("BatchJobLifecycleManager stopped");
+		}
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		stop();
+		callback.run();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return this.autoStartup;
+	}
+
+	/**
+	 * Set whether this lifecycle manager should auto-start.
+	 * @param autoStartup {@code true} to auto-start, {@code false} otherwise
+	 */
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	@Override
+	public int getPhase() {
+		return this.phase;
+	}
+
+	/**
+	 * Set the phase in which this lifecycle manager should stop.
+	 * @param phase the phase value
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+	private void stopRunningExecutions() {
+		if (this.jobExecutions.isEmpty()) {
+			if (logger.isInfoEnabled()) {
+				logger.info("No active job executions to stop");
+			}
+			return;
+		}
+
+		if (logger.isInfoEnabled()) {
+			logger.info("Attempting to gracefully stop " + this.jobExecutions.size() + " job execution(s)");
+		}
+
+		for (JobExecution jobExecution : this.jobExecutions) {
+			try {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Stopping job execution " + jobExecution.getId());
+				}
+				this.jobOperator.stop(jobExecution);
+			}
+			catch (JobExecutionNotRunningException e) {
+				logger.warn("Job execution " + jobExecution.getId() + " is not running");
+			}
+			catch (Exception e) {
+				logger.warn("Failed to stop job execution " + jobExecution.getId(), e);
+			}
+		}
+	}
+
+	private void waitForCompletion() {
+		if (this.jobExecutions.isEmpty()) {
+			return;
+		}
+
+		long deadline = System.nanoTime() + this.shutdownTimeout.toNanos();
+		int pollIntervalMs = 1000;
+
+		while (!this.jobExecutions.isEmpty() && System.nanoTime() < deadline) {
+			if (logger.isInfoEnabled()) {
+				logger.info("Waiting for " + this.jobExecutions.size() + " job execution(s) to complete");
+			}
+			try {
+				Thread.sleep(pollIntervalMs);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				logger.warn("Interrupted while waiting for job executions to complete");
+				break;
+			}
+		}
+
+		if (!this.jobExecutions.isEmpty()) {
+			logger.warn("Shutdown timeout reached. " + this.jobExecutions.size()
+					+ " job execution(s) may still be running");
+		}
+		else if (logger.isInfoEnabled()) {
+			logger.info("All job executions completed");
+		}
+	}
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/JobExecutionTrackingListener.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/JobExecutionTrackingListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.launch.support.BatchJobLifecycleManager;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link org.springframework.batch.core.listener.JobExecutionListener} that tracks and
+ * untracks job executions in a {@link BatchJobLifecycleManager}.
+ *
+ * <p>
+ * This listener integrates with the {@link BatchJobLifecycleManager} to ensure job
+ * executions are properly managed during application shutdown, allowing jobs to complete
+ * gracefully and save their metadata before database connections are closed.
+ *
+ * @author Mahmoud Ben Hassine
+ * @since 6.0
+ */
+public class JobExecutionTrackingListener implements org.springframework.batch.core.listener.JobExecutionListener {
+
+	private static final Log logger = LogFactory.getLog(JobExecutionTrackingListener.class);
+
+	private final BatchJobLifecycleManager lifecycleManager;
+
+	/**
+	 * Create a new {@link JobExecutionTrackingListener}.
+	 * @param lifecycleManager the lifecycle manager to track job executions with
+	 */
+	public JobExecutionTrackingListener(BatchJobLifecycleManager lifecycleManager) {
+		Assert.notNull(lifecycleManager, "lifecycleManager must not be null");
+		this.lifecycleManager = lifecycleManager;
+	}
+
+	@Override
+	public void beforeJob(JobExecution jobExecution) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Tracking job execution " + jobExecution.getId() + " before job start");
+		}
+		this.lifecycleManager.track(jobExecution);
+	}
+
+	@Override
+	public void afterJob(JobExecution jobExecution) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Untracking job execution " + jobExecution.getId() + " after job completion");
+		}
+		this.lifecycleManager.untrack(jobExecution);
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/BatchJobLifecycleManagerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/BatchJobLifecycleManagerTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.launch.support;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.JobExecutionNotRunningException;
+import org.springframework.batch.core.launch.JobOperator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link BatchJobLifecycleManager}.
+ *
+ * @author Mahmoud Ben Hassine
+ */
+class BatchJobLifecycleManagerTests {
+
+	private JobOperator jobOperator;
+
+	private BatchJobLifecycleManager lifecycleManager;
+
+	@BeforeEach
+	void setUp() {
+		this.jobOperator = mock(JobOperator.class);
+		this.lifecycleManager = new BatchJobLifecycleManager(jobOperator, Duration.ofSeconds(2));
+	}
+
+	@Test
+	void constructorWhenJobOperatorNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> new BatchJobLifecycleManager(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("jobOperator must not be null");
+	}
+
+	@Test
+	void constructorWhenShutdownTimeoutNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> new BatchJobLifecycleManager(jobOperator, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("shutdownTimeout must not be null");
+	}
+
+	@Test
+	void trackWhenJobExecutionNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> this.lifecycleManager.track(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("jobExecution must not be null");
+	}
+
+	@Test
+	void untrackWhenJobExecutionNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> this.lifecycleManager.untrack(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("jobExecution must not be null");
+	}
+
+	@Test
+	void trackAndUntrackJobExecution() {
+		// given
+		JobExecution jobExecution = createJobExecution(1L);
+
+		// when
+		this.lifecycleManager.track(jobExecution);
+
+		// then
+		assertThat(this.lifecycleManager).isNotNull();
+
+		// when
+		this.lifecycleManager.untrack(jobExecution);
+
+		// then
+		assertThat(this.lifecycleManager).isNotNull();
+	}
+
+	@Test
+	void startWhenCalledThenSetsRunningToTrue() {
+		// when
+		this.lifecycleManager.start();
+
+		// then
+		assertThat(this.lifecycleManager.isRunning()).isTrue();
+
+		// cleanup
+		this.lifecycleManager.stop();
+	}
+
+	@Test
+	void stopWhenNoJobExecutionsTrackedThenDoesNotCallJobOperator() throws Exception {
+		// given
+		this.lifecycleManager.start();
+
+		// when
+		this.lifecycleManager.stop();
+
+		// then
+		verify(this.jobOperator, never()).stop(any());
+		assertThat(this.lifecycleManager.isRunning()).isFalse();
+	}
+
+	@Test
+	void stopWhenJobExecutionsTrackedThenStopsAllExecutions() throws Exception {
+		// given
+		JobExecution jobExecution1 = createJobExecution(1L);
+		JobExecution jobExecution2 = createJobExecution(2L);
+		this.lifecycleManager.track(jobExecution1);
+		this.lifecycleManager.track(jobExecution2);
+		this.lifecycleManager.start();
+
+		// when
+		this.lifecycleManager.stop();
+
+		// then
+		verify(this.jobOperator).stop(jobExecution1);
+		verify(this.jobOperator).stop(jobExecution2);
+		assertThat(this.lifecycleManager.isRunning()).isFalse();
+	}
+
+	@Test
+	void stopWhenJobExecutionNotRunningThenContinuesStoppingOtherExecutions() throws Exception {
+		// given
+		JobExecution jobExecution1 = createJobExecution(1L);
+		JobExecution jobExecution2 = createJobExecution(2L);
+		this.lifecycleManager.track(jobExecution1);
+		this.lifecycleManager.track(jobExecution2);
+		this.lifecycleManager.start();
+
+		// when - first execution throws exception, second succeeds
+		doThrow(new JobExecutionNotRunningException("Not running")).when(this.jobOperator).stop(jobExecution1);
+
+		this.lifecycleManager.stop();
+
+		// then
+		verify(this.jobOperator).stop(jobExecution1);
+		verify(this.jobOperator).stop(jobExecution2);
+		assertThat(this.lifecycleManager.isRunning()).isFalse();
+	}
+
+	@Test
+	void stopWithCallbackWhenCalledThenInvokesCallback() {
+		// given
+		this.lifecycleManager.start();
+		AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+		Runnable callback = () -> callbackInvoked.set(true);
+
+		// when
+		this.lifecycleManager.stop(callback);
+
+		// then
+		assertThat(callbackInvoked).isTrue();
+		assertThat(this.lifecycleManager.isRunning()).isFalse();
+	}
+
+	@Test
+	void waitForCompletionWhenJobExecutionsCompleteBeforeTimeoutThenReturns() throws Exception {
+		// given
+		CountDownLatch jobStartLatch = new CountDownLatch(1);
+		CountDownLatch jobCompleteLatch = new CountDownLatch(1);
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		JobExecution jobExecution = createJobExecution(1L);
+		this.lifecycleManager.track(jobExecution);
+		this.lifecycleManager.start();
+
+		// Simulate a job that completes quickly
+		executorService.submit(() -> {
+			jobStartLatch.countDown();
+			try {
+				Thread.sleep(100); // Simulate some work
+				this.lifecycleManager.untrack(jobExecution);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			jobCompleteLatch.countDown();
+		});
+
+		jobStartLatch.await(1, TimeUnit.SECONDS);
+
+		// when
+		this.lifecycleManager.stop();
+
+		// then
+		assertThat(jobCompleteLatch.await(2, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.lifecycleManager.isRunning()).isFalse();
+
+		executorService.shutdown();
+		executorService.awaitTermination(1, TimeUnit.SECONDS);
+	}
+
+	@Test
+	void isAutoStartupWhenDefaultThenReturnsTrue() {
+		assertThat(this.lifecycleManager.isAutoStartup()).isTrue();
+	}
+
+	@Test
+	void setAutoStartupWhenCalledThenUpdatesValue() {
+		// given
+		this.lifecycleManager.setAutoStartup(false);
+
+		// then
+		assertThat(this.lifecycleManager.isAutoStartup()).isFalse();
+	}
+
+	@Test
+	void getPhaseWhenDefaultThenReturnsMaxMinus1000() {
+		assertThat(this.lifecycleManager.getPhase()).isEqualTo(Integer.MAX_VALUE - 1000);
+	}
+
+	@Test
+	void setPhaseWhenCalledThenUpdatesValue() {
+		// given
+		int expectedPhase = 100;
+
+		// when
+		this.lifecycleManager.setPhase(expectedPhase);
+
+		// then
+		assertThat(this.lifecycleManager.getPhase()).isEqualTo(expectedPhase);
+	}
+
+	private JobExecution createJobExecution(Long id) {
+		JobInstance jobInstance = new JobInstance(1L, "test-job");
+		JobExecution jobExecution = new JobExecution(id, jobInstance, new JobParameters());
+		jobExecution.setStatus(BatchStatus.STARTED);
+		return jobExecution;
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/JobExecutionTrackingListenerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/JobExecutionTrackingListenerTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.listener;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.support.BatchJobLifecycleManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link JobExecutionTrackingListener}.
+ *
+ * @author Mahmoud Ben Hassine
+ */
+class JobExecutionTrackingListenerTests {
+
+	private BatchJobLifecycleManager lifecycleManager;
+
+	private JobExecutionTrackingListener listener;
+
+	@BeforeEach
+	void setUp() {
+		this.lifecycleManager = mock(BatchJobLifecycleManager.class);
+		this.listener = new JobExecutionTrackingListener(lifecycleManager);
+	}
+
+	@Test
+	void constructorWhenLifecycleManagerNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> new JobExecutionTrackingListener(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("lifecycleManager must not be null");
+	}
+
+	@Test
+	void beforeJobWhenCalledThenTracksJobExecution() {
+		// given
+		JobExecution jobExecution = createJobExecution(1L);
+
+		// when
+		this.listener.beforeJob(jobExecution);
+
+		// then
+		ArgumentCaptor<JobExecution> captor = ArgumentCaptor.forClass(JobExecution.class);
+		verify(this.lifecycleManager).track(captor.capture());
+		assertThat(captor.getValue()).isEqualTo(jobExecution);
+	}
+
+	@Test
+	void afterJobWhenCalledThenUntracksJobExecution() {
+		// given
+		JobExecution jobExecution = createJobExecution(1L);
+
+		// when
+		this.listener.afterJob(jobExecution);
+
+		// then
+		ArgumentCaptor<JobExecution> captor = ArgumentCaptor.forClass(JobExecution.class);
+		verify(this.lifecycleManager).untrack(captor.capture());
+		assertThat(captor.getValue()).isEqualTo(jobExecution);
+	}
+
+	@Test
+	void beforeJobAndAfterJobWhenCalledThenTracksAndUntracksJobExecution() {
+		// given
+		JobExecution jobExecution = createJobExecution(1L);
+
+		// when
+		this.listener.beforeJob(jobExecution);
+		this.listener.afterJob(jobExecution);
+
+		// then
+		ArgumentCaptor<JobExecution> trackCaptor = ArgumentCaptor.forClass(JobExecution.class);
+		ArgumentCaptor<JobExecution> untrackCaptor = ArgumentCaptor.forClass(JobExecution.class);
+		verify(this.lifecycleManager).track(trackCaptor.capture());
+		verify(this.lifecycleManager).untrack(untrackCaptor.capture());
+		assertThat(trackCaptor.getValue()).isEqualTo(jobExecution);
+		assertThat(untrackCaptor.getValue()).isEqualTo(jobExecution);
+	}
+
+	private JobExecution createJobExecution(Long id) {
+		JobInstance jobInstance = new JobInstance(1L, "test-job");
+		JobExecution jobExecution = new JobExecution(id, jobInstance, new JobParameters());
+		jobExecution.setStatus(BatchStatus.STARTED);
+		return jobExecution;
+	}
+
+}


### PR DESCRIPTION
Fixes #5307

## Problem

The current `JobExecutionShutdownHook` is fire-and-forget - it sends a stop signal to job executions but does not wait for them to complete. This causes issues when the JVM shuts down because:

1. HikariCP and EntityManagerFactory start closing their connections
2. Job threads are still running and try to save task metadata
3. Database connections are already closed (SocketException)
4. Task metadata cannot be saved

## Solution

This PR introduces two new components:

### 1. BatchJobLifecycleManager
- A `SmartLifecycle` implementation that hooks into Spring's lifecycle
- Tracks active JobExecutions using a `ConcurrentHashMap`
- In `stop()` method:
  - Stops all tracked job executions via `JobOperator.stop()`
  - Waits up to a configurable timeout (default 30 seconds) for jobs to complete
  - Logs progress during shutdown

### 2. JobExecutionTrackingListener  
- A `JobExecutionListener` that tracks and untracks job executions
- Tracks job executions in `beforeJob()` callback
- Untracks job executions in `afterJob()` callback

## Changes

- **New classes**:
  - `org.springframework.batch.core.launch.support.BatchJobLifecycleManager`
  - `org.springframework.batch.core.listener.JobExecutionTrackingListener`

- **Tests added**:
  - `BatchJobLifecycleManagerTests` - 13 tests covering tracking, lifecycle management, and shutdown behavior
  - `JobExecutionTrackingListenerTests` - 4 tests covering tracking behavior

## Usage Example

```java
@Configuration
class JobConfiguration {
    
    @Bean
    public BatchJobLifecycleManager batchJobLifecycleManager(JobOperator jobOperator) {
        return new BatchJobLifecycleManager(jobOperator);
    }
    
    @Bean
    public JobExecutionTrackingListener jobExecutionTrackingListener(BatchJobLifecycleManager lifecycleManager) {
        return new JobExecutionTrackingListener(lifecycleManager);
    }
}

@Configuration
class MyJobConfig {
    
    @Bean
    public Job myJob(JobExecutionTrackingListener trackingListener) {
        return JobBuilder.builder("myJob")
            .listener(trackingListener)
            // ... job configuration
            .build();
    }
}
```

This implementation follows the proposed solution from the issue comments and ensures that job executions can properly save their metadata during graceful shutdown.