### PR TITLE
Add null check in JsonObjectReader close() implementations

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/GsonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/GsonJsonObjectReader.java
@@ -97,11 +97,14 @@ public class GsonJsonObjectReader<T> implements JsonObjectReader<T> {
 		return null;
 	}
 
-	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws Exception {
-		this.inputStream.close();
-		this.jsonReader.close();
+		if (this.inputStream != null) {
+			this.inputStream.close();
+		}
+		if (this.jsonReader != null) {
+			this.jsonReader.close();
+		}
 	}
 
 	@SuppressWarnings("DataFlowIssue")

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JacksonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JacksonJsonObjectReader.java
@@ -106,11 +106,14 @@ public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 		return null;
 	}
 
-	@SuppressWarnings("DataFlowIssue")
 	@Override
 	public void close() throws Exception {
-		this.inputStream.close();
-		this.jsonParser.close();
+		if (this.inputStream != null) {
+			this.inputStream.close();
+		}
+		if (this.jsonParser != null) {
+			this.jsonParser.close();
+		}
 	}
 
 	@SuppressWarnings("DataFlowIssue")

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/JsonItemReaderFunctionalTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/JsonItemReaderFunctionalTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.batch.infrastructure.item.json;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
@@ -25,9 +27,11 @@ import org.springframework.batch.infrastructure.item.ItemStreamException;
 import org.springframework.batch.infrastructure.item.ParseException;
 import org.springframework.batch.infrastructure.item.json.builder.JsonItemReaderBuilder;
 import org.springframework.batch.infrastructure.item.json.domain.Trade;
+import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -128,6 +132,32 @@ abstract class JsonItemReaderFunctionalTests {
 
 		// then
 		assertTrue(getJsonParsingException().isInstance(expectedException.getCause()));
+	}
+
+	@Test
+	void testCloseWhenOpenFailsShouldNotThrowNpe() {
+		// given
+		AbstractResource failingResource = new AbstractResource() {
+			@Override
+			public String getDescription() {
+				return "failing resource";
+			}
+
+			@Override
+			public InputStream getInputStream() throws IOException {
+				throw new IOException("Simulated connection failure");
+			}
+		};
+		JsonItemReader<Trade> itemReader = new JsonItemReaderBuilder<Trade>().jsonObjectReader(getJsonObjectReader())
+			.resource(failingResource)
+			.name("tradeJsonItemReader")
+			.build();
+
+		// when
+		assertThrows(ItemStreamException.class, () -> itemReader.open(new ExecutionContext()));
+
+		// then
+		assertDoesNotThrow(itemReader::close);
 	}
 
 	@Test


### PR DESCRIPTION
JacksonJsonObjectReader.close() and GsonJsonObjectReader.close() throw NullPointerException when close() is called after open() fails. Added null checks for inputStream and parser/reader fields. Added test to verify close() is null-safe after a failed open(). Closes #5281
