### PR TITLE
GH-5435: Add MongoDB runtime hints

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the original author or authors.
+ * Copyright 2022-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,13 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 				"java.util.concurrent.locks.ReentrantLock$FairSync",
 				"java.util.concurrent.locks.ReentrantLock$NonfairSync",
 				"java.util.concurrent.ConcurrentHashMap$Segment");
+		Set<Class<?>> mongoDbPersistenceTypes = Set.of(
+				org.springframework.batch.core.repository.persistence.ExecutionContext.class,
+				org.springframework.batch.core.repository.persistence.ExitStatus.class,
+				org.springframework.batch.core.repository.persistence.JobExecution.class,
+				org.springframework.batch.core.repository.persistence.JobInstance.class,
+				org.springframework.batch.core.repository.persistence.JobParameter.class,
+				org.springframework.batch.core.repository.persistence.StepExecution.class);
 
 		// resource hints
 		hints.resources().registerPattern("org/springframework/batch/core/schema-h2.sql");
@@ -112,6 +119,10 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 		hints.resources().registerPattern("org/springframework/batch/core/schema-postgresql.sql");
 		hints.resources().registerPattern("org/springframework/batch/core/schema-sqlserver.sql");
 		hints.resources().registerPattern("org/springframework/batch/core/schema-sybase.sql");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-mongodb.jsonl");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-mongodb.js");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-drop-mongodb.jsonl");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-drop-mongodb.js");
 
 		// proxy hints
 		hints.proxies()
@@ -153,6 +164,7 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 		jdkTypes.stream()
 			.map(TypeReference::of)
 			.forEach(type -> hints.reflection().registerType(type, MemberCategory.values()));
+		mongoDbPersistenceTypes.forEach(type -> hints.reflection().registerType(type, MemberCategory.values()));
 
 		// reflection hints: methods
 		Method jobContextGetJobParametersMethod = ReflectionUtils.findMethod(JobContext.class, "getJobParameters");

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/aot/CoreRuntimeHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the original author or authors.
+ * Copyright 2022-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 
 import org.springframework.aop.SpringProxy;
 import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
 import org.springframework.aot.hint.ExecutableMode;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -112,6 +113,10 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 		hints.resources().registerPattern("org/springframework/batch/core/schema-postgresql.sql");
 		hints.resources().registerPattern("org/springframework/batch/core/schema-sqlserver.sql");
 		hints.resources().registerPattern("org/springframework/batch/core/schema-sybase.sql");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-mongodb.jsonl");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-mongodb.js");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-drop-mongodb.jsonl");
+		hints.resources().registerPattern("org/springframework/batch/core/schema-drop-mongodb.js");
 
 		// proxy hints
 		hints.proxies()
@@ -153,6 +158,13 @@ public class CoreRuntimeHints implements RuntimeHintsRegistrar {
 		jdkTypes.stream()
 			.map(TypeReference::of)
 			.forEach(type -> hints.reflection().registerType(type, MemberCategory.values()));
+		new BindingReflectionHintsRegistrar().registerReflectionHints(hints.reflection(),
+				org.springframework.batch.core.repository.persistence.ExecutionContext.class,
+				org.springframework.batch.core.repository.persistence.ExitStatus.class,
+				org.springframework.batch.core.repository.persistence.JobExecution.class,
+				org.springframework.batch.core.repository.persistence.JobInstance.class,
+				org.springframework.batch.core.repository.persistence.JobParameter.class,
+				org.springframework.batch.core.repository.persistence.StepExecution.class);
 
 		// reflection hints: methods
 		Method jobContextGetJobParametersMethod = ReflectionUtils.findMethod(JobContext.class, "getJobParameters");

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/aot/CoreRuntimeHintsTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/aot/CoreRuntimeHintsTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.aot;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.batch.core.repository.persistence.ExecutionContext;
+import org.springframework.batch.core.repository.persistence.ExitStatus;
+import org.springframework.batch.core.repository.persistence.JobExecution;
+import org.springframework.batch.core.repository.persistence.JobInstance;
+import org.springframework.batch.core.repository.persistence.JobParameter;
+import org.springframework.batch.core.repository.persistence.StepExecution;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CoreRuntimeHintsTests {
+
+	private RuntimeHints runtimeHints;
+
+	@BeforeEach
+	void setUp() {
+		this.runtimeHints = new RuntimeHints();
+		new CoreRuntimeHints().registerHints(this.runtimeHints, getClass().getClassLoader());
+	}
+
+	@Test
+	void testMongoDbSchemaResourcesAreRegistered() {
+		Stream
+			.of("org/springframework/batch/core/schema-mongodb.jsonl",
+					"org/springframework/batch/core/schema-mongodb.js",
+					"org/springframework/batch/core/schema-drop-mongodb.jsonl",
+					"org/springframework/batch/core/schema-drop-mongodb.js")
+			.forEach(resource -> {
+				assertNotNull(getClass().getClassLoader().getResource(resource),
+						() -> "Resource not found: " + resource);
+				assertTrue(RuntimeHintsPredicates.resource().forResource(resource).test(this.runtimeHints),
+						() -> "Resource hint not found for " + resource);
+			});
+	}
+
+	@Test
+	void testMongoDbPersistenceTypesAreRegisteredForReflection() {
+		Stream
+			.of(JobInstance.class, ExecutionContext.class, ExitStatus.class, StepExecution.class, JobExecution.class,
+					JobParameter.class)
+			.forEach(type -> assertTrue(RuntimeHintsPredicates.reflection()
+				.onType(type)
+				.withMemberCategories(MemberCategory.values())
+				.test(this.runtimeHints), () -> "Reflection hint not found for " + type.getName()));
+	}
+
+}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/aot/CoreRuntimeHintsTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/aot/CoreRuntimeHintsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.aot;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.batch.core.repository.persistence.ExecutionContext;
+import org.springframework.batch.core.repository.persistence.ExitStatus;
+import org.springframework.batch.core.repository.persistence.JobExecution;
+import org.springframework.batch.core.repository.persistence.JobInstance;
+import org.springframework.batch.core.repository.persistence.JobParameter;
+import org.springframework.batch.core.repository.persistence.StepExecution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.aot.hint.predicate.RuntimeHintsPredicates.reflection;
+import static org.springframework.aot.hint.predicate.RuntimeHintsPredicates.resource;
+
+class CoreRuntimeHintsTests {
+
+	@Test
+	void mongoDbHintsAreRegistered() {
+
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new CoreRuntimeHints().registerHints(runtimeHints, getClass().getClassLoader());
+
+		Stream
+			.of("org/springframework/batch/core/schema-mongodb.jsonl",
+					"org/springframework/batch/core/schema-mongodb.js",
+					"org/springframework/batch/core/schema-drop-mongodb.jsonl",
+					"org/springframework/batch/core/schema-drop-mongodb.js")
+			.forEach(path -> assertThat(runtimeHints).matches(resource().forResource(path)));
+		Stream
+			.of(JobInstance.class, ExecutionContext.class, ExitStatus.class, StepExecution.class, JobExecution.class,
+					JobParameter.class)
+			.forEach(type -> assertThat(runtimeHints).matches(reflection().onType(type)
+				.withMemberCategories(MemberCategory.ACCESS_DECLARED_FIELDS,
+						MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)));
+	}
+
+}


### PR DESCRIPTION
Closes #5435.

Register the four MongoDB schema resources used by Spring Batch and the MongoDB persistence model types needed for Spring Data binding. The reflection hints use Spring Framework's `BindingReflectionHintsRegistrar`, limiting access to the binding contract instead of enabling every member category.

One focused test verifies the resource hints and required field/constructor access for all six persistence types.

Tests:
- `./mvnw --no-transfer-progress -pl spring-batch-core -Dtest=CoreRuntimeHintsTests test`
- `./mvnw --no-transfer-progress --quiet -pl spring-batch-core test` (819 tests, 0 failures/errors)
- `git diff --check`

I did not run a native-image build locally because the issue does not include a reproducer.