### PR TITLE
GH-5356: Optimize findRunningJobExecutions to use batch query

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobExecutionDao.java
@@ -21,11 +21,11 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.batch.core.job.JobExecution;
@@ -122,10 +122,8 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 		if (jobInstances.isEmpty()) {
 			return Collections.emptySet();
 		}
-		Map<Long, JobInstance> jobInstanceMap = new HashMap<>();
-		for (JobInstance jobInstance : jobInstances) {
-			jobInstanceMap.put(jobInstance.getId(), jobInstance);
-		}
+		Map<Long, JobInstance> jobInstanceMap = jobInstances.stream()
+			.collect(Collectors.toMap(JobInstance::getId, Function.identity()));
 		Query query = query(
 				where("jobInstanceId").in(jobInstanceMap.keySet()).and("status").in("STARTING", "STARTED", "STOPPING"));
 		return this.mongoOperations

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoJobExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,12 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
@@ -116,18 +119,21 @@ public class MongoJobExecutionDao implements JobExecutionDao {
 	@Override
 	public Set<JobExecution> findRunningJobExecutions(String jobName) {
 		List<JobInstance> jobInstances = this.jobInstanceDao.findJobInstancesByName(jobName);
-		Set<JobExecution> runningJobExecutions = new HashSet<>();
-		for (JobInstance jobInstance : jobInstances) {
-			Query query = query(
-					where("jobInstanceId").is(jobInstance.getId()).and("status").in("STARTING", "STARTED", "STOPPING"));
-			this.mongoOperations
-				.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
-						JOB_EXECUTIONS_COLLECTION_NAME)
-				.stream()
-				.map(jobExecution -> convert(jobExecution, jobInstance))
-				.forEach(runningJobExecutions::add);
+		if (jobInstances.isEmpty()) {
+			return Collections.emptySet();
 		}
-		return runningJobExecutions;
+		Map<Long, JobInstance> jobInstanceMap = new HashMap<>();
+		for (JobInstance jobInstance : jobInstances) {
+			jobInstanceMap.put(jobInstance.getId(), jobInstance);
+		}
+		Query query = query(
+				where("jobInstanceId").in(jobInstanceMap.keySet()).and("status").in("STARTING", "STARTED", "STOPPING"));
+		return this.mongoOperations
+			.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
+					JOB_EXECUTIONS_COLLECTION_NAME)
+			.stream()
+			.map(jobExecution -> convert(jobExecution, jobInstanceMap.get(jobExecution.getJobInstanceId())))
+			.collect(Collectors.toSet());
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoJobExecutionDaoIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoJobExecutionDaoIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 the original author or authors.
+ * Copyright 2008-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -239,6 +240,39 @@ class MongoJobExecutionDaoIntegrationTests extends AbstractMongoDBDaoIntegration
 			.orElseThrow();
 		assertTemporalEquals(now.plusSeconds(3), value.getLastUpdated());
 
+	}
+
+	@Test
+	void testFindRunningExecutionsAcrossMultipleInstances(@Autowired JobInstanceDao jobInstanceDao) {
+		String jobName = "multiInstanceJob";
+		JobInstance instance1 = jobInstanceDao.createJobInstance(jobName,
+				new JobParametersBuilder().addLong("id", 1L).toJobParameters());
+		JobInstance instance2 = jobInstanceDao.createJobInstance(jobName,
+				new JobParametersBuilder().addLong("id", 2L).toJobParameters());
+		LocalDateTime now = LocalDateTime.now();
+
+		JobExecution running1 = dao.createJobExecution(instance1, jobParameters);
+		running1.setStatus(BatchStatus.STARTED);
+		running1.setStartTime(now);
+		dao.updateJobExecution(running1);
+
+		JobExecution completed = dao.createJobExecution(instance2, jobParameters);
+		completed.setStatus(BatchStatus.COMPLETED);
+		completed.setStartTime(now);
+		completed.setEndTime(now);
+		dao.updateJobExecution(completed);
+
+		JobExecution running2 = dao.createJobExecution(instance2, jobParameters);
+		running2.setStatus(BatchStatus.STARTED);
+		running2.setStartTime(now);
+		dao.updateJobExecution(running2);
+
+		Set<JobExecution> result = dao.findRunningJobExecutions(jobName);
+
+		assertEquals(2, result.size());
+		Set<Long> ids = result.stream().map(JobExecution::getId).collect(Collectors.toSet());
+		assertTrue(ids.contains(running1.getId()));
+		assertTrue(ids.contains(running2.getId()));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`MongoJobExecutionDao.findRunningJobExecutions()` issues N+1 MongoDB queries, where N is the total number of job instances for a given job name.

This change replaces individual per-instance queries with a single batch query using the `$in` operator.

**Before**: 1 query (load all instances) + N queries (one per instance) = 1+N queries
**After**: 1 query (load all instances) + 1 batch query (`$in`) = 2 queries

## Changes

- Build a `Map<Long, JobInstance>` from loaded instances for O(1) lookup
- Use `$in(jobInstanceMap.keySet())` to find all running executions in a single query
- Add early return for empty instances
- Add integration test for running executions across multiple job instances

Closes #5356

---

- [x] Rebase on latest `main` and squash commits
- [x] Add/Update unit tests as needed
- [x] Sign-off commits according to the DCO