### PR TITLE
GH-3946: Document chunk scanning behaviour in fault-tolerant steps

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/processor.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/processor.adoc
@@ -396,5 +396,53 @@ When a chunk is rolled back, items that have been cached during reading may be
 reprocessed. If a step is configured to be fault-tolerant (typically by using skip or
 retry processing), any `ItemProcessor` used should be implemented in a way that is
 idempotent. Typically that would consist of performing no changes on the input item for
-the `ItemProcessor` and updating only the
-instance that is the result.
+the `ItemProcessor` and updating only the instance that is the result.
+
+This behaviour is driven by _chunk scanning_: when an exception is thrown from an
+`ItemWriter`, Spring Batch re-processes each item individually to determine which specific
+item caused the failure. As a result, the `ItemProcessor` may be called more than once for
+the same item. If re-processing the same input twice is not safe (for example, because it
+invokes a non-idempotent external service), you can mark the processor as non-transactional
+so that its output is cached and reused during chunk scanning:
+
+[tabs]
+====
+Java::
++
+[source, java]
+----
+@Bean
+public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+    return new StepBuilder("step1", jobRepository)
+                .<String, String>chunk(10).transactionManager(transactionManager)
+                .reader(itemReader())
+                .processor(itemProcessor())
+                .writer(itemWriter())
+                .faultTolerant()
+                .skip(Exception.class)
+                .skipLimit(10)
+                .processorNonTransactional() // cache processor output; skip re-processing during chunk scanning
+                .build();
+}
+----
+
+XML::
++
+[source, xml]
+----
+<step id="step1">
+    <tasklet>
+        <chunk reader="itemReader" processor="itemProcessor" writer="itemWriter"
+               commit-interval="10" skip-limit="10"
+               processor-transactional="false">
+            <skippable-exception-classes>
+                <include class="java.lang.Exception"/>
+            </skippable-exception-classes>
+        </chunk>
+    </tasklet>
+</step>
+----
+====
+
+For a full explanation of the chunk scanning mechanism, see
+xref:step/chunk-oriented-processing/configuring-skip.adoc#chunkScanning[Chunk Scanning].

--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/configuring-skip.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/configuring-skip.adoc
@@ -72,3 +72,31 @@ skip triggers the exception, not the tenth.
 The skip limit applies to all skips (read, process and write).
 ====
 
+[[chunkScanning]]
+=== Chunk Scanning
+
+When an exception is thrown from an `ItemProcessor` or `ItemWriter` (collectively the
+"`chunk processor`"), Spring Batch cannot know which individual item in the chunk caused
+the failure, because both components receive a batch of items at once. To isolate the
+faulty item, Spring Batch automatically re-processes the chunk item-by-item in a
+single-item mode — a process called _chunk scanning_.
+
+During chunk scanning each item is processed and written individually, allowing Spring
+Batch to identify which specific item triggered the exception. Once found, that item is
+counted toward the skip limit and excluded from the output. Items that do not cause an
+exception are written normally.
+
+[IMPORTANT]
+====
+Chunk scanning means that the `ItemProcessor` and `ItemWriter` are called more times than
+the number of items in the chunk. In the worst case (when the bad item is last), a chunk
+of N items causes N write attempts (N-1 successful single writes, then 1 failed write for
+the bad item). For this reason, `ItemProcessor` implementations in fault-tolerant steps
+must be _idempotent_ — processing the same item twice must produce the same result.
+If re-processing an item has side effects (for example, calling an external service), use
+`processorNonTransactional()` to instruct Spring Batch to cache the processed output and
+skip re-processing during chunk scanning.
+====
+
+See also: xref:processor.adoc#faultTolerant[Fault Tolerance in Item Processing].
+

--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/retry-logic.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/retry-logic.adoc
@@ -62,3 +62,14 @@ In XML, retry should be configured as follows:
 The `Step` allows a limit for the number of times an individual item can be retried and a
 list of exceptions that are "`retryable`".
 
+[NOTE]
+====
+Configuring a `NeverRetryPolicy` (or setting `retry-limit="0"`) disables Spring Batch's
+own retry loop, but it does not suppress _chunk scanning_. When an exception is thrown
+from an `ItemProcessor` or `ItemWriter`, Spring Batch still re-processes the chunk
+item-by-item to identify the bad item before skipping it. If you observe more writer
+invocations than the number of items in the chunk, this is expected behaviour.
+See xref:step/chunk-oriented-processing/configuring-skip.adoc#chunkScanning[Chunk Scanning]
+for details.
+====
+


### PR DESCRIPTION
## What

Closes #3946.

Adds documentation for **chunk scanning** — the mechanism Spring Batch uses to isolate the bad item when an `ItemProcessor` or `ItemWriter` throws an exception inside a fault-tolerant step.

## Changes

### `configuring-skip.adoc` — new "Chunk Scanning" subsection
- Explains that when a write-phase exception occurs, Spring Batch re-processes the chunk item-by-item in single-item mode to find the offending item
- Warns that the processor/writer will be invoked more than `chunk-size` times (worst case: N times for a chunk of N items)
- Directs readers to `processorNonTransactional()` / `processor-transactional="false"` for non-idempotent processors

### `retry-logic.adoc` — new NOTE
- Clarifies that configuring `NeverRetryPolicy` (or `retry-limit="0"`) does not suppress chunk scanning; they are independent mechanisms

### `processor.adoc` — expanded Fault Tolerance section
- Explains why chunk scanning requires idempotent processors
- Shows Java and XML examples of `processorNonTransactional()` / `processor-transactional="false"` to cache processor output
- Cross-references the new Chunk Scanning section in configuring-skip.adoc

## Motivation

Users configuring `NeverRetryPolicy` + `AlwaysSkipItemSkipPolicy` are surprised to see their writer called more times than the number of items in the chunk. The existing docs cover skip and retry in isolation but do not explain chunk scanning or its interaction with those policies (as confirmed by @fmbenhassine in #3946).

🤖 Generated with [Claude Code](https://claude.com/claude-code)