### PR TITLE
Fix the tracing example in the reference documentation

### DIFF
--- a/spring-batch-docs/modules/ROOT/pages/spring-batch-observability/micrometer.adoc
+++ b/spring-batch-docs/modules/ROOT/pages/spring-batch-observability/micrometer.adoc
@@ -89,8 +89,9 @@ public class MyTimedTasklet implements Tasklet {
 == Tracing
 
 As of version 5, Spring Batch provides tracing through Micrometer's `Observation` API. By default, tracing is disabled.
-To enable it, you need to define an `ObservationRegistry` bean configured with an `ObservationHandler` that supports tracing,
-such as `TracingAwareMeterObservationHandler`:
+To enable it, you need to define an `ObservationRegistry` bean configured with a `TracingObservationHandler`,
+such as `DefaultTracingObservationHandler`. The following example registers it next to the metrics handler
+shown above, so that the same registry collects both metrics and traces:
 
 [source, java]
 ----
@@ -99,10 +100,15 @@ public ObservationRegistry observationRegistry(MeterRegistry meterRegistry, Trac
     DefaultMeterObservationHandler observationHandler = new DefaultMeterObservationHandler(meterRegistry);
     ObservationRegistry observationRegistry = ObservationRegistry.create();
     observationRegistry.observationConfig()
+            .observationHandler(new DefaultTracingObservationHandler(tracer))
             .observationHandler(new TracingAwareMeterObservationHandler<>(observationHandler, tracer));
     return observationRegistry;
 }
 ----
+
+NOTE: `TracingAwareMeterObservationHandler` does not create spans. It wraps a `MeterObservationHandler` to make
+tracing data available to it (for exemplars, for example), so it requires a `TracingObservationHandler` to be
+registered as well.
 
 With that in place, Spring Batch will create a trace for each job execution and a span for each step execution.
 


### PR DESCRIPTION
Resolves #5475

The example now registers a `DefaultTracingObservationHandler`, and the sentence above it no longer presents `TracingAwareMeterObservationHandler` as a handler that supports tracing on its own.

I kept the metrics handler in the example rather than replacing it, because both sections define a bean named `observationRegistry`: a tracing-only snippet here would quietly drop the metrics from the section above. Happy to reduce it to the tracing handler alone if you prefer the shorter example.

Handler order is not a requirement, the reversed order produced the same spans and meters, but I registered the tracing handler first to match `TracingAndMeterObservationHandlerGroup` in Spring Boot.
