### PR TITLE
Fix #5346: Add MongoDatabaseFactory support to MongoJobRepositoryFactoryBean

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/MongoJobExplorerFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/explore/support/MongoJobExplorerFactoryBean.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.core.repository.explore.support;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.batch.core.repository.dao.ExecutionContextDao;
 import org.springframework.batch.core.repository.dao.JobExecutionDao;
 import org.springframework.batch.core.repository.dao.JobInstanceDao;
@@ -25,17 +27,21 @@ import org.springframework.batch.core.repository.dao.mongodb.MongoJobInstanceDao
 import org.springframework.batch.core.repository.dao.mongodb.MongoStepExecutionDao;
 import org.springframework.batch.core.repository.support.MongoJobRepositoryFactoryBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.util.Assert;
 
 /**
- * This factory bean creates a job explorer backed by MongoDB. It requires a mongo
- * template and a mongo transaction manager. <strong>The mongo template must be configured
- * with a {@link MappingMongoConverter} having a {@code MapKeyDotReplacement} set to a non
- * null value. See {@code MongoDBJobRepositoryIntegrationTests} for an example. This is
- * required to support execution context keys containing dots (like "step.type" or
- * "batch.version")</strong>
+ * This factory bean creates a job explorer backed by MongoDB. It requires a
+ * {@link MongoDatabaseFactory} or a mongo template. <strong>When providing a
+ * {@link MongoOperations}, it must be configured with a {@link MappingMongoConverter}
+ * having a {@code MapKeyDotReplacement} set to a non null value to support execution
+ * context keys containing dots (like "step.type" or "batch.version").</strong>
+ * <p>
+ * For convenience, this factory can create the required {@link MongoTemplate} internally
+ * when a {@link MongoDatabaseFactory} is provided.
  *
  * @author Mahmoud Ben Hassine
  * @since 5.2.0
@@ -45,8 +51,35 @@ import org.springframework.util.Assert;
 @Deprecated(since = "6.0", forRemoval = true)
 public class MongoJobExplorerFactoryBean extends AbstractJobExplorerFactoryBean implements InitializingBean {
 
-	private MongoOperations mongoOperations;
+	private @Nullable MongoDatabaseFactory mongoDatabaseFactory;
 
+	private @Nullable MongoOperations mongoOperations;
+
+	/**
+	 * Set the {@link MongoDatabaseFactory} to use for creating a {@link MongoTemplate}
+	 * internally. The created template will be configured with the required
+	 * {@code MapKeyDotReplacement} to support execution context keys containing dots.
+	 * <p>
+	 * This is the recommended way to configure this factory bean, as it avoids the need
+	 * to create a separate {@link MongoTemplate} specifically for Spring Batch.
+	 * @param mongoDatabaseFactory the MongoDB database factory to use
+	 */
+	public void setMongoDatabaseFactory(MongoDatabaseFactory mongoDatabaseFactory) {
+		this.mongoDatabaseFactory = mongoDatabaseFactory;
+	}
+
+	/**
+	 * Set the {@link MongoOperations} to use. <strong>The provided template must be
+	 * configured with a {@link MappingMongoConverter} having a
+	 * {@code MapKeyDotReplacement} set to a non null value.</strong>
+	 * <p>
+	 * For convenience, consider using
+	 * {@link #setMongoDatabaseFactory(MongoDatabaseFactory)} instead, which will create
+	 * the required template internally.
+	 * @param mongoOperations the MongoOperations to use
+	 * @deprecated Use {@link #setMongoDatabaseFactory(MongoDatabaseFactory)} instead
+	 */
+	@Deprecated(since = "5.2.1", forRemoval = true)
 	public void setMongoOperations(MongoOperations mongoOperations) {
 		this.mongoOperations = mongoOperations;
 	}
