### PR TITLE
GH-5439 Surface the real reason a job execution cannot be restarted

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -245,9 +245,12 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		try {
 			return run(job, parameters);
 		}
-		catch (Exception e) {
+		catch (JobExecutionAlreadyRunningException e) {
 			throw new JobRestartException(
 					String.format(ILLEGAL_STATE_MSG, "job execution already running", jobName, parameters), e);
+		}
+		catch (JobInstanceAlreadyCompleteException | InvalidJobParametersException e) {
+			throw new JobRestartException(e.getMessage(), e);
 		}
 
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperatorTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.batch.core.launch.support;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,6 +127,26 @@ class TaskExecutorJobOperatorTests {
 
 		Assertions.assertNotNull(jobExecution);
 		Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+	}
+
+	@Test
+	void testRestartFromUnknownStatusSurfacesRealReason() throws Exception {
+		JobParameters jobParameters = new JobParameters();
+		JobExecution jobExecution = jobOperator.start(job, jobParameters);
+
+		Assertions.assertNotNull(jobExecution);
+		Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+
+		// Simulate an execution that ended in UNKNOWN status.
+		jobExecution.setStatus(BatchStatus.UNKNOWN);
+		jobExecution.setEndTime(LocalDateTime.now());
+		jobRepository.update(jobExecution);
+
+		JobRestartException exception = Assertions.assertThrows(JobRestartException.class,
+				() -> jobOperator.restart(jobExecution));
+
+		Assertions.assertTrue(exception.getMessage().contains("Cannot restart job from UNKNOWN status"),
+				"Expected the UNKNOWN status reason to be surfaced but was: " + exception.getMessage());
 	}
 
 }


### PR DESCRIPTION
Resolves #5439

## Problem

`SimpleJobOperator.restart(JobExecution)` wraps *every* exception thrown by `run(...)` into a `JobRestartException` with a hardcoded `"job execution already running"` message:

  ```java
  try {
      return run(job, parameters);
  }
  catch (Exception e) {
      throw new JobRestartException(
          String.format(ILLEGAL_STATE_MSG, "job execution already running", jobName, parameters), e);
  }
```

The launcher (TaskExecutorJobLauncher.createJobExecution) already throws accurate, specific exceptions for the various non-restartable conditions. For example, when the last execution (or one of its step executions) ended in UNKNOWN status:

> Cannot restart job from UNKNOWN status. The last execution ended with a failure that could not be rolled back, so it may be dangerous to proceed. Manual intervention is probably necessary.

Because the operator catches the broad Exception and rebuilds the message, that accurate reason is demoted to the cause and the top-level message wrongly states the job is "already running" — even though it is not (it is UNKNOWN, already complete, or had invalid parameters). Users and logs are then sent down the wrong debugging path.

Note: although SimpleJobOperator is deprecated in favour of TaskExecutorJobOperator, the latter inherits this method via super.restart(...), so the active operator is affected.

## Change

Replace the broad catch (Exception e) with per-type handling:

- JobExecutionAlreadyRunningException → keep the "job execution already running" message(the only genuinely-running case);
- JobInstanceAlreadyCompleteException / InvalidJobParametersException → wrap while preserving their own message;
- JobRestartException → propagate unchanged so its specific reason (e.g. the UNKNOWN-status message above) survives.
