### PR TITLE
Make JFR optional to support minimized JREs without jdk.jfr module

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperator.java
@@ -109,7 +109,17 @@ public class TaskExecutorJobOperator extends SimpleJobOperator {
 			JobExecutionAlreadyRunningException, JobRestartException, InvalidJobParametersException {
 		Assert.notNull(job, "Job must not be null");
 		Assert.notNull(jobParameters, "JobParameters must not be null");
-		new JobLaunchEvent(job.getName(), jobParameters.toString()).commit();
+		try {
+			new JobLaunchEvent(job.getName(), jobParameters.toString()).commit();
+		}
+		catch (NoClassDefFoundError e) {
+			// JFR is not available on this runtime (e.g., minimized JRE without jdk.jfr
+			// module)
+			// Silently ignore and continue without JFR events
+			if (logger.isDebugEnabled()) {
+				logger.debug("JFR is not available, skipping JFR event creation");
+			}
+		}
 		Observation observation = MicrometerMetrics
 			.createObservation(METRICS_PREFIX + "job.launch.count", this.observationRegistry)
 			.start();


### PR DESCRIPTION
Fixes #5326

**Problem:**
TaskExecutorJobOperator.start() creates a JobLaunchEvent which extends jdk.jfr.Event. On minimized JREs without the jdk.jfr module, this causes NoClassDefFoundError: jdk/jfr/Event.

**Solution:**
Wrap the JFR event creation in a try-catch block to handle the case when JFR is not available, allowing Spring Batch to work on minimized JREs without JFR support.