### PR TITLE
Fix #5321: Add addListener method in StepBuilder and JobBuilder

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/builder/JobBuilderHelper.java
@@ -143,6 +143,19 @@ public abstract class JobBuilderHelper<B extends JobBuilderHelper<B>> {
 	}
 
 	/**
+	 * Add a job execution listener. This is an alias for
+	 * {@link #listener(JobExecutionListener)} that makes it more explicit that the
+	 * listener is being added to a collection rather than replacing any existing
+	 * listeners.
+	 * @param listener a job execution listener
+	 * @return this to enable fluent chaining
+	 * @since 6.0.4
+	 */
+	public B addListener(JobExecutionListener listener) {
+		return listener(listener);
+	}
+
+	/**
 	 * Register a job execution listener.
 	 * @param listener a job execution listener
 	 * @return this to enable fluent chaining

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/StepBuilderHelper.java
@@ -112,6 +112,19 @@ public abstract class StepBuilderHelper<B extends StepBuilderHelper<B>> {
 		return self();
 	}
 
+	/**
+	 * Add a step execution listener. This is an alias for
+	 * {@link #listener(StepExecutionListener)} that makes it more explicit that the
+	 * listener is being added to a collection rather than replacing any existing
+	 * listeners.
+	 * @param listener a step execution listener
+	 * @return this for fluent chaining
+	 * @since 6.0.4
+	 */
+	public B addListener(StepExecutionListener listener) {
+		return listener(listener);
+	}
+
 	public B listener(StepExecutionListener listener) {
 		properties.addStepExecutionListener(listener);
 		return self();


### PR DESCRIPTION
This PR addresses #5321 by introducing `addListener()` methods in `StepBuilderHelper` and `JobBuilderHelper` as aliases to the existing `listener()` methods.

## Motivation
The current `.listener()` method name can be ambiguous since it doesn"t explicitly communicate its additive behavior. In the Spring ecosystem, a method named after a property often implies setting a single value (potentially overwriting), but in Spring Batch, calling `.listener()` multiple times actually **appends** the listeners to an internal list.

## Proposed Change
Added `addListener()` as an alias that makes it clear that listeners are being added to a collection:

### In StepBuilderHelper:
```java
public B addListener(StepExecutionListener listener) {
    return listener(listener);
}
```

### In JobBuilderHelper:
```java
public B addListener(JobExecutionListener listener) {
    return listener(listener);
}
```

## Benefits
- **Improved Readability**: `addListener` makes it clear that the listener is being added to a collection
- **API Consistency**: Aligns with modern Java library conventions where `add*` is used for collection-based properties
- **Self-Documenting Code**: Reduces the need for developers to check Javadoc to confirm additive behavior
- **Backward Compatibility**: The existing `.listener()` method remains for backward compatibility

---