### PR TITLE
Document name requirement of FlatFileItemReaderBuilder

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/readers-and-writers/flat-files/file-item-reader.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/readers-and-writers/flat-files/file-item-reader.adoc
@@ -38,15 +38,22 @@ interpreted, as described in the following table:
 |encoding|String|Specifies what text encoding to use. The default value is `UTF-8`.
 |lineMapper|`LineMapper`|Converts a `String` to an `Object` representing the item.
 |linesToSkip|int|Number of lines to ignore at the top of the file.
+|name|String|The name used to compute the keys of the values stored in the `ExecutionContext`. Required if `saveState` is `true`.
 |recordSeparatorPolicy|RecordSeparatorPolicy|Used to determine where the line endings are
 and do things like continue over a line ending if inside a quoted string.
 |resource|`Resource`|The resource from which to read.
+|saveState|boolean|Specifies whether the state of the reader is saved in the `ExecutionContext` for restartability. The default value is `true`.
 |skippedLinesCallback|LineCallbackHandler|Interface that passes the raw line content of
 the lines in the file to be skipped. If `linesToSkip` is set to 2, then this interface is
 called twice.
 |strict|boolean|In strict mode, the reader throws an exception on `ExecutionContext` if
 the input resource does not exist. Otherwise, it logs the problem and continues.
 |===============
+
+[NOTE]
+====
+Unlike `FlatFileItemReader`, which defaults its name to the short class name, `FlatFileItemReaderBuilder` requires you to set a name when `saveState` is `true` (the default). The name is used to prefix the keys of the values stored in the `ExecutionContext`, so a unique name is required to avoid key collisions between stateful readers of the same type within a job. If restartability is not needed, you can set `saveState(false)`, in which case no name is required.
+====
 
 [[lineMapper]]
 == `LineMapper`


### PR DESCRIPTION
Document the name and saveState properties in the FlatFileItemReader reference documentation, and explain why FlatFileItemReaderBuilder requires a name when saveState is true.

Resolves #981

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
* Sign-off commits according to the [Developer Certificate of Origin](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring)

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-batch/blob/main/CONTRIBUTING.md