### PR TITLE
GH-5308: Stop a job execution by signalling and awaiting its running step(s)

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobExecutionStopException.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobExecutionStopException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.launch;
+
+/**
+ * Exception thrown when a request to stop a job execution does not complete within the
+ * configured timeout, i.e. its running step(s) did not reach a terminal state in time.
+ *
+ * @author Kyungrae Kim
+ * @since 6.0
+ */
+public class JobExecutionStopException extends RuntimeException {
+
+	/**
+	 * Create a {@link JobExecutionStopException} with a message and a cause.
+	 * @param msg the message to signal the cause of failure
+	 * @param cause the underlying cause
+	 */
+	public JobExecutionStopException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobOperator.java
@@ -187,14 +187,17 @@ public interface JobOperator extends JobLauncher {
 	boolean stop(long executionId) throws NoSuchJobExecutionException, JobExecutionNotRunningException;
 
 	/**
-	 * Send a stop signal to the supplied {@link JobExecution}. The signal is successfully
-	 * sent if this method returns true, but that doesn't mean that the job has stopped.
-	 * The only way to be sure of that is to poll the job execution status.
+	 * Stop the supplied {@link JobExecution} and wait for its running step(s) to stop.
+	 * The job execution is marked as
+	 * {@link org.springframework.batch.core.BatchStatus#STOPPING STOPPING}, the running
+	 * step(s) are signalled to stop, and this method blocks until they have terminated
+	 * and persisted their stopped state, up to a configurable timeout.
 	 * @param jobExecution the running {@link JobExecution}
-	 * @return true if the message was successfully sent (does not guarantee that the job
-	 * has stopped)
+	 * @return {@code true} once the job execution has stopped
 	 * @throws JobExecutionNotRunningException if the supplied {@link JobExecution} is not
 	 * running (so cannot be stopped)
+	 * @throws JobExecutionStopException if the running step(s) do not stop within the
+	 * configured timeout
 	 */
 	boolean stop(JobExecution jobExecution) throws JobExecutionNotRunningException;
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/JobOperatorFactoryBean.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/JobOperatorFactoryBean.java
@@ -16,6 +16,7 @@
 package org.springframework.batch.core.launch.support;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
@@ -76,6 +77,8 @@ public class JobOperatorFactoryBean implements FactoryBean<JobOperator>, Applica
 	private JobRepository jobRepository;
 
 	private JobParametersConverter jobParametersConverter = new DefaultJobParametersConverter();
+
+	private Duration stopTimeout = Duration.ofSeconds(30);
 
 	@SuppressWarnings("NullAway.Init")
 	private TaskExecutor taskExecutor;
@@ -176,6 +179,18 @@ public class JobOperatorFactoryBean implements FactoryBean<JobOperator>, Applica
 	}
 
 	/**
+	 * Set how long {@code stop(JobExecution)} waits for the running step(s) to actually
+	 * stop before failing with a {@code JobExecutionStopException}. Defaults to 30
+	 * seconds.
+	 * @param stopTimeout the maximum time to wait for a job to stop
+	 * @since 6.0
+	 */
+	public void setStopTimeout(Duration stopTimeout) {
+		Assert.notNull(stopTimeout, "stopTimeout must not be null");
+		this.stopTimeout = stopTimeout;
+	}
+
+	/**
 	 * Set the transaction attributes source to use in the created proxy.
 	 * @param transactionAttributeSource the transaction attributes source to use in the
 	 * created proxy.
@@ -217,6 +232,8 @@ public class JobOperatorFactoryBean implements FactoryBean<JobOperator>, Applica
 			taskExecutorJobOperator.setObservationRegistry(this.observationRegistry);
 		}
 		taskExecutorJobOperator.setJobParametersConverter(this.jobParametersConverter);
+		taskExecutorJobOperator.setTransactionManager(this.transactionManager);
+		taskExecutorJobOperator.setStopTimeout(this.stopTimeout);
 		taskExecutorJobOperator.afterPropertiesSet();
 		return taskExecutorJobOperator;
 	}
@@ -226,10 +243,8 @@ public class JobOperatorFactoryBean implements FactoryBean<JobOperator>, Applica
 		public DefaultJobOperatorTransactionAttributeSource() {
 			DefaultTransactionAttribute transactionAttribute = new DefaultTransactionAttribute();
 			try {
-				Method stopMethod = TaskExecutorJobOperator.class.getMethod("stop", JobExecution.class);
 				Method abandonMethod = TaskExecutorJobOperator.class.getMethod("abandon", JobExecution.class);
 				Method recoverMethod = TaskExecutorJobOperator.class.getMethod("recover", JobExecution.class);
-				addTransactionalMethod(stopMethod, transactionAttribute);
 				addTransactionalMethod(abandonMethod, transactionAttribute);
 				addTransactionalMethod(recoverMethod, transactionAttribute);
 			}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.launch.support;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -24,13 +25,16 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.NullUnmarked;
 
 import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
@@ -54,10 +58,13 @@ import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException
 import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.launch.JobRestartException;
+import org.springframework.batch.core.launch.JobExecutionStopException;
+import org.springframework.batch.infrastructure.support.transaction.ResourcelessTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.core.step.StepLocator;
 import org.springframework.batch.core.step.tasklet.StoppableTasklet;
-import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.batch.infrastructure.support.PropertiesConverter;
 import org.springframework.beans.factory.InitializingBean;
@@ -101,6 +108,34 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 	protected JobParametersConverter jobParametersConverter = new DefaultJobParametersConverter();
 
 	private final Log logger = LogFactory.getLog(getClass());
+
+	private PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
+
+	private Duration stopTimeout = Duration.ofSeconds(30);
+
+	/**
+	 * Set the transaction manager used to persist the stopping state of a job execution
+	 * atomically before waiting for it to stop. Defaults to a
+	 * {@link ResourcelessTransactionManager}.
+	 * @param transactionManager the transaction manager to use
+	 * @since 6.0
+	 */
+	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+		Assert.notNull(transactionManager, "transactionManager must not be null");
+		this.transactionManager = transactionManager;
+	}
+
+	/**
+	 * Set how long {@link #stop(JobExecution)} waits for the running step(s) to actually
+	 * stop before giving up with a {@link JobExecutionStopException}. Defaults to 30
+	 * seconds (aligned with the Spring graceful shutdown convention).
+	 * @param stopTimeout the maximum time to wait for the job to stop
+	 * @since 6.0
+	 */
+	public void setStopTimeout(Duration stopTimeout) {
+		Assert.notNull(stopTimeout, "stopTimeout must not be null");
+		this.stopTimeout = stopTimeout;
+	}
 
 	/**
 	 * Check mandatory properties.
@@ -342,49 +377,76 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		if (logger.isInfoEnabled()) {
 			logger.info("Stopping job execution: " + jobExecution);
 		}
-		jobExecution.setStatus(BatchStatus.STOPPING); // will be upgraded to STOPPED in
-														// JobRepository.update
-		jobExecution.setExitStatus(ExitStatus.STOPPED);
-		jobExecution.setEndTime(LocalDateTime.now());
-		jobRepository.update(jobExecution);
-		jobRepository.updateExecutionContext(jobExecution);
 
+		List<CompletableFuture<StepExecution>> terminations = new ArrayList<>();
+		List<Runnable> stopSignals = new ArrayList<>();
 		Job job = jobRegistry.getJob(jobExecution.getJobInstance().getJobName());
-		if (job != null) {
-			if (job instanceof StepLocator stepLocator) {
-				// can only process as StepLocator is the only way to get the step object
-				// get the current stepExecution
-				for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
-					if (stepExecution.getStatus().isRunning()) {
-						// have the step execution that's running -> need to 'stop' it
-						Step step = stepLocator.getStep(stepExecution.getStepName());
-						if (step != null) {
-							if (step instanceof TaskletStep taskletStep) {
-								Tasklet tasklet = taskletStep.getTasklet();
-								if (tasklet instanceof StoppableTasklet stoppableTasklet) {
-									StepSynchronizationManager.register(stepExecution);
-									stoppableTasklet.stop(stepExecution);
-									jobRepository.update(stepExecution);
-									jobRepository.updateExecutionContext(stepExecution);
-									StepSynchronizationManager.release();
-								}
-							}
-							if (step instanceof StoppableStep stoppableStep) {
-								StepSynchronizationManager.register(stepExecution);
-								stoppableStep.stop(stepExecution);
-								jobRepository.update(stepExecution);
-								jobRepository.updateExecutionContext(stepExecution);
-								StepSynchronizationManager.release();
-							}
+		if (job instanceof StepLocator stepLocator) {
+			for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+				if (!stepExecution.getStatus().isRunning()) {
+					continue;
+				}
+				Step step = stepLocator.getStep(stepExecution.getStepName());
+				if (step instanceof StoppableStep stoppableStep) {
+					terminations.add(stoppableStep.subscribeToTermination(stepExecution));
+					stopSignals.add(() -> {
+						StepSynchronizationManager.register(stepExecution);
+						try {
+							stoppableStep.stop(stepExecution);
 						}
-					}
+						finally {
+							StepSynchronizationManager.release();
+						}
+					});
+				}
+				if (step instanceof TaskletStep taskletStep
+						&& taskletStep.getTasklet() instanceof StoppableTasklet stoppableTasklet) {
+					stopSignals.add(() -> {
+						StepSynchronizationManager.register(stepExecution);
+						try {
+							stoppableTasklet.stop(stepExecution);
+						}
+						finally {
+							StepSynchronizationManager.release();
+						}
+					});
 				}
 			}
 			// TODO what if the job is not a StepLocator? ie a job with no steps?
 			// FIXME Job should provide a stop() method
 
 		}
+
+		// Persist STOPPING in its own short transaction that commits at once,
+		// so it is durable and holds no lock during the wait.
+		new TransactionTemplate(this.transactionManager).executeWithoutResult(transactionStatus -> {
+			jobExecution.setStatus(BatchStatus.STOPPING);
+			jobRepository.update(jobExecution);
+		});
+
+		stopSignals.forEach(Runnable::run);
+		awaitStop(jobExecution, terminations);
 		return true;
+	}
+
+	private void awaitStop(JobExecution jobExecution, List<CompletableFuture<StepExecution>> terminations) {
+		try {
+			CompletableFuture.allOf(terminations.toArray(new CompletableFuture[0]))
+				.get(this.stopTimeout.toMillis(), TimeUnit.MILLISECONDS);
+		}
+		catch (TimeoutException e) {
+			throw new JobExecutionStopException("Timed out after " + this.stopTimeout
+					+ " while waiting for job execution " + jobExecution.getId() + " to stop", e);
+		}
+		catch (ExecutionException e) {
+			throw new JobExecutionStopException(
+					"Failure while waiting for job execution " + jobExecution.getId() + " to stop", e.getCause());
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new JobExecutionStopException(
+					"Interrupted while waiting for job execution " + jobExecution.getId() + " to stop", e);
+		}
 	}
 
 	@Override

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -164,7 +164,6 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 		this.jobExecutionDao.synchronizeStatus(jobExecution);
 
 		if (jobExecution.isStopped() || jobExecution.isStopping()) {
-			this.stepExecutionDao.synchronizeStatus(stepExecution);
 			stepExecution.setTerminateOnly();
 		}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
@@ -18,6 +18,10 @@ package org.springframework.batch.core.step;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import io.micrometer.observation.Observation;
@@ -73,6 +77,10 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 	private boolean allowStartIfComplete = false;
 
 	private final CompositeStepExecutionListener stepExecutionListener = new CompositeStepExecutionListener();
+
+	private final Set<Long> executingStepExecutions = ConcurrentHashMap.newKeySet();
+
+	private final Map<Long, CompletableFuture<StepExecution>> terminationSignals = new ConcurrentHashMap<>();
 
 	private JobRepository jobRepository;
 
@@ -212,6 +220,7 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 			throws JobInterruptedException, UnexpectedJobExecutionException {
 
 		Assert.notNull(stepExecution, "stepExecution must not be null");
+		this.executingStepExecutions.add(stepExecution.getId());
 		stepExecution.getExecutionContext().put(SpringBatchVersion.BATCH_VERSION_KEY, SpringBatchVersion.getVersion());
 
 		if (logger.isDebugEnabled()) {
@@ -355,7 +364,28 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 			if (logger.isDebugEnabled()) {
 				logger.debug("Step execution complete: " + stepExecution.getSummary());
 			}
+
+			// Notify any caller of stop(StepExecution) that this execution has terminated
+			// and its final metadata has been saved.
+			this.executingStepExecutions.remove(stepExecution.getId());
+			CompletableFuture<StepExecution> terminationSignal = this.terminationSignals.remove(stepExecution.getId());
+			if (terminationSignal != null) {
+				terminationSignal.complete(stepExecution);
+			}
 		}
+	}
+
+	@Override
+	public CompletableFuture<StepExecution> subscribeToTermination(StepExecution stepExecution) {
+		Long stepExecutionId = stepExecution.getId();
+		CompletableFuture<StepExecution> terminationSignal = this.terminationSignals
+			.computeIfAbsent(stepExecutionId, key -> new CompletableFuture<>());
+		// If the execution is not running in this JVM, it has already terminated.
+		if (!this.executingStepExecutions.contains(stepExecution.getId())) {
+			terminationSignal.complete(stepExecution);
+			this.terminationSignals.remove(stepExecutionId, terminationSignal);
+		}
+		return terminationSignal;
 	}
 
 	private void stopObservation(StepExecution stepExecution, Observation observation) {

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/StoppableStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/StoppableStep.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.batch.core.step;
 
-import java.time.LocalDateTime;
-
-import org.springframework.batch.core.BatchStatus;
-import org.springframework.batch.core.ExitStatus;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Extension of the {@link Step} interface to be implemented by steps that support being
@@ -30,17 +27,25 @@ import org.springframework.batch.core.ExitStatus;
 public interface StoppableStep extends Step {
 
 	/**
-	 * Callback to signal the step to stop. The default implementation marks the
-	 * {@link StepExecution} as terminate only and set its status to stopped and its end
-	 * time to the current time. Concrete implementations can override this method to add
-	 * custom stop logic.
+	 * Callback to signal the step to stop. The default implementation sets the
+	 * {@link StepExecution} to terminate only. Concrete implementations can override this
+	 * method to add custom stop logic.
 	 * @param stepExecution the current step execution
 	 */
 	default void stop(StepExecution stepExecution) {
 		stepExecution.setTerminateOnly();
-		stepExecution.setStatus(BatchStatus.STOPPED);
-		stepExecution.setExitStatus(ExitStatus.STOPPED);
-		stepExecution.setEndTime(LocalDateTime.now());
+	}
+
+	/**
+	 * Subscribe to the termination of the given step execution in the current JVM. The
+	 * returned future completes once the step execution running in this JVM has reached a
+	 * terminal state and its final metadata has been saved.
+	 * @param stepExecution the step execution to observe
+	 * @return a future completed when the step execution terminates
+	 * @since 6.0
+	 */
+	default CompletableFuture<StepExecution> subscribeToTermination(StepExecution stepExecution) {
+		return CompletableFuture.completedFuture(stepExecution);
 	}
 
 }


### PR DESCRIPTION
## Problem

`JobOperator.stop()` runs on the caller thread and itself calls `jobRepository.update(stepExecution)` on the running step. The thread executing that step also writes the same `BATCH_STEP_EXECUTION` row (per chunk and on completion). Both use optimistic locking, so they race:

- **caller loses** → `OptimisticLockingFailureException` propagates out of `stop()`;
- **worker loses** → `AbstractStep` marks the step `UNKNOWN` ("should not be restarted") → the job can no longer be restarted.

The re-sync added in #5217 only narrows the window (get-then-update isn't atomic, and under `REPEATABLE READ` the re-read returns a stale snapshot). Full analysis + per-vendor reproduction: #5308.

## Approach — single writer + signal/await

Make the thread executing the step the **sole writer** of its `StepExecution`:

- `stop()` no longer persists the step execution (removes the second writer → the race is gone).
- It marks the job `STOPPING` in a short transaction, signals each running step, then **waits — outside the transaction — for the step to confirm it has stopped** (a future completed by `AbstractStep` once the execution terminates and its final metadata is saved), bounded by a configurable `stopTimeout` (default 30s; `JobExecutionStopException` on timeout).

### Why wait?

The wait is the point of the change, for two reasons:

1. **Durability during shutdown.** The main motivation behind persisting the stopped state from `stop()` (#4023) was that on `SIGTERM` the job would otherwise be left `STARTED` in the database. With this change the worker is the one that
records the terminal state, but `stop()` **blocks until that record is persisted** — so when `stop()` is called from a shutdown hook, it keeps the JVM alive long enough for the worker to durably write `STOPPED` before resources are torn down. We get the same durability guarantee without the operator racing the worker.
2. **`stop()` becomes a reliable, synchronous operation.** Previously `stop()` was fire-and-forget: it requested a stop and returned, with no guarantee the job had actually stopped. Now it returns only after the running step(s) have genuinely terminated, so the caller can trust that on return the job is stopped (or get a `JobExecutionStopException` if it didn't stop within the timeout).

### Notes (behavior change)

- **`stop()` now blocks** until the running step(s) confirm they have stopped, where it previously returned immediately (fire-and-forget). This is the intended improvement — it makes stop reliable and durable. The wait is bounded by a configurable `stopTimeout` (default 30s); only a step that genuinely cannot be interrupted in time (e.g. a long single tasklet that never reaches a chunk boundary) hits the timeout and surfaces a `JobExecutionStopException`. If a step is no longer actually running in this JVM, there is nothing to wait for and `stop()` returns immediately.
- `stop()` no longer runs inside one operator-wide transaction; it persists `STOPPING` in its own short, atomic transaction and waits outside it. Since that `STOPPING` update is now the only write `stop()` makes, there is no multi-write atomicity to preserve.

## Testing

Existing unit + functional tests pass.

**Per-vendor reproduction across both tests** — `JobOperatorFunctionalTests` (restart scenario) and `GracefulShutdownFunctionalTests` (the test this issue references, previously `@Disabled` because of exactly this race). Looped 100× per cell against HSQLDB / MySQL 8 / PostgreSQL 16:

| Test | Vendor | Baseline (no fix) | After this PR |
|---|---|---|---|
| `GracefulShutdownFunctionalTests` | HSQLDB | 3/100 | **0/100** |
| `GracefulShutdownFunctionalTests` | MySQL | 27/100 | **0/100** |
| `GracefulShutdownFunctionalTests` | PostgreSQL | 3/100 | **0/100** |
| `JobOperatorFunctionalTests` | HSQLDB | 1/100 | **0/100** |
| `JobOperatorFunctionalTests` | MySQL | 22/100 | **0/100** |
| `JobOperatorFunctionalTests` | PostgreSQL | 8/100 | **0/100** |

Both tests show the same vendor spread under baseline (MySQL ≫ PostgreSQL ≈ HSQLDB), confirming they exercise the same `StepExecution` write race. After this PR, no optimistic-lock conflicts, no `UNKNOWN` step states, and no flaky failures in any of the 600 baseline-reproducing cells.

Harness + script: [`experiment/olf-investigation`](https://github.com/kyungrae/spring-batch/tree/experiment/olf-investigation). Run with:
```bash
RUNS=100 ./reproduce-gh-5308.sh   # before the fix (baseline), then again after applying this PR
```

Resolves #5308
