### PR TITLE
GH-4551: Add foreign key index recommendations to schema appendix

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/schema-appendix.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/schema-appendix.adoc
@@ -393,3 +393,33 @@ about indexing:
 |`BATCH_STEP_EXECUTION`|`STEP_NAME = ? and JOB_EXECUTION_ID = ?`|Before each step execution
 
 |===============
+
+=== Foreign Key Indexes
+
+The metadata tables contain several foreign key relationships.
+Some databases (MySQL/InnoDB in particular) automatically create an index on a foreign key column,
+but many others (PostgreSQL, Oracle, SQL Server, H2) do not.
+On those platforms, queries that JOIN on these columns — for example, when loading all step
+executions for a job execution — will perform a full table scan unless you add indexes manually.
+
+The following foreign key columns are candidates for an index:
+
+|===============
+|Table|Foreign Key Column|References
+|`BATCH_JOB_EXECUTION`|`JOB_INSTANCE_ID`|`BATCH_JOB_INSTANCE(JOB_INSTANCE_ID)`
+|`BATCH_JOB_EXECUTION_PARAMS`|`JOB_EXECUTION_ID`|`BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)`
+|`BATCH_STEP_EXECUTION`|`JOB_EXECUTION_ID`|`BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)`
+|===============
+
+NOTE: `BATCH_JOB_EXECUTION_CONTEXT.JOB_EXECUTION_ID` and
+`BATCH_STEP_EXECUTION_CONTEXT.STEP_EXECUTION_ID` are both primary keys and therefore
+already indexed.
+
+Example DDL for PostgreSQL:
+
+[source,sql]
+----
+CREATE INDEX BATCH_JOB_EXECUTION_JOB_INST_ID_IX ON BATCH_JOB_EXECUTION(JOB_INSTANCE_ID);
+CREATE INDEX BATCH_JOB_EXEC_PARAMS_JOB_EXEC_ID_IX ON BATCH_JOB_EXECUTION_PARAMS(JOB_EXECUTION_ID);
+CREATE INDEX BATCH_STEP_EXECUTION_JOB_EXEC_ID_IX ON BATCH_STEP_EXECUTION(JOB_EXECUTION_ID);
+----


### PR DESCRIPTION
## Summary

Fixes #4551.

The existing _Recommendations for Indexing Metadata Tables_ section only covers columns used in `WHERE` clauses. It does not mention foreign key columns, which are equally important for JOIN-heavy queries (e.g., loading all step executions for a job execution).

Many databases (PostgreSQL, Oracle, SQL Server, H2) do **not** automatically create indexes on foreign key columns. Without explicit indexes those queries will perform a full table scan.

This PR adds a new **"Foreign Key Indexes"** subsection that:
- Explains which databases auto-index FK columns (InnoDB) and which don't
- Lists the three un-indexed FK columns that are candidates for manual indexing
- Notes that `BATCH_JOB_EXECUTION_CONTEXT` and `BATCH_STEP_EXECUTION_CONTEXT` FK columns are primary keys and are already indexed
- Provides example `CREATE INDEX` DDL for PostgreSQL

No code changes — docs only.

## Test plan

- [ ] Verify rendered docs show the new subsection under the existing indexing recommendations.
- [ ] Cross-check FK columns against `schema-postgresql.sql` / `schema-mysql.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)