### PR TITLE
Propagate step context to worker threads in ChunkTaskExecutorItemWriter

### DIFF
--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkTaskExecutorItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkTaskExecutorItemWriter.java
@@ -17,6 +17,7 @@ package org.springframework.batch.integration.chunk;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.core.step.StepContribution;
 import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.core.listener.StepExecutionListener;
@@ -94,8 +95,15 @@ public class ChunkTaskExecutorItemWriter<T> implements ItemWriter<T>, StepExecut
 	public void write(Chunk<? extends T> chunk) {
 		ChunkRequest<T> request = new ChunkRequest<>(++sequence, chunk, this.stepExecution.getJobExecutionId(),
 				this.stepExecution.createStepContribution());
-		FutureTask<ChunkResponse> chunkResponseFutureTask = new FutureTask<>(
-				() -> this.chunkProcessorChunkHandler.handle(request));
+		FutureTask<ChunkResponse> chunkResponseFutureTask = new FutureTask<>(() -> {
+			try {
+				StepSynchronizationManager.register(this.stepExecution);
+				return this.chunkProcessorChunkHandler.handle(request);
+			}
+			finally {
+				StepSynchronizationManager.close();
+			}
+		});
 		this.responses.add(chunkResponseFutureTask);
 		this.taskExecutor.execute(chunkResponseFutureTask);
 	}

--- a/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkTaskExecutorItemWriterTests.java
+++ b/spring-batch-integration/src/test/java/org/springframework/batch/integration/chunk/ChunkTaskExecutorItemWriterTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.integration.chunk;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.step.item.ChunkProcessor;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.test.MetaDataInstanceFactory;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ChunkTaskExecutorItemWriterTests {
+
+	@Test
+	void stepContextIsPropagatedToWorkerThread() throws Exception {
+		// given
+		StepExecution stepExecution = MetaDataInstanceFactory.createStepExecution();
+		AtomicReference<StepContext> capturedContext = new AtomicReference<>();
+		ChunkProcessor<String> chunkProcessor = (chunk, contribution) -> {
+			capturedContext.set(StepSynchronizationManager.getContext());
+			contribution.setExitStatus(ExitStatus.COMPLETED);
+		};
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+		taskExecutor.setCorePoolSize(1);
+		taskExecutor.setThreadNamePrefix("worker-thread-");
+		taskExecutor.setWaitForTasksToCompleteOnShutdown(true);
+		taskExecutor.afterPropertiesSet();
+		try {
+			ChunkTaskExecutorItemWriter<String> itemWriter = new ChunkTaskExecutorItemWriter<>(chunkProcessor,
+					taskExecutor);
+			itemWriter.beforeStep(stepExecution);
+
+			// when
+			itemWriter.write(Chunk.of("foo", "bar"));
+			ExitStatus exitStatus = itemWriter.afterStep(stepExecution);
+
+			// then
+			assertEquals(ExitStatus.COMPLETED.getExitCode(), exitStatus.getExitCode());
+			StepContext context = capturedContext.get();
+			assertNotNull(context, "StepContext should be available on the worker thread");
+			assertEquals(stepExecution, context.getStepExecution());
+		}
+		finally {
+			taskExecutor.shutdown();
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

`ChunkTaskExecutorItemWriter` submits chunk processing to a `TaskExecutor` but did not register a `StepContext` on the worker thread. As a result, `@StepScope` beans accessed from inside the delegate `ChunkProcessor` fail with `ScopeNotActiveException`, and `DisposableBean.destroy()` is skipped for step-scoped beans.

This change registers the step execution with `StepSynchronizationManager` before the delegate handles the request, and closes it in a `finally` block — the same pattern applied to multi-threaded `ChunkOrientedStep` in #5183 (see [commit 5642911](https://github.com/spring-projects/spring-batch/commit/564291127752f0c107508f853131fc4d8acfd4bd)).

Fixes #5398.

## Changes

- `ChunkTaskExecutorItemWriter.write(Chunk)`: wrap the worker-thread callable in `StepSynchronizationManager.register(stepExecution)` / `close()`.
- New test `ChunkTaskExecutorItemWriterTests.stepContextIsPropagatedToWorkerThread` — verifies `StepSynchronizationManager.getContext()` returns the active `StepContext` from inside the delegate `ChunkProcessor`.

## Test plan

- [x] `./mvnw -pl spring-batch-integration -am test` — all 150 tests pass, including the new test
- [x] Confirmed the new test fails on `main` without this fix (`StepContext should be available on the worker thread`) and passes with it
- [x] No changes to public API; existing `ChunkTaskExecutorItemWriter` tests unaffected