### PR TITLE
Fix JavaDoc of BatchStatus.isLessThanOrEqualTo

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
@@ -137,7 +137,7 @@ public enum BatchStatus {
 
 	/**
 	 * @param other A status value to which to compare.
-	 * @return {@code true} if this is less than {@code other}.
+	 * @return {@code true} if this is less than or equal to {@code other}.
 	 */
 	public boolean isLessThanOrEqualTo(BatchStatus other) {
 		return this.compareTo(other) <= 0;


### PR DESCRIPTION
Fix the @return JavaDoc tag to correctly state less than or equal to. Closes #5285
