### PR TITLE
Fix QName deserialization in JacksonExecutionContextStringSerializer

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JacksonExecutionContextStringSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JacksonExecutionContextStringSerializer.java
@@ -56,7 +56,7 @@ public class JacksonExecutionContextStringSerializer implements ExecutionContext
 			.allowIfSubType("java.math.")
 			.allowIfSubType("java.time.")
 			.allowIfSubType("java.net.")
-			.allowIfSubType("javax.xml.")
+			.allowIfSubType("javax.xml.namespace.QName")
 			.allowIfSubType("org.springframework.batch.")
 			.build();
 		this.jsonMapper = JsonMapper.builder().activateDefaultTyping(polymorphicTypeValidator).build();

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JacksonExecutionContextStringSerializer.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/dao/JacksonExecutionContextStringSerializer.java
@@ -36,6 +36,7 @@ import org.springframework.batch.core.repository.ExecutionContextSerializer;
  * provide your own {@link JsonMapper} instance through the constructor.
  *
  * @author Mahmoud Ben Hassine
+ * @author Soonjae Jung
  * @since 6.0.0
  */
 public class JacksonExecutionContextStringSerializer implements ExecutionContextSerializer {
@@ -55,7 +56,7 @@ public class JacksonExecutionContextStringSerializer implements ExecutionContext
 			.allowIfSubType("java.math.")
 			.allowIfSubType("java.time.")
 			.allowIfSubType("java.net.")
-			.allowIfSubType("java.xml.")
+			.allowIfSubType("javax.xml.")
 			.allowIfSubType("org.springframework.batch.")
 			.build();
 		this.jsonMapper = JsonMapper.builder().activateDefaultTyping(polymorphicTypeValidator).build();

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JacksonExecutionContextStringSerializerTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/dao/JacksonExecutionContextStringSerializerTests.java
@@ -26,6 +26,8 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.namespace.QName;
+
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -34,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Mahmoud Ben Hassine
+ * @author Soonjae Jung
  */
 class JacksonExecutionContextStringSerializerTests {
 
@@ -94,6 +97,25 @@ class JacksonExecutionContextStringSerializerTests {
 		// then
 		LocalDate deserializedNow = (LocalDate) deserializedContext.get("now");
 		assertEquals(now, deserializedNow);
+	}
+
+	@Test
+	void testQNameSerialization() throws IOException {
+		// given
+		JacksonExecutionContextStringSerializer serializer = new JacksonExecutionContextStringSerializer();
+		Map<String, Object> context = new HashMap<>();
+		QName qName = new QName("https://www.springframework.org/batch", "element");
+		context.put("qName", qName);
+
+		// when
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		serializer.serialize(context, outputStream);
+		InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+		Map<String, Object> deserializedContext = serializer.deserialize(inputStream);
+
+		// then
+		QName deserializedQName = (QName) deserializedContext.get("qName");
+		assertEquals(qName, deserializedQName);
 	}
 
 }


### PR DESCRIPTION
`JacksonExecutionContextStringSerializer` allows `java.xml.` in its `BasicPolymorphicTypeValidator`. But `java.xml` is a JPMS module name, not a package. The JDK package is `javax.xml.`, so the entry matches nothing and every `javax.xml.*` type is denied.

The type this hits is `javax.xml.namespace.QName`, which Spring Batch writes to the execution context itself. With `saveState` enabled, `StaxEventItemWriter` stores the elements its header callback left open as a `List<QName>`, and reads them back in `open()`.

Serialization succeeds, so the run completes normally. Only the restart fails, with `InvalidTypeIdException ... denied resolution`.

Both other serializers allow the class deliberately: `Jackson2ExecutionContextStringSerializer` since 398d52a5, which fixed #4044, and `DefaultExecutionContextSerializer` since 46768dc7.

The change is one line, `java.xml.` to `javax.xml.`. The added test round-trips a `QName` through the serializer. It fails on `main` with the exception above and passes with the change. The `spring-batch-infrastructure`, `spring-batch-core`, `spring-batch-test` and `spring-batch-integration` suites all pass.

If you would rather match the other two serializers exactly, `allowIfSubType("javax.xml.namespace.QName")` also works and I am happy to change it.

The same line is present in `v6.0.0` and on `6.0.x`, so I have left the backport judgement to you.

Related to but distinct from #4697. That issue is about the deprecated `Jackson2ExecutionContextStringSerializer` dropping a `QName` prefix. That behaviour is unchanged here and I will follow up there separately.
