### PR TITLE
GH-5285: Fix incorrect @return Javadoc for BatchStatus.isLessThanOrEqualTo

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/BatchStatus.java
@@ -137,7 +137,7 @@ public enum BatchStatus {
 
 	/**
 	 * @param other A status value to which to compare.
-	 * @return {@code true} if this is less than {@code other}.
+	 * @return {@code true} if this is less than or equal to {@code other}.
 	 */
 	public boolean isLessThanOrEqualTo(BatchStatus other) {
 		return this.compareTo(other) <= 0;


### PR DESCRIPTION
## Summary

Fixes #5285.

The `@return` Javadoc on `BatchStatus.isLessThanOrEqualTo(BatchStatus)` incorrectly read:

```
@return {@code true} if this is less than {@code other}.
```

This is a copy-paste error from `isLessThan`. The method name and its implementation (`compareTo(other) <= 0`) both indicate _less than **or equal to**_. This PR corrects the Javadoc to match.

## Test plan

- [ ] No behaviour change — Javadoc-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)