### PR TITLE
GH-5388: Warn about mismatched JobRepository DataSource

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2002-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.batch.core.repository.support;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer;
@@ -28,6 +31,10 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.ResourceTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
 
 import javax.sql.DataSource;
 import java.nio.charset.Charset;
@@ -47,6 +54,8 @@ import java.nio.charset.Charset;
  */
 @SuppressWarnings("removal")
 public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
+
+	private static final Log log = LogFactory.getLog(JdbcJobRepositoryFactoryBean.class);
 
 	/**
 	 * @param type a value from the {@link java.sql.Types} class to indicate the type to
@@ -210,6 +219,42 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
+		validateTransactionManagerDataSource();
+	}
+
+	private void validateTransactionManagerDataSource() {
+		PlatformTransactionManager transactionManager = getTransactionManager();
+		if (!(transactionManager instanceof ResourceTransactionManager resourceTransactionManager)) {
+			return;
+		}
+
+		Object resourceFactory = resourceTransactionManager.getResourceFactory();
+		if (resourceFactory == null) {
+			return;
+		}
+
+		Object unwrappedResourceFactory = TransactionSynchronizationUtils.unwrapResourceIfNecessary(resourceFactory);
+		if (!(unwrappedResourceFactory instanceof DataSource)) {
+			return;
+		}
+
+		DataSource dataSource = getResourceFactoryDataSource(this.dataSource);
+
+		if (!TransactionSynchronizationUtils.sameResourceFactory(resourceTransactionManager, dataSource)) {
+			log.warn("The DataSource configured for the JobRepository does not appear to match the DataSource managed "
+					+ "by the configured transaction manager. Spring Batch metadata updates may not participate in "
+					+ "the same transaction.");
+		}
+	}
+
+	private DataSource getResourceFactoryDataSource(DataSource dataSource) {
+		if (dataSource instanceof TransactionAwareDataSourceProxy transactionAwareDataSourceProxy) {
+			DataSource targetDataSource = transactionAwareDataSourceProxy.getTargetDataSource();
+			if (targetDataSource != null) {
+				return targetDataSource;
+			}
+		}
+		return dataSource;
 	}
 
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2002-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.batch.core.repository.support;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer;
@@ -28,6 +31,9 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.transaction.support.ResourceTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
 
 import javax.sql.DataSource;
 import java.nio.charset.Charset;
@@ -47,6 +53,8 @@ import java.nio.charset.Charset;
  */
 @SuppressWarnings("removal")
 public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
