### PR TITLE
Fix incorrect Javadoc reference in JobExecution.isStopped()

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/job/JobExecution.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/job/JobExecution.java
@@ -214,7 +214,7 @@ public class JobExecution extends Entity {
 	}
 
 	/**
-	 * Test if this {@link StepExecution} indicates that it has been stopped.
+	 * Test if this {@link JobExecution} indicates that it has been stopped.
 	 * @return {@code true} if the status is {@link BatchStatus#STOPPED}.
 	 */
 	public boolean isStopped() {


### PR DESCRIPTION
The `isStopped()` Javadoc refers to `{@link StepExecution}`, but the method operates on the `JobExecution` instance (`this`). The sibling `isRunning()` and `isStopping()` methods correctly refer to `{@link JobExecution}`. Update `isStopped()` to match.

Javadoc only — no behavior change.
