### PR TITLE
Fail TaskletStep on checked exceptions in non-rollback mode

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -417,8 +417,8 @@ public class TaskletStep extends AbstractStep {
 					catch (Exception e) {
 						if (transactionAttribute.rollbackOn(e)) {
 							chunkContext.setAttribute(ChunkListener.ROLLBACK_EXCEPTION_KEY, e);
-							throw e;
 						}
+						throw e;
 					}
 				}
 				finally {
@@ -489,7 +489,9 @@ public class TaskletStep extends AbstractStep {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Rollback for Exception: " + e.getClass().getName() + ": " + e.getMessage());
 				}
-				rollback(stepExecution);
+				if (transactionAttribute.rollbackOn(e)) {
+					rollback(stepExecution);
+				}
 				// Allow checked exceptions
 				throw new UncheckedTransactionException(e);
 			}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -38,7 +38,9 @@ import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.batch.infrastructure.support.transaction.ResourcelessTransactionManager;
 import org.jspecify.annotations.Nullable;
 import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -90,6 +92,31 @@ class TaskletStepExceptionTests {
 		taskletStep.execute(stepExecution);
 		assertEquals(FAILED, stepExecution.getStatus());
 		assertEquals(FAILED.toString(), stepExecution.getExitStatus().getExitCode());
+	}
+
+	@Test
+	void testCheckedExceptionWithNoRollbackStillFailsStep() throws Exception {
+		final int[] invocations = new int[1];
+		taskletStep.setTasklet(new Tasklet() {
+			@Nullable
+			@Override
+			public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+				invocations[0]++;
+				if (invocations[0] == 1) {
+					throw new Exception("Planned checked exception");
+				}
+				return RepeatStatus.FINISHED;
+			}
+		});
+		RuleBasedTransactionAttribute transactionAttribute = new RuleBasedTransactionAttribute();
+		transactionAttribute.setPropagationBehavior(TransactionDefinition.PROPAGATION_NOT_SUPPORTED);
+		taskletStep.setTransactionAttribute(transactionAttribute);
+
+		taskletStep.execute(stepExecution);
+
+		assertEquals(FAILED, stepExecution.getStatus());
+		assertEquals(1, invocations[0]);
+		assertEquals("Planned checked exception", stepExecution.getFailureExceptions().get(0).getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- propagate checked exceptions from `Tasklet.execute` even when `transactionAttribute.rollbackOn(e)` returns `false`
- only mark rollback metadata (`ROLLBACK_EXCEPTION_KEY` and rollback count) when rollback is actually configured for the exception
- add a regression test for `PROPAGATION_NOT_SUPPORTED` to ensure a checked exception fails the step instead of being silently retried

## Why
With `TaskletStep` and a transaction attribute like `PROPAGATION_NOT_SUPPORTED`, a checked exception can be swallowed when rollback is disabled for that exception type. This causes the step loop to continue and re-execute the tasklet instead of failing.

Closes #5292

## Testing
- Attempted locally: `./mvnw -Dmaven.user.home=/tmp/m2 -pl spring-batch-core -Dtest=org.springframework.batch.core.step.item.TaskletStepExceptionTests test`
- Local build is blocked by Error Prone/NullAway JSpecify requirement (JDK 22+).
