### PR TITLE
GH-5391: Update stop restart sample instructions

### DIFF
--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/restart/stop/README.md
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/restart/stop/README.md
@@ -8,9 +8,12 @@ restart capabilities.
 
 ### Run the sample
 
-You can run the sample from the command line as following:
+For a command-line stop and restart walkthrough, use the
+[Graceful Shutdown sample](../../shutdown/README.md). It provides executable
+entry points to start, stop, and restart a job:
 
 ```
-$>cd spring-batch-samples
-$>../mvnw -Dtest=JobOperatorFunctionalTests#testStartStopResumeJob test
+$>./mvnw -pl org.springframework.batch:spring-batch-samples exec:java -Dexec.mainClass=org.springframework.batch.samples.shutdown.StartJobExecutionApp
+$>./mvnw -pl org.springframework.batch:spring-batch-samples exec:java -Dexec.mainClass=org.springframework.batch.samples.shutdown.StopJobExecutionApp
+$>./mvnw -pl org.springframework.batch:spring-batch-samples exec:java -Dexec.mainClass=org.springframework.batch.samples.shutdown.RestartJobExecutionApp
 ```


### PR DESCRIPTION
Closes GH-5391

Updated the stop/restart sample README so it no longer references the removed `JobOperatorFunctionalTests#testStartStopResumeJob` test. The README now points to the current Graceful Shutdown sample and its start, stop, and restart entry points.

Verification:

* Confirmed the old documented command fails because `JobOperatorFunctionalTests#testStartStopResumeJob` no longer exists.
* Ran `./mvnw -pl org.springframework.batch:spring-batch-samples -DskipTests compile`
