### PR TITLE
Fix incorrect nullability contract for encoding in StaxEventItemReader

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemReader.java
@@ -154,7 +154,7 @@ public class StaxEventItemReader<T> extends AbstractItemCountingItemStreamItemRe
 	 * @param encoding the encoding to be used. Can be {@code null}, in which case, the
 	 * XML event reader will attempt to auto-detect the encoding from tht input file.
 	 */
-	public void setEncoding(String encoding) {
+	public void setEncoding(@Nullable String encoding) {
 		this.encoding = encoding;
 	}
 

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/builder/StaxEventItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/builder/StaxEventItemReaderBuilder.java
@@ -66,7 +66,7 @@ public class StaxEventItemReaderBuilder<T> {
 
 	private XMLInputFactory xmlInputFactory = StaxUtils.createDefensiveInputFactory();
 
-	private String encoding = StaxEventItemReader.DEFAULT_ENCODING;
+	private @Nullable String encoding = StaxEventItemReader.DEFAULT_ENCODING;
 
 	/**
 	 * Configure if the state of the {@link ItemStreamSupport} should be persisted within
@@ -202,7 +202,7 @@ public class StaxEventItemReaderBuilder<T> {
 	 * @return the current instance of the builder
 	 * @see StaxEventItemReader#setEncoding(String)
 	 */
-	public StaxEventItemReaderBuilder<T> encoding(String encoding) {
+	public StaxEventItemReaderBuilder<T> encoding(@Nullable String encoding) {
 		this.encoding = encoding;
 
 		return this;


### PR DESCRIPTION
The encoding can be null Based on the Javadoc but Jspecify gives a warning when passing null. Which is confusing

this is my first Contribution to Spring Batch so please tell me if i forget something.
