### PR TITLE
docs: add Chunk Scanning documentation to fault-tolerant step section

### DIFF
--- a/spring-batch-docs/modules/ROOT/nav.adoc
+++ b/spring-batch-docs/modules/ROOT/nav.adoc
@@ -18,6 +18,7 @@
 *** xref:step/chunk-oriented-processing/restart.adoc[]
 *** xref:step/chunk-oriented-processing/configuring-skip.adoc[]
 *** xref:step/chunk-oriented-processing/retry-logic.adoc[]
+*** xref:step/chunk-oriented-processing/chunk-scanning.adoc[]
 *** xref:step/chunk-oriented-processing/transaction-attributes.adoc[]
 *** xref:step/chunk-oriented-processing/registering-item-streams.adoc[]
 *** xref:step/chunk-oriented-processing/intercepting-execution.adoc[]

--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/chunk-scanning.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/chunk-scanning.adoc
@@ -1,0 +1,103 @@
+[[chunkScanning]]
+= Chunk Scanning
+
+When an exception is thrown from an `ItemWriter` (or from an `ItemProcessor` when
+`processorTransactional` is `true`) in a fault-tolerant step, Spring Batch performs
+_chunk scanning_ before deciding whether to skip or fail the step.
+
+== How Chunk Scanning Works
+
+Normally, Spring Batch processes items in chunks: it reads a whole chunk, processes it,
+and then writes the entire chunk in a single transaction. When a write exception occurs,
+it is impossible to tell which individual item caused the failure from within that batch
+write. Chunk scanning resolves this ambiguity:
+
+1. The current transaction is rolled back.
+2. Each item in the failed chunk is _scanned_ individually: it is processed and written
+   one at a time, each in its own transaction.
+3. If an individual item fails during the scan and the skip policy allows it, the item
+   is skipped and the scan continues with the next item.
+4. If the skip policy does not allow the exception, the step fails immediately.
+
+The net effect is that all non-failing items in the chunk are committed, and only the
+offending item(s) are skipped or cause a failure.
+
+[IMPORTANT]
+====
+Chunk scanning is triggered by write (or transactional-processor) exceptions and occurs
+*regardless* of the retry policy. Even when `NeverRetryPolicy` is configured, chunk
+scanning still takes place to identify which item failed. The item count for a failed
+chunk will therefore appear higher than `chunkSize` in the step execution metadata.
+====
+
+== Impact on the ItemProcessor
+
+During chunk scanning, the `ItemProcessor` is re-invoked for each item (unless
+`processorNonTransactional()` is set on the step). This means that for a chunk of N
+items, the processor is called at least N additional times during the scan phase. You
+have two options:
+
+- **Idempotent processor**: Design your `ItemProcessor` so that calling it multiple
+  times for the same input produces the same output and does not have observable
+  side-effects.
+- **Non-transactional processor** (`processorNonTransactional()`): Spring Batch caches
+  the processed items from the original chunk run and reuses them during the scan,
+  skipping the re-processing step.
+
+[tabs]
+====
+Java::
++
+[source, java]
+----
+@Bean
+public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+    return new StepBuilder("step1", jobRepository)
+            .<String, String>chunk(10).transactionManager(transactionManager)
+            .reader(itemReader())
+            .processor(itemProcessor())
+            .writer(itemWriter())
+            .faultTolerant()
+            .skip(MyException.class)
+            .skipLimit(5)
+            .processorNonTransactional() // <1>
+            .build();
+}
+----
+<1> Reuse cached processor output during chunk scanning instead of re-invoking the
+    processor for each scanned item.
+
+XML::
++
+[source,xml]
+----
+<step id="step1">
+    <tasklet>
+        <chunk reader="itemReader" processor="itemProcessor" writer="itemWriter"
+               commit-interval="10" skip-limit="5"
+               processor-transactional="false"> <!-- (1) -->
+            <skippable-exception-classes>
+                <include class="com.example.MyException"/>
+            </skippable-exception-classes>
+        </chunk>
+    </tasklet>
+</step>
+----
+<1> Setting `processor-transactional="false"` is the XML equivalent of
+    `processorNonTransactional()`.
+====
+
+== Relationship to Skip and Retry
+
+Chunk scanning and retry are independent mechanisms in fault-tolerant steps:
+
+- **Retry** re-processes the entire chunk (or a single item, if used together with
+  chunk scanning) up to a configured `retryLimit`. Retry is typically used for
+  transient errors such as a database deadlock.
+- **Chunk scanning** is always triggered on a write exception, irrespective of the
+  retry configuration. It operates at the level of a single item within the failed
+  chunk.
+
+If both retry and skip are configured, Spring Batch first exhausts the retry attempts
+for a failing item during the scan phase; only after all retries are consumed does the
+skip policy take effect.

--- a/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/configuring-skip.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/step/chunk-oriented-processing/configuring-skip.adoc
@@ -72,3 +72,9 @@ skip triggers the exception, not the tenth.
 The skip limit applies to all skips (read, process and write).
 ====
 
+NOTE: When an exception is thrown from the `ItemWriter`, Spring Batch performs
+_chunk scanning_ to identify the specific item(s) that caused the failure before
+applying skip or fail semantics. This scanning phase occurs regardless of retry
+configuration. See xref:step/chunk-oriented-processing/chunk-scanning.adoc[Chunk Scanning]
+for details.
+


### PR DESCRIPTION
## Summary

Closes #3946

The existing fault-tolerant step documentation (configuring-skip and retry-logic) did not explain chunk scanning, which is the mechanism Spring Batch uses to identify which individual item caused a write failure. This caused confusion: users who set `NeverRetryPolicy` expected no re-processing to occur, but were surprised when Spring Batch still re-invoked their processor multiple times per chunk.

### Changes

Added a new `chunk-scanning.adoc` page (linked in nav after `retry-logic.adoc`) covering:

1. **How chunk scanning works**: on a write exception → rollback → re-process each item individually → skip or fail per-item based on skip policy
2. **Key insight**: chunk scanning is triggered regardless of retry policy (even with `NeverRetryPolicy`)
3. **Impact on ItemProcessor**: the processor is re-invoked for each scanned item; use `processorNonTransactional()` to avoid this (with Java and XML examples)
4. **Relationship to skip and retry**: these three mechanisms are orthogonal — chunk scanning enables per-item skip; retry operates within the scan phase

Also added:
- Nav entry in `nav.adoc` after `retry-logic.adoc`
- A NOTE cross-reference at the bottom of `configuring-skip.adoc` pointing to the new page

## Test plan

- [ ] Docs build with Antora renders new page and nav entry correctly
- [ ] Cross-reference link in configuring-skip.adoc resolves
- [ ] Java/XML examples are syntactically correct