### PR TITLE
Restore JsonLineMapper compatibility with Jackson 2

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/mapping/JsonLineMapper.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/mapping/JsonLineMapper.java
@@ -15,11 +15,17 @@
  */
 package org.springframework.batch.infrastructure.item.file.mapping;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.batch.infrastructure.item.file.LineMapper;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * Interpret a line as a JSON object and parse it up to a Map. The line should be a
@@ -42,13 +48,14 @@ import org.springframework.batch.infrastructure.item.file.LineMapper;
  */
 public class JsonLineMapper implements LineMapper<Map<String, Object>> {
 
-	private final JsonMapper jsonMapper;
+	private final JsonObjectMapper jsonMapper;
 
 	/**
-	 * Create a new {@link JsonLineMapper} with a default {@link JsonMapper}.
+	 * Create a new {@link JsonLineMapper} with a default Jackson 3 or Jackson 2 object
+	 * mapper.
 	 */
 	public JsonLineMapper() {
-		this(new JsonMapper());
+		this(createDefaultJsonObjectMapper());
 	}
 
 	/**
@@ -57,6 +64,21 @@ public class JsonLineMapper implements LineMapper<Map<String, Object>> {
 	 * @since 6.0
 	 */
 	public JsonLineMapper(JsonMapper jsonMapper) {
+		this((line) -> jsonMapper.readValue(line, Map.class));
+	}
+
+	/**
+	 * Create a new {@link JsonLineMapper} with the provided Jackson 2
+	 * {@link ObjectMapper}.
+	 * @param jsonMapper the json mapper to use
+	 * @since 6.0
+	 */
+	public JsonLineMapper(ObjectMapper jsonMapper) {
+		this((line) -> jsonMapper.readValue(line, Map.class));
+	}
+
+	private JsonLineMapper(JsonObjectMapper jsonMapper) {
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
 		this.jsonMapper = jsonMapper;
 	}
 
@@ -68,7 +90,81 @@ public class JsonLineMapper implements LineMapper<Map<String, Object>> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> mapLine(String line, int lineNumber) throws Exception {
-		return this.jsonMapper.readValue(line, Map.class);
+		return this.jsonMapper.readValue(line);
+	}
+
+	private static JsonObjectMapper createDefaultJsonObjectMapper() {
+		ClassLoader classLoader = JsonLineMapper.class.getClassLoader();
+		Object jsonMapper = instantiateJsonMapper("tools.jackson.databind.json.JsonMapper", classLoader);
+		if (jsonMapper == null) {
+			jsonMapper = instantiateJsonMapper("com.fasterxml.jackson.databind.ObjectMapper", classLoader);
+		}
+		if (jsonMapper == null) {
+			throw new IllegalStateException("Either Jackson 3 or Jackson 2 is required to use JsonLineMapper");
+		}
+		Method readValueMethod = findReadValueMethod(jsonMapper.getClass());
+		return new ReflectionJsonObjectMapper(jsonMapper, readValueMethod);
+	}
+
+	private static @Nullable Object instantiateJsonMapper(String className, ClassLoader classLoader) {
+		try {
+			Class<?> mapperClass = ClassUtils.forName(className, classLoader);
+			return mapperClass.getConstructor().newInstance();
+		}
+		catch (ClassNotFoundException ex) {
+			return null;
+		}
+		catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException ex) {
+			throw new IllegalStateException("Failed to create JSON mapper of type " + className, ex);
+		}
+	}
+
+	private static Method findReadValueMethod(Class<?> mapperClass) {
+		try {
+			return mapperClass.getMethod("readValue", String.class, Class.class);
+		}
+		catch (NoSuchMethodException ex) {
+			throw new IllegalStateException(
+					"The JSON mapper of type " + mapperClass.getName() + " does not expose readValue(String, Class)",
+					ex);
+		}
+	}
+
+	private interface JsonObjectMapper {
+
+		Map<String, Object> readValue(String line) throws Exception;
+
+	}
+
+	private static final class ReflectionJsonObjectMapper implements JsonObjectMapper {
+
+		private final Object jsonMapper;
+
+		private final Method readValueMethod;
+
+		private ReflectionJsonObjectMapper(Object jsonMapper, Method readValueMethod) {
+			this.jsonMapper = jsonMapper;
+			this.readValueMethod = readValueMethod;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Map<String, Object> readValue(String line) throws Exception {
+			try {
+				return (Map<String, Object>) this.readValueMethod.invoke(this.jsonMapper, line, Map.class);
+			}
+			catch (InvocationTargetException ex) {
+				Throwable targetException = ex.getTargetException();
+				if (targetException instanceof Exception exception) {
+					throw exception;
+				}
+				throw new IllegalStateException(targetException);
+			}
+			catch (IllegalAccessException ex) {
+				throw new IllegalStateException("Failed to invoke JSON mapper", ex);
+			}
+		}
+
 	}
 
 }

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/mapping/JsonLineMapperJackson2OnlyRunner.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/mapping/JsonLineMapperJackson2OnlyRunner.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2009-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.infrastructure.item.file.mapping;
+
+import java.util.Map;
+
+public final class JsonLineMapperJackson2OnlyRunner {
+
+	private JsonLineMapperJackson2OnlyRunner() {
+	}
+
+	public static Map<String, Object> mapLine(String line) throws Exception {
+		return new JsonLineMapper().mapLine(line, 1);
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/mapping/JsonLineMapperTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/mapping/JsonLineMapperTests.java
@@ -17,8 +17,10 @@ package org.springframework.batch.infrastructure.item.file.mapping;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import tools.jackson.core.exc.UnexpectedEndOfInputException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.OverridingClassLoader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,6 +46,37 @@ class JsonLineMapperTests {
 	@Test
 	void testMappingError() {
 		assertThrows(UnexpectedEndOfInputException.class, () -> mapper.mapLine("{\"foo\": 1", 1));
+	}
+
+	@Test
+	void testMapLineWithJackson2ObjectMapper() throws Exception {
+		JsonLineMapper mapper = new JsonLineMapper(new ObjectMapper());
+		Map<String, Object> map = mapper.mapLine("{\"foo\": 1}", 1);
+		assertEquals(1, map.get("foo"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testMapLineWithDefaultConstructorAndJackson2Only() throws Exception {
+		ClassLoader classLoader = new OverridingClassLoader(JsonLineMapper.class.getClassLoader()) {
+			@Override
+			public Class<?> loadClass(String name) throws ClassNotFoundException {
+				if (name.startsWith("tools.jackson")) {
+					throw new ClassNotFoundException(name);
+				}
+				return super.loadClass(name);
+			}
+
+			@Override
+			protected boolean isEligibleForOverriding(String className) {
+				return className.startsWith(JsonLineMapper.class.getName())
+						|| JsonLineMapperJackson2OnlyRunner.class.getName().equals(className);
+			}
+		};
+		Class<?> runnerClass = classLoader.loadClass(JsonLineMapperJackson2OnlyRunner.class.getName());
+		Map<String, Object> map = (Map<String, Object>) runnerClass.getMethod("mapLine", String.class)
+			.invoke(null, "{\"foo\": 1}");
+		assertEquals(1, map.get("foo"));
 	}
 
 }


### PR DESCRIPTION
Fixes #5330

`JsonLineMapper` currently instantiates Jackson 3's `JsonMapper` by default, which makes the default constructor unusable when only Jackson 2 is present on the classpath.

This change updates `JsonLineMapper` to:
- keep the existing Jackson 3 constructor
- add a Jackson 2 `ObjectMapper` constructor
- fall back to Jackson 2 when Jackson 3 is not available
- add regression tests for both the explicit Jackson 2 constructor and the default-constructor fallback path

Tests:
- `./mvnw -pl spring-batch-infrastructure -Dtest=org.springframework.batch.infrastructure.item.file.mapping.JsonLineMapperTests test`