@@ -74,7 +107,35 @@ public class MongoJobExplorerFactoryBean extends AbstractJobExplorerFactoryBean 
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
+
+		if (this.mongoOperations == null && this.mongoDatabaseFactory == null) {
+			throw new IllegalArgumentException(
+					"Either MongoDatabaseFactory or MongoOperations must be set. Use setMongoDatabaseFactory() for automatic configuration.");
+		}
+
+		// Create MongoTemplate internally if not provided
+		if (this.mongoOperations == null) {
+			MongoDatabaseFactory factory = this.mongoDatabaseFactory;
+			Assert.state(factory != null, "MongoDatabaseFactory must be set when MongoOperations is null");
+			this.mongoOperations = createMongoTemplate(factory);
+		}
+
 		Assert.notNull(this.mongoOperations, "MongoOperations must not be null.");
+	}
+
+	/**
+	 * Create a {@link MongoTemplate} configured with the required settings for Spring
+	 * Batch. The template will have {@code MapKeyDotReplacement} set to support execution
+	 * context keys containing dots.
+	 * @param mongoDatabaseFactory the MongoDB database factory
+	 * @return a configured MongoTemplate
+	 */
+	private MongoOperations createMongoTemplate(MongoDatabaseFactory mongoDatabaseFactory) {
+		MongoTemplate template = new MongoTemplate(mongoDatabaseFactory);
+		MappingMongoConverter converter = (MappingMongoConverter) template.getConverter();
+		// Set MapKeyDotReplacement to support keys with dots in execution context
+		converter.setMapKeyDotReplacement(".");
+		return template;
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/MongoJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/MongoJobRepositoryFactoryBean.java
@@ -23,23 +23,30 @@ import org.springframework.batch.core.repository.dao.mongodb.MongoJobInstanceDao
 import org.springframework.batch.core.repository.dao.mongodb.MongoSequenceIncrementer;
 import org.springframework.batch.core.repository.dao.mongodb.MongoStepExecutionDao;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
 import org.springframework.util.Assert;
 
 /**
- * This factory bean creates a job repository backed by MongoDB. It requires a mongo
- * template and a mongo transaction manager. <strong>The mongo template must be configured
- * with a {@link MappingMongoConverter} having a {@code MapKeyDotReplacement} set to a non
- * null value. See {@code MongoDBJobRepositoryIntegrationTests} for an example. This is
- * required to support execution context keys containing dots (like "step.type" or
- * "batch.version")</strong>
+ * This factory bean creates a job repository backed by MongoDB. It requires a
+ * {@link MongoDatabaseFactory} or a mongo template and a mongo transaction manager.
+ * <strong>When providing a {@link MongoOperations}, it must be configured with a
+ * {@link MappingMongoConverter} having a {@code MapKeyDotReplacement} set to a non null
+ * value to support execution context keys containing dots (like "step.type" or
+ * "batch.version").</strong>
+ * <p>
+ * For convenience, this factory can create the required {@link MongoTemplate} internally
+ * when a {@link MongoDatabaseFactory} is provided.
  *
  * @author Mahmoud Ben Hassine
  * @since 5.2.0
  */
 public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryBean implements InitializingBean {
+
+	private @Nullable MongoDatabaseFactory mongoDatabaseFactory;
 
 	private @Nullable MongoOperations mongoOperations;
 
@@ -49,6 +56,31 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 
 	private @Nullable DataFieldMaxValueIncrementer stepExecutionIncrementer;
 
+	/**
+	 * Set the {@link MongoDatabaseFactory} to use for creating a {@link MongoTemplate}
+	 * internally. The created template will be configured with the required
+	 * {@code MapKeyDotReplacement} to support execution context keys containing dots.
+	 * <p>
+	 * This is the recommended way to configure this factory bean, as it avoids the need
+	 * to create a separate {@link MongoTemplate} specifically for Spring Batch.
+	 * @param mongoDatabaseFactory the MongoDB database factory to use
+	 */
+	public void setMongoDatabaseFactory(MongoDatabaseFactory mongoDatabaseFactory) {
+		this.mongoDatabaseFactory = mongoDatabaseFactory;
+	}
+
+	/**
+	 * Set the {@link MongoOperations} to use. <strong>The provided template must be
+	 * configured with a {@link MappingMongoConverter} having a
+	 * {@code MapKeyDotReplacement} set to a non null value.</strong>
+	 * <p>
+	 * For convenience, consider using
+	 * {@link #setMongoDatabaseFactory(MongoDatabaseFactory)} instead, which will create
+	 * the required template internally.
+	 * @param mongoOperations the MongoOperations to use
+	 * @deprecated Use {@link #setMongoDatabaseFactory(MongoDatabaseFactory)} instead
+	 */
+	@Deprecated(since = "5.2.1", forRemoval = true)
 	public void setMongoOperations(MongoOperations mongoOperations) {
 		this.mongoOperations = mongoOperations;
 	}
@@ -106,7 +138,19 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
-		Assert.notNull(this.mongoOperations, "MongoOperations must not be null.");
+
+		if (this.mongoOperations == null && this.mongoDatabaseFactory == null) {
+			throw new IllegalArgumentException(
+					"Either MongoDatabaseFactory or MongoOperations must be set. Use setMongoDatabaseFactory() for automatic configuration.");
+		}
+
+		// Create MongoTemplate internally if not provided
+		if (this.mongoOperations == null) {
+			MongoDatabaseFactory factory = this.mongoDatabaseFactory;
+			Assert.state(factory != null, "MongoDatabaseFactory must be set when MongoOperations is null");
+			this.mongoOperations = createMongoTemplate(factory);
+		}
+
 		if (this.jobInstanceIncrementer == null) {
 			this.jobInstanceIncrementer = new MongoSequenceIncrementer(this.mongoOperations, "BATCH_JOB_INSTANCE_SEQ");
 		}
@@ -118,6 +162,21 @@ public class MongoJobRepositoryFactoryBean extends AbstractJobRepositoryFactoryB
 			this.stepExecutionIncrementer = new MongoSequenceIncrementer(this.mongoOperations,
 					"BATCH_STEP_EXECUTION_SEQ");
 		}
+	}
+
+	/**
+	 * Create a {@link MongoTemplate} configured with the required settings for Spring
+	 * Batch. The template will have {@code MapKeyDotReplacement} set to support execution
+	 * context keys containing dots.
+	 * @param mongoDatabaseFactory the MongoDB database factory
+	 * @return a configured MongoTemplate
+	 */
+	private MongoOperations createMongoTemplate(MongoDatabaseFactory mongoDatabaseFactory) {
+		MongoTemplate template = new MongoTemplate(mongoDatabaseFactory);
+		MappingMongoConverter converter = (MappingMongoConverter) template.getConverter();
+		// Set MapKeyDotReplacement to support keys with dots in execution context
+		converter.setMapKeyDotReplacement(".");
+		return template;
 	}
 
 }


### PR DESCRIPTION
This PR addresses #5346 by adding support for `MongoDatabaseFactory` in `MongoJobRepositoryFactoryBean` and `MongoJobExplorerFactoryBean`.

## Problem
Users had to create a separate `MongoTemplate` with `MapKeyDotReplacement` configuration specifically for Spring Batch, which was cumbersome.

## Solution
- Added `setMongoDatabaseFactory()` method to accept a `MongoDatabaseFactory`
- The factory now creates the required `MongoTemplate` internally with proper `MapKeyDotReplacement` configuration
- Deprecated `setMongoOperations()` in favor of the new approach
- Applied the same changes to `MongoJobExplorerFactoryBean`

## Benefits
- Users can now simply provide a `MongoDatabaseFactory` instead of creating a separate `MongoTemplate`
- The required `MapKeyDotReplacement` configuration is handled automatically
- Backward compatibility is maintained with the deprecated `setMongoOperations()` method

---