### PR TITLE
Make BatchObservabilityBeanPostProcessor proxy-aware

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchObservabilityBeanPostProcessor.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/BatchObservabilityBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the original author or authors.
+ * Copyright 2022-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.launch.support.TaskExecutorJobOperator;
 import org.springframework.batch.core.step.AbstractStep;
@@ -34,6 +35,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
  * steps) with a Micrometer's observation registry.
  *
  * @author Mahmoud Ben Hassine
+ * @author Sanghyuk Jung
  * @since 5.0
  */
 public class BatchObservabilityBeanPostProcessor implements BeanFactoryPostProcessor, BeanPostProcessor {
@@ -54,16 +56,20 @@ public class BatchObservabilityBeanPostProcessor implements BeanFactoryPostProce
 			return bean;
 		}
 		try {
-			if (bean instanceof AbstractJob || bean instanceof AbstractStep
-					|| bean instanceof TaskExecutorJobOperator) {
+			Object target = AopProxyUtils.getSingletonTarget(bean);
+			if (target == null) {
+				target = bean;
+			}
+			if (target instanceof AbstractJob || target instanceof AbstractStep
+					|| target instanceof TaskExecutorJobOperator) {
 				ObservationRegistry observationRegistry = this.beanFactory.getBean(ObservationRegistry.class);
-				if (bean instanceof AbstractJob job) {
+				if (target instanceof AbstractJob job) {
 					job.setObservationRegistry(observationRegistry);
 				}
-				if (bean instanceof AbstractStep step) {
+				if (target instanceof AbstractStep step) {
 					step.setObservationRegistry(observationRegistry);
 				}
-				if (bean instanceof TaskExecutorJobOperator operator) {
+				if (target instanceof TaskExecutorJobOperator operator) {
 					operator.setObservationRegistry(observationRegistry);
 				}
 			}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchObservabilityBeanPostProcessorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchObservabilityBeanPostProcessorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.core.configuration.annotation;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.launch.support.TaskExecutorJobOperator;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Test class for {@link BatchObservabilityBeanPostProcessor}.
+ *
+ * @author Sanghyuk Jung
+ */
+class BatchObservabilityBeanPostProcessorTests {
+
+	private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+	private final ObservationRegistry observationRegistry = ObservationRegistry.create();
+
+	private final BatchObservabilityBeanPostProcessor postProcessor = new BatchObservabilityBeanPostProcessor();
+
+	@Test
+	void observationRegistryShouldBeSetOnJobOperator() {
+		// given
+		this.beanFactory.registerSingleton("observationRegistry", this.observationRegistry);
+		this.postProcessor.postProcessBeanFactory(this.beanFactory);
+		TaskExecutorJobOperator jobOperator = new TaskExecutorJobOperator();
+
+		// when
+		this.postProcessor.postProcessAfterInitialization(jobOperator, "jobOperator");
+
+		// then
+		assertSame(this.observationRegistry, ReflectionTestUtils.getField(jobOperator, "observationRegistry"));
+	}
+
+	@Test
+	void observationRegistryShouldBeSetOnProxiedJobOperator() {
+		// given
+		this.beanFactory.registerSingleton("observationRegistry", this.observationRegistry);
+		this.postProcessor.postProcessBeanFactory(this.beanFactory);
+		TaskExecutorJobOperator target = new TaskExecutorJobOperator();
+		ProxyFactory proxyFactory = new ProxyFactory();
+		proxyFactory.setTarget(target);
+		proxyFactory.setProxyTargetClass(false);
+		proxyFactory.addInterface(JobOperator.class);
+		Object jobOperator = proxyFactory.getProxy();
+
+		// when
+		this.postProcessor.postProcessAfterInitialization(jobOperator, "jobOperator");
+
+		// then
+		assertSame(this.observationRegistry, ReflectionTestUtils.getField(target, "observationRegistry"));
+	}
+
+}


### PR DESCRIPTION
Resolves #5463

The `jobOperator` bean created by `JobOperatorFactoryBean` is a JDK dynamic proxy that implements only the `JobOperator` interface, so the `bean instanceof TaskExecutorJobOperator` check in `BatchObservabilityBeanPostProcessor` never matches and the operator is silently skipped (DEBUG log only). The operator therefore keeps `ObservationRegistry.NOOP` on the `DefaultBatchConfiguration` and Spring Boot auto-configuration paths, and on the `@EnableBatchProcessing` path whenever the `observationRegistry` bean definition does not happen to exist before `BatchRegistrar` runs.

This change unwraps the candidate bean with `AopProxyUtils.getSingletonTarget()` before the type checks, so proxied batch artifacts are handled like plain ones. Since the post processor resolves the `ObservationRegistry` from the bean factory by type at instantiation time, this also removes the registration-order and bean-name constraints described in the issue: an `ObservationRegistry` bean now reaches the operator regardless of where it is declared.

## Verification

- New unit tests (`BatchObservabilityBeanPostProcessorTests`): the proxied-operator test fails on `main` and passes with this change.
- Both reproducers from #5463 were re-run against `6.0.5-SNAPSHOT` with this patch:
    - the Spring Boot auto-configuration reproducer now records `spring.batch.job.launch.count` (the operator's registry is the actual `ObservationRegistry` instead of NOOP, and the `spring.batch.job` timer count stays 1),
    - the plain-Spring reproducer records the metric in all three registration-order scenarios, including the previously failing one.

The documentation part of #5463 (the manual `DefaultMeterObservationHandler` snippet leading to double-counted metrics in a Spring Boot application) is not addressed by this change.