+
+	private static final Log logger = LogFactory.getLog(JdbcJobRepositoryFactoryBean.class);
 
 	/**
 	 * @param type a value from the {@link java.sql.Types} class to indicate the type to
@@ -210,6 +218,22 @@ public class JdbcJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		super.afterPropertiesSet();
+		validateTransactionManagerDataSource();
+	}
+
+	private void validateTransactionManagerDataSource() {
+		DataSource dataSource = this.dataSource;
+		if (dataSource instanceof TransactionAwareDataSourceProxy proxy && proxy.getTargetDataSource() != null) {
+			dataSource = proxy.getTargetDataSource();
+		}
+		if (getTransactionManager() instanceof ResourceTransactionManager transactionManager
+				&& transactionManager.getResourceFactory() instanceof DataSource
+				&& !TransactionSynchronizationUtils.sameResourceFactory(transactionManager, dataSource)) {
+			logger
+				.warn("The DataSource configured for the JobRepository does not appear to match the DataSource managed "
+						+ "by the configured transaction manager. Spring Batch metadata updates may not participate in "
+						+ "the same transaction.");
+		}
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBeanTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository.support;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.sql.DataSource;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.jdbc.support.JdbcTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.ResourceTransactionManager;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link JdbcJobRepositoryFactoryBean}.
+ */
+class JdbcJobRepositoryFactoryBeanTests {
+
+	private static final String MISMATCH_WARNING = "The DataSource configured for the JobRepository does not appear to "
+			+ "match the DataSource managed by the configured transaction manager.";
+
+	private Logger logger;
+
+	private Level originalLevel;
+
+	private TestAppender appender;
+
+	@BeforeEach
+	void setUp() {
+		this.logger = (Logger) LogManager.getLogger(JdbcJobRepositoryFactoryBean.class);
+		this.originalLevel = this.logger.getLevel();
+		this.appender = new TestAppender();
+		this.appender.start();
+		this.logger.addAppender(this.appender);
+		this.logger.setLevel(Level.WARN);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.logger.removeAppender(this.appender);
+		this.logger.setLevel(this.originalLevel);
+		this.appender.stop();
+	}
+
+	@Test
+	void afterPropertiesSetWhenTransactionManagerUsesSameDataSourceDoesNotLogWarning() throws Exception {
+		DataSource dataSource = mock();
+		JdbcJobRepositoryFactoryBean factoryBean = createFactoryBean(dataSource,
+				new JdbcTransactionManager(dataSource));
+
+		factoryBean.afterPropertiesSet();
+
+		assertFalse(this.appender.containsMessage(MISMATCH_WARNING));
+	}
+
+	@Test
+	void afterPropertiesSetWhenTransactionManagerUsesDifferentDataSourceLogsWarning() throws Exception {
+		DataSource dataSource = mock();
+		DataSource transactionManagerDataSource = mock();
+		JdbcJobRepositoryFactoryBean factoryBean = createFactoryBean(dataSource,
+				new JdbcTransactionManager(transactionManagerDataSource));
+
+		factoryBean.afterPropertiesSet();
+
+		assertTrue(this.appender.containsMessage(MISMATCH_WARNING));
+	}
+
+	@Test
+	void afterPropertiesSetWhenTransactionManagerIsNotResourceTransactionManagerDoesNotLogWarning() throws Exception {
+		DataSource dataSource = mock();
+		PlatformTransactionManager transactionManager = mock();
+		JdbcJobRepositoryFactoryBean factoryBean = createFactoryBean(dataSource, transactionManager);
+
+		factoryBean.afterPropertiesSet();
+
+		assertFalse(this.appender.containsMessage(MISMATCH_WARNING));
+	}
+
+	@Test
+	void afterPropertiesSetWhenTransactionManagerResourceFactoryIsNotDataSourceDoesNotLogWarning() throws Exception {
+		DataSource dataSource = mock();
+		ResourceTransactionManager transactionManager = mock();
+		when(transactionManager.getResourceFactory()).thenReturn("resource");
+		JdbcJobRepositoryFactoryBean factoryBean = createFactoryBean(dataSource, transactionManager);
+
+		factoryBean.afterPropertiesSet();
+
+		assertFalse(this.appender.containsMessage(MISMATCH_WARNING));
+	}
+
+	@Test
+	void afterPropertiesSetWhenTransactionManagerResourceFactoryIsNullDoesNotLogWarning() throws Exception {
+		DataSource dataSource = mock();
+		ResourceTransactionManager transactionManager = mock();
+		when(transactionManager.getResourceFactory()).thenReturn(null);
+		JdbcJobRepositoryFactoryBean factoryBean = createFactoryBean(dataSource, transactionManager);
+
+		factoryBean.afterPropertiesSet();
+
+		assertFalse(this.appender.containsMessage(MISMATCH_WARNING));
+	}
+
+	@Test
+	void afterPropertiesSetWhenDataSourceIsTransactionAwareProxyUsesTargetDataSource() throws Exception {
+		DataSource targetDataSource = mock();
+		TransactionAwareDataSourceProxy dataSource = new TransactionAwareDataSourceProxy(targetDataSource);
+		JdbcJobRepositoryFactoryBean factoryBean = createFactoryBean(dataSource,
+				new JdbcTransactionManager(targetDataSource));
+
+		factoryBean.afterPropertiesSet();
+
+		assertFalse(this.appender.containsMessage(MISMATCH_WARNING));
+	}
+
+	private JdbcJobRepositoryFactoryBean createFactoryBean(DataSource dataSource,
+			PlatformTransactionManager transactionManager) {
+		JdbcJobRepositoryFactoryBean factoryBean = new JdbcJobRepositoryFactoryBean();
+		factoryBean.setDataSource(dataSource);
+		factoryBean.setTransactionManager(transactionManager);
+		factoryBean.setDatabaseType("H2");
+		return factoryBean;
+	}
+
+	private static class TestAppender extends AbstractAppender {
+
+		private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+		TestAppender() {
+			super("test", null, null, false, Property.EMPTY_ARRAY);
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			this.events.add(event.toImmutable());
+		}
+
+		boolean containsMessage(String message) {
+			return this.events.stream().anyMatch(event -> event.getMessage().getFormattedMessage().contains(message));
+		}
+
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/JdbcJobRepositoryFactoryBeanTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.repository.support;
+
+import java.io.StringWriter;
+
+import javax.sql.DataSource;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+import org.springframework.jdbc.support.JdbcTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.ResourceTransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JdbcJobRepositoryFactoryBeanTests {
+
+	@Test
+	void warnsOnlyWhenDataSourcesDoNotMatch() throws Exception {
+
+		String warning = "The DataSource configured for the JobRepository does not appear to match";
+		StringWriter output = new StringWriter();
+		WriterAppender appender = WriterAppender.newBuilder().setName("test").setTarget(output).build();
+		Logger logger = (Logger) LogManager.getLogger(JdbcJobRepositoryFactoryBean.class);
+		Level originalLevel = logger.getLevel();
+		appender.start();
+		logger.addAppender(appender);
+		logger.setLevel(Level.WARN);
+
+		try {
+			createFactoryBean(mock(), new JdbcTransactionManager(mock())).afterPropertiesSet();
+			assertThat(output.toString()).contains(warning);
+
+			output.getBuffer().setLength(0);
+			DataSource targetDataSource = mock();
+			createFactoryBean(new TransactionAwareDataSourceProxy(targetDataSource),
+					new JdbcTransactionManager(targetDataSource))
+				.afterPropertiesSet();
+			assertThat(output.toString()).doesNotContain(warning);
+
+			output.getBuffer().setLength(0);
+			createFactoryBean(mock(), mock(PlatformTransactionManager.class)).afterPropertiesSet();
+			assertThat(output.toString()).doesNotContain(warning);
+
+			output.getBuffer().setLength(0);
+			ResourceTransactionManager transactionManager = mock();
+			when(transactionManager.getResourceFactory()).thenReturn(new Object());
+			createFactoryBean(mock(), transactionManager).afterPropertiesSet();
+			assertThat(output.toString()).doesNotContain(warning);
+		}
+		finally {
+			logger.removeAppender(appender);
+			logger.setLevel(originalLevel);
+			appender.stop();
+		}
+	}
+
+	private JdbcJobRepositoryFactoryBean createFactoryBean(DataSource dataSource,
+			PlatformTransactionManager transactionManager) {
+		JdbcJobRepositoryFactoryBean factoryBean = new JdbcJobRepositoryFactoryBean();
+		factoryBean.setDataSource(dataSource);
+		factoryBean.setTransactionManager(transactionManager);
+		factoryBean.setDatabaseType("H2");
+		return factoryBean;
+	}
+
+}


### PR DESCRIPTION
Closes #5388.

Add a warning during `JdbcJobRepositoryFactoryBean` initialization when a `ResourceTransactionManager` exposes a different `DataSource` from the repository. The check is best-effort and reuses Spring's resource comparison; unsupported transaction managers are left unchanged. A `TransactionAwareDataSourceProxy` is compared using its target to avoid false warnings.

One focused test verifies the mismatch warning, the valid proxy case, and unsupported transaction managers.

Tests:
- `./mvnw --no-transfer-progress -pl spring-batch-core -Dtest=JdbcJobRepositoryFactoryBeanTests test`
- `./mvnw --no-transfer-progress --quiet -pl spring-batch-core test` (819 tests, 0 failures/errors)
- `git diff --check`