### PR TITLE
Improve DefaultJobParametersConverter and JsonJobParametersConverter

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/converter/DefaultJobParametersConverter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/converter/DefaultJobParametersConverter.java
@@ -73,6 +73,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Michael Minella
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  *
  */
 public class DefaultJobParametersConverter implements JobParametersConverter {
@@ -155,14 +156,14 @@ public class DefaultJobParametersConverter implements JobParametersConverter {
 	 * @param encodedJobParameter the encoded job parameter
 	 * @return the decoded job parameter
 	 */
-	@SuppressWarnings(value = { "unchecked", "rawtypes" })
-	protected JobParameter decode(String parameterName, String encodedJobParameter) {
+	@SuppressWarnings("unchecked")
+	protected <T> JobParameter<T> decode(String parameterName, String encodedJobParameter) {
 		String parameterStringValue = parseValue(encodedJobParameter);
-		Class<?> parameterType = parseType(encodedJobParameter);
+		Class<T> parameterType = (Class<T>) parseType(encodedJobParameter);
 		boolean parameterIdentifying = parseIdentifying(encodedJobParameter);
 		try {
-			Object typedValue = this.conversionService.convert(parameterStringValue, parameterType);
-			return new JobParameter(parameterName, typedValue, parameterType, parameterIdentifying);
+			T typedValue = this.conversionService.convert(parameterStringValue, parameterType);
+			return new JobParameter<>(parameterName, typedValue, parameterType, parameterIdentifying);
 		}
 		catch (Exception e) {
 			throw new JobParametersConversionException(

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/converter/JsonJobParametersConverter.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/converter/JsonJobParametersConverter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.batch.core.converter;
 
+import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -63,6 +64,7 @@ import org.springframework.batch.core.job.parameters.JobParameters;
  * </ul>
  *
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  * @since 5.0
  *
  */
@@ -98,16 +100,16 @@ public class JsonJobParametersConverter extends DefaultJobParametersConverter {
 		}
 		try {
 			return this.jsonMapper.writeValueAsString(new JobParameterDefinition(parameterName, parameterStringValue,
-					parameterType.getName(), Boolean.toString(parameterIdentifying)));
+					parameterType.getName(), parameterIdentifying));
 		}
 		catch (JacksonException e) {
 			throw new JobParametersConversionException("Unable to encode job parameter " + jobParameter, e);
 		}
 	}
 
-	@SuppressWarnings(value = { "unchecked", "rawtypes" })
+	@SuppressWarnings("unchecked")
 	@Override
-	protected JobParameter decode(String parameterName, String encodedJobParameter) {
+	protected <T> JobParameter<T> decode(String parameterName, String encodedJobParameter) {
 		try {
 			JobParameterDefinition jobParameterDefinition = this.jsonMapper.readValue(encodedJobParameter,
 					JobParameterDefinition.class);
@@ -116,18 +118,20 @@ public class JsonJobParametersConverter extends DefaultJobParametersConverter {
 				parameterType = Class.forName(jobParameterDefinition.type());
 			}
 			boolean parameterIdentifying = true;
-			if (jobParameterDefinition.identifying() != null && !jobParameterDefinition.identifying().isEmpty()) {
-				parameterIdentifying = Boolean.parseBoolean(jobParameterDefinition.identifying());
+			if (jobParameterDefinition.identifying() != null) {
+				parameterIdentifying = jobParameterDefinition.identifying();
 			}
-			Object parameterTypedValue = this.conversionService.convert(jobParameterDefinition.value(), parameterType);
-			return new JobParameter(parameterName, parameterTypedValue, parameterType, parameterIdentifying);
+			Class<T> parameterTypeToUse = (Class<T>) parameterType;
+			T parameterTypedValue = this.conversionService.convert(jobParameterDefinition.value(), parameterTypeToUse);
+			return new JobParameter<>(parameterName, parameterTypedValue, parameterTypeToUse, parameterIdentifying);
 		}
 		catch (JacksonException | ClassNotFoundException e) {
 			throw new JobParametersConversionException("Unable to decode job parameter " + encodedJobParameter, e);
 		}
 	}
 
-	public record JobParameterDefinition(String name, String value, String type, String identifying) {
+	public record JobParameterDefinition(String name, String value, @Nullable String type,
+			@Nullable Boolean identifying) {
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/converter/JsonJobParametersConverterTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/converter/JsonJobParametersConverterTests.java
@@ -22,6 +22,7 @@ import org.springframework.batch.core.job.parameters.JobParameter;
 
 /**
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  */
 class JsonJobParametersConverterTests {
 
@@ -36,7 +37,7 @@ class JsonJobParametersConverterTests {
 
 		// then
 		Assertions.assertEquals(
-				"{\"name\":\"name\",\"value\":\"foo\",\"type\":\"java.lang.String\",\"identifying\":\"false\"}",
+				"{\"name\":\"name\",\"value\":\"foo\",\"type\":\"java.lang.String\",\"identifying\":false}",
 				encodedJobParameter);
 	}
 
@@ -51,7 +52,7 @@ class JsonJobParametersConverterTests {
 
 		// then
 		Assertions.assertEquals(
-				"{\"name\":\"name\",\"value\":\"foo\",\"type\":\"java.lang.String\",\"identifying\":\"true\"}",
+				"{\"name\":\"name\",\"value\":\"foo\",\"type\":\"java.lang.String\",\"identifying\":true}",
 				encodedJobParameter);
 	}
 
@@ -69,6 +70,22 @@ class JsonJobParametersConverterTests {
 		Assertions.assertEquals("foo", jobParameter.value());
 		Assertions.assertEquals(String.class, jobParameter.type());
 		Assertions.assertFalse(jobParameter.identifying());
+	}
+
+	@Test
+	void testDecodeWithBooleanIdentifyingFlag() {
+		// given
+		JsonJobParametersConverter converter = new JsonJobParametersConverter();
+		String encodedJobParameter = "{\"name\":\"name\",\"value\":\"foo\",\"type\":\"java.lang.String\",\"identifying\":true}";
+
+		// when
+		JobParameter<String> jobParameter = converter.decode("name", encodedJobParameter);
+
+		// then
+		Assertions.assertNotNull(jobParameter);
+		Assertions.assertEquals("foo", jobParameter.value());
+		Assertions.assertEquals(String.class, jobParameter.type());
+		Assertions.assertTrue(jobParameter.identifying());
 	}
 
 	@Test


### PR DESCRIPTION
1. let `decode()` supports generics.
2. add `@Nullable` to `JobParameterDefinition`.
3. let `JsonJobParametersConverter` encode `identifying` as boolean instead of String, and add tests to verify both boolean and String can be decoded to java `Boolean`.