### PR TITLE
Fix duplicate listener registration in ChunkOrientedStepBuilder

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/ChunkOrientedStepBuilder.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/builder/ChunkOrientedStepBuilder.java
@@ -485,13 +485,14 @@ public class ChunkOrientedStepBuilder<I, O> extends StepBuilderHelper<ChunkOrien
 		if (itemHandler instanceof ItemStream itemStream) {
 			this.streams.add(itemStream);
 		}
-		// Register as listener if implements the interface
-		if (itemHandler instanceof StepListener listener) {
-			this.stepListeners.add(listener);
-		}
-		// Register as listener if annotated methods are present
+		// Register as listener if it implements a listener interface or has annotated
+		// methods. The factory covers both cases, so the item handler is registered
+		// only once even if it mixes interfaces and annotations.
 		if (StepListenerFactoryBean.isListener(itemHandler)) {
 			StepListener listener = StepListenerFactoryBean.getListener(itemHandler);
+			this.stepListeners.add(listener);
+		}
+		else if (itemHandler instanceof StepListener listener) {
 			this.stepListeners.add(listener);
 		}
 	}

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkOrientedStepIntegrationTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/ChunkOrientedStepIntegrationTests.java
@@ -15,10 +15,12 @@
  */
 package org.springframework.batch.core.step.item;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.EnableJdbcJobRepository;
 import org.springframework.batch.core.job.Job;
@@ -27,6 +29,7 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.listener.ItemProcessListener;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.StepExecution;
@@ -183,6 +186,42 @@ public class ChunkOrientedStepIntegrationTests {
 		Assertions.assertEquals(2, itemWriter.getWrittenItems().size());
 	}
 
+	// Issue: https://github.com/spring-projects/spring-batch/issues/5466
+	@Test
+	void testItemHandlerImplementingListenerInterfaceIsRegisteredOnce() throws Exception {
+		// given
+		ApplicationContext context = new AnnotationConfigApplicationContext(
+				InterfaceOnlyListenerStepConfiguration.class);
+		JobOperator jobOperator = context.getBean(JobOperator.class);
+		Job job = context.getBean(Job.class);
+
+		// when
+		jobOperator.start(job, new JobParametersBuilder().addLong("run.id", 1L).toJobParameters());
+
+		// then
+		InterfaceOnlyListenerProcessor processor = context.getBean(InterfaceOnlyListenerProcessor.class);
+		Assertions.assertEquals(1, processor.beforeProcessCount);
+		Assertions.assertEquals(1, processor.afterProcessCount);
+	}
+
+	// Issue: https://github.com/spring-projects/spring-batch/issues/5466
+	@Test
+	void testItemHandlerMixingListenerInterfaceAndAnnotationIsRegisteredOnce() throws Exception {
+		// given
+		ApplicationContext context = new AnnotationConfigApplicationContext(MixedListenerStepConfiguration.class);
+		JobOperator jobOperator = context.getBean(JobOperator.class);
+		Job job = context.getBean(Job.class);
+
+		// when
+		jobOperator.start(job, new JobParametersBuilder().addLong("run.id", 1L).toJobParameters());
+
+		// then
+		MixedListenerProcessor processor = context.getBean(MixedListenerProcessor.class);
+		Assertions.assertEquals(1, processor.beforeStepCount);
+		Assertions.assertEquals(1, processor.beforeProcessCount);
+		Assertions.assertEquals(1, processor.afterProcessCount);
+	}
+
 	@Configuration
 	static class ChunkOrientedStepConfiguration {
 
@@ -238,6 +277,97 @@ public class ChunkOrientedStepIntegrationTests {
 				.writer(itemWriter)
 				.build();
 			return new JobBuilder(jobRepository).start(step).build();
+		}
+
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	@EnableJdbcJobRepository
+	@Import(JdbcInfrastructureConfiguration.class)
+	static class InterfaceOnlyListenerStepConfiguration {
+
+		@Bean
+		public InterfaceOnlyListenerProcessor itemProcessor() {
+			return new InterfaceOnlyListenerProcessor();
+		}
+
+		@Bean
+		Job job(JobRepository jobRepository, JdbcTransactionManager transactionManager,
+				InterfaceOnlyListenerProcessor itemProcessor) {
+			ChunkOrientedStep<String, String> step = new StepBuilder("step", jobRepository).<String, String>chunk(1)
+				.transactionManager(transactionManager)
+				.reader(new SingleItemStreamReader<>("foo"))
+				.processor(itemProcessor)
+				.writer(items -> {
+				})
+				.build();
+			return new JobBuilder(jobRepository).start(step).build();
+		}
+
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	@EnableJdbcJobRepository
+	@Import(JdbcInfrastructureConfiguration.class)
+	static class MixedListenerStepConfiguration {
+
+		@Bean
+		public MixedListenerProcessor itemProcessor() {
+			return new MixedListenerProcessor();
+		}
+
+		@Bean
+		Job job(JobRepository jobRepository, JdbcTransactionManager transactionManager,
+				MixedListenerProcessor itemProcessor) {
+			ChunkOrientedStep<String, String> step = new StepBuilder("step", jobRepository).<String, String>chunk(1)
+				.transactionManager(transactionManager)
+				.reader(new SingleItemStreamReader<>("foo"))
+				.processor(itemProcessor)
+				.writer(items -> {
+				})
+				.build();
+			return new JobBuilder(jobRepository).start(step).build();
+		}
+
+	}
+
+	// item processor that implements a listener interface without any listener
+	// annotation, the control case for the processor below
+	static class InterfaceOnlyListenerProcessor
+			implements ItemProcessor<String, String>, ItemProcessListener<String, String> {
+
+		int beforeProcessCount;
+
+		int afterProcessCount;
+
+		@Override
+		public @Nullable String process(String item) {
+			return item;
+		}
+
+		@Override
+		public void beforeProcess(String item) {
+			this.beforeProcessCount++;
+		}
+
+		@Override
+		public void afterProcess(String item, @Nullable String result) {
+			this.afterProcessCount++;
+		}
+
+	}
+
+	// the same item processor with an annotated listener method added, so it must
+	// still be registered as a listener only once
+	static class MixedListenerProcessor extends InterfaceOnlyListenerProcessor {
+
+		int beforeStepCount;
+
+		@BeforeStep
+		public void init(StepExecution stepExecution) {
+			this.beforeStepCount++;
 		}
 
 	}


### PR DESCRIPTION
Resolves #5466

`ChunkOrientedStepBuilder#addAsStreamAndListener` registered an item handler as a listener in two non-exclusive branches: once as the raw object (`instanceof StepListener`) and once as a `StepListenerFactoryBean` proxy (`isListener(...)`). Since `AbstractListenerFactoryBean#getObject` resolves callbacks by interface as well as by annotation, an item handler that implements a listener interface **and** has a listener-annotated method was registered twice, and every interface callback fired twice per item.

This change registers through `StepListenerFactoryBean` only, restoring the 5.2.x behavior of `SimpleStepBuilder#registerAsStreamsAndListeners`:

- `isListener(...)` already returns `true` for interface-only implementations, and
- `getObject()` returns the delegate unchanged when no annotated methods are present (`synthetic == false`), so interface-only handlers are still registered as before.

The added integration test fails on `main` with `expected: <1> but was: <2>` for `beforeProcess`/`afterProcess` counts and passes with this fix.
