### PR TITLE
Update outdated Javadoc links in reference docs

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/job/advanced-meta-data.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/job/advanced-meta-data.adoc
@@ -49,7 +49,7 @@ need to populate it manually with the jobs that you want to operate through the 
 
 Most of the methods on `JobOperator` are
 self-explanatory, and you can find more detailed explanations in the
-https://docs.spring.io/spring-batch/docs/current/api/org/springframework/batch/core/launch/JobOperator.html[Javadoc of the interface]. However, the
+https://docs.spring.io/spring-batch/docs/current-SNAPSHOT/api/org/springframework/batch/core/launch/JobOperator.html[Javadoc of the interface]. However, the
 `startNextInstance` method is worth noting. This
 method always starts a new instance of a `Job`.
 This can be extremely useful if there are serious issues in a

--- a/spring-batch-docs/modules/ROOT/pages/testing.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/testing.adoc
@@ -344,4 +344,4 @@ public void testAfterStep() {
 
 The preceding method for creating a simple `StepExecution` is only one convenience method
 available within the factory. You can find a full method listing in its
-link:$$http://docs.spring.io/spring-batch/apidocs/org/springframework/batch/test/MetaDataInstanceFactory.html$$[Javadoc].
+link:$$https://docs.spring.io/spring-batch/docs/current-SNAPSHOT/api/org/springframework/batch/test/MetaDataInstanceFactory.html$$[Javadoc].


### PR DESCRIPTION
## Summary
- update outdated Javadoc link in `advanced-meta-data.adoc`
- replace legacy `http://docs.spring.io/spring-batch/apidocs/...` link in `testing.adoc`
- point both links to `https://docs.spring.io/spring-batch/docs/current-SNAPSHOT/api/...` (Spring Batch 6 API)

## Why
The `current/api` path currently resolves to Spring Batch 5.2.4 API, which is inconsistent with the Spring Batch 6 reference docs.

Closes #5290
