### PR TITLE
GH-5432: Fix JsonFileItemWriter append with custom callbacks

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JsonFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JsonFileItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2025 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,15 +138,25 @@ public class JsonFileItemWriter<T> extends AbstractFileItemWriter<T> {
 		try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
 			long pos = raf.length();
 			boolean stopFound = false;
+			boolean trailingWhitespaceOnly = true;
 			while (--pos >= 0) {
 				raf.seek(pos);
 				int current = raf.readByte();
 				if (!stopFound && current == JSON_ARRAY_STOP) {
 					stopFound = true;
 				}
+				else if (!stopFound && current == JSON_ARRAY_START && trailingWhitespaceOnly) {
+					this.hasExistingItems = false;
+					raf.setLength(pos > 0 ? pos + 1 : pos);
+					break;
+				}
+				else if (!stopFound && !Character.isWhitespace(current)) {
+					trailingWhitespaceOnly = false;
+				}
 				else if (stopFound && !Character.isWhitespace(current)) {
 					this.hasExistingItems = current != JSON_ARRAY_START;
-					raf.setLength(this.hasExistingItems ? pos + 1 : pos);
+					boolean hasContentBeforeArrayStart = current == JSON_ARRAY_START && pos > 0;
+					raf.setLength(this.hasExistingItems || hasContentBeforeArrayStart ? pos + 1 : pos);
 					break;
 				}
 			}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JsonFileItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JsonFileItemWriter.java
@@ -147,7 +147,7 @@ public class JsonFileItemWriter<T> extends AbstractFileItemWriter<T> {
 				}
 				else if (!stopFound && current == JSON_ARRAY_START && trailingWhitespaceOnly) {
 					this.hasExistingItems = false;
-					raf.setLength(pos > 0 ? pos + 1 : pos);
+					raf.setLength(pos + 1);
 					break;
 				}
 				else if (!stopFound && !Character.isWhitespace(current)) {
@@ -155,8 +155,7 @@ public class JsonFileItemWriter<T> extends AbstractFileItemWriter<T> {
 				}
 				else if (stopFound && !Character.isWhitespace(current)) {
 					this.hasExistingItems = current != JSON_ARRAY_START;
-					boolean hasContentBeforeArrayStart = current == JSON_ARRAY_START && pos > 0;
-					raf.setLength(this.hasExistingItems || hasContentBeforeArrayStart ? pos + 1 : pos);
+					raf.setLength(pos + 1);
 					break;
 				}
 			}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/JsonFileItemWriterTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/JsonFileItemWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.batch.infrastructure.item.json;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -122,6 +124,70 @@ class JsonFileItemWriterTests {
 	}
 
 	@Test
+	void appendAllowedWithCustomHeaderAndFooter() throws Exception {
+		JsonFileItemWriter<String> writer = new JsonFileItemWriter<>(this.resource,
+				new JacksonJsonObjectMarshaller<>());
+		writer.setAppendAllowed(true);
+		writer.setHeaderCallback(headerWriter -> headerWriter.write("{\"entries\":["));
+		writer.setFooterCallback(footerWriter -> footerWriter.write("]}"));
+
+		writer.open(new ExecutionContext());
+		writer.close();
+
+		wrappedResourceShouldContain();
+
+		writer.open(new ExecutionContext());
+		writer.write(Chunk.of("foo"));
+		writer.close();
+
+		wrappedResourceShouldContain("foo");
+
+		writer.open(new ExecutionContext());
+		writer.write(Chunk.of("bar"));
+		writer.close();
+
+		wrappedResourceShouldContain("foo", "bar");
+	}
+
+	@Test
+	void appendAllowedWithExistingContentContainingArrayBeforeCustomArray() throws Exception {
+		JsonFileItemWriter<String> writer = new JsonFileItemWriter<>(this.resource,
+				new JacksonJsonObjectMarshaller<>());
+		writer.setAppendAllowed(true);
+		writer.setFooterCallback(footerWriter -> footerWriter.write("]}"));
+
+		Files.writeString(this.resource.getFilePath(), "{\"existing\": [1, 2], \"entries\":[", StandardCharsets.UTF_8);
+
+		writer.open(new ExecutionContext());
+		writer.close();
+
+		writer.open(new ExecutionContext());
+		writer.write(Chunk.of("foo"));
+		writer.close();
+
+		wrappedResourceShouldContain(List.of(1, 2), "foo");
+	}
+
+	@Test
+	void appendAllowedWithCustomFooterContainingArrayStartInString() throws Exception {
+		JsonFileItemWriter<String> writer = new JsonFileItemWriter<>(this.resource,
+				new JacksonJsonObjectMarshaller<>());
+		writer.setAppendAllowed(true);
+		writer.setHeaderCallback(headerWriter -> headerWriter.write("{\"entries\":["));
+		writer.setFooterCallback(footerWriter -> footerWriter.write("],\"status\":\"[pending\"}"));
+
+		writer.open(new ExecutionContext());
+		writer.write(Chunk.of("foo"));
+		writer.close();
+
+		writer.open(new ExecutionContext());
+		writer.write(Chunk.of("bar"));
+		writer.close();
+
+		wrappedResourceShouldContainStatus("[pending", "foo", "bar");
+	}
+
+	@Test
 	void appendNotAllowed() throws Exception {
 		JsonFileItemWriter<String> writer = new JsonFileItemWriter<>(this.resource,
 				new JacksonJsonObjectMarshaller<>());
@@ -158,6 +224,26 @@ class JsonFileItemWriterTests {
 
 	private void resourceShouldContain(String... array) throws Exception {
 		assertArrayEquals(array, new JsonMapper().readValue(this.resource.getContentAsByteArray(), String[].class));
+	}
+
+	@SuppressWarnings("unchecked")
+	private void wrappedResourceShouldContain(String... entries) throws Exception {
+		Map<String, Object> wrapper = new JsonMapper().readValue(this.resource.getContentAsByteArray(), Map.class);
+		assertEquals(List.of(entries), wrapper.get("entries"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private void wrappedResourceShouldContain(List<Integer> existing, String... entries) throws Exception {
+		Map<String, Object> wrapper = new JsonMapper().readValue(this.resource.getContentAsByteArray(), Map.class);
+		assertEquals(existing, wrapper.get("existing"));
+		assertEquals(List.of(entries), wrapper.get("entries"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private void wrappedResourceShouldContainStatus(String status, String... entries) throws Exception {
+		Map<String, Object> wrapper = new JsonMapper().readValue(this.resource.getContentAsByteArray(), Map.class);
+		assertEquals(status, wrapper.get("status"));
+		assertEquals(List.of(entries), wrapper.get("entries"));
 	}
 
 }


### PR DESCRIPTION
Closes #5432.

This PR updates `JsonFileItemWriter#reopen` to keep the array start when append mode reopens an empty file that was created with custom header/footer callbacks. Without that, the truncation step can leave the custom wrapper incomplete before the next append.

The existing root-array behavior is unchanged, and the regression test covers an empty close followed by subsequent appends with a custom wrapper.

Tests:
- `./mvnw -pl spring-batch-infrastructure test`