### PR TITLE
Allow tasklets to run without transaction synchronization

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/step/tasklet/TaskletStep.java
@@ -272,13 +272,21 @@ public class TaskletStep extends AbstractStep {
 				interruptionPolicy.checkInterrupted(stepExecution);
 
 				RepeatStatus result;
+				ChunkTransactionCallback callback = new ChunkTransactionCallback(chunkContext, semaphore);
 				try {
-					result = new TransactionTemplate(transactionManager, transactionAttribute)
-						.execute(new ChunkTransactionCallback(chunkContext, semaphore));
+					result = new TransactionTemplate(transactionManager, transactionAttribute).execute(callback);
 				}
 				catch (UncheckedTransactionException e) {
 					// Allow checked exceptions to be thrown inside callback
 					throw (Exception) e.getCause();
+				}
+				finally {
+					// When transaction synchronization is not active (e.g. with a
+					// transaction manager configured with SYNCHRONIZATION_NEVER or
+					// SYNCHRONIZATION_ON_ACTUAL_TRANSACTION and no actual
+					// transaction), the afterCompletion callback is never invoked,
+					// so release the lock here, after the commit/rollback.
+					callback.releaseLockIfHeld();
 				}
 
 				chunkListener.afterChunk(chunkContext);
@@ -382,17 +390,22 @@ public class TaskletStep extends AbstractStep {
 			finally {
 				// Only release the lock if we acquired it, and release as late
 				// as possible
-				if (locked) {
-					semaphore.release();
-				}
+				releaseLockIfHeld();
+			}
+		}
 
+		private void releaseLockIfHeld() {
+			if (locked) {
+				semaphore.release();
 				locked = false;
 			}
 		}
 
 		@Override
 		public RepeatStatus doInTransaction(TransactionStatus status) {
-			TransactionSynchronizationManager.registerSynchronization(this);
+			if (TransactionSynchronizationManager.isSynchronizationActive()) {
+				TransactionSynchronizationManager.registerSynchronization(this);
+			}
 
 			RepeatStatus result = RepeatStatus.CONTINUABLE;
 

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/step/item/TaskletStepExceptionTests.java
@@ -39,8 +39,11 @@ import org.springframework.batch.infrastructure.support.transaction.Resourceless
 import org.jspecify.annotations.Nullable;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -90,6 +93,30 @@ class TaskletStepExceptionTests {
 		taskletStep.execute(stepExecution);
 		assertEquals(FAILED, stepExecution.getStatus());
 		assertEquals(FAILED.toString(), stepExecution.getExitStatus().getExitCode());
+	}
+
+	@Test
+	void testTaskletRunsWithoutTransactionSynchronization() throws Exception {
+		ResourcelessTransactionManager transactionManager = new ResourcelessTransactionManager();
+		transactionManager.setTransactionSynchronization(AbstractPlatformTransactionManager.SYNCHRONIZATION_NEVER);
+		taskletStep.setTransactionManager(transactionManager);
+		taskletStep.setTasklet((contribution, chunkContext) -> RepeatStatus.FINISHED);
+		taskletStep.execute(stepExecution);
+		assertEquals(COMPLETED, stepExecution.getStatus());
+	}
+
+	@Test
+	void testTaskletRepeatsWithoutTransactionSynchronization() throws Exception {
+		ResourcelessTransactionManager transactionManager = new ResourcelessTransactionManager();
+		transactionManager.setTransactionSynchronization(AbstractPlatformTransactionManager.SYNCHRONIZATION_NEVER);
+		taskletStep.setTransactionManager(transactionManager);
+		AtomicInteger executions = new AtomicInteger();
+		taskletStep.setTasklet((contribution, chunkContext) -> executions.incrementAndGet() < 2
+				? RepeatStatus.CONTINUABLE : RepeatStatus.FINISHED);
+		taskletStep.execute(stepExecution);
+		assertEquals(COMPLETED, stepExecution.getStatus());
+		assertEquals(2, executions.get());
+		assertEquals(2, stepExecution.getCommitCount());
 	}
 
 	@Test


### PR DESCRIPTION
Resolves gh-4912

## Summary

`TaskletStep$ChunkTransactionCallback.doInTransaction` called
`TransactionSynchronizationManager.registerSynchronization(this)`
unconditionally. When the configured transaction manager does not
activate transaction synchronization (e.g. `SYNCHRONIZATION_NEVER`, or
`SYNCHRONIZATION_ON_ACTUAL_TRANSACTION` without an actual
transaction), this throws `IllegalStateException: Transaction
synchronization is not active` and fails the step.

This PR:

- Registers the chunk transaction synchronization only when
  `TransactionSynchronizationManager.isSynchronizationActive()`.
- Releases the step execution lock after the transaction completes
  when the `afterCompletion` callback can never fire. Without this, a
  repeating tasklet would hang on the next chunk because the lock is
  only released in `afterCompletion`.

## Tests

- `testTaskletRunsWithoutTransactionSynchronization`: a tasklet step
  completes with a transaction manager configured with
  `SYNCHRONIZATION_NEVER`.
- `testTaskletRepeatsWithoutTransactionSynchronization`: a
  `CONTINUABLE` tasklet runs to completion in the same configuration
  (guards against the lock-release hang).