### PR TITLE
Fix 'occured' -> 'occurred' typo in StaxEventItemWriter @throws javadoc

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemWriter.java
@@ -451,7 +451,7 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * @param writer the {@link Writer} to be used by the {@link XMLEventWriter} for
 	 * writing to character streams.
 	 * @return an xml writer
-	 * @throws XMLStreamException thrown if error occured creating {@link XMLEventWriter}.
+	 * @throws XMLStreamException thrown if error occurred creating {@link XMLEventWriter}.
 	 */
 	protected XMLEventWriter createXmlEventWriter(XMLOutputFactory outputFactory, Writer writer)
 			throws XMLStreamException {


### PR DESCRIPTION
The `@throws` javadoc on `StaxEventItemWriter` in `spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemWriter.java:454` read `thrown if error occured creating XMLEventWriter`. Doc-only Java change inside a `/** */` block.