### PR TITLE
Restore backward-compatible default job key format

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/DefaultJobKeyGenerator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/DefaultJobKeyGenerator.java
@@ -50,10 +50,15 @@ public class DefaultJobKeyGenerator implements JobKeyGenerator {
 		for (String key : keys) {
 			JobParameter<?> jobParameter = source.getParameter(key);
 			if (jobParameter != null && jobParameter.identifying()) {
-				stringBuffer.append(jobParameter);
+				stringBuffer.append(key).append("=").append(asLegacyParameterValue(jobParameter)).append(";");
 			}
 		}
 		return DigestUtils.md5DigestAsHex(stringBuffer.toString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String asLegacyParameterValue(JobParameter<?> jobParameter) {
+		return "{" + "value=" + jobParameter.value() + ", type=" + jobParameter.type() + ", identifying="
+				+ jobParameter.identifying() + '}';
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/DefaultJobKeyGeneratorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/DefaultJobKeyGeneratorTests.java
@@ -71,6 +71,15 @@ class DefaultJobKeyGeneratorTests {
 	}
 
 	@Test
+	void testCreateJobKeyBackwardCompatibility() {
+		JobParameters jobParameters = new JobParametersBuilder().addString("foo", "bar")
+			.addString("bar", "foo")
+			.toJobParameters();
+		String key = jobKeyGenerator.generateKey(jobParameters);
+		assertEquals("0e2a48a17d785b4ec5f073a849a79c9d", key);
+	}
+
+	@Test
 	public void testCreateJobKeyForEmptyParameters() {
 		JobParameters jobParameters1 = new JobParameters();
 		JobParameters jobParameters2 = new JobParameters();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobInstanceDaoTests.java
@@ -34,6 +34,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.jdbc.support.incrementer.H2SequenceMaxValueIncrementer;
 import org.springframework.test.jdbc.JdbcTestUtils;
+import org.springframework.util.DigestUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -189,6 +190,24 @@ public class JdbcJobInstanceDaoTests {
 		jdbcJobInstanceDao.createJobInstance("job", jobParameters);
 
 		assertThrows(IllegalStateException.class, () -> jdbcJobInstanceDao.createJobInstance("job", jobParameters));
+	}
+
+	@Test
+	void testGetExistingLegacyJobInstance() {
+		JobParameters jobParameters = new JobParametersBuilder().addString("foo", "bar")
+			.addString("bar", "foo")
+			.toJobParameters();
+		String legacySerializedParameters = "bar={value=foo, type=class java.lang.String, identifying=true};"
+				+ "foo={value=bar, type=class java.lang.String, identifying=true};";
+		String legacyJobKey = DigestUtils.md5DigestAsHex(legacySerializedParameters.getBytes(StandardCharsets.UTF_8));
+
+		jdbcTemplate.update(
+				"INSERT INTO BATCH_JOB_INSTANCE(JOB_INSTANCE_ID, JOB_NAME, JOB_KEY, VERSION) VALUES (?, ?, ?, ?)", 3L,
+				"job", legacyJobKey, 0);
+
+		JobInstance jobInstance = jdbcJobInstanceDao.getJobInstance("job", jobParameters);
+		assertNotNull(jobInstance);
+		assertEquals(3L, jobInstance.getInstanceId());
 	}
 
 }


### PR DESCRIPTION
## Summary
- restore the default job key serialization format used before the JobParameter refactor
- avoid relying on JobParameter.toString for key generation to keep key values stable
- add a regression test in DefaultJobKeyGeneratorTests for backward-compatible key generation
- add a JDBC DAO regression test to verify lookup of existing job instances created with the legacy key format

## Testing
- ./mvnw -pl spring-batch-core -Dtest=DefaultJobKeyGeneratorTests,JdbcJobInstanceDaoTests test

Fixes #5283