### PR TITLE
GH-5308: Serialize step execution updates with concurrent stop requests

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobOperator.java
@@ -187,12 +187,12 @@ public interface JobOperator extends JobLauncher {
 	boolean stop(long executionId) throws NoSuchJobExecutionException, JobExecutionNotRunningException;
 
 	/**
-	 * Send a stop signal to the supplied {@link JobExecution}. The signal is successfully
-	 * sent if this method returns true, but that doesn't mean that the job has stopped.
-	 * The only way to be sure of that is to poll the job execution status.
+	 * Stop the supplied {@link JobExecution}. The job execution is marked as STOPPED and
+	 * the currently running step is signalled to stop at the next chunk boundary.
+	 * Returning {@code true} means the stop was recorded; the worker thread may still be
+	 * winding down its current chunk when this method returns.
 	 * @param jobExecution the running {@link JobExecution}
-	 * @return true if the message was successfully sent (does not guarantee that the job
-	 * has stopped)
+	 * @return true if the stop was successfully recorded
 	 * @throws JobExecutionNotRunningException if the supplied {@link JobExecution} is not
 	 * running (so cannot be stopped)
 	 */

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/SimpleJobOperator.java
@@ -331,9 +331,8 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 	@Override
 	public boolean stop(JobExecution jobExecution) throws JobExecutionNotRunningException {
 		Assert.notNull(jobExecution, "JobExecution must not be null");
-		// Indicate the execution should be stopped by setting it's status to
-		// 'STOPPING'. It is assumed that
-		// the step implementation will check this status at chunk boundaries.
+		// Indicate the execution should be stopped. The step implementation is
+		// expected to check this status at chunk boundaries.
 		BatchStatus status = jobExecution.getStatus();
 		if (!(status == BatchStatus.STARTED || status == BatchStatus.STARTING)) {
 			throw new JobExecutionNotRunningException(
@@ -342,8 +341,7 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 		if (logger.isInfoEnabled()) {
 			logger.info("Stopping job execution: " + jobExecution);
 		}
-		jobExecution.setStatus(BatchStatus.STOPPING); // will be upgraded to STOPPED in
-														// JobRepository.update
+		jobExecution.setStatus(BatchStatus.STOPPED);
 		jobExecution.setExitStatus(ExitStatus.STOPPED);
 		jobExecution.setEndTime(LocalDateTime.now());
 		jobRepository.update(jobExecution);
@@ -364,16 +362,20 @@ public class SimpleJobOperator extends TaskExecutorJobLauncher implements JobOpe
 								if (tasklet instanceof StoppableTasklet stoppableTasklet) {
 									StepSynchronizationManager.register(stepExecution);
 									stoppableTasklet.stop(stepExecution);
-									jobRepository.update(stepExecution);
-									jobRepository.updateExecutionContext(stepExecution);
+									taskletStep.callUnderLock(stepExecution, () -> {
+										jobRepository.update(stepExecution);
+										jobRepository.updateExecutionContext(stepExecution);
+									});
 									StepSynchronizationManager.release();
 								}
 							}
 							if (step instanceof StoppableStep stoppableStep) {
 								StepSynchronizationManager.register(stepExecution);
 								stoppableStep.stop(stepExecution);
-								jobRepository.update(stepExecution);
-								jobRepository.updateExecutionContext(stepExecution);
+								stoppableStep.callUnderLock(stepExecution, () -> {
+									jobRepository.update(stepExecution);
+									jobRepository.updateExecutionContext(stepExecution);
+								});
 								StepSynchronizationManager.release();
 							}
 						}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -164,7 +164,6 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 		this.jobExecutionDao.synchronizeStatus(jobExecution);
 
 		if (jobExecution.isStopped() || jobExecution.isStopping()) {
-			this.stepExecutionDao.synchronizeStatus(stepExecution);
 			stepExecution.setTerminateOnly();
 		}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/AbstractStep.java
@@ -18,6 +18,9 @@ package org.springframework.batch.core.step;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
 import io.micrometer.observation.Observation;
@@ -77,6 +80,9 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 	private JobRepository jobRepository;
 
 	protected ObservationRegistry observationRegistry;
+
+	// One lock per running step execution, guarding updates to its metadata.
+	private final ConcurrentMap<Long, Semaphore> stepExecutionLocks = new ConcurrentHashMap<>();
 
 	/**
 	 * Create a new {@link AbstractStep}.
@@ -213,6 +219,7 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 
 		Assert.notNull(stepExecution, "stepExecution must not be null");
 		stepExecution.getExecutionContext().put(SpringBatchVersion.BATCH_VERSION_KEY, SpringBatchVersion.getVersion());
+		this.stepExecutionLocks.put(stepExecution.getId(), createSemaphore());
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("Executing: id=" + stepExecution.getId());
@@ -232,7 +239,7 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 			.lowCardinalityKeyValue(BatchMetrics.METRICS_PREFIX + "step.job.name",
 					stepExecution.getJobExecution().getJobInstance().getJobName())
 			.start();
-		getJobRepository().update(stepExecution);
+		callUnderLock(stepExecution, () -> getJobRepository().update(stepExecution));
 
 		if (logger.isInfoEnabled()) {
 			logger.info("Executing step: [" + stepExecution.getStepName() + "]");
@@ -299,8 +306,10 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 			// save status in job repository before calling listeners
 			// https://github.com/spring-projects/spring-batch/issues/4362
 			try {
-				getJobRepository().update(stepExecution);
-				getJobRepository().updateExecutionContext(stepExecution);
+				callUnderLock(stepExecution, () -> {
+					getJobRepository().update(stepExecution);
+					getJobRepository().updateExecutionContext(stepExecution);
+				});
 			}
 			catch (Exception e) {
 				stepExecution.setStatus(BatchStatus.UNKNOWN);
@@ -328,8 +337,10 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 			// save status in job repository after calling listeners (since afterStep
 			// might have changed it)
 			try {
-				getJobRepository().update(stepExecution);
-				getJobRepository().updateExecutionContext(stepExecution);
+				callUnderLock(stepExecution, () -> {
+					getJobRepository().update(stepExecution);
+					getJobRepository().updateExecutionContext(stepExecution);
+				});
 			}
 			catch (Exception e) {
 				stepExecution.setStatus(BatchStatus.UNKNOWN);
@@ -354,6 +365,53 @@ public abstract class AbstractStep implements StoppableStep, InitializingBean, B
 
 			if (logger.isDebugEnabled()) {
 				logger.debug("Step execution complete: " + stepExecution.getSummary());
+			}
+
+			this.stepExecutionLocks.remove(stepExecution.getId());
+		}
+	}
+
+	/**
+	 * Create the semaphore guarding updates to a single step execution's metadata (one
+	 * per running step execution).
+	 * @return a new semaphore guarding updates to a step execution
+	 */
+	protected Semaphore createSemaphore() {
+		return new Semaphore(1);
+	}
+
+	/**
+	 * @param stepExecution the running step execution
+	 * @return the lock for the step execution, or {@code null}
+	 */
+	protected Semaphore getStepExecutionLock(StepExecution stepExecution) {
+		return this.stepExecutionLocks.get(stepExecution.getId());
+	}
+
+	@Override
+	public void callUnderLock(StepExecution stepExecution, Runnable action) {
+		Semaphore semaphore = getStepExecutionLock(stepExecution);
+		if (semaphore == null) {
+			// Not executing in this JVM, so there is nothing to serialise against.
+			action.run();
+			return;
+		}
+		boolean locked = false;
+		try {
+			semaphore.acquire();
+			locked = true;
+		}
+		catch (InterruptedException e) {
+			// Proceed without the lock; the interrupted thread is being torn down anyway.
+			logger.error("Thread interrupted while locking for step execution update");
+			Thread.currentThread().interrupt();
+		}
+		try {
+			action.run();
+		}
+		finally {
+			if (locked) {
+				semaphore.release();
 			}
 		}
 	}

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/StoppableStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/StoppableStep.java
@@ -43,4 +43,18 @@ public interface StoppableStep extends Step {
 		stepExecution.setEndTime(LocalDateTime.now());
 	}
 
+	/**
+	 * Run the given action while holding the lock that serialises updates to the given
+	 * step execution's metadata. This lets a caller that persists the stopped state (for
+	 * example a job operator on its own thread) run mutually exclusive with the step's
+	 * own concurrent updates, such as chunk commits on the worker thread, so that neither
+	 * writer observes a stale version. The default implementation runs the action
+	 * directly without any locking.
+	 * @param stepExecution the step execution whose updates should be serialised
+	 * @param action the action to run while holding the lock
+	 */
+	default void callUnderLock(StepExecution stepExecution, Runnable action) {
+		action.run();
+	}
+
 }

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkOrientedStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/item/ChunkOrientedStep.java
@@ -369,7 +369,7 @@ public class ChunkOrientedStep<I, O> extends AbstractStep {
 		stepExecution.getExecutionContext().put(STEP_TYPE_KEY, this.getClass().getName());
 		while (this.chunkTracker.get().moreItems() && !interrupted(stepExecution)) {
 			// process next chunk in its own transaction
-			this.transactionTemplate.executeWithoutResult(transactionStatus -> {
+			callUnderLock(stepExecution, () -> this.transactionTemplate.executeWithoutResult(transactionStatus -> {
 				ChunkTransactionEvent chunkTransactionEvent = new ChunkTransactionEvent(stepExecution.getStepName(),
 						stepExecution.getId());
 				chunkTransactionEvent.begin();
@@ -393,7 +393,7 @@ public class ChunkOrientedStep<I, O> extends AbstractStep {
 				getJobRepository().update(stepExecution);
 				chunkTransactionEvent.transactionStatus = BatchMetrics.STATUS_COMMITTED;
 				chunkTransactionEvent.commit();
-			});
+			}));
 		}
 	}
 

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -255,9 +255,10 @@ public class TaskletStep extends AbstractStep {
 		stream.update(stepExecution.getExecutionContext());
 		getJobRepository().updateExecutionContext(stepExecution);
 
-		// Shared semaphore per step execution, so other step executions can run
-		// in parallel without needing the lock
-		final Semaphore semaphore = createSemaphore();
+		// Lock guarding updates to this step execution's metadata, created in
+		// AbstractStep.execute and shared with any thread that stops the step, so a
+		// chunk commit never races the stop's update on the optimistic-locking version.
+		final Semaphore semaphore = getStepExecutionLock(stepExecution);
 
 		stepOperations.iterate(new StepContextRepeatCallback(stepExecution) {
 
@@ -295,15 +296,6 @@ public class TaskletStep extends AbstractStep {
 
 		taskletExecutionEvent.taskletStatus = stepExecution.getExitStatus().getExitCode();
 		taskletExecutionEvent.commit();
-	}
-
-	/**
-	 * Extension point mainly for test purposes so that the behaviour of the lock can be
-	 * manipulated to simulate various pathologies.
-	 * @return a semaphore for locking access to the JobRepository
-	 */
-	protected Semaphore createSemaphore() {
-		return new Semaphore(1);
 	}
 
 	@Override

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/AbstractStepTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/AbstractStepTests.java
@@ -16,6 +16,13 @@
 package org.springframework.batch.core.step;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +33,10 @@ import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.listener.StepExecutionListener;
 import org.springframework.batch.core.repository.JobRepository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -54,6 +64,56 @@ class AbstractStepTests {
 
 		// then
 		assertNotNull(stepListener.getStepEndTime());
+	}
+
+	@Test
+	void testCallUnderLockSerializesConcurrentUpdates() throws Exception {
+		// given
+		StepExecution execution = new StepExecution(1L, "step",
+				new JobExecution(0L, new JobInstance(1L, "job"), new JobParameters()));
+		JobRepository jobRepository = mock();
+		AtomicInteger concurrent = new AtomicInteger();
+		AtomicBoolean overlap = new AtomicBoolean(false);
+		AtomicInteger completed = new AtomicInteger();
+		int threads = 8;
+		int iterations = 200;
+		AbstractStep tested = new AbstractStep(jobRepository) {
+			@Override
+			protected void doExecute(StepExecution stepExecution) throws Exception {
+				// While the step is executing, the per-execution lock is registered, so
+				// concurrent callers (the worker and a stopping thread) are serialized.
+				ExecutorService pool = Executors.newFixedThreadPool(threads);
+				try {
+					List<Future<?>> futures = new ArrayList<>();
+					for (int t = 0; t < threads; t++) {
+						futures.add(pool.submit(() -> {
+							for (int i = 0; i < iterations; i++) {
+								callUnderLock(stepExecution, () -> {
+									if (concurrent.incrementAndGet() != 1) {
+										overlap.set(true);
+									}
+									completed.incrementAndGet();
+									concurrent.decrementAndGet();
+								});
+							}
+						}));
+					}
+					for (Future<?> future : futures) {
+						future.get();
+					}
+				}
+				finally {
+					pool.shutdown();
+				}
+			}
+		};
+
+		// when
+		tested.execute(execution);
+
+		// then
+		assertFalse(overlap.get(), "callUnderLock allowed concurrent updates to the same step execution");
+		assertEquals(threads * iterations, completed.get());
 	}
 
 	static class Listener implements StepExecutionListener {

--- a/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/GracefulShutdownFunctionalTests.java
+++ b/spring-batch-samples/src/test/java/org/springframework/batch/samples/restart/stop/GracefulShutdownFunctionalTests.java
@@ -22,7 +22,6 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -63,7 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Mahmoud Ben Hassine
  *
  */
-@Disabled("Fails intermittently") // https://github.com/spring-projects/spring-batch/issues/5308
 @ExtendWith(SpringExtension.class)
 class GracefulShutdownFunctionalTests {
 


### PR DESCRIPTION
## Problem

When `JobOperator.stop(jobExecution)` is called while a step is running, the stopping thread persists the step execution's stopped state (`jobRepository.update(stepExecution)`) on its own thread — concurrently with the worker thread still committing chunks for the same BATCH_STEP_EXECUTION row. Both issue optimistic-locking updates:

```SQL
UPDATE BATCH_STEP_EXECUTION SET ..., VERSION = ? WHERE STEP_EXECUTION_ID = ? AND VERSION = ?
```

so one matches 0 rows and fails with `OptimisticLockingFailureException`. It is timing- and vendor-sensitive: frequent on MySQL (`REPEATABLE READ`), occasional on PostgreSQL (`READ COMMITTED`), almost never on in-memory HSQLDB — which is why CI rarely catches it and `GracefulShutdownFunctionalTests` was `@Disabled`.

A contributing factor: SimpleJobRepository.update(StepExecution) re-read the row version via stepExecutionDao.synchronizeStatus(stepExecution) while the job was stopping. Under MySQL REPEATABLE READ that read returns the stale snapshot version, overwriting the correct in-memory version and guaranteeing the stopping thread's update loses.

## Solution

Guard every update to a step execution's metadata with a **per-execution lock**, held across the surrounding transaction's commit, shared between the worker and the stopping thread:

- `AbstractStep` keeps one `Semaphore` per running step execution and exposes `StoppableStep.callUnderLock(StepExecution, Runnable)`. The worker's start/chunk/final updates and the operator's stop update all run under it, so they serialize and neither observes a stale version.
- `TaskletStep` and `ChunkOrientedStep` take this shared lock around their chunk transactions.
- `SimpleJobRepository.update(StepExecution)` no longer re-reads the version while stopping — under the lock the shared in-memory execution already holds the current version (the stale re-read was the root failure on MySQL).
- The operator sets the job execution status to `STOPPED` directly instead of `STOPPING` (which update(JobExecution) upgraded to STOPPED anyway).
- Re-enables `GracefulShutdownFunctionalTests` (disabled under #5308).

## Validation

JobOperatorFunctionalTests and GracefulShutdownFunctionalTests, 100 runs per vendor (MySQL 8 / PostgreSQL 16 in Docker, HSQLDB in-memory), after the fix:

| Test | Vendor | Baseline (no fix) | After this PR |
|---|---|---|---|
| `GracefulShutdownFunctionalTests` | HSQLDB | 3/100 | **0/100** |
| `GracefulShutdownFunctionalTests` | MySQL | 27/100 | **0/100** |
| `GracefulShutdownFunctionalTests` | PostgreSQL | 3/100 | **0/100** |
| `JobOperatorFunctionalTests` | HSQLDB | 1/100 | **0/100** |
| `JobOperatorFunctionalTests` | MySQL | 22/100 | **0/100** |
| `JobOperatorFunctionalTests` | PostgreSQL | 8/100 | **0/100** |

(0 failures / 600 runs. Before-fix numbers: see #5442.) Plus a new AbstractStepTests unit test asserting t updates to one step execution; full spring-batch-core suite passes.

Resolves #5308