### PR TITLE
Add missing StepListenerMetaData entry for @OnChunkError

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/listener/StepListenerMetaData.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/listener/StepListenerMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2002-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.batch.core.annotation.BeforeProcess;
 import org.springframework.batch.core.annotation.BeforeRead;
 import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.core.annotation.BeforeWrite;
+import org.springframework.batch.core.annotation.OnChunkError;
 import org.springframework.batch.core.annotation.OnProcessError;
 import org.springframework.batch.core.annotation.OnReadError;
 import org.springframework.batch.core.annotation.OnSkipInProcess;
@@ -59,6 +60,8 @@ public enum StepListenerMetaData implements ListenerMetaData {
 	AFTER_CHUNK("afterChunk", "after-chunk-method", AfterChunk.class, ChunkListener.class, Chunk.class),
 	AFTER_CHUNK_ERROR("afterChunkError", "after-chunk-error-method", AfterChunkError.class, ChunkListener.class,
 			ChunkContext.class),
+	ON_CHUNK_ERROR("onChunkError", "on-chunk-error-method", OnChunkError.class, ChunkListener.class, Exception.class,
+			Chunk.class),
 	BEFORE_READ("beforeRead", "before-read-method", BeforeRead.class, ItemReadListener.class),
 	AFTER_READ("afterRead", "after-read-method", AfterRead.class, ItemReadListener.class, Object.class),
 	ON_READ_ERROR("onReadError", "on-read-error-method", OnReadError.class, ItemReadListener.class, Exception.class),

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/listener/StepListenerFactoryBeanTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/listener/StepListenerFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2002-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.batch.core.annotation.BeforeProcess;
 import org.springframework.batch.core.annotation.BeforeRead;
 import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.core.annotation.BeforeWrite;
+import org.springframework.batch.core.annotation.OnChunkError;
 import org.springframework.batch.core.annotation.OnProcessError;
 import org.springframework.batch.core.annotation.OnReadError;
 import org.springframework.batch.core.annotation.OnWriteError;
@@ -87,6 +88,7 @@ class StepListenerFactoryBeanTests {
 		((ChunkListener) listener).beforeChunk((ChunkContext) null);
 		((ChunkListener) listener).afterChunk((ChunkContext) null);
 		((ChunkListener) listener).afterChunkError(new ChunkContext(null));
+		((ChunkListener<String, Integer>) listener).onChunkError(new Exception(), writeItems);
 		((ItemReadListener<String>) listener).beforeRead();
 		((ItemReadListener<String>) listener).afterRead(readItem);
 		((ItemReadListener<String>) listener).onReadError(new Exception());
@@ -103,6 +105,7 @@ class StepListenerFactoryBeanTests {
 		assertTrue(testListener.beforeChunkCalled);
 		assertTrue(testListener.afterChunkCalled);
 		assertTrue(testListener.afterChunkErrorCalled);
+		assertTrue(testListener.onChunkErrorCalled);
 		assertTrue(testListener.beforeReadCalled);
 		assertTrue(testListener.afterReadCalled);
 		assertTrue(testListener.onReadErrorCalled);
@@ -320,6 +323,8 @@ class StepListenerFactoryBeanTests {
 
 		boolean afterChunkErrorCalled = false;
 
+		boolean onChunkErrorCalled = false;
+
 		boolean beforeReadCalled = false;
 
 		boolean afterReadCalled = false;
@@ -367,6 +372,11 @@ class StepListenerFactoryBeanTests {
 		@AfterChunkError
 		public void afterChunkError(ChunkContext context) {
 			afterChunkErrorCalled = true;
+		}
+
+		@OnChunkError
+		public void onChunkError(Exception exception, Chunk<Integer> chunk) {
+			onChunkErrorCalled = true;
 		}
 
 		@BeforeRead


### PR DESCRIPTION
Resolves #5468

The parameter types follow `ON_WRITE_ERROR`, which has the same `(Exception, Chunk)` shape. No other change was needed: `ChunkOrientedStepBuilder#listener(Object)` already scans for the annotation and `StepListenerFactoryBean` reads `StepListenerMetaData.values()`.

## Points for review

- The new constant sits after `AFTER_CHUNK_ERROR` to keep the chunk callbacks together, which shifts the ordinals below it. Nothing reads the ordinal, but say the word if you would rather have it appended at the end.
- `taskletListenerMetaData()` is untouched. It feeds the XML namespace for `TaskletStep`, which calls `afterChunkError(ChunkContext)` and not `onChunkError`. Happy to expose `on-chunk-error-method` there too if you want it in the namespace.
- `@AfterChunkError` on a chunk-oriented step stays broken: `listener(Object)` does not scan for it. Since it maps to a method deprecated for removal in 6.2 that `ChunkOrientedStep` never calls, wiring it up seemed like the wrong direction. Noted in the issue rather than fixed here.

## Verification

Besides the unit test in the diff, the reproducer from #5468 was re-run against a locally built `6.0.5-SNAPSHOT`:

```text
[DIAG] @OnChunkError = [annotation:beforeChunk, annotation:afterChunk, annotation:beforeChunk, annotation:onChunkError]
```
