### PR TITLE
Fix getLastJobExecution to handle no job execution found and add test for this case

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/jdbc/JdbcJobExecutionDao.java
@@ -310,11 +310,13 @@ public class JdbcJobExecutionDao extends AbstractJdbcBatchMetadataDao implements
 	@Override
 	public JobExecution getLastJobExecution(JobInstance jobInstance) {
 		long jobInstanceId = jobInstance.getId();
-
-		Long lastJobExecutionId = getJdbcTemplate().queryForObject(getQuery(GET_LAST_JOB_EXECUTION_ID), Long.class,
-				jobInstanceId, jobInstanceId);
-
-		return lastJobExecutionId != null ? getJobExecution(lastJobExecutionId) : null;
+		try {
+			Long lastJobExecutionId = getJdbcTemplate().queryForObject(getQuery(GET_LAST_JOB_EXECUTION_ID), Long.class, jobInstanceId, jobInstanceId);
+			return lastJobExecutionId != null ? getJobExecution(lastJobExecutionId) : null;
+		}
+		catch (EmptyResultDataAccessException e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobDaoTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/AbstractJobDaoTests.java
@@ -267,6 +267,17 @@ public abstract class AbstractJobDaoTests {
 		assertEquals("jobKey", lastExecution.getJobParameters().getString("job.key"));
 	}
 
+	@Transactional
+	@Test
+	void testGetLastJobExecutionNoExecution() {
+		jobExecutionDao.deleteJobExecutionParameters(jobExecution);
+		jobExecutionDao.deleteJobExecution(jobExecution);
+
+		JobExecution je = jobExecutionDao.getLastJobExecution(jobInstance);
+
+		assertNull(je);
+	}
+
 	/**
 	 * Trying to create instance twice for the same job+parameters causes error
 	 */


### PR DESCRIPTION
Closes #5389

As 
```java
getJdbcTemplate().queryForObject
```
Expects exactly one result, when no execution is found, exception was thrown. This fix catchs exception and returns null
Null element is handle by the caller.