### PR TITLE
GH-3632: Clarify thread-safety wording in ItemReader javadoc

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/ItemReader.java
@@ -25,8 +25,10 @@ import org.jspecify.annotations.Nullable;
  * batch, with each call to {@link #read()} returning a different value and finally
  * returning <code>null</code> when all input data is exhausted.<br>
  *
- * Implementations need <b>not</b> be thread-safe and clients of a {@link ItemReader} need
- * to be aware that this is the case.<br>
+ * Implementations <b>might not</b> be thread-safe and clients of a {@link ItemReader} need
+ * to be aware that this is the case. To make a non-thread-safe reader safe for use in a
+ * multi-threaded step, wrap it in a
+ * {@link org.springframework.batch.infrastructure.item.support.SynchronizedItemStreamReader}.<br>
  *
  * A richer interface (e.g. with a look ahead or peek) is not feasible because we need to
  * support transactions in an asynchronous batch.


### PR DESCRIPTION
## Summary

Closes #3632

The javadoc on `ItemReader` previously said:
> Implementations **need not** be thread-safe and clients of a `ItemReader` **need** to be aware that this is the case.

The phrase _"need not"_ in English is a double-negative that means _"are not required to"_, but it reads as confusing (especially for non-native speakers) because the bold `not` makes it look like a strong "they are NOT thread-safe."

Per maintainer @fmbenhassine's comment on the issue:

> _If we replace "need" with "might" the sentence will be correct._

**Changes:**
- `need <b>not</b>` → `<b>might not</b>` — removes the confusing double negative
- Adds a cross-reference to `SynchronizedItemStreamReader` as the recommended way to make a non-thread-safe reader safe in a multi-threaded step (also suggested by @fmbenhassine in the issue)

## Test plan

- [ ] `./gradlew :spring-batch-infrastructure:javadoc` passes with no warnings on the updated class

🤖 Generated with [Claude Code](https://claude.com/claude-code)