### PR TITLE
GH-4551: Add foreign key index recommendations to schema appendix

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/schema-appendix.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/schema-appendix.adoc
@@ -393,3 +393,36 @@ about indexing:
 |`BATCH_STEP_EXECUTION`|`STEP_NAME = ? and JOB_EXECUTION_ID = ?`|Before each step execution
 
 |===============
+
+=== Foreign Key Columns
+
+Several Spring Batch tables reference each other via foreign key relationships.
+On some database platforms (notably PostgreSQL), foreign key columns are **not** automatically indexed.
+Unindexed foreign keys can cause significant performance degradation for queries that join these tables, which Spring Batch performs frequently when loading step executions for a job execution, looking up job execution parameters, and so on.
+
+The following foreign key columns are candidates for additional indexes:
+
+[cols="2,2", options="header"]
+|===
+| Table | Foreign Key Column(s)
+
+| `BATCH_JOB_EXECUTION_PARAMS`
+| `JOB_EXECUTION_ID` (references `BATCH_JOB_EXECUTION`)
+
+| `BATCH_JOB_EXECUTION`
+| `JOB_INSTANCE_ID` (references `BATCH_JOB_INSTANCE`)
+
+| `BATCH_STEP_EXECUTION`
+| `JOB_EXECUTION_ID` (references `BATCH_JOB_EXECUTION`)
+
+| `BATCH_JOB_EXECUTION_CONTEXT`
+| `JOB_EXECUTION_ID` (references `BATCH_JOB_EXECUTION`)
+
+| `BATCH_STEP_EXECUTION_CONTEXT`
+| `STEP_EXECUTION_ID` (references `BATCH_STEP_EXECUTION`)
+
+|===
+
+NOTE: Check whether your database automatically creates indexes for foreign keys.
+MySQL and Oracle create them automatically; PostgreSQL does not.
+You can use database-specific queries to detect unindexed foreign keys — for example, the https://wiki.postgresql.org/wiki/Unindexed_foreign_keys[PostgreSQL unindexed foreign keys query].


### PR DESCRIPTION
## What

Closes #4551.

Extends the **Recommendations for Indexing Metadata Tables** section in `schema-appendix.adoc` with a new **Foreign Key Columns** subsection.

## Changes

The existing table lists WHERE-clause columns as indexing candidates but does not mention foreign key columns. On databases that do **not** automatically create indexes for FK columns (notably PostgreSQL, as mentioned in the issue), this leads to unindexed FK lookups on the frequent JOIN queries that Spring Batch issues via its DAO layer.

New subsection includes:
- A table listing each FK column in the five related metadata tables
- A NOTE explaining which databases create FK indexes automatically (MySQL, Oracle) vs which do not (PostgreSQL)
- A link to the PostgreSQL unindexed FK detection query referenced in the issue

## Test plan
- [ ] Review the rendered AsciiDoc to verify the new table and NOTE block render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)