### PR TITLE
Align PostgreSQL Testcontainers image version across integration tests

### DIFF
--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/PostgreSQLJobRepositoryIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/PostgreSQLJobRepositoryIntegrationTests.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class PostgreSQLJobRepositoryIntegrationTests {
 
 	// TODO find the best way to externalize and manage image versions
-	private static final DockerImageName POSTGRESQL_IMAGE = DockerImageName.parse("postgres:17.5");
+	private static final DockerImageName POSTGRESQL_IMAGE = DockerImageName.parse("postgres:18.1");
 
 	@Container
 	public static PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRESQL_IMAGE);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/support/PostgresPagingQueryProviderIntegrationTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/database/support/PostgresPagingQueryProviderIntegrationTests.java
@@ -40,7 +40,7 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 class PostgresPagingQueryProviderIntegrationTests extends AbstractPagingQueryProviderIntegrationTests {
 
 	// TODO find the best way to externalize and manage image versions
-	private static final DockerImageName POSTGRESQL_IMAGE = DockerImageName.parse("postgres:17.5");
+	private static final DockerImageName POSTGRESQL_IMAGE = DockerImageName.parse("postgres:18.1");
 
 	@Container
 	public static PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRESQL_IMAGE);

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/jpa/PostgreSQLJpaIntegrationTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/jpa/PostgreSQLJpaIntegrationTests.java
@@ -66,7 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class PostgreSQLJpaIntegrationTests {
 
 	// TODO find the best way to externalize and manage image versions
-	private static final DockerImageName POSTGRESQL_IMAGE = DockerImageName.parse("postgres:17.5");
+	private static final DockerImageName POSTGRESQL_IMAGE = DockerImageName.parse("postgres:18.1");
 
 	@Container
 	public static PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRESQL_IMAGE);


### PR DESCRIPTION
## Summary

Aligns the PostgreSQL Testcontainers image version across the four PostgreSQL-based integration tests in spring-batch. After this change all four tests use `postgres:18.1`.

| File | Before | After |
|---|---|---|
| `spring-batch-core/.../migration/PostgreSQLMigrationScriptIntegrationTests.java` | `postgres:18.1` | `postgres:18.1` (unchanged) |
| `spring-batch-core/.../PostgreSQLJobRepositoryIntegrationTests.java` | `postgres:17.5` | `postgres:18.1` |
| `spring-batch-infrastructure/.../PostgresPagingQueryProviderIntegrationTests.java` | `postgres:17.5` | `postgres:18.1` |
| `spring-batch-samples/.../PostgreSQLJpaIntegrationTests.java` | `postgres:17.5` | `postgres:18.1` |

This eliminates the drift described in #5383, where the migration tests and the rest of the suite were validated against different PostgreSQL major versions.

## Test plan

- [x] Confirmed before the change: three files referenced `postgres:17.5`, one referenced `postgres:18.1`.
- [x] Confirmed after the change: all four files reference `postgres:18.1`.
- [x] Diff is a literal version-string update inside `DockerImageName.parse(...)` — no logic change.
- [ ] Full `./mvnw verify` could not be executed locally: the `spring-batch-infrastructure` main compile fails on JDK 21 with a pre-existing `NullAway` / JSpecify error (`Running NullAway in JSpecify mode requires either JDK 22+ ...`). The project's CI uses Java 25 (`.github/workflows/continuous-integration.yml`), so this is an environment limitation, not a regression introduced by this change. Verified by reproducing the same error against unmodified `main`.

## Verification done

1. No in-flight PR: `gh pr list --repo spring-projects/spring-batch --search "postgres testcontainers" / "5383" / "postgres:18.1"` returned no matching PR; `/issues/5383/events` shows only the original `labeled` event with no cross-reference.
2. No active claim: the issue author mentioned "I would like to submit a PR for this" 33 days ago (2026-04-21) without follow-up, so the implicit claim is treated as stalled.
3. Code-focused: change touches three `.java` integration test files.
4. Verified the bug still exists on `main` via `gh search code`: 3 files use `postgres:17.5`, 1 uses `postgres:18.1` (matching the issue body exactly).
5. No umbrella/parent issue closed silently — issue is still open with `status: waiting-for-triage`.

Resolves #5383