### PR TITLE
Add ExitStatus overload for on() method in builder classes

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/FlowBuilder.java
@@ -225,6 +225,16 @@ public class FlowBuilder<Q> {
 	}
 
 	/**
+	 * Start a transition to a new state if the exit status from the previous state
+	 * matches the status given.
+	 * @param status the exit status on which to take this transition
+	 * @return a builder to enable fluent chaining
+	 */
+	public TransitionBuilder<Q> on(ExitStatus status) {
+		return on(status.getExitCode());
+	}
+
+	/**
 	 * A synonym for {@link #build()} which callers might find useful. Subclasses can
 	 * override build to create an object of the desired type (e.g. a parent builder or an
 	 * actual flow).
@@ -435,6 +445,16 @@ public class FlowBuilder<Q> {
 		 */
 		public TransitionBuilder<Q> on(String pattern) {
 			return new TransitionBuilder<>(parent, pattern);
+		}
+
+		/**
+		 * Start a transition to a new state if the exit status from the previous state
+		 * matches the status given.
+		 * @param status the exit status on which to take this transition
+		 * @return a TransitionBuilder
+		 */
+		public TransitionBuilder<Q> on(ExitStatus status) {
+			return on(status.getExitCode());
 		}
 
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/SimpleJobBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/SimpleJobBuilder.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.jspecify.annotations.NullUnmarked;
 
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.job.SimpleJob;
@@ -97,6 +98,15 @@ public class SimpleJobBuilder extends JobBuilderHelper<SimpleJobBuilder> {
 			}
 		}
 		return builder.on(pattern);
+	}
+
+	/**
+	 * Branch into a flow conditional on the outcome of the current step.
+	 * @param status the exit status of the current step
+	 * @return a builder for fluent chaining
+	 */
+	public FlowBuilder.TransitionBuilder<FlowJobBuilder> on(ExitStatus status) {
+		return on(status.getExitCode());
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowBuilderTests.java
@@ -166,6 +166,49 @@ class FlowBuilderTests {
 		assertFalse(stepExecutions.hasNext());
 	}
 
+	@Test
+	void testOnExitStatus() throws Exception {
+		FlowBuilder<Flow> builder = new FlowBuilder<>("transitionsFlow");
+		JobRepository jobRepository = new ResourcelessJobRepository();
+		JobParameters jobParameters = new JobParameters();
+		JobInstance jobInstance = jobRepository.createJobInstance("foo", jobParameters);
+		JobExecution jobExecution = jobRepository.createJobExecution(jobInstance, jobParameters,
+				new ExecutionContext());
+
+		StepSupport stepA = new StepSupport("stepA") {
+			@Override
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
+				stepExecution.setExitStatus(ExitStatus.FAILED);
+			}
+		};
+
+		StepSupport stepB = new StepSupport("stepB") {
+			@Override
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
+			}
+		};
+
+		StepSupport stepC = new StepSupport("stepC") {
+			@Override
+			public void execute(StepExecution stepExecution) throws UnexpectedJobExecutionException {
+			}
+		};
+
+		FlowExecution flowExecution = builder.start(stepA)
+			.on("*")
+			.to(stepB)
+			.from(stepA)
+			.on(ExitStatus.FAILED)
+			.to(stepC)
+			.end()
+			.start(new JobFlowExecutor(jobRepository, new SimpleStepHandler(jobRepository), jobExecution));
+
+		Iterator<StepExecution> stepExecutions = jobExecution.getStepExecutions().iterator();
+		assertEquals("stepA", stepExecutions.next().getStepName());
+		assertEquals("stepC", stepExecutions.next().getStepName());
+		assertFalse(stepExecutions.hasNext());
+	}
+
 	private static StepSupport createCompleteStep(String name) {
 		return new StepSupport(name) {
 			@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/job/builder/FlowJobBuilderTests.java
@@ -172,6 +172,18 @@ class FlowJobBuilderTests {
 	}
 
 	@Test
+	void testBuildOnExitStatus() throws JobInterruptedException {
+		FlowJobBuilder builder = new JobBuilder("flow", jobRepository).start(step1)
+			.on(ExitStatus.COMPLETED)
+			.to(step2)
+			.end();
+		builder.preventRestart();
+		builder.build().execute(execution);
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(2, execution.getStepExecutions().size());
+	}
+
+	@Test
 	void testBuildSubflow() throws JobInterruptedException {
 		Flow flow = new FlowBuilder<Flow>("subflow").from(step1).end();
 		JobFlowBuilder builder = new JobBuilder("flow", jobRepository).start(flow);
@@ -273,6 +285,24 @@ class FlowJobBuilderTests {
 		};
 		JobFlowBuilder builder = new JobBuilder("flow", jobRepository).start(decider);
 		builder.on("COMPLETED").end().from(decider).on("*").to(step1).end();
+		builder.build().preventRestart().build().execute(execution);
+		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+		assertEquals(1, execution.getStepExecutions().size());
+	}
+
+	@Test
+	void testBuildWithDeciderAtStartOnExitStatus() throws JobInterruptedException {
+		JobExecutionDecider decider = new JobExecutionDecider() {
+			private int count = 0;
+
+			@Override
+			public FlowExecutionStatus decide(JobExecution jobExecution, @Nullable StepExecution stepExecution) {
+				count++;
+				return count < 2 ? new FlowExecutionStatus("ONGOING") : FlowExecutionStatus.COMPLETED;
+			}
+		};
+		JobFlowBuilder builder = new JobBuilder("flow", jobRepository).start(decider);
+		builder.on(ExitStatus.COMPLETED).end().from(decider).on("*").to(step1).end();
 		builder.build().preventRestart().build().execute(execution);
 		assertEquals(BatchStatus.COMPLETED, execution.getStatus());
 		assertEquals(1, execution.getStepExecutions().size());


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-batch/issues/5306

## Motivation

The current `.on(String pattern)` method in builder classes requires developers to use string literals (e.g., `"COMPLETED"`) to conditionally branch the flow. This approach is prone to typographical errors and does not leverage the predefined, type-safe constants provided by the `ExitStatus` class.

Furthermore, developers intuitively expect to pass an `ExitStatus` object since it represents the actual outcome of a step.

---

## Proposed Change

Added `on(ExitStatus status)` methods as overloaded convenience methods that delegate directly to the existing `.on(String pattern)` methods by extracting the underlying exit code.

---

## Benefits

### Improved Type Safety
Allows using explicitly defined constants like `ExitStatus.COMPLETED` instead of "magic strings", significantly reducing the risk of typos.

### Better IDE Support
Enhances developer experience through reliable code completion and static analysis features.

### API Consistency
Standardizes flow transition declarations across the builder API, providing a unified and predictable developer experience.

### Self-Documenting Code
Makes code more readable by explicitly showing that the transition depends on a predefined exit status.

---

## Changes

- `SimpleJobBuilder.on(ExitStatus)` → delegates to `.on(String)`
- `FlowBuilder.on(ExitStatus)` → delegates to `.on(String)`
- `FlowBuilder.UnterminatedFlowBuilder.on(ExitStatus)` → delegates to `.on(String)`

---

## Backward Compatibility

The existing `.on(String)` methods remain for full backward compatibility, ensuring existing wildcard pattern matches (e.g., `"FAIL*"`, `"*"`, or `"CUST?M"`) continue to function perfectly.
