### PR TITLE
Update Groovy version to 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<spring-rabbit.version>${spring-amqp.version}</spring-rabbit.version>
 		<quartz.version>2.5.1</quartz.version>
 		<prometheus-metrics-exporter-pushgateway>1.4.2</prometheus-metrics-exporter-pushgateway>
-		<groovy.version>3.0.25</groovy.version> <!-- change to org.apache.groovy:groovy + update to latest 5.0.2 -->
+		<groovy.version>5.0.4</groovy.version>
         <logback.version>1.5.21</logback.version>
 
 		<!-- documentation dependencies -->

--- a/spring-batch-samples/pom.xml
+++ b/spring-batch-samples/pom.xml
@@ -282,13 +282,13 @@
 			<version>${hsqldb.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
+			<groupId>org.apache.groovy</groupId>
 			<artifactId>groovy</artifactId>
 			<version>${groovy.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
+			<groupId>org.apache.groovy</groupId>
 			<artifactId>groovy-ant</artifactId>
 			<version>${groovy.version}</version>
 			<scope>test</scope>

--- a/spring-batch-samples/src/main/resources/org/springframework/batch/samples/misc/groovy/job/groovyJob.xml
+++ b/spring-batch-samples/src/main/resources/org/springframework/batch/samples/misc/groovy/job/groovyJob.xml
@@ -31,6 +31,7 @@
 
 	<lang:groovy id="unzip-script">
 		<lang:inline-script>
+			import groovy.ant.AntBuilder
 			class UnzipTasklet {
 			void execute() {
 			def ant = new AntBuilder()
@@ -43,6 +44,7 @@
 
 	<lang:groovy id="zip-script">
 		<lang:inline-script>
+			import groovy.ant.AntBuilder
 			class ZipTasklet {
 			void execute() {
 			def ant = new AntBuilder()


### PR DESCRIPTION
## Summary                                                                                                                                 
  - Upgrade Groovy from 3.0.25 to 5.0.4
  - Migrate groupId from org.codehaus.groovy to org.apache.groovy                                                                                                                                                                              
  - Add explicit import groovy.ant.AntBuilder in Groovy inline scripts (package moved in Groovy 5.0)

  Closes gh-5289