### PR TITLE
GH-5385: Improve performance of MongoStepExecutionDao::getLastStepExecution

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoStepExecutionDao.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/mongodb/MongoStepExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  */
 package org.springframework.batch.core.repository.dao.mongodb;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
 
@@ -27,6 +25,7 @@ import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.core.repository.dao.StepExecutionDao;
 import org.springframework.batch.core.repository.persistence.converter.JobExecutionConverter;
 import org.springframework.batch.core.repository.persistence.converter.StepExecutionConverter;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
@@ -113,37 +112,32 @@ public class MongoStepExecutionDao implements StepExecutionDao {
 	@Nullable
 	@Override
 	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
-		// TODO optimize the query
-		// get all step executions
-		Query query = query(where("jobInstanceId").is(jobInstance.getId()));
+		Query jobExecutionsQuery = query(where("jobInstanceId").is(jobInstance.getId()));
 		List<org.springframework.batch.core.repository.persistence.JobExecution> jobExecutions = this.mongoOperations
-			.find(query, org.springframework.batch.core.repository.persistence.JobExecution.class,
+			.find(jobExecutionsQuery, org.springframework.batch.core.repository.persistence.JobExecution.class,
 					JOB_EXECUTIONS_COLLECTION_NAME);
-		List<org.springframework.batch.core.repository.persistence.StepExecution> stepExecutions = this.mongoOperations
-			.find(query(where("jobExecutionId").in(jobExecutions.stream()
-				.map(org.springframework.batch.core.repository.persistence.JobExecution::getJobExecutionId)
-				.toList())), org.springframework.batch.core.repository.persistence.StepExecution.class,
-					STEP_EXECUTIONS_COLLECTION_NAME);
-		// sort step executions by creation date then id (see contract) and return the
-		// last one
-		Optional<org.springframework.batch.core.repository.persistence.StepExecution> lastStepExecution = stepExecutions
-			.stream()
-			.filter(stepExecution -> stepExecution.getName().equals(stepName))
-			.max(Comparator
-				.comparing(org.springframework.batch.core.repository.persistence.StepExecution::getCreateTime)
-				.thenComparing(
-						org.springframework.batch.core.repository.persistence.StepExecution::getStepExecutionId));
-		if (lastStepExecution.isPresent()) {
-			org.springframework.batch.core.repository.persistence.StepExecution stepExecution = lastStepExecution.get();
-			JobExecution jobExecution = this.jobExecutionConverter.toJobExecution(jobExecutions.stream()
-				.filter(execution -> execution.getJobExecutionId() == stepExecution.getJobExecutionId())
-				.findFirst()
-				.get(), jobInstance);
-			return this.stepExecutionConverter.toStepExecution(stepExecution, jobExecution);
-		}
-		else {
+		if (jobExecutions.isEmpty()) {
 			return null;
 		}
+		List<Long> jobExecutionIds = jobExecutions.stream()
+			.map(org.springframework.batch.core.repository.persistence.JobExecution::getJobExecutionId)
+			.toList();
+		// filter by step name and sort by creation date then id (see contract) at the
+		// database level, then return the most recent step execution
+		Query stepExecutionQuery = query(where("jobExecutionId").in(jobExecutionIds).and("name").is(stepName))
+			.with(Sort.by(Sort.Direction.DESC, "createTime", "stepExecutionId"))
+			.limit(1);
+		org.springframework.batch.core.repository.persistence.StepExecution lastStepExecution = this.mongoOperations
+			.findOne(stepExecutionQuery, org.springframework.batch.core.repository.persistence.StepExecution.class,
+					STEP_EXECUTIONS_COLLECTION_NAME);
+		if (lastStepExecution == null) {
+			return null;
+		}
+		JobExecution jobExecution = this.jobExecutionConverter.toJobExecution(jobExecutions.stream()
+			.filter(execution -> execution.getJobExecutionId() == lastStepExecution.getJobExecutionId())
+			.findFirst()
+			.get(), jobInstance);
+		return this.stepExecutionConverter.toStepExecution(lastStepExecution, jobExecution);
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoStepExecutionDaoIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/MongoStepExecutionDaoIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 the original author or authors.
+ * Copyright 2008-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,24 @@ class MongoStepExecutionDaoIntegrationTests extends AbstractMongoDBDaoIntegratio
 		StepExecution retrieved = dao.getLastStepExecution(jobInstance, "step1");
 		assertNotNull(retrieved);
 		assertEquals(lastStepExecution.getId(), retrieved.getId());
+	}
+
+	@Test
+	void testGetLastExecutionFiltersByStepName() {
+		dao.createStepExecution("stepA", jobExecution);
+		dao.createStepExecution("stepB", jobExecution);
+		StepExecution stepA2 = dao.createStepExecution("stepA", jobExecution);
+		StepExecution stepB2 = dao.createStepExecution("stepB", jobExecution);
+
+		StepExecution lastA = dao.getLastStepExecution(jobInstance, "stepA");
+		assertNotNull(lastA);
+		assertEquals(stepA2.getId(), lastA.getId());
+
+		StepExecution lastB = dao.getLastStepExecution(jobInstance, "stepB");
+		assertNotNull(lastB);
+		assertEquals(stepB2.getId(), lastB.getId());
+
+		assertNull(dao.getLastStepExecution(jobInstance, "nonExistentStep"));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #5385.

## Summary

`MongoStepExecutionDao#getLastStepExecution` currently fetches all step executions for the job instance into memory, then filters by step name and sorts on `(createTime, stepExecutionId)` in Java. The single-row contract makes this an O(N) cost that grows with the step-execution history despite the O(1) result.

This PR pushes the step name filter, ordering (`createTime` DESC, then `stepExecutionId` DESC) and `limit(1)` down to MongoDB, mirroring the optimization PR #4798 applied to the JDBC variant. It also removes the existing `// TODO optimize the query` marker.

The contract `StepExecutionDao#getLastStepExecution` ("Retrieve the last `StepExecution` for a given `JobInstance` ordered by creation time and then id") is preserved.

## Changes

- `MongoStepExecutionDao#getLastStepExecution`: filter (`name`), sort (`createTime` DESC, `stepExecutionId` DESC), and `limit(1)` are now applied via the `Query` and resolved by `MongoOperations#findOne` (which respects `Query#getSortObject` by delegating to `find` with `limit(1)`).
- `MongoStepExecutionDaoIntegrationTests`: added `testGetLastExecutionFiltersByStepName` to assert correct filtering when multiple step names share the same job instance, and to assert that a non-existent step name returns `null`. Existing tests (`testSaveAndGetLastExecution`, `testSaveAndGetLastExecutionWhenSameStartTime`) remain unchanged and continue to cover the createTime-then-id ordering contract.

## Test plan

- `./mvnw -pl spring-batch-core compile -DskipTests` — passes
- `./mvnw -pl spring-batch-core test-compile -DskipTests` — passes
- `./mvnw -pl spring-batch-core spring-javaformat:validate` — passes
- Mongo integration tests are gated on `@Testcontainers(disabledWithoutDocker = true)` and could not be executed in my local environment (no Docker daemon access). They are exercised by upstream CI.

## Verification done

- (1) PR list searched on `5385`: none found at the time of writing.
- (2) Issue thread: no in-flight claim; the reporter mentioned willingness to submit a PR on 2026-04-22 but no PR has materialized in the 36 days since. Treating as stalled per "no follow-up in >21 days." Credit to @config25 for the detailed problem description, current-behavior trace, and direction in the issue body.
- (3) Code-focused change: `.java` only.
- (4) Verified the pattern still exists on `main` (`// TODO optimize the query` + in-memory filter/sort at `MongoStepExecutionDao.java:115-147`).
- (5) Prior art: PR #4798 (`Improve performance of JdbcStepExecutionDao::getLastStepExecution`) — same shape of fix on the JDBC side, mirrored here for Mongo.