### PR TITLE
Fix race condition in SimpleJobOperator.stop()

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -364,16 +364,44 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 								if (tasklet instanceof StoppableTasklet stoppableTasklet) {
 									StepSynchronizationManager.register(stepExecution);
 									stoppableTasklet.stop(stepExecution);
-									jobRepository.update(stepExecution);
-									jobRepository.updateExecutionContext(stepExecution);
+									try {
+										jobRepository.update(stepExecution);
+										jobRepository.updateExecutionContext(stepExecution);
+									}
+									catch (org.springframework.dao.OptimisticLockingFailureException e) {
+										// Ignore - the job thread is likely updating the
+										// step execution
+										// The job will check the STOPPING status and stop
+										// anyway
+										if (logger.isDebugEnabled()) {
+											logger
+												.debug("OptimisticLockingFailureException while stopping step execution "
+														+ stepExecution.getId()
+														+ ". This is expected if the job thread is updating concurrently.",
+														e);
+										}
+									}
 									StepSynchronizationManager.release();
 								}
 							}
 							if (step instanceof StoppableStep stoppableStep) {
 								StepSynchronizationManager.register(stepExecution);
 								stoppableStep.stop(stepExecution);
-								jobRepository.update(stepExecution);
-								jobRepository.updateExecutionContext(stepExecution);
+								try {
+									jobRepository.update(stepExecution);
+									jobRepository.updateExecutionContext(stepExecution);
+								}
+								catch (org.springframework.dao.OptimisticLockingFailureException e) {
+									// Ignore - the job thread is likely updating the step
+									// execution
+									// The job will check the STOPPING status and stop
+									// anyway
+									if (logger.isDebugEnabled()) {
+										logger.debug("OptimisticLockingFailureException while stopping step execution "
+												+ stepExecution.getId()
+												+ ". This is expected if the job thread is updating concurrently.", e);
+									}
+								}
 								StepSynchronizationManager.release();
 							}
 						}

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/GracefulShutdownFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/GracefulShutdownFunctionalTests.java
@@ -79,14 +79,24 @@ class GracefulShutdownFunctionalTests {
 
 		jobOperator.stop(jobExecution);
 
+		// Wait for the job to stop. The job needs to finish processing the current chunk
+		// before it can stop, so we need to be generous with the timeout.
+		// With 5 items, chunk size 2, and 500ms per item processing time:
+		// - Chunk 1: 2 items = 1000ms
+		// - Chunk 2: 2 items = 1000ms
+		// - Chunk 3: 1 item = 500ms
+		// If stop is called at the start of a chunk, we might need up to 1 second
+		// for the chunk to complete, plus time for the stop signal to be processed.
+		int maxWaitCount = 50; // 50 * 100ms = 5 seconds
 		int count = 0;
-		while (jobExecution.isRunning() && count <= 10) {
-			logger.info("Checking for end time in JobExecution: count=" + count);
+		while (jobExecution.isRunning() && count < maxWaitCount) {
+			logger.info("Checking for job to stop: status=" + jobExecution.getStatus() + ", count=" + count);
 			Thread.sleep(100);
 			count++;
 		}
 
-		assertFalse(jobExecution.isRunning(), "Timed out waiting for job to end.");
+		assertFalse(jobExecution.isRunning(), "Timed out waiting for job to stop after " + (count * 100)
+				+ "ms. Final status: " + jobExecution.getStatus());
 		assertEquals(BatchStatus.STOPPED, jobExecution.getStatus());
 	}
 


### PR DESCRIPTION
Fixes #5308

## Problem

The test `GracefulShutdownFunctionalTests.testStopJob` fails intermittently due to a race condition. The previous fix for #5217 addressed the `OptimisticLockingFailureException` by checking for `isStopping()` status, but this did not completely eliminate the race condition.

The issue occurs when:
1. The main thread calls `jobOperator.stop()`
2. The main thread tries to update step executions
3. The job thread is also updating step executions (after processing a chunk)
4. Both threads try to update simultaneously → `OptimisticLockingFailureException`

## Solution

This PR:
1. **Catches `OptimisticLockingFailureException`** when updating step executions in `SimpleJobOperator.stop()`
   - Logs the exception at DEBUG level for diagnosis
   - Allows the stop process to continue since the job will check the STOPPING status and stop anyway

2. **Improves `GracefulShutdownFunctionalTests.testStopJob` test**:
   - Increases timeout from 1 second to 5 seconds to give jobs more time to stop
   - Adds better logging to diagnose failures
   - Adds detailed comments explaining the timing considerations

## Changes

- `SimpleJobOperator.java`: Added try-catch blocks around `jobRepository.update(stepExecution)` calls to handle optimistic locking gracefully
- `GracefulShutdownFunctionalTests.java`: Increased timeout and improved error messages

## Testing

- Ran the test multiple times to verify stability
- The fix allows the test to complete successfully even when concurrent updates occur