### PR TITLE
GH-5040: Document PostgreSQL auto-commit requirement for JdbcCursorItemReader

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/readers-and-writers/database.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/readers-and-writers/database.adoc
@@ -163,8 +163,9 @@ The following example shows how to inject an `ItemReader` into a `Step` in XML:
 
 ====
 
-
-
+NOTE: When using `JdbcCursorItemReader` with PostgreSQL, the JDBC driver fetches the entire result set into memory by default unless `auto-commit` is disabled on the connection.
+To enable server-side cursoring and avoid out-of-memory errors on large data sets, set `auto-commit` to `false` on the `DataSource` (for example, `spring.datasource.hikari.auto-commit=false` when using HikariCP).
+See the https://jdbc.postgresql.org/documentation/query/#getting-results-based-on-a-cursor[PostgreSQL JDBC documentation] for details.
 
 [[JdbcCursorItemReaderProperties]]
 ==== Additional Properties


### PR DESCRIPTION
## Summary

Partially addresses #5040 (database caveats appendix).

The PostgreSQL JDBC driver fetches the entire `ResultSet` into memory when `auto-commit` is enabled (the default). This silently defeats the streaming behaviour of `JdbcCursorItemReader` and can cause out-of-memory errors on large datasets — a gotcha that is easy to miss and hard to diagnose.

This PR adds a `NOTE` admonition directly after the `JdbcCursorItemReader` configuration examples, explaining the issue and pointing to the PostgreSQL JDBC documentation, as well as the `spring.datasource.hikari.auto-commit=false` property for HikariCP users.

## Test plan

- [ ] Documentation renders correctly (AsciiDoc NOTE block)
- [ ] Link to PostgreSQL JDBC docs is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)