### PR TITLE
Introduce addListener method in StepBuilder and JobBuilder for better clarity

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java
@@ -155,6 +155,28 @@ public abstract class JobBuilderHelper<B extends JobBuilderHelper<B>> {
 	}
 
 	/**
+	 * Add a {@link JobExecutionListener} to the job.
+	 * This method makes the additive nature of adding listeners explicit.
+	 * @param listener the job execution listener to add
+	 * @return this for fluent chaining
+	 * @since 6.1
+	 */
+	public B addListener(JobExecutionListener listener) {
+		return listener(listener);
+	}
+
+	/**
+	 * Add a job execution listener using annotation-based configuration.
+	 * This method makes the additive nature of adding listeners explicit.
+	 * @param listener the object that has a method configured with listener annotation
+	 * @return this for fluent chaining
+	 * @since 6.1
+	 */
+	public B addListener(Object listener) {
+		return listener(listener);
+	}
+
+	/**
 	 * Set a flag to prevent restart an execution of this job even if it has failed.
 	 * @return this to enable fluent chaining
 	 */

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
@@ -117,6 +117,28 @@ public abstract class StepBuilderHelper<B extends StepBuilderHelper<B>> {
 		return self();
 	}
 
+	/**
+	 * Add a {@link StepExecutionListener} to the step.
+	 * This method makes the additive nature of adding listeners explicit.
+	 * @param listener the step execution listener to add
+	 * @return this for fluent chaining
+	 * @since 6.1
+	 */
+	public B addListener(StepExecutionListener listener) {
+		return listener(listener);
+	}
+
+	/**
+	 * Add a step execution listener using annotation-based configuration.
+	 * This method makes the additive nature of adding listeners explicit.
+	 * @param listener the object that has a method configured with listener annotation
+	 * @return this for fluent chaining
+	 * @since 6.1
+	 */
+	public B addListener(Object listener) {
+		return listener(listener);
+	}
+
 	public B allowStartIfComplete(boolean allowStartIfComplete) {
 		properties.allowStartIfComplete = allowStartIfComplete;
 		return self();


### PR DESCRIPTION
Fixes #5321

## Motivation

The current `.listener()` method in `StepBuilder` and `JobBuilder` can be ambiguous. A method named after a property (without a prefix) often implies setting a single value, potentially overwriting previous ones. However, in Spring Batch, calling `.listener()` multiple times actually **appends** the listeners to an internal list rather than replacing them.

## Proposed Change

Added `addListener()` methods as aliases that delegate to the existing `listener()` methods. The new method names make the additive behavior explicit and improve API consistency.

## Benefits

- **Improved Readability**: `addListener` makes it clear that the listener is being added to a collection
- **API Consistency**: Aligns with modern Java libraries where `add*` is used for collection-based properties
- **Self-Documenting Code**: Reduces the need for developers to check the internal implementation or Javadoc

## Changes

- `StepBuilderHelper.addListener(StepExecutionListener)` - delegates to `listener()`
- `StepBuilderHelper.addListener(Object)` - delegates to `listener()` for annotation-based config
- `JobBuilderHelper.addListener(JobExecutionListener)` - delegates to `listener()`
- `JobBuilderHelper.addListener(Object)` - delegates to `listener()` for annotation-based config

## Backward Compatibility

The existing `.listener()` methods remain for full backward compatibility.