### PR TITLE
GH-5185: Move async processing APIs to core

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/AsyncItemProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/AsyncItemProcessor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2006-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
+import org.springframework.batch.core.step.StepExecution;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.core.listener.ItemProcessListener;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link ItemProcessor} that delegates to a nested processor and in the background. To
+ * allow for background processing the return value from the processor is a {@link Future}
+ * which needs to be unpacked before the item can be used by a client.
+ * <p>
+ * Because the {@link Future} is typically unwrapped in the {@link ItemWriter}, there are
+ * lifecycle and stats limitations (since the framework doesn't know what the result of
+ * the processor is). While not an exhaustive list, things like
+ * {@link StepExecution#getFilterCount()} will not reflect the number of filtered items
+ * and {@link ItemProcessListener#onProcessError(Object, Exception)} will not be called.
+ *
+ * @author Dave Syer
+ * @author Mahmoud Ben Hassine
+ * @param <I> the input object type
+ * @param <O> the output object type (will be wrapped in a Future)
+ * @see AsyncItemWriter
+ */
+public class AsyncItemProcessor<I, O> implements ItemProcessor<I, Future<O>> {
+
+	private ItemProcessor<I, O> delegate;
+
+	/**
+	 * Create a new {@link AsyncItemProcessor} with the delegate {@link ItemProcessor}.
+	 * @param delegate the {@link ItemProcessor} to use as a delegate
+	 * @since 6.0
+	 */
+	public AsyncItemProcessor(ItemProcessor<I, O> delegate) {
+		Assert.notNull(delegate, "The delegate ItemProcessor must not be null");
+		this.delegate = delegate;
+	}
+
+	private TaskExecutor taskExecutor = new SyncTaskExecutor();
+
+	/**
+	 * The {@link ItemProcessor} to use to delegate processing to in a background thread.
+	 * @param delegate the {@link ItemProcessor} to use as a delegate
+	 */
+	public void setDelegate(ItemProcessor<I, O> delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * The {@link TaskExecutor} to use to allow the item processing to proceed in the
+	 * background. Defaults to a {@link SyncTaskExecutor} so no threads are created unless
+	 * this is overridden.
+	 * @param taskExecutor a {@link TaskExecutor}
+	 */
+	public void setTaskExecutor(TaskExecutor taskExecutor) {
+		this.taskExecutor = taskExecutor;
+	}
+
+	/**
+	 * Transform the input by delegating to the provided item processor. The return value
+	 * is wrapped in a {@link Future} so that clients can unpack it later.
+	 *
+	 * @see ItemProcessor#process(Object)
+	 */
+	@SuppressWarnings("DataFlowIssue")
+	@Override
+	public @Nullable Future<O> process(I item) throws Exception {
+		final StepExecution stepExecution = getStepExecution();
+		FutureTask<O> task = new FutureTask<>(() -> {
+			if (stepExecution != null) {
+				StepSynchronizationManager.register(stepExecution);
+			}
+			try {
+				return delegate.process(item);
+			}
+			finally {
+				if (stepExecution != null) {
+					StepSynchronizationManager.close();
+				}
+			}
+		});
+		taskExecutor.execute(task);
+		return task;
+	}
+
+	/**
+	 * @return the current step execution if there is one
+	 */
+	private @Nullable StepExecution getStepExecution() {
+		StepContext context = StepSynchronizationManager.getContext();
+		if (context == null) {
+			return null;
+		}
+		return context.getStepExecution();
+	}
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/AsyncItemWriter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/AsyncItemWriter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2006-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.batch.infrastructure.item.ItemStream;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.batch.infrastructure.item.ItemStreamWriter;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.util.Assert;
+
+public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>> {
+
+	private static final Log logger = LogFactory.getLog(AsyncItemWriter.class);
+
+	private ItemWriter<T> delegate;
+
+	/**
+	 * Create a new instance of {@link AsyncItemWriter} with the provided delegate.
+	 * @param delegate the delegate item writer
+	 * @since 6.0
+	 */
+	public AsyncItemWriter(ItemWriter<T> delegate) {
+		Assert.notNull(delegate, "The delegate ItemWriter must not be null");
+		this.delegate = delegate;
+	}
+
+	/**
+	 * @param delegate ItemWriter that does the actual writing of the Future results
+	 */
+	public void setDelegate(ItemWriter<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * In the processing of the {@link java.util.concurrent.Future}s passed, nulls are
+	 * <em>not</em> passed to the delegate since they are considered filtered out by the
+	 * {@link AsyncItemProcessor}'s delegated {@link ItemProcessor}. If the unwrapping of
+	 * the {@link Future} results in an {@link ExecutionException}, that will be unwrapped
+	 * and the cause will be thrown.
+	 * @param items {@link java.util.concurrent.Future}s to be unwrapped and passed to the
+	 * delegate
+	 * @throws Exception The exception returned by the Future if one was thrown
+	 */
+	@Override
+	public void write(Chunk<? extends Future<T>> items) throws Exception {
+		List<T> list = new ArrayList<>();
+		for (Future<T> future : items) {
+			try {
+				T item = future.get();
+
+				if (item != null) {
+					list.add(item);
+				}
+			}
+			catch (ExecutionException e) {
+				Throwable cause = e.getCause();
+
+				if (cause instanceof Exception exception) {
+					logger.debug("An exception was thrown while processing an item", e);
+
+					throw exception;
+				}
+				else {
+					throw e;
+				}
+			}
+		}
+
+		delegate.write(new Chunk<>(list));
+	}
+
+	@Override
+	public void open(ExecutionContext executionContext) throws ItemStreamException {
+		if (delegate instanceof ItemStream) {
+			((ItemStream) delegate).open(executionContext);
+		}
+	}
+
+	@Override
+	public void update(ExecutionContext executionContext) throws ItemStreamException {
+		if (delegate instanceof ItemStream) {
+			((ItemStream) delegate).update(executionContext);
+		}
+	}
+
+	@Override
+	public void close() throws ItemStreamException {
+		if (delegate instanceof ItemStream) {
+			((ItemStream) delegate).close();
+		}
+	}
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkTaskExecutorItemWriter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkTaskExecutorItemWriter.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.JobInterruptedException;
+import org.springframework.batch.core.listener.StepExecutionListener;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.step.skip.NonSkippableReadException;
+import org.springframework.batch.core.step.skip.SkipLimitExceededException;
+import org.springframework.batch.core.step.skip.SkipListenerFailedException;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.retry.RetryException;
+
+/**
+ * This item writer submits chunk requests to local workers from a {@link TaskExecutor}.
+ *
+ * <p>
+ * The aggregation of worker contributions is done in the {@code afterStep} method, which
+ * waits for all worker responses and updates the step execution accordingly. If any
+ * worker response indicates a failure, the step execution is marked as failed and the
+ * exception is added to the step execution's failure exceptions. Otherwise, the step
+ * execution is marked as completed and the write counts and skip counts from all worker
+ * contributions are aggregated into the step execution's write count and write skip
+ * count. The commit count is also incremented for each successful worker contribution,
+ * while the rollback count is incremented for each failed worker contribution.
+ *
+ * <p>
+ * It should be noted that transaction management of the chunk as well as fault tolerance
+ * features are not handled by this item writer and are the responsibility of the delegate
+ * chunk processor.
+ *
+ * <p>
+ * Moreover, the lifecycle of the task executor is not handled by this item writer.
+ *
+ * @param <T> type of items
+ * @author Mahmoud Ben Hassine
+ * @since 6.0
+ */
+public class ChunkTaskExecutorItemWriter<T> implements ItemWriter<T>, StepExecutionListener {
+
+	private static final Log logger = LogFactory.getLog(ChunkTaskExecutorItemWriter.class);
+
+	@SuppressWarnings("NullAway.Init")
+	private StepExecution stepExecution;
+
+	private int sequence;
+
+	private final TaskExecutor taskExecutor;
+
+	private final ChunkProcessor<T> chunkProcessor;
+
+	private final Set<Future<StepContribution>> responses = new HashSet<>();
+
+	/**
+	 * Create a new {@link ChunkTaskExecutorItemWriter}.
+	 * @param chunkRequestProcessor the chunk processor to process chunks
+	 * @param taskExecutor the task executor to submit chunk processing tasks to
+	 */
+	public ChunkTaskExecutorItemWriter(ChunkProcessor<T> chunkRequestProcessor, TaskExecutor taskExecutor) {
+		this.taskExecutor = taskExecutor;
+		this.chunkProcessor = chunkRequestProcessor;
+	}
+
+	@Override
+	public void write(Chunk<? extends T> chunk) {
+		StepContribution contribution = this.stepExecution.createStepContribution();
+		FutureTask<StepContribution> chunkResponseFutureTask = new FutureTask<>(() -> {
+			try {
+				StepSynchronizationManager.register(this.stepExecution);
+				process(chunk, contribution);
+				return contribution;
+			}
+			finally {
+				StepSynchronizationManager.close();
+			}
+		});
+		this.responses.add(chunkResponseFutureTask);
+		this.taskExecutor.execute(chunkResponseFutureTask);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private void process(Chunk<? extends T> chunk, StepContribution contribution) throws Exception {
+		try {
+			this.chunkProcessor.process((Chunk) chunk, contribution);
+		}
+		catch (SkipLimitExceededException | NonSkippableReadException | SkipListenerFailedException | RetryException
+				| JobInterruptedException e) {
+			markContributionFailed(contribution, e);
+		}
+		catch (Exception e) {
+			if (this.chunkProcessor instanceof FaultTolerantChunkProcessor<?, ?>) {
+				throw e;
+			}
+			markContributionFailed(contribution, e);
+		}
+	}
+
+	private void markContributionFailed(StepContribution contribution, Exception exception) {
+		contribution.setExitStatus(ExitStatus.FAILED.addExitDescription(exception));
+	}
+
+	@Override
+	public void beforeStep(StepExecution stepExecution) {
+		this.stepExecution = stepExecution;
+		this.responses.clear();
+		this.sequence = 0;
+	}
+
+	@Override
+	public ExitStatus afterStep(StepExecution stepExecution) {
+		try {
+			ExitStatus result = ExitStatus.COMPLETED
+				.addExitDescription("Waited for " + this.responses.size() + " results.");
+			resetCounter(stepExecution);
+			for (StepContribution contribution : getStepContributions()) {
+				// only write counts and skip counts are aggregated here
+				// read counts and process/filter counts are managed by the driving step
+				stepExecution.setWriteCount(stepExecution.getWriteCount() + contribution.getWriteCount());
+				stepExecution.setWriteSkipCount(stepExecution.getWriteSkipCount() + contribution.getWriteSkipCount());
+				ExitStatus exitStatus = contribution.getExitStatus();
+				if (ExitStatus.FAILED.getExitCode().equals(exitStatus.getExitCode())) {
+					logger.error("Chunk processing failed for contribution: " + contribution
+							+ ", marking step execution as failed.");
+					result = exitStatus;
+					Throwable exitException = exitStatus.getExitException();
+					if (exitException != null) {
+						stepExecution.addFailureException(exitException);
+					}
+					stepExecution.setStatus(BatchStatus.FAILED);
+					stepExecution.incrementRollbackCount();
+				}
+				else {
+					stepExecution.incrementCommitCount();
+				}
+			}
+			return result;
+		}
+		catch (ExecutionException | InterruptedException e) {
+			stepExecution.setStatus(BatchStatus.FAILED);
+			stepExecution.addFailureException(e);
+			return ExitStatus.FAILED.addExitDescription(e);
+		}
+	}
+
+	/**
+	 * Reset the write count, write skip count, commit count and rollback count of the
+	 * step execution to avoid counting them twice as they are updated by workers and
+	 * aggregated in the afterStep method. The read count and process/filter count are not
+	 * reset as they are managed by the driving step
+	 * @param stepExecution the step execution to reset the counters for
+	 */
+	private void resetCounter(StepExecution stepExecution) {
+		stepExecution.setWriteCount(0);
+		stepExecution.setWriteSkipCount(0);
+		stepExecution.setCommitCount(0);
+		stepExecution.setRollbackCount(0);
+	}
+
+	private Collection<StepContribution> getStepContributions() throws ExecutionException, InterruptedException {
+		List<StepContribution> contributions = new ArrayList<>();
+		for (Future<StepContribution> task : this.responses) {
+			contributions.add(task.get());
+		}
+		return contributions;
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/AsyncItemProcessorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/AsyncItemProcessorTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2006-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+class AsyncItemProcessorTests {
+
+	private AsyncItemProcessor<String, String> processor;
+
+	private ItemProcessor<String, String> delegate = item -> item + item;
+
+	@Test
+	void testExecution() throws Exception {
+		processor = new AsyncItemProcessor<>(delegate);
+		Future<String> result = processor.process("foo");
+		assertEquals("foofoo", result.get());
+	}
+
+	@Test
+	void testExecutionInStepScope() throws Exception {
+		delegate = item -> {
+			StepContext context = StepSynchronizationManager.getContext();
+			assertTrue(context != null && context.getStepExecution() != null);
+			return item + item;
+		};
+		processor = new AsyncItemProcessor<>(delegate);
+		StepSynchronizationManager.register(createStepExecution());
+		try {
+			Future<String> result = processor.process("foo");
+			assertEquals("foofoo", result.get());
+		}
+		finally {
+			StepSynchronizationManager.close();
+		}
+	}
+
+	@Test
+	void testMultiExecution() throws Exception {
+		processor = new AsyncItemProcessor<>(delegate);
+		processor.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		List<Future<String>> list = new ArrayList<>();
+		for (int count = 0; count < 10; count++) {
+			list.add(processor.process("foo" + count));
+		}
+		for (Future<String> future : list) {
+			assertTrue(future.get().matches("foo.*foo.*"));
+		}
+	}
+
+	private StepExecution createStepExecution() {
+		return new StepExecution("step", new JobExecution(1, new JobInstance(1, "job"), new JobParameters()));
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/AsyncItemWriterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/AsyncItemWriterTests.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2014-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.batch.infrastructure.item.ItemStreamWriter;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author mminella
+ * @author Mahmoud Ben Hassine
+ */
+class AsyncItemWriterTests {
+
+	private AsyncItemWriter<String> writer;
+
+	private List<String> writtenItems;
+
+	private TaskExecutor taskExecutor;
+
+	@BeforeEach
+	void setup() {
+		taskExecutor = new SimpleAsyncTaskExecutor();
+		writtenItems = new ArrayList<>();
+		writer = new AsyncItemWriter<>(new ListItemWriter(writtenItems));
+	}
+
+	@Test
+	void testRoseyScenario() throws Exception {
+		Chunk<FutureTask<String>> processedItems = new Chunk<>();
+
+		processedItems.add(new FutureTask<>(() -> "foo"));
+
+		processedItems.add(new FutureTask<>(() -> "bar"));
+
+		for (FutureTask<String> processedItem : processedItems) {
+			taskExecutor.execute(processedItem);
+		}
+
+		writer.write(processedItems);
+
+		assertEquals(2, writtenItems.size());
+		assertTrue(writtenItems.contains("foo"));
+		assertTrue(writtenItems.contains("bar"));
+	}
+
+	@Test
+	void testFilteredItem() throws Exception {
+		Chunk<FutureTask<String>> processedItems = new Chunk<>();
+
+		processedItems.add(new FutureTask<>(() -> "foo"));
+
+		processedItems.add(new FutureTask<>(() -> null));
+
+		for (FutureTask<String> processedItem : processedItems) {
+			taskExecutor.execute(processedItem);
+		}
+
+		writer.write(processedItems);
+
+		assertEquals(1, writtenItems.size());
+		assertTrue(writtenItems.contains("foo"));
+	}
+
+	@Test
+	void testException() {
+		Chunk<FutureTask<String>> processedItems = new Chunk<>();
+
+		processedItems.add(new FutureTask<>(() -> "foo"));
+
+		processedItems.add(new FutureTask<>(() -> {
+			throw new RuntimeException("This was expected");
+		}));
+
+		for (FutureTask<String> processedItem : processedItems) {
+			taskExecutor.execute(processedItem);
+		}
+
+		Exception exception = assertThrows(RuntimeException.class, () -> writer.write(processedItems));
+		assertEquals("This was expected", exception.getMessage());
+	}
+
+	@Test
+	void testExecutionException() {
+		Chunk<Future<String>> processedItems = new Chunk<>();
+
+		processedItems.add(new Future<>() {
+
+			@Override
+			public boolean cancel(boolean mayInterruptIfRunning) {
+				return false;
+			}
+
+			@Override
+			public boolean isCancelled() {
+				return false;
+			}
+
+			@Override
+			public boolean isDone() {
+				return false;
+			}
+
+			@Override
+			public String get() throws InterruptedException, ExecutionException {
+				throw new InterruptedException("expected");
+			}
+
+			@Override
+			public String get(long timeout, TimeUnit unit)
+					throws InterruptedException, ExecutionException, TimeoutException {
+				return null;
+			}
+		});
+
+		Exception exception = assertThrows(Exception.class, () -> writer.write(processedItems));
+		assertFalse(exception instanceof ExecutionException);
+
+		assertEquals(0, writtenItems.size());
+	}
+
+	@Test
+	void testStreamDelegate() throws Exception {
+		ListItemStreamWriter itemWriter = new ListItemStreamWriter(writtenItems);
+		writer.setDelegate(itemWriter);
+
+		Chunk<FutureTask<String>> processedItems = new Chunk<>();
+
+		ExecutionContext executionContext = new ExecutionContext();
+		writer.open(executionContext);
+		writer.write(processedItems);
+		writer.update(executionContext);
+		writer.close();
+
+		assertTrue(itemWriter.isOpened);
+		assertTrue(itemWriter.isUpdated);
+		assertTrue(itemWriter.isClosed);
+	}
+
+	@Test
+	void testNonStreamDelegate() throws Exception {
+		ListItemWriter itemWriter = new ListItemWriter(writtenItems);
+		writer.setDelegate(itemWriter);
+
+		Chunk<FutureTask<String>> processedItems = new Chunk<>();
+
+		ExecutionContext executionContext = new ExecutionContext();
+		writer.open(executionContext);
+		writer.write(processedItems);
+		writer.update(executionContext);
+		writer.close();
+
+		assertFalse(itemWriter.isOpened);
+		assertFalse(itemWriter.isUpdated);
+		assertFalse(itemWriter.isClosed);
+	}
+
+	private static class ListItemWriter implements ItemWriter<String> {
+
+		protected List<String> items;
+
+		public boolean isOpened = false;
+
+		public boolean isUpdated = false;
+
+		public boolean isClosed = false;
+
+		public ListItemWriter(List<String> items) {
+			this.items = items;
+		}
+
+		@Override
+		public void write(Chunk<? extends String> chunk) throws Exception {
+			this.items.addAll(chunk.getItems());
+		}
+
+	}
+
+	private static class ListItemStreamWriter implements ItemStreamWriter<String> {
+
+		public boolean isOpened = false;
+
+		public boolean isUpdated = false;
+
+		public boolean isClosed = false;
+
+		protected List<String> items;
+
+		public ListItemStreamWriter(List<String> items) {
+			this.items = items;
+		}
+
+		@Override
+		public void write(Chunk<? extends String> chunk) throws Exception {
+			this.items.addAll(chunk.getItems());
+		}
+
+		@Override
+		public void open(ExecutionContext executionContext) throws ItemStreamException {
+			isOpened = true;
+		}
+
+		@Override
+		public void update(ExecutionContext executionContext) throws ItemStreamException {
+			isUpdated = true;
+		}
+
+		@Override
+		public void close() throws ItemStreamException {
+			isClosed = true;
+		}
+
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkTaskExecutorItemWriterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkTaskExecutorItemWriterTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.step.item;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ChunkTaskExecutorItemWriterTests {
+
+	@Test
+	void stepContextIsPropagatedToWorkerThread() throws Exception {
+		// given
+		StepExecution stepExecution = createStepExecution();
+		AtomicReference<StepContext> capturedContext = new AtomicReference<>();
+		ChunkProcessor<String> chunkProcessor = (chunk, contribution) -> {
+			capturedContext.set(StepSynchronizationManager.getContext());
+			contribution.setExitStatus(ExitStatus.COMPLETED);
+		};
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+		taskExecutor.setCorePoolSize(1);
+		taskExecutor.setThreadNamePrefix("worker-thread-");
+		taskExecutor.setWaitForTasksToCompleteOnShutdown(true);
+		taskExecutor.afterPropertiesSet();
+		try {
+			ChunkTaskExecutorItemWriter<String> itemWriter = new ChunkTaskExecutorItemWriter<>(chunkProcessor,
+					taskExecutor);
+			itemWriter.beforeStep(stepExecution);
+
+			// when
+			itemWriter.write(Chunk.of("foo", "bar"));
+			ExitStatus exitStatus = itemWriter.afterStep(stepExecution);
+
+			// then
+			assertEquals(ExitStatus.COMPLETED.getExitCode(), exitStatus.getExitCode());
+			StepContext context = capturedContext.get();
+			assertNotNull(context, "StepContext should be available on the worker thread");
+			assertEquals(stepExecution, context.getStepExecution());
+		}
+		finally {
+			taskExecutor.shutdown();
+		}
+	}
+
+	@Test
+	void stateIsResetBeforeEachStep() {
+		// given
+		ChunkProcessor<String> chunkProcessor = (chunk, contribution) -> {
+			contribution.incrementWriteCount(chunk.size());
+			contribution.setExitStatus(ExitStatus.COMPLETED);
+		};
+		ChunkTaskExecutorItemWriter<String> itemWriter = new ChunkTaskExecutorItemWriter<>(chunkProcessor,
+				new SyncTaskExecutor());
+		StepExecution firstStepExecution = createStepExecution();
+		itemWriter.beforeStep(firstStepExecution);
+		itemWriter.write(Chunk.of("foo", "bar"));
+		itemWriter.afterStep(firstStepExecution);
+		assertEquals(2, firstStepExecution.getWriteCount());
+		assertEquals(1, firstStepExecution.getCommitCount());
+
+		// when
+		StepExecution secondStepExecution = createStepExecution();
+		itemWriter.beforeStep(secondStepExecution);
+		ExitStatus exitStatus = itemWriter.afterStep(secondStepExecution);
+
+		// then
+		assertEquals(ExitStatus.COMPLETED.getExitCode(), exitStatus.getExitCode());
+		assertEquals("Waited for 0 results.", exitStatus.getExitDescription());
+		assertEquals(0, secondStepExecution.getWriteCount());
+		assertEquals(0, secondStepExecution.getCommitCount());
+	}
+
+	private StepExecution createStepExecution() {
+		return new StepExecution("step", new JobExecution(1, new JobInstance(1, "job"), new JobParameters()));
+	}
+
+}

--- a/spring-batch-docs/modules/ROOT/pages/spring-batch-integration/asynchronous-processing.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/spring-batch-integration/asynchronous-processing.adoc
@@ -37,7 +37,7 @@ The following example shows how to configuration the `AsyncItemProcessor` in XML
 [source, xml]
 ----
 <bean id="processor"
-    class="org.springframework.batch.integration.async.AsyncItemProcessor">
+    class="org.springframework.batch.core.step.item.AsyncItemProcessor">
   <property name="delegate">
     <bean class="your.ItemProcessor"/>
   </property>
@@ -78,7 +78,7 @@ The following example shows how to configure the `AsyncItemWriter` in XML:
 [source, xml]
 ----
 <bean id="itemWriter"
-    class="org.springframework.batch.integration.async.AsyncItemWriter">
+    class="org.springframework.batch.core.step.item.AsyncItemWriter">
   <property name="delegate">
     <bean id="itemWriter" class="your.ItemWriter"/>
   </property>

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemProcessor.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2025 the original author or authors.
+ * Copyright 2006-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,41 +15,18 @@
  */
 package org.springframework.batch.integration.async;
 
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-
-import org.springframework.batch.core.step.StepExecution;
-
-import org.jspecify.annotations.Nullable;
-import org.springframework.batch.core.listener.ItemProcessListener;
-import org.springframework.batch.core.scope.context.StepContext;
-import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
-import org.springframework.batch.infrastructure.item.ItemWriter;
-import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.core.task.TaskExecutor;
-import org.springframework.util.Assert;
 
 /**
- * An {@link ItemProcessor} that delegates to a nested processor and in the background. To
- * allow for background processing the return value from the processor is a {@link Future}
- * which needs to be unpacked before the item can be used by a client.
- * <p>
- * Because the {@link Future} is typically unwrapped in the {@link ItemWriter}, there are
- * lifecycle and stats limitations (since the framework doesn't know what the result of
- * the processor is). While not an exhaustive list, things like
- * {@link StepExecution#getFilterCount()} will not reflect the number of filtered items
- * and {@link ItemProcessListener#onProcessError(Object, Exception)} will not be called.
- *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
  * @param <I> the input object type
- * @param <O> the output object type (will be wrapped in a Future)
- * @see AsyncItemWriter
+ * @param <O> the output object type
+ * @deprecated since 6.0.4 in favor of
+ * {@link org.springframework.batch.core.step.item.AsyncItemProcessor}
  */
-public class AsyncItemProcessor<I, O> implements ItemProcessor<I, Future<O>> {
-
-	private ItemProcessor<I, O> delegate;
+@Deprecated(since = "6.0.4")
+public class AsyncItemProcessor<I, O> extends org.springframework.batch.core.step.item.AsyncItemProcessor<I, O> {
 
 	/**
 	 * Create a new {@link AsyncItemProcessor} with the delegate {@link ItemProcessor}.
@@ -57,66 +34,7 @@ public class AsyncItemProcessor<I, O> implements ItemProcessor<I, Future<O>> {
 	 * @since 6.0
 	 */
 	public AsyncItemProcessor(ItemProcessor<I, O> delegate) {
-		Assert.notNull(delegate, "The delegate ItemProcessor must not be null");
-		this.delegate = delegate;
-	}
-
-	private TaskExecutor taskExecutor = new SyncTaskExecutor();
-
-	/**
-	 * The {@link ItemProcessor} to use to delegate processing to in a background thread.
-	 * @param delegate the {@link ItemProcessor} to use as a delegate
-	 */
-	public void setDelegate(ItemProcessor<I, O> delegate) {
-		this.delegate = delegate;
-	}
-
-	/**
-	 * The {@link TaskExecutor} to use to allow the item processing to proceed in the
-	 * background. Defaults to a {@link SyncTaskExecutor} so no threads are created unless
-	 * this is overridden.
-	 * @param taskExecutor a {@link TaskExecutor}
-	 */
-	public void setTaskExecutor(TaskExecutor taskExecutor) {
-		this.taskExecutor = taskExecutor;
-	}
-
-	/**
-	 * Transform the input by delegating to the provided item processor. The return value
-	 * is wrapped in a {@link Future} so that clients can unpack it later.
-	 *
-	 * @see ItemProcessor#process(Object)
-	 */
-	@SuppressWarnings("DataFlowIssue")
-	@Override
-	public @Nullable Future<O> process(I item) throws Exception {
-		final StepExecution stepExecution = getStepExecution();
-		FutureTask<O> task = new FutureTask<>(() -> {
-			if (stepExecution != null) {
-				StepSynchronizationManager.register(stepExecution);
-			}
-			try {
-				return delegate.process(item);
-			}
-			finally {
-				if (stepExecution != null) {
-					StepSynchronizationManager.close();
-				}
-			}
-		});
-		taskExecutor.execute(task);
-		return task;
-	}
-
-	/**
-	 * @return the current step execution if there is one
-	 */
-	private @Nullable StepExecution getStepExecution() {
-		StepContext context = StepSynchronizationManager.getContext();
-		if (context == null) {
-			return null;
-		}
-		return context.getStepExecution();
+		super(delegate);
 	}
 
 }

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/async/AsyncItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,15 @@
  */
 package org.springframework.batch.integration.async;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import org.springframework.batch.infrastructure.item.ItemWriter;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import org.springframework.batch.infrastructure.item.*;
-import org.springframework.batch.infrastructure.item.ItemStreamWriter;
-import org.springframework.util.Assert;
-
-public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>> {
-
-	private static final Log logger = LogFactory.getLog(AsyncItemWriter.class);
-
-	private ItemWriter<T> delegate;
+/**
+ * @param <T> the output item type
+ * @deprecated since 6.0.4 in favor of
+ * {@link org.springframework.batch.core.step.item.AsyncItemWriter}
+ */
+@Deprecated(since = "6.0.4")
+public class AsyncItemWriter<T> extends org.springframework.batch.core.step.item.AsyncItemWriter<T> {
 
 	/**
 	 * Create a new instance of {@link AsyncItemWriter} with the provided delegate.
@@ -39,74 +31,7 @@ public class AsyncItemWriter<T> implements ItemStreamWriter<Future<T>> {
 	 * @since 6.0
 	 */
 	public AsyncItemWriter(ItemWriter<T> delegate) {
-		Assert.notNull(delegate, "The delegate ItemWriter must not be null");
-		this.delegate = delegate;
-	}
-
-	/**
-	 * @param delegate ItemWriter that does the actual writing of the Future results
-	 */
-	public void setDelegate(ItemWriter<T> delegate) {
-		this.delegate = delegate;
-	}
-
-	/**
-	 * In the processing of the {@link java.util.concurrent.Future}s passed, nulls are
-	 * <em>not</em> passed to the delegate since they are considered filtered out by the
-	 * {@link org.springframework.batch.integration.async.AsyncItemProcessor}'s delegated
-	 * {@link ItemProcessor}. If the unwrapping of the {@link Future} results in an
-	 * {@link ExecutionException}, that will be unwrapped and the cause will be thrown.
-	 * @param items {@link java.util.concurrent.Future}s to be unwrapped and passed to the
-	 * delegate
-	 * @throws Exception The exception returned by the Future if one was thrown
-	 */
-	@Override
-	public void write(Chunk<? extends Future<T>> items) throws Exception {
-		List<T> list = new ArrayList<>();
-		for (Future<T> future : items) {
-			try {
-				T item = future.get();
-
-				if (item != null) {
-					list.add(item);
-				}
-			}
-			catch (ExecutionException e) {
-				Throwable cause = e.getCause();
-
-				if (cause instanceof Exception exception) {
-					logger.debug("An exception was thrown while processing an item", e);
-
-					throw exception;
-				}
-				else {
-					throw e;
-				}
-			}
-		}
-
-		delegate.write(new Chunk<>(list));
-	}
-
-	@Override
-	public void open(ExecutionContext executionContext) throws ItemStreamException {
-		if (delegate instanceof ItemStream) {
-			((ItemStream) delegate).open(executionContext);
-		}
-	}
-
-	@Override
-	public void update(ExecutionContext executionContext) throws ItemStreamException {
-		if (delegate instanceof ItemStream) {
-			((ItemStream) delegate).update(executionContext);
-		}
-	}
-
-	@Override
-	public void close() throws ItemStreamException {
-		if (delegate instanceof ItemStream) {
-			((ItemStream) delegate).close();
-		}
+		super(delegate);
 	}
 
 }

--- a/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkTaskExecutorItemWriter.java
+++ b/spring-batch-integration/src/main/java/org/springframework/batch/integration/chunk/ChunkTaskExecutorItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-present the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,71 +15,19 @@
  */
 package org.springframework.batch.integration.chunk;
 
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.scope.context.StepSynchronizationManager;
-import org.springframework.batch.core.step.StepContribution;
-import org.springframework.batch.core.step.StepExecution;
-import org.springframework.batch.core.listener.StepExecutionListener;
 import org.springframework.batch.core.step.item.ChunkProcessor;
-import org.springframework.batch.infrastructure.item.Chunk;
-import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.core.task.TaskExecutor;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 /**
- * Similar to {@code ChunkMessageChannelItemWriter}, this item writer submits chunk
- * requests to local workers from a {@link TaskExecutor} instead of sending them over a
- * message channel to remote workers.
- *
- * <p>
- * The aggregation of worker contributions is done in the {@code afterStep} method, which
- * waits for all worker responses and updates the step execution accordingly. If any
- * worker response indicates a failure, the step execution is marked as failed and the
- * exception is added to the step execution's failure exceptions. Otherwise, the step
- * execution is marked as completed and the write counts and skip counts from all worker
- * contributions are aggregated into the step execution's write count and write skip
- * count. The commit count is also incremented for each successful worker contribution,
- * while the rollback count is incremented for each failed worker contribution.
- *
- * <p>
- * It should be noted that transaction management of the chunk as well as fault tolerance
- * features are not handled by this item writer and are the responsibility of the delegate
- * chunk processor.
- *
- * <p>
- * Moreover, the lifecycle of the task executor is not handled by this item writer.
- *
  * @param <T> type of items
- * @see ChunkMessageChannelItemWriter
  * @author Mahmoud Ben Hassine
  * @since 6.0
+ * @deprecated since 6.0.4 in favor of
+ * {@link org.springframework.batch.core.step.item.ChunkTaskExecutorItemWriter}
  */
-public class ChunkTaskExecutorItemWriter<T> implements ItemWriter<T>, StepExecutionListener {
-
-	private static final Log logger = LogFactory.getLog(ChunkTaskExecutorItemWriter.class);
-
-	@SuppressWarnings("NullAway.Init")
-	private StepExecution stepExecution;
-
-	private int sequence;
-
-	private final TaskExecutor taskExecutor;
-
-	private final ChunkProcessorChunkRequestHandler<T> chunkProcessorChunkHandler = new ChunkProcessorChunkRequestHandler<>();
-
-	private final Set<Future<ChunkResponse>> responses = new HashSet<>();
+@Deprecated(since = "6.0.4")
+public class ChunkTaskExecutorItemWriter<T>
+		extends org.springframework.batch.core.step.item.ChunkTaskExecutorItemWriter<T> {
 
 	/**
 	 * Create a new {@link ChunkTaskExecutorItemWriter}.
@@ -87,88 +35,7 @@ public class ChunkTaskExecutorItemWriter<T> implements ItemWriter<T>, StepExecut
 	 * @param taskExecutor the task executor to submit chunk processing tasks to
 	 */
 	public ChunkTaskExecutorItemWriter(ChunkProcessor<T> chunkRequestProcessor, TaskExecutor taskExecutor) {
-		this.taskExecutor = taskExecutor;
-		this.chunkProcessorChunkHandler.setChunkProcessor(chunkRequestProcessor);
-	}
-
-	@Override
-	public void write(Chunk<? extends T> chunk) {
-		ChunkRequest<T> request = new ChunkRequest<>(++sequence, chunk, this.stepExecution.getJobExecutionId(),
-				this.stepExecution.createStepContribution());
-		FutureTask<ChunkResponse> chunkResponseFutureTask = new FutureTask<>(() -> {
-			try {
-				StepSynchronizationManager.register(this.stepExecution);
-				return this.chunkProcessorChunkHandler.handle(request);
-			}
-			finally {
-				StepSynchronizationManager.close();
-			}
-		});
-		this.responses.add(chunkResponseFutureTask);
-		this.taskExecutor.execute(chunkResponseFutureTask);
-	}
-
-	@Override
-	public void beforeStep(StepExecution stepExecution) {
-		this.stepExecution = stepExecution;
-	}
-
-	@Override
-	public ExitStatus afterStep(StepExecution stepExecution) {
-		try {
-			ExitStatus result = ExitStatus.COMPLETED
-				.addExitDescription("Waited for " + this.responses.size() + " results.");
-			resetCounter(stepExecution);
-			for (StepContribution contribution : getStepContributions()) {
-				// only write counts and skip counts are aggregated here
-				// read counts and process/filter counts are managed by the driving step
-				stepExecution.setWriteCount(stepExecution.getWriteCount() + contribution.getWriteCount());
-				stepExecution.setWriteSkipCount(stepExecution.getWriteSkipCount() + contribution.getWriteSkipCount());
-				ExitStatus exitStatus = contribution.getExitStatus();
-				if (ExitStatus.FAILED.getExitCode().equals(exitStatus.getExitCode())) {
-					logger.error("Chunk processing failed for contribution: " + contribution
-							+ ", marking step execution as failed.");
-					result = exitStatus;
-					Throwable exitException = exitStatus.getExitException();
-					if (exitException != null) {
-						stepExecution.addFailureException(exitException);
-					}
-					stepExecution.setStatus(BatchStatus.FAILED);
-					stepExecution.incrementRollbackCount();
-				}
-				else {
-					stepExecution.incrementCommitCount();
-				}
-			}
-			return result;
-		}
-		catch (ExecutionException | InterruptedException e) {
-			stepExecution.setStatus(BatchStatus.FAILED);
-			stepExecution.addFailureException(e);
-			return ExitStatus.FAILED.addExitDescription(e);
-		}
-	}
-
-	/**
-	 * Reset the write count, write skip count, commit count and rollback count of the
-	 * step execution to avoid counting them twice as they are updated by workers and
-	 * aggregated in the afterStep method. The read count and process/filter count are not
-	 * reset as they are managed by the driving step
-	 * @param stepExecution the step execution to reset the counters for
-	 */
-	private void resetCounter(StepExecution stepExecution) {
-		stepExecution.setWriteCount(0);
-		stepExecution.setWriteSkipCount(0);
-		stepExecution.setCommitCount(0);
-		stepExecution.setRollbackCount(0);
-	}
-
-	private Collection<StepContribution> getStepContributions() throws ExecutionException, InterruptedException {
-		List<StepContribution> contributions = new ArrayList<>();
-		for (Future<ChunkResponse> task : this.responses) {
-			contributions.add(task.get().getStepContribution());
-		}
-		return contributions;
+		super(chunkRequestProcessor, taskExecutor);
 	}
 
 }

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/chunking/local/LocalChunkingJobConfiguration.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/chunking/local/LocalChunkingJobConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.batch.infrastructure.item.database.JdbcBatchItemWrite
 import org.springframework.batch.infrastructure.item.database.builder.JdbcBatchItemWriterBuilder;
 import org.springframework.batch.infrastructure.item.file.FlatFileItemReader;
 import org.springframework.batch.infrastructure.item.file.builder.FlatFileItemReaderBuilder;
-import org.springframework.batch.integration.chunk.ChunkTaskExecutorItemWriter;
+import org.springframework.batch.core.step.item.ChunkTaskExecutorItemWriter;
 import org.springframework.batch.samples.common.DataSourceConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/loom/JobConfigurationForAsynchronousItemProcessingWithVirtualThreads.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/loom/JobConfigurationForAsynchronousItemProcessingWithVirtualThreads.java
@@ -25,8 +25,8 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.integration.async.AsyncItemProcessor;
-import org.springframework.batch.integration.async.AsyncItemWriter;
+import org.springframework.batch.core.step.item.AsyncItemProcessor;
+import org.springframework.batch.core.step.item.AsyncItemWriter;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.ItemWriter;

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/loom/VirtualThreadsSupportFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/loom/VirtualThreadsSupportFunctionalTests.java
@@ -33,7 +33,7 @@ import org.springframework.batch.core.launch.support.TaskExecutorJobOperator;
 import org.springframework.batch.core.partition.support.TaskExecutorPartitionHandler;
 import org.springframework.batch.core.step.builder.TaskletStepBuilder;
 import org.springframework.batch.core.step.tasklet.SystemCommandTasklet;
-import org.springframework.batch.integration.async.AsyncItemProcessor;
+import org.springframework.batch.core.step.item.AsyncItemProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.task.TaskExecutor;


### PR DESCRIPTION
Closes #5185

This pull request moves async item processing and local chunking support into `spring-batch-core`:

- Adds `AsyncItemProcessor`, `AsyncItemWriter`, and `ChunkTaskExecutorItemWriter` to `spring-batch-core`
- Keeps the existing `spring-batch-integration` types as deprecated wrappers for source compatibility
- Updates samples and documentation to use the core package
- Adds unit tests for the moved core types

Validation:

- `./mvnw -pl spring-batch-core -Dtest=AsyncItemProcessorTests,AsyncItemWriterTests,ChunkTaskExecutorItemWriterTests test`
- `./mvnw -pl spring-batch-integration,spring-batch-samples -am -DskipTests compile`

Note: local validation was run on JDK 21 with temporary compiler settings for NullAway JSpecify support; those local settings are not part of this pull request.