### PR TITLE
Update Apache Artemis groupId to org.apache.artemis

### DIFF
--- a/spring-batch-infrastructure/pom.xml
+++ b/spring-batch-infrastructure/pom.xml
@@ -393,7 +393,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-server</artifactId>
 			<version>${artemis.version}</version>
 			<scope>test</scope>
@@ -405,7 +405,7 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-jakarta-client</artifactId>
 			<version>${artemis.version}</version>
 			<scope>test</scope>

--- a/spring-batch-integration/pom.xml
+++ b/spring-batch-integration/pom.xml
@@ -124,13 +124,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-server</artifactId>
 			<version>${artemis.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-jakarta-client</artifactId>
 			<version>${artemis.version}</version>
 			<scope>test</scope>

--- a/spring-batch-samples/pom.xml
+++ b/spring-batch-samples/pom.xml
@@ -89,12 +89,12 @@
 			<version>${jakarta.inject-api.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-jakarta-client</artifactId>
 			<version>${artemis.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-server</artifactId>
 			<version>${artemis.version}</version>
 		</dependency>


### PR DESCRIPTION
Updated the Maven dependency `groupId` for Apache Artemis modules:
- Old: `org.apache.activemq`
- New: `org.apache.artemis`

Reference: https://artemis.apache.org/artemis-tlp-groupid-migration