### PR TITLE
Deprecate `setRepository` in `RepositoryItemWriter`

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/RepositoryItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/RepositoryItemWriter.java
@@ -89,9 +89,12 @@ public class RepositoryItemWriter<T> implements ItemWriter<T>, InitializingBean 
 
 	/**
 	 * Set the {@link org.springframework.data.repository.CrudRepository} implementation
-	 * for persistence
+	 * for persistence.
 	 * @param repository the Spring Data repository to be set
+	 * @deprecated since 6.1 in favor of passing the repository to the constructor.
+	 * Scheduled for removal in 7.0.
 	 */
+	@Deprecated(since = "6.1", forRemoval = true)
 	public void setRepository(CrudRepository<T, ?> repository) {
 		this.repository = repository;
 	}

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/RepositoryItemWriterBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/builder/RepositoryItemWriterBuilder.java
@@ -62,10 +62,9 @@ public class RepositoryItemWriterBuilder<T> {
 
 	/**
 	 * Set the {@link org.springframework.data.repository.CrudRepository} implementation
-	 * for persistence
+	 * for persistence.
 	 * @param repository the Spring Data repository to be set
 	 * @return The current instance of the builder.
-	 * @see RepositoryItemWriter#setRepository(CrudRepository)
 	 */
 	public RepositoryItemWriterBuilder<T> repository(CrudRepository<T, ?> repository) {
 		this.repository = repository;
@@ -74,11 +73,10 @@ public class RepositoryItemWriterBuilder<T> {
 	}
 
 	/**
-	 * Specifies a repository and the type-safe method to call for the writer. The method
-	 * configured via this mechanism must take
-	 * {@link org.springframework.data.domain.Pageable} as the <em>last</em> argument.
-	 * This method can be used in place of {@link #repository(CrudRepository)},
-	 * {@link #methodName(String)}}.
+	 * Specifies a repository and the type-safe method to call for the writer. The
+	 * selected method must accept the item type as its <em>sole</em> argument. This
+	 * method can be used in place of {@link #repository(CrudRepository)},
+	 * {@link #methodName(String)}.
 	 * <p>
 	 * Note: The repository that is used by the repositoryMethodReference must be
 	 * non-final.
@@ -86,7 +84,6 @@ public class RepositoryItemWriterBuilder<T> {
 	 * method for use by the writer.
 	 * @return The current instance of the builder.
 	 * @see RepositoryItemWriter#setMethodName(String)
-	 * @see RepositoryItemWriter#setRepository(CrudRepository)
 	 *
 	 */
 	public RepositoryItemWriterBuilder<T> repository(
@@ -110,7 +107,6 @@ public class RepositoryItemWriterBuilder<T> {
 		Assert.notNull(this.repository, "repository is required.");
 
 		RepositoryItemWriter<T> writer = new RepositoryItemWriter<>(this.repository);
-		writer.setRepository(this.repository);
 		if (this.methodName != null) {
 			Assert.hasText(this.methodName, "methodName must not be empty.");
 			writer.setMethodName(this.methodName);

--- a/spring-batch-samples/src/main/resources/org/springframework/batch/samples/jpa/job/repository.xml
+++ b/spring-batch-samples/src/main/resources/org/springframework/batch/samples/jpa/job/repository.xml
@@ -42,8 +42,8 @@
 
 	<bean id="itemWriter"
 		class="org.springframework.batch.infrastructure.item.data.RepositoryItemWriter">
+		<constructor-arg name="repository" ref="customerCreditCrudRepository"/>
 		<property name="methodName" value="save"/>
-		<property name="repository" ref="customerCreditCrudRepository"/>
 	</bean>
 	
 	<bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">


### PR DESCRIPTION
Similar to #5472, `RepositoryItemWriter(CrudRepository<T, ?>)` was added as part of 21af80d6, making it the main code path for specifying the `repository`.

For this reason, the corresponding setter can be deprecated for removal.