### PR TITLE
GH-5280: Include job execution details in JobExecutionAlreadyRunningException

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
@@ -134,7 +134,7 @@ public class TaskExecutorJobLauncher implements JobLauncher, InitializingBean {
 				for (JobExecution execution : executions) {
 					if (execution.isRunning()) {
 						throw new JobExecutionAlreadyRunningException(
-								"A job execution for this job is already running: " + jobInstance);
+								"A job execution for this job is already running: " + execution);
 					}
 					BatchStatus status = execution.getStatus();
 					if (status == BatchStatus.UNKNOWN) {


### PR DESCRIPTION
## Summary

Fixes #5280.

When `TaskExecutorJobLauncher` detects that a job execution is already running, it throws `JobExecutionAlreadyRunningException`. Previously the exception message included the `JobInstance` details:

```
A job execution for this job is already running: JobExecution: id=1, version=null, startTime=..., status=STARTED, ...
job=[JobInstance: id=1, version=null, Job=[job]], jobParameters=[...]
```

Wait, no. The old message was:
```
A job execution for this job is already running: JobInstance: id=1, version=null, Job=[job]
```

This only shows the job instance details (name and parameters), **not** which execution is running. Switching to the running `execution` object makes the message immediately useful, showing the execution id, start time, status, and other execution-level details.

**Before:**
```
JobExecutionAlreadyRunningException: A job execution for this job is already running: JobInstance: id=1, version=null, Job=[job]
```

**After:**
```
JobExecutionAlreadyRunningException: A job execution for this job is already running: JobExecution: id=1, version=null, startTime=..., endTime=null, lastUpdated=..., status=STARTED, ...
```

## Test plan

- [ ] No existing tests assert the specific exception message text.
- [ ] `TaskExecutorJobLauncherTests` and `JobRestartIntegrationTests` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)