### PR TITLE
GH-5486: Fix NPE in JpaCursorItemReader.doClose() when reader was nev…

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JpaCursorItemReader.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/database/JpaCursorItemReader.java
@@ -174,7 +174,9 @@ public class JpaCursorItemReader<T> extends AbstractItemCountingItemStreamItemRe
 	@SuppressWarnings("DataFlowIssue")
 	@Override
 	protected void doClose() {
-		this.entityManager.close();
+		if (this.entityManager != null) {
+			this.entityManager.close();
+		}
 	}
 
 }


### PR DESCRIPTION
…er opened
`entityManager` is only assigned in `doOpen()` and is `@Nullable`, but
`doClose()` called `entityManager.close()` with no null check. Spring
calls `close()` on every singleton `ItemReader` bean at context
shutdown regardless of whether its step ran, causing an NPE wrapped
as `ItemStreamException` for readers that were never opened.

The check was accidentally dropped in 551e26d when `@Nullable` was
added without preserving the runtime guard.

Fixes #5486

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
* Sign-off commits according to the [Developer Certificate of Origin](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring)

For more details, please check the [contributor guide][1].
Thank you upfront!

