### PR TITLE
Add `PageableItemReader`

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/PageableItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/data/PageableItemReader.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.infrastructure.item.data;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.batch.infrastructure.item.support.AbstractItemCountingItemStreamItemReader;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.util.Assert;
+
+/**
+ * A paging {@link ItemReader} that reads records by applying a query function to a
+ * {@link Pageable}.
+ * <p>
+ * Performance of the reader is dependent on the query implementation, however setting a
+ * reasonably large page size and matching that to the commit interval should yield better
+ * performance.
+ * <p>
+ * The reader must be configured with a query function, {@linkplain Sort sort parameters},
+ * and a pageSize greater than 0.
+ * <p>
+ * This implementation is thread-safe between calls to {@link #open(ExecutionContext)},
+ * but remember to use {@code saveState=false} if used in a multi-threaded client (no
+ * restart available).
+ * <p>
+ * It is important to note that this is a paging item reader and exceptions that are
+ * thrown while reading the page itself (e.g., mapping results to objects in the
+ * {@link PageableItemReader#doPageRead()}) will not be skippable since this reader has no
+ * way of knowing if an exception should be skipped and therefore will continue to read
+ * the same page until the skip limit is exceeded.
+ * <p>
+ * NOTE: The {@code PageableItemReader} only reads Java Objects, i.e., non primitives.
+ *
+ * @author Stefano Cordio
+ * @since 6.1
+ */
+public class PageableItemReader<T> extends AbstractItemCountingItemStreamItemReader<T> {
+
+	protected Log logger = LogFactory.getLog(getClass());
+
+	private final int pageSize;
+
+	private final Function<Pageable, ? extends Slice<? extends T>> query;
+
+	private final Sort sort;
+
+	private int page = 0;
+
+	private int current = 0;
+
+	private @Nullable List<? extends T> results;
+
+	private final Lock lock = new ReentrantLock();
+
+	/**
+	 * Create a new {@link PageableItemReader}.
+	 * @param pageSize the number of items to retrieve per page. Must be greater than 0.
+	 * @param query a function that accepts a {@link Pageable} and returns a {@link Slice}
+	 * of items
+	 * @param sorts the sort parameters to use when building the {@link PageRequest}. Must
+	 * not be empty. Use a {@link java.util.LinkedHashMap} for multiple entries to
+	 * preserve sort order.
+	 * @since 6.1
+	 */
+	public PageableItemReader(int pageSize, Function<Pageable, ? extends Slice<? extends T>> query,
+			Map<String, Direction> sorts) {
+		Assert.isTrue(pageSize > 0, "'pageSize' must be greater than 0");
+		Assert.notNull(query, "'query' cannot be null");
+		Assert.notEmpty(sorts, "'sorts' must not be empty");
+		this.pageSize = pageSize;
+		this.query = query;
+		this.sort = Sort.by(sorts.entrySet().stream().map(PageableItemReader::createOrder).toList());
+	}
+
+	private static Order createOrder(Entry<String, Direction> entry) {
+		return new Order(entry.getValue(), entry.getKey());
+	}
+
+	@Override
+	protected @Nullable T doRead() throws Exception {
+
+		lock.lock();
+		try {
+			boolean nextPageNeeded = (results != null && current >= results.size());
+
+			if (results == null || nextPageNeeded) {
+
+				if (logger.isDebugEnabled()) {
+					logger.debug("Reading page " + page);
+				}
+
+				results = doPageRead();
+				page++;
+
+				if (results.isEmpty()) {
+					return null;
+				}
+
+				if (nextPageNeeded) {
+					current = 0;
+				}
+			}
+
+			if (current < results.size()) {
+				T item = results.get(current);
+				current++;
+				return item;
+			}
+			return null;
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Performs the actual reading of a page by applying the configured query. Available
+	 * for overriding as needed.
+	 * @return the list of items that make up the page
+	 */
+	protected List<? extends T> doPageRead() {
+		PageRequest pageRequest = PageRequest.of(page, pageSize, sort);
+		return query.apply(pageRequest).getContent();
+	}
+
+	@Override
+	protected void doOpen() throws Exception {
+	}
+
+	@Override
+	protected void doClose() throws Exception {
+		lock.lock();
+		try {
+			current = 0;
+			page = 0;
+			results = null;
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	protected void jumpToItem(int itemLastIndex) throws Exception {
+		lock.lock();
+		try {
+			page = itemLastIndex / pageSize;
+			current = itemLastIndex % pageSize;
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+}

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/PageableItemReaderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/data/PageableItemReaderTests.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.batch.infrastructure.item.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentCaptor.captor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PageableItemReaderTests {
+
+	private final Map<String, Direction> sorts = Map.of("id", Direction.ASC);
+
+	@Test
+	void testDoReadFirstReadNoResults() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(1, query, this.sorts);
+		ArgumentCaptor<Pageable> captor = captor();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(new ArrayList<>()));
+
+		assertNull(reader.doRead());
+
+		assertThat(captor.getValue()).isEqualTo(PageRequest.of(0, 1, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testDoReadFirstReadResults() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(1, query, this.sorts);
+		ArgumentCaptor<Pageable> captor = captor();
+		Object result = new Object();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(List.of(result)));
+
+		assertEquals(result, reader.doRead());
+
+		assertThat(captor.getValue()).isEqualTo(PageRequest.of(0, 1, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testDoReadFirstReadSecondPage() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(1, query, this.sorts);
+		ArgumentCaptor<Pageable> captor = captor();
+		Object result = new Object();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(List.of(new Object())))
+			.thenReturn(new PageImpl<>(List.of(result)));
+
+		assertNotSame(result, reader.doRead());
+		assertEquals(result, reader.doRead());
+
+		assertThat(captor.getAllValues()).containsExactly(PageRequest.of(0, 1, Sort.by(Direction.ASC, "id")),
+				PageRequest.of(1, 1, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testDoReadFirstReadExhausted() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(1, query, this.sorts);
+		ArgumentCaptor<Pageable> captor = captor();
+		Object result = new Object();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(List.of(new Object())))
+			.thenReturn(new PageImpl<>(List.of(result)))
+			.thenReturn(new PageImpl<>(emptyList()));
+
+		assertNotSame(result, reader.doRead());
+		assertEquals(result, reader.doRead());
+		assertNull(reader.doRead());
+
+		assertThat(captor.getAllValues()).containsExactly(PageRequest.of(0, 1, Sort.by(Direction.ASC, "id")),
+				PageRequest.of(1, 1, Sort.by(Direction.ASC, "id")), PageRequest.of(2, 1, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testJumpToItem() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(100, query, this.sorts);
+		List<Object> objectList = fillWithNewObjects(100);
+		ArgumentCaptor<Pageable> captor = captor();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(objectList));
+
+		reader.jumpToItem(485);
+		verify(query, never()).apply(any(Pageable.class));
+
+		Object item = reader.doRead();
+
+		assertSame(objectList.get(85), item, "Fetched object should be at index 85 in the current page");
+		assertThat(captor.getValue()).isEqualTo(PageRequest.of(4, 100, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testJumpToItemFirstItemOnPage() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(50, query, this.sorts);
+		List<Object> objectList = fillWithNewObjects(50);
+		ArgumentCaptor<Pageable> captor = captor();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(objectList));
+
+		reader.jumpToItem(150);
+		verify(query, never()).apply(any(Pageable.class));
+
+		assertSame(objectList.get(0), reader.doRead(), "Fetched object should be the first one in the current page");
+		assertThat(captor.getValue()).isEqualTo(PageRequest.of(3, 50, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testPageSizeFromConstructor() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(5, query, this.sorts);
+		ArgumentCaptor<Pageable> captor = captor();
+
+		when(query.apply(captor.capture())).thenReturn(new PageImpl<>(List.of(new Object())));
+
+		reader.doRead();
+
+		assertThat(captor.getValue()).isEqualTo(PageRequest.of(0, 5, Sort.by(Direction.ASC, "id")));
+	}
+
+	@Test
+	void testEmptySortsNotAllowed() {
+		assertThrows(IllegalArgumentException.class, () -> new PageableItemReader<>(1, mock(), Map.of()));
+	}
+
+	@Test
+	void testWithQueryProducingSliceItemSubclass() throws Exception {
+		Function<Pageable, Slice<String>> query = pageable -> new SliceImpl<>(List.of("result"));
+		PageableItemReader<CharSequence> reader = new PageableItemReader<>(1, query, this.sorts);
+
+		assertEquals("result", reader.doRead());
+	}
+
+	@Test
+	void testSettingCurrentItemCountExplicitly() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(2, query, this.sorts);
+
+		when(query.apply(PageRequest.of(1, 2, Sort.by(Direction.ASC, "id"))))
+			.thenReturn(new PageImpl<>(List.of("3", "4")));
+		when(query.apply(PageRequest.of(2, 2, Sort.by(Direction.ASC, "id"))))
+			.thenReturn(new PageImpl<>(List.of("5", "6")));
+
+		reader.setCurrentItemCount(3);
+		reader.open(new ExecutionContext());
+
+		Object result = reader.read();
+
+		assertEquals("4", result);
+		assertEquals("5", reader.read());
+		assertEquals("6", reader.read());
+	}
+
+	@Test
+	void testSettingCurrentItemCountRestart() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(2, query, this.sorts);
+
+		when(query.apply(PageRequest.of(1, 2, Sort.by(Direction.ASC, "id"))))
+			.thenReturn(new PageImpl<>(List.of("3", "4")));
+		when(query.apply(PageRequest.of(2, 2, Sort.by(Direction.ASC, "id"))))
+			.thenReturn(new PageImpl<>(List.of("5", "6")));
+
+		reader.setCurrentItemCount(3);
+		ExecutionContext executionContext = new ExecutionContext();
+		reader.open(executionContext);
+
+		Object result = reader.read();
+		reader.update(executionContext);
+		reader.close();
+
+		assertEquals("4", result);
+
+		reader.open(executionContext);
+		assertEquals("5", reader.read());
+		assertEquals("6", reader.read());
+	}
+
+	@Test
+	void testResetOfPage() throws Exception {
+		Function<Pageable, Slice<Object>> query = mock();
+		PageableItemReader<Object> reader = new PageableItemReader<>(2, query, this.sorts);
+
+		when(query.apply(PageRequest.of(0, 2, Sort.by(Direction.ASC, "id"))))
+			.thenReturn(new PageImpl<>(List.of("1", "2")));
+		when(query.apply(PageRequest.of(1, 2, Sort.by(Direction.ASC, "id"))))
+			.thenReturn(new PageImpl<>(List.of("3", "4")));
+
+		ExecutionContext executionContext = new ExecutionContext();
+		reader.open(executionContext);
+
+		Object result = reader.read();
+		reader.close();
+
+		assertEquals("1", result);
+
+		reader.open(executionContext);
+		assertEquals("1", reader.read());
+		assertEquals("2", reader.read());
+		assertEquals("3", reader.read());
+	}
+
+	private static List<Object> fillWithNewObjects(int nb) {
+		List<Object> result = new ArrayList<>();
+		for (int i = 0; i < nb; i++) {
+			result.add(new TestItem(i));
+		}
+		return result;
+	}
+
+	private static class TestItem {
+
+		private final int myIndex;
+
+		TestItem(int myIndex) {
+			this.myIndex = myIndex;
+		}
+
+		@Override
+		public String toString() {
+			return "TestItem at index " + myIndex;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR adds `PageableItemReader`, a type-safe `RepositoryItemReader` alternative that uses a `Function<Pageable, Slice<?>>` instead of the reflection-based strategy for query invocation.

`PageableItemReader` is deliberately designed after `RepositoryItemReader` in its paging, restart, and locking behavior. However, it favors constructor parameters instead of setters for mandatory configuration.

In addition, compared to `RepositoryItemReader`, there are two improvements:
* Precomputes `org.springframework.data.domain.Sort` at construction time instead of inside `doPageRead()`
* Simplifies concurrency by relying only on lock-based visibility/atomicity, as `volatile` field modifiers were redundant with the existing `ReentrantLock`

Such improvements could also be applied to `RepositoryItemReader`, but I preferred keeping this PR focused on the new class. Please let me know if `RepositoryItemReader` should get the same; I'll be happy to raise a separate PR for it.

Please note that I preferred introducing a dedicated reader rather than enhancing `RepositoryItemReader` to support both use cases (following the rationale at https://github.com/spring-projects/spring-batch/issues/4484#issuecomment-3376323307). However, in case enhancing `RepositoryItemReader` would be preferred, let me know and I'll take care of the changes.

### Open Points

There are at least two more things to do:

- [ ] Add `PageableItemReader` to the documentation
- [ ] Deprecate `RepositoryItemReader` in favor of `PageableItemReader`?

However, before starting, I'd like a preliminary feedback to make sure I'm going in the right direction.

---

* Closes #910