### PR TITLE
Fix #5415: add new KafkaConsumerRecodItemStreamReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/AbstractKafkaItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/AbstractKafkaItemReader.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.kafka;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.batch.infrastructure.item.support.AbstractItemStreamItemReader;
+import org.springframework.util.Assert;
+
+/**
+ * <p>
+ * Base {@link ItemReader} implementation for Apache Kafka. Uses a {@link KafkaConsumer}
+ * to read data from a given topic. Multiple partitions within the same topic can be
+ * assigned to this reader.
+ * </p>
+ *
+ * <p>
+ * Since {@link KafkaConsumer} is not thread-safe, this reader is not thread-safe.
+ * </p>
+ *
+ * @param <K> key type
+ * @param <V> value type
+ * @param <T> item type returned by this reader
+ * @author djechelon@github.com
+ * @since 6.0
+ */
+public abstract class AbstractKafkaItemReader<K, V, T> extends AbstractItemStreamItemReader<T> {
+
+	protected static final String TOPIC_PARTITION_OFFSETS = "topic.partition.offsets";
+
+	protected static final long DEFAULT_POLL_TIMEOUT = 30L;
+
+	protected final String topicName;
+
+	protected final List<TopicPartition> topicPartitions;
+
+	protected @Nullable Map<TopicPartition, Long> partitionOffsets;
+
+	protected @Nullable KafkaConsumer<K, V> kafkaConsumer;
+
+	protected final Properties consumerProperties;
+
+	protected @Nullable Iterator<ConsumerRecord<K, V>> consumerRecords;
+
+	protected Duration pollTimeout = Duration.ofSeconds(DEFAULT_POLL_TIMEOUT);
+
+	protected boolean saveState = true;
+
+	/**
+	 * Create a new {@link AbstractKafkaItemReader}.
+	 * <p>
+	 * <strong>{@code consumerProperties} must contain the following keys:
+	 * 'bootstrap.servers', 'group.id', 'key.deserializer' and 'value.deserializer'
+	 * </strong>
+	 * </p>
+	 * .
+	 * @param consumerProperties properties of the consumer
+	 * @param topicName name of the topic to read data from
+	 * @param partitions list of partitions to read data from
+	 */
+	protected AbstractKafkaItemReader(Properties consumerProperties, String topicName, Integer... partitions) {
+		this(consumerProperties, topicName, Arrays.asList(partitions));
+	}
+
+	/**
+	 * Create a new {@link AbstractKafkaItemReader}.
+	 * <p>
+	 * <strong>{@code consumerProperties} must contain the following keys:
+	 * 'bootstrap.servers', 'group.id', 'key.deserializer' and 'value.deserializer'
+	 * </strong>
+	 * </p>
+	 * .
+	 * @param consumerProperties properties of the consumer
+	 * @param topicName name of the topic to read data from
+	 * @param partitions list of partitions to read data from
+	 */
+	protected AbstractKafkaItemReader(Properties consumerProperties, String topicName, List<Integer> partitions) {
+		Assert.notNull(consumerProperties, "Consumer properties must not be null");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+				ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG + " property must be provided");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.GROUP_ID_CONFIG),
+				ConsumerConfig.GROUP_ID_CONFIG + " property must be provided");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG),
+				ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG + " property must be provided");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG),
+				ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG + " property must be provided");
+		this.consumerProperties = consumerProperties;
+		Assert.hasLength(topicName, "Topic name must not be null or empty");
+		this.topicName = topicName;
+		Assert.isTrue(!partitions.isEmpty(), "At least one partition must be provided");
+		this.topicPartitions = new ArrayList<>();
+		for (Integer partition : partitions) {
+			this.topicPartitions.add(new TopicPartition(topicName, partition));
+		}
+	}
+
+	/**
+	 * Set a timeout for the consumer topic polling duration. Default to 30 seconds.
+	 * @param pollTimeout for the consumer poll operation
+	 */
+	public void setPollTimeout(Duration pollTimeout) {
+		Assert.notNull(pollTimeout, "pollTimeout must not be null");
+		Assert.isTrue(!pollTimeout.isZero(), "pollTimeout must not be zero");
+		Assert.isTrue(!pollTimeout.isNegative(), "pollTimeout must not be negative");
+		this.pollTimeout = pollTimeout;
+	}
+
+	/**
+	 * Set the flag that determines whether to save internal data for
+	 * {@link ExecutionContext}. Only switch this to false if you don't want to save any
+	 * state from this stream, and you don't need it to be restartable. Always set it to
+	 * false if the reader is being used in a concurrent environment.
+	 * @param saveState flag value (default true).
+	 */
+	public void setSaveState(boolean saveState) {
+		this.saveState = saveState;
+	}
+
+	/**
+	 * The flag that determines whether to save internal state for restarts.
+	 * @return true if the flag was set
+	 */
+	public boolean isSaveState() {
+		return this.saveState;
+	}
+
+	/**
+	 * Setter for partition offsets. This mapping tells the reader the offset to start
+	 * reading from in each partition. This is optional, defaults to starting from offset
+	 * 0 in each partition. Passing an empty map makes the reader start from the offset
+	 * stored in Kafka for the consumer group ID.
+	 *
+	 * <p>
+	 * <strong>In case of a restart, offsets stored in the execution context will take
+	 * precedence.</strong>
+	 * </p>
+	 * @param partitionOffsets mapping of starting offset in each partition
+	 */
+	public void setPartitionOffsets(Map<TopicPartition, Long> partitionOffsets) {
+		this.partitionOffsets = partitionOffsets;
+	}
+
+	@SuppressWarnings({ "unchecked", "DataFlowIssue" })
+	@Override
+	public void open(ExecutionContext executionContext) {
+		this.kafkaConsumer = new KafkaConsumer<>(this.consumerProperties);
+		if (this.partitionOffsets == null) {
+			this.partitionOffsets = new HashMap<>();
+			for (TopicPartition topicPartition : this.topicPartitions) {
+				this.partitionOffsets.put(topicPartition, 0L);
+			}
+		}
+		if (this.saveState && executionContext.containsKey(TOPIC_PARTITION_OFFSETS)) {
+			Map<String, Long> offsets = (Map<String, Long>) executionContext.get(TOPIC_PARTITION_OFFSETS);
+			for (Map.Entry<String, Long> entry : offsets.entrySet()) {
+				this.partitionOffsets.put(new TopicPartition(this.topicName, Integer.parseInt(entry.getKey())),
+						entry.getValue() == 0 ? 0 : entry.getValue() + 1);
+			}
+		}
+		this.kafkaConsumer.assign(this.topicPartitions);
+		this.partitionOffsets.forEach(this.kafkaConsumer::seek);
+	}
+
+	@SuppressWarnings("DataFlowIssue")
+	@Override
+	public @Nullable T read() {
+		if (this.consumerRecords == null || !this.consumerRecords.hasNext()) {
+			this.consumerRecords = this.kafkaConsumer.poll(this.pollTimeout).iterator();
+		}
+		if (this.consumerRecords.hasNext()) {
+			ConsumerRecord<K, V> record = this.consumerRecords.next();
+			this.partitionOffsets.put(new TopicPartition(record.topic(), record.partition()), record.offset());
+			return mapRecord(record);
+		}
+		else {
+			return null;
+		}
+	}
+
+	@SuppressWarnings("DataFlowIssue")
+	@Override
+	public void update(ExecutionContext executionContext) {
+		if (this.saveState) {
+			Map<String, Long> offsets = new HashMap<>();
+			for (Map.Entry<TopicPartition, Long> entry : this.partitionOffsets.entrySet()) {
+				offsets.put(String.valueOf(entry.getKey().partition()), entry.getValue());
+			}
+			executionContext.put(TOPIC_PARTITION_OFFSETS, offsets);
+		}
+		this.kafkaConsumer.commitSync();
+	}
+
+	@Override
+	public void close() {
+		if (this.kafkaConsumer != null) {
+			this.kafkaConsumer.close();
+		}
+	}
+
+	/**
+	 * Map a consumed record to the item type exposed by this reader.
+	 * @param record consumed record
+	 * @return mapped item
+	 */
+	protected abstract T mapRecord(ConsumerRecord<K, V> record);
+
+}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/KafkaConsumerRecordItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/KafkaConsumerRecordItemReader.java
@@ -36,15 +36,13 @@ import org.springframework.batch.infrastructure.item.ItemReader;
  * Since {@link KafkaConsumer} is not thread-safe, this reader is not thread-safe.
  * </p>
  *
- * @author Mathieu Ouellet
- * @author Mahmoud Ben Hassine
- * @author Hyunwoo Jung
- * @since 4.2
+ * @author djechelon@github.com
+ * @since 6.0
  */
-public class KafkaItemReader<K, V> extends AbstractKafkaItemReader<K, V, V> {
+public class KafkaConsumerRecordItemReader<K, V> extends AbstractKafkaItemReader<K, V, ConsumerRecord<K, V>> {
 
 	/**
-	 * Create a new {@link KafkaItemReader}.
+	 * Create a new {@link KafkaConsumerRecordItemReader}.
 	 * <p>
 	 * <strong>{@code consumerProperties} must contain the following keys:
 	 * 'bootstrap.servers', 'group.id', 'key.deserializer' and 'value.deserializer'
@@ -55,12 +53,12 @@ public class KafkaItemReader<K, V> extends AbstractKafkaItemReader<K, V, V> {
 	 * @param topicName name of the topic to read data from
 	 * @param partitions list of partitions to read data from
 	 */
-	public KafkaItemReader(Properties consumerProperties, String topicName, Integer... partitions) {
+	public KafkaConsumerRecordItemReader(Properties consumerProperties, String topicName, Integer... partitions) {
 		this(consumerProperties, topicName, Arrays.asList(partitions));
 	}
 
 	/**
-	 * Create a new {@link KafkaItemReader}.
+	 * Create a new {@link KafkaConsumerRecordItemReader}.
 	 * <p>
 	 * <strong>{@code consumerProperties} must contain the following keys:
 	 * 'bootstrap.servers', 'group.id', 'key.deserializer' and 'value.deserializer'
@@ -71,13 +69,13 @@ public class KafkaItemReader<K, V> extends AbstractKafkaItemReader<K, V, V> {
 	 * @param topicName name of the topic to read data from
 	 * @param partitions list of partitions to read data from
 	 */
-	public KafkaItemReader(Properties consumerProperties, String topicName, List<Integer> partitions) {
+	public KafkaConsumerRecordItemReader(Properties consumerProperties, String topicName, List<Integer> partitions) {
 		super(consumerProperties, topicName, partitions);
 	}
 
 	@Override
-	protected V mapRecord(ConsumerRecord<K, V> record) {
-		return record.value();
+	protected ConsumerRecord<K, V> mapRecord(ConsumerRecord<K, V> record) {
+		return record;
 	}
 
 }

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/builder/KafkaItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/kafka/builder/KafkaItemReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,16 +30,20 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.item.ItemStreamSupport;
+import org.springframework.batch.infrastructure.item.kafka.KafkaConsumerRecordItemReader;
 import org.springframework.batch.infrastructure.item.kafka.KafkaItemReader;
 import org.springframework.util.Assert;
 
 /**
- * A builder implementation for the {@link KafkaItemReader}.
+ * A builder implementation for the Kafka-based
+ * {@link org.springframework.batch.infrastructure.item.ItemReader}s.
  *
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author djechelon@github.com
  * @since 4.2
  * @see KafkaItemReader
+ * @see KafkaConsumerRecordItemReader
  */
 public class KafkaItemReaderBuilder<K, V> {
 
@@ -154,6 +158,11 @@ public class KafkaItemReaderBuilder<K, V> {
 		return this;
 	}
 
+	/**
+	 * Constructs the reader in order to read only the message body from Kafka.
+	 * @return an instance of {@link KafkaItemReader} to be considered as an
+	 * <pre>ItemReader&lt;V&gt;</pre>
+	 */
 	public KafkaItemReader<K, V> build() {
 		if (this.saveState) {
 			Assert.hasText(this.name, "A name is required when saveState is set to true");
@@ -174,6 +183,43 @@ public class KafkaItemReaderBuilder<K, V> {
 		Assert.isTrue(!partitions.isEmpty(), "At least one partition must be provided");
 
 		KafkaItemReader<K, V> reader = new KafkaItemReader<>(this.consumerProperties, this.topic, this.partitions);
+		reader.setPollTimeout(this.pollTimeout);
+		reader.setSaveState(this.saveState);
+		if (this.name != null) {
+			reader.setName(this.name);
+		}
+		if (this.partitionOffsets != null) {
+			reader.setPartitionOffsets(this.partitionOffsets);
+		}
+		return reader;
+	}
+
+	/**
+	 * Constructs the reader in order to read the whole message envelope from Kafka.
+	 * @return an instance of {@link KafkaItemReader} to be considered as an
+	 * <pre>ItemReader&lt;ConsumerRecord&lt;K,V&gt;&gt;</pre>
+	 */
+	public KafkaConsumerRecordItemReader<K, V> buildWithConsumerRecord() {
+		if (this.saveState) {
+			Assert.hasText(this.name, "A name is required when saveState is set to true");
+		}
+		Assert.notNull(consumerProperties, "Consumer properties must not be null");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+				ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG + " property must be provided");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.GROUP_ID_CONFIG),
+				ConsumerConfig.GROUP_ID_CONFIG + " property must be provided");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG),
+				ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG + " property must be provided");
+		Assert.isTrue(consumerProperties.containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG),
+				ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG + " property must be provided");
+		Assert.hasLength(topic, "Topic name must not be null or empty");
+		Assert.notNull(pollTimeout, "pollTimeout must not be null");
+		Assert.isTrue(!pollTimeout.isZero(), "pollTimeout must not be zero");
+		Assert.isTrue(!pollTimeout.isNegative(), "pollTimeout must not be negative");
+		Assert.isTrue(!partitions.isEmpty(), "At least one partition must be provided");
+
+		KafkaConsumerRecordItemReader<K, V> reader = new KafkaConsumerRecordItemReader<>(this.consumerProperties,
+				this.topic, this.partitions);
 		reader.setPollTimeout(this.pollTimeout);
 		reader.setSaveState(this.saveState);
 		if (this.name != null) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/kafka/KafkaConsumerRecordItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/kafka/KafkaConsumerRecordItemReaderTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.kafka;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Mathieu Ouellet
+ * @author Mahmoud Ben Hassine
+ * @author djechelon@github.com
+ */
+class KafkaConsumerRecordItemReaderTests {
+
+	@Test
+	void testValidation() {
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> new KafkaConsumerRecordItemReader<>(null, "topic", 0));
+		assertEquals("Consumer properties must not be null", exception.getMessage());
+
+		exception = assertThrows(IllegalArgumentException.class,
+				() -> new KafkaConsumerRecordItemReader<>(new Properties(), "topic", 0));
+		assertEquals("bootstrap.servers property must be provided", exception.getMessage());
+
+		Properties consumerProperties = new Properties();
+		consumerProperties.put("bootstrap.servers", "mockServer");
+		exception = assertThrows(IllegalArgumentException.class,
+				() -> new KafkaConsumerRecordItemReader<>(consumerProperties, "topic", 0));
+		assertEquals("group.id property must be provided", exception.getMessage());
+
+		consumerProperties.put("group.id", "1");
+		exception = assertThrows(IllegalArgumentException.class,
+				() -> new KafkaConsumerRecordItemReader<>(consumerProperties, "topic", 0));
+		assertEquals("key.deserializer property must be provided", exception.getMessage());
+
+		consumerProperties.put("key.deserializer", StringDeserializer.class.getName());
+		exception = assertThrows(IllegalArgumentException.class,
+				() -> new KafkaConsumerRecordItemReader<>(consumerProperties, "topic", 0));
+		assertEquals("value.deserializer property must be provided", exception.getMessage());
+
+		consumerProperties.put("value.deserializer", StringDeserializer.class.getName());
+		exception = assertThrows(IllegalArgumentException.class,
+				() -> new KafkaConsumerRecordItemReader<>(consumerProperties, "", 0));
+		assertEquals("Topic name must not be null or empty", exception.getMessage());
+
+		exception = assertThrows(Exception.class,
+				() -> new KafkaConsumerRecordItemReader<>(consumerProperties, "topic"));
+		assertEquals("At least one partition must be provided", exception.getMessage());
+
+		KafkaConsumerRecordItemReader<String, String> reader = new KafkaConsumerRecordItemReader<>(consumerProperties,
+				"topic", 0);
+
+		exception = assertThrows(IllegalArgumentException.class, () -> reader.setPollTimeout(null));
+		assertEquals("pollTimeout must not be null", exception.getMessage());
+
+		exception = assertThrows(IllegalArgumentException.class, () -> reader.setPollTimeout(Duration.ZERO));
+		assertEquals("pollTimeout must not be zero", exception.getMessage());
+
+		exception = assertThrows(IllegalArgumentException.class, () -> reader.setPollTimeout(Duration.ofSeconds(-1)));
+		assertEquals("pollTimeout must not be negative", exception.getMessage());
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/kafka/builder/KafkaItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/kafka/builder/KafkaItemReaderBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -29,19 +29,17 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.batch.infrastructure.item.kafka.KafkaConsumerRecordItemReader;
 import org.springframework.batch.infrastructure.item.kafka.KafkaItemReader;
-import org.springframework.batch.infrastructure.item.kafka.builder.KafkaItemReaderBuilder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Mathieu Ouellet
  * @author Mahmoud Ben Hassine
+ * @author djechelon@github.com
  */
 class KafkaItemReaderBuilderTests {
 
@@ -94,11 +92,13 @@ class KafkaItemReaderBuilderTests {
 		assertEquals("value.deserializer property must be provided", exception.getMessage());
 
 		consumerProperties.put("value.deserializer", StringDeserializer.class.getName());
-		new KafkaItemReaderBuilder<>().name("kafkaItemReader")
+		builder = new KafkaItemReaderBuilder<>().name("kafkaItemReader")
 			.consumerProperties(consumerProperties)
 			.topic("test")
-			.partitions(0, 1)
-			.build();
+			.partitions(0, 1);
+		assertDoesNotThrow(builder::build);
+		assertDoesNotThrow(builder::buildWithConsumerRecord);
+
 	}
 
 	@Test
@@ -210,6 +210,47 @@ class KafkaItemReaderBuilderTests {
 			.pollTimeout(pollTimeout)
 			.saveState(saveState)
 			.build();
+
+		// then
+		assertNotNull(reader);
+		assertFalse((Boolean) ReflectionTestUtils.getField(reader, "saveState"));
+		assertEquals(pollTimeout, ReflectionTestUtils.getField(reader, "pollTimeout"));
+		List<TopicPartition> topicPartitions = (List<TopicPartition>) ReflectionTestUtils.getField(reader,
+				"topicPartitions");
+		assertEquals(2, topicPartitions.size());
+		assertEquals(topic, topicPartitions.get(0).topic());
+		assertEquals(partitions.get(0).intValue(), topicPartitions.get(0).partition());
+		assertEquals(topic, topicPartitions.get(1).topic());
+		assertEquals(partitions.get(1).intValue(), topicPartitions.get(1).partition());
+		Map<TopicPartition, Long> partitionOffsetsMap = (Map<TopicPartition, Long>) ReflectionTestUtils.getField(reader,
+				"partitionOffsets");
+		assertEquals(2, partitionOffsetsMap.size());
+		assertEquals(Long.valueOf(10L), partitionOffsetsMap.get(new TopicPartition(topic, partitions.get(0))));
+		assertEquals(Long.valueOf(15L), partitionOffsetsMap.get(new TopicPartition(topic, partitions.get(1))));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testKafkaConsumerRecordItemReaderCreation() {
+		// given
+		boolean saveState = false;
+		Duration pollTimeout = Duration.ofSeconds(100);
+		String topic = "test";
+		List<Integer> partitions = Arrays.asList(0, 1);
+		Map<TopicPartition, Long> partitionOffsets = new HashMap<>();
+		partitionOffsets.put(new TopicPartition(topic, partitions.get(0)), 10L);
+		partitionOffsets.put(new TopicPartition(topic, partitions.get(1)), 15L);
+
+		// when
+		KafkaConsumerRecordItemReader<String, String> reader = new KafkaItemReaderBuilder<String, String>()
+			.name("kafkaItemReader")
+			.consumerProperties(this.consumerProperties)
+			.topic(topic)
+			.partitions(partitions)
+			.partitionOffsets(partitionOffsets)
+			.pollTimeout(pollTimeout)
+			.saveState(saveState)
+			.buildWithConsumerRecord();
 
 		// then
 		assertNotNull(reader);


### PR DESCRIPTION
As discussed in #5415, goal is to implement a new Kafka-based ItemReader that returns not only the message body (generic V), but the whole envelope (as ConsumerRecord<K,V>).

In order to maintain backwards compatibility, the following has been done:

- KafkaItemReader was mostly moved to an abstract class, with 3 generics. Of these, <K,V> are the usual Kafka key-value, and T is the actual type returned by the reader
- KafkaItemReader changed to extend the abstract class and set T to be V
- KafkaConsumerRecordItemReader to extend the abstract class and set T to be ConsumerRecord<K,V>
- Changed the builder to return the consumer record instance with a different build() method
- Worked on the unit tests
- Signed off commit and updated copyright notice

Please consider that locally I am experiencing `mvn verify` even on main as I started working on the fork. I was able to verify that **my** affected tests work, failing tests occur on unaffected classes.

I wish to thank whoever will spend their precious time paying attention to this contribution.