### PR TITLE
Skip malformed JSON object after a parse error

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JacksonJsonObjectReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/json/JacksonJsonObjectReader.java
@@ -97,13 +97,38 @@ public class JacksonJsonObjectReader<T> implements JsonObjectReader<T> {
 	public @Nullable T read() throws Exception {
 		try {
 			if (this.jsonParser.nextToken() == JsonToken.START_OBJECT) {
-				return this.mapper.readValue(this.jsonParser, this.itemType);
+				return readObject();
 			}
 		}
 		catch (JacksonException e) {
 			throw new ParseException("Unable to read next JSON object", e);
 		}
 		return null;
+	}
+
+	@SuppressWarnings("DataFlowIssue")
+	private T readObject() {
+		int objectDepth = this.jsonParser.streamReadContext().getNestingDepth();
+		try {
+			return this.mapper.readValue(this.jsonParser, this.itemType);
+		}
+		catch (JacksonException e) {
+			// A failed mapping leaves the cursor inside the malformed object, where the
+			// next read would find a token other than START_OBJECT and report the end of
+			// the input. Skipping to the end of the object keeps the remaining items
+			// readable, so a fault-tolerant step can skip this one and carry on.
+			skipToEndOfObject(objectDepth);
+			throw e;
+		}
+	}
+
+	@SuppressWarnings("DataFlowIssue")
+	private void skipToEndOfObject(int objectDepth) {
+		while (this.jsonParser.streamReadContext().getNestingDepth() >= objectDepth) {
+			if (this.jsonParser.nextToken() == null) {
+				return;
+			}
+		}
 	}
 
 	@Override

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/JacksonJsonObjectReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/json/JacksonJsonObjectReaderTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.batch.infrastructure.item.json;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.infrastructure.item.ParseException;
+import org.springframework.batch.infrastructure.item.json.domain.Trade;
+import org.springframework.core.io.ByteArrayResource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Donghwan Kim
+ */
+class JacksonJsonObjectReaderTests {
+
+	@Test
+	void testReadObjectAfterParseException() throws Exception {
+		// given
+		String json = """
+				[
+					{"isin":"AAA","quantity":1,"price":1.0,"customer":"foo"},
+					{"isin":"BBB","quantity":"not a number","price":2.0,"customer":"bar"},
+					{"isin":"CCC","quantity":3,"price":3.0,"customer":"baz"}
+				]
+				""";
+		JacksonJsonObjectReader<Trade> objectReader = new JacksonJsonObjectReader<>(Trade.class);
+		objectReader.open(new ByteArrayResource(json.getBytes()));
+
+		// when
+		Trade firstItem = objectReader.read();
+		assertThrows(ParseException.class, objectReader::read);
+		Trade thirdItem = objectReader.read();
+
+		// then
+		assertNotNull(firstItem);
+		assertEquals("AAA", firstItem.getIsin());
+		assertNotNull(thirdItem);
+		assertEquals("CCC", thirdItem.getIsin());
+
+		objectReader.close();
+	}
+
+	@Test
+	void testReadObjectAfterParseExceptionInObjectWithNestedObject() throws Exception {
+		// given
+		String json = """
+				[
+					{"isin":"AAA","quantity":1,"price":1.0,"customer":"foo"},
+					{"isin":"BBB","quantity":"not a number","price":2.0,"customer":"bar",
+						"details":{"origin":{"country":"FR"}}},
+					{"isin":"CCC","quantity":3,"price":3.0,"customer":"baz"}
+				]
+				""";
+		JacksonJsonObjectReader<Trade> objectReader = new JacksonJsonObjectReader<>(Trade.class);
+		objectReader.open(new ByteArrayResource(json.getBytes()));
+
+		// when
+		Trade firstItem = objectReader.read();
+		assertThrows(ParseException.class, objectReader::read);
+		Trade thirdItem = objectReader.read();
+
+		// then
+		assertNotNull(firstItem);
+		assertEquals("AAA", firstItem.getIsin());
+		assertNotNull(thirdItem);
+		assertEquals("CCC", thirdItem.getIsin());
+
+		objectReader.close();
+	}
+
+	@Test
+	void testReadAfterParseExceptionInLastObject() throws Exception {
+		// given
+		String json = """
+				[
+					{"isin":"AAA","quantity":1,"price":1.0,"customer":"foo"},
+					{"isin":"BBB","quantity":"not a number","price":2.0,"customer":"bar"}
+				]
+				""";
+		JacksonJsonObjectReader<Trade> objectReader = new JacksonJsonObjectReader<>(Trade.class);
+		objectReader.open(new ByteArrayResource(json.getBytes()));
+
+		// when
+		Trade firstItem = objectReader.read();
+		assertThrows(ParseException.class, objectReader::read);
+
+		// then
+		assertNotNull(firstItem);
+		assertEquals("AAA", firstItem.getIsin());
+		assertNull(objectReader.read());
+
+		objectReader.close();
+	}
+
+}


### PR DESCRIPTION
`JacksonJsonObjectReader.read()` rethrows a `JacksonException` as a `ParseException`, but it leaves the parser cursor inside the malformed object. The next `read()` then finds a token other than `START_OBJECT` and returns `null`, which the caller takes as the end of the input, so the step stops early while valid items are still there. That makes it impossible to skip a `ParseException`.

With this input the first item reads fine and the second throws `ParseException` as expected, but the third comes back `null` instead of `CCC`:

```json
[
  {"isin":"AAA","quantity":1,"price":1.0,"customer":"foo"},
  {"isin":"BBB","quantity":"not a number","price":2.0,"customer":"bar"},
  {"isin":"CCC","quantity":3,"price":3.0,"customer":"baz"}
]
```

This skips to the end of the malformed object before rethrowing, so the remaining items stay readable. It tracks the nesting depth rather than looking for the next `END_OBJECT`, so an item containing nested objects is drained correctly too.

`GsonJsonObjectReader` reads through a `JsonReader` and I didn't touch it here — happy to look at it separately if it has the same gap.

Resolves #4701

---

Written with AI assistance (Claude); I reviewed the change and verified it myself. `JacksonJsonObjectReaderTests` fails on current `main` (the first two cases) and passes with the fix, and the `item.json` package suite plus `spring-javaformat:validate` are green.
