### PR TITLE
Check only the last execution when restarting a job instance

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the original author or authors.
+ * Copyright 2022-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.springframework.batch.core.launch.support;
 
 import java.time.Duration;
-import java.util.List;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
@@ -125,65 +124,53 @@ public class TaskExecutorJobLauncher implements JobLauncher, InitializingBean {
 		else { // restart
 			logger.debug(
 					"Found existing job instance for job = " + job.getName() + " with parameters = " + jobParameters);
-			List<JobExecution> executions = jobRepository.getJobExecutions(jobInstance);
-			if (executions.isEmpty()) {
+			JobExecution lastJobExecution = jobRepository.getLastJobExecution(jobInstance);
+			if (lastJobExecution == null) {
 				throw new IllegalStateException("Cannot find any job execution for job instance: " + jobInstance);
 			}
-			else {
-				// check for running executions and find the last started
-				for (JobExecution execution : executions) {
-					if (execution.isRunning()) {
-						throw new JobExecutionAlreadyRunningException(
-								"A job execution for this job is already running: " + jobInstance);
-					}
-					BatchStatus status = execution.getStatus();
-					if (status == BatchStatus.UNKNOWN) {
-						throw new JobRestartException("Cannot restart job from UNKNOWN status. "
-								+ "The last execution ended with a failure that could not be rolled back, "
-								+ "so it may be dangerous to proceed. Manual intervention is probably necessary.");
-					}
-					JobParameters allJobParameters = execution.getJobParameters();
-					JobParameters identifyingJobParameters = new JobParameters(
-							allJobParameters.getIdentifyingParameters());
-					if (status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED) {
-						throw new JobInstanceAlreadyCompleteException(
-								"A job instance already exists and is complete for identifying parameters="
-										+ identifyingJobParameters + ".  If you want to run this job again, "
-										+ "change the parameters.");
-					}
+			// A new execution is only created once these checks pass on the previous one,
+			// so only the last execution can be running or complete.
+			if (lastJobExecution.isRunning()) {
+				throw new JobExecutionAlreadyRunningException(
+						"A job execution for this job is already running: " + jobInstance);
+			}
+			BatchStatus status = lastJobExecution.getStatus();
+			if (status == BatchStatus.UNKNOWN) {
+				throw new JobRestartException("Cannot restart job from UNKNOWN status. "
+						+ "The last execution ended with a failure that could not be rolled back, "
+						+ "so it may be dangerous to proceed. Manual intervention is probably necessary.");
+			}
+			if (status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED) {
+				JobParameters identifyingJobParameters = new JobParameters(
+						lastJobExecution.getJobParameters().getIdentifyingParameters());
+				throw new JobInstanceAlreadyCompleteException(
+						"A job instance already exists and is complete for identifying parameters="
+								+ identifyingJobParameters + ".  If you want to run this job again, "
+								+ "change the parameters.");
+			}
+			// check if the job is restartable
+			if (!job.isRestartable()) {
+				throw new JobRestartException("JobInstance already exists and is not restartable");
+			}
+			/*
+			 * validate here if it has stepExecutions that are UNKNOWN, STARTING, STARTED
+			 * and STOPPING retrieve the previous execution and check
+			 */
+			for (StepExecution execution : lastJobExecution.getStepExecutions()) {
+				BatchStatus stepStatus = execution.getStatus();
+				if (stepStatus.isRunning()) {
+					throw new JobExecutionAlreadyRunningException(
+							"A job execution for this job is already running: " + lastJobExecution);
+				}
+				else if (stepStatus == BatchStatus.UNKNOWN) {
+					throw new JobRestartException(
+							"Cannot restart step [" + execution.getStepName() + "] from UNKNOWN status. "
+									+ "The last execution ended with a failure that could not be rolled back, "
+									+ "so it may be dangerous to proceed. Manual intervention is probably necessary.");
 				}
 			}
 
-			JobExecution lastJobExecution = jobRepository.getLastJobExecution(jobInstance);
-			if (lastJobExecution == null) { // should never happen, already checked above
-				throw new IllegalStateException("A job instance with no job executions exists for job = "
-						+ job.getName() + " and parameters = " + jobParameters);
-			}
-			else {
-				// check if the job is restartable
-				if (!job.isRestartable()) {
-					throw new JobRestartException("JobInstance already exists and is not restartable");
-				}
-				/*
-				 * validate here if it has stepExecutions that are UNKNOWN, STARTING,
-				 * STARTED and STOPPING retrieve the previous execution and check
-				 */
-				for (StepExecution execution : lastJobExecution.getStepExecutions()) {
-					BatchStatus status = execution.getStatus();
-					if (status.isRunning()) {
-						throw new JobExecutionAlreadyRunningException(
-								"A job execution for this job is already running: " + lastJobExecution);
-					}
-					else if (status == BatchStatus.UNKNOWN) {
-						throw new JobRestartException("Cannot restart step [" + execution.getStepName()
-								+ "] from UNKNOWN status. "
-								+ "The last execution ended with a failure that could not be rolled back, "
-								+ "so it may be dangerous to proceed. Manual intervention is probably necessary.");
-					}
-				}
-
-				executionContext = lastJobExecution.getExecutionContext();
-			}
+			executionContext = lastJobExecution.getExecutionContext();
 		}
 
 		// Check the validity of the parameters before creating anything

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperatorTests.java
@@ -27,7 +27,9 @@ import org.springframework.batch.core.configuration.support.MapJobRegistry;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
@@ -39,6 +41,7 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.StepContribution;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
 import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -147,6 +150,54 @@ class TaskExecutorJobOperatorTests {
 
 		Assertions.assertTrue(exception.getMessage().contains("Cannot restart job from UNKNOWN status"),
 				"Expected the UNKNOWN status reason to be surfaced but was: " + exception.getMessage());
+	}
+
+	@Test
+	void testStartWhenLastExecutionIsRunning() {
+		JobParameters jobParameters = new JobParametersBuilder().addString("name", "foo").toJobParameters();
+		JobInstance jobInstance = jobRepository.createJobInstance(job.getName(), jobParameters);
+		// a freshly created execution is in STARTING status, i.e. running
+		jobRepository.createJobExecution(jobInstance, jobParameters, new ExecutionContext());
+
+		Assertions.assertThrows(JobExecutionAlreadyRunningException.class, () -> jobOperator.start(job, jobParameters));
+	}
+
+	@Test
+	void testStartWhenLastExecutionIsComplete() throws Exception {
+		JobParameters jobParameters = new JobParametersBuilder().addString("name", "foo").toJobParameters();
+		JobExecution jobExecution = jobOperator.start(job, jobParameters);
+		Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+
+		Assertions.assertThrows(JobInstanceAlreadyCompleteException.class, () -> jobOperator.start(job, jobParameters));
+	}
+
+	@Test
+	void testRestartAfterSeveralFailedExecutions() throws Exception {
+		Tasklet tasklet = new Tasklet() {
+			int attempts = 0;
+
+			@Override
+			public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+				if (++attempts < 4) {
+					throw new RuntimeException("Planned failure " + attempts);
+				}
+				return RepeatStatus.FINISHED;
+			}
+		};
+		job = new JobBuilder("job", jobRepository)
+			.start(new StepBuilder("step", jobRepository).tasklet(tasklet).build())
+			.build();
+		JobParameters jobParameters = new JobParametersBuilder().addString("name", "foo").toJobParameters();
+
+		// starting the same instance again is a restart
+		JobExecution jobExecution = jobOperator.start(job, jobParameters);
+		for (int i = 0; i < 3; i++) {
+			Assertions.assertEquals(BatchStatus.FAILED, jobExecution.getStatus());
+			jobExecution = jobOperator.start(job, jobParameters);
+		}
+
+		Assertions.assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+		Assertions.assertEquals(4, jobRepository.getJobExecutions(jobExecution.getJobInstance()).size());
 	}
 
 }


### PR DESCRIPTION
Resolves #5495

When a job instance is restarted, `TaskExecutorJobLauncher.createJobExecution` reads the instance history twice: `getJobExecutions(jobInstance)` for the running / `UNKNOWN` / `COMPLETED` / `ABANDONED` checks, then `getLastJobExecution(jobInstance)` for the step checks and the execution context. Since `SimpleJobRepository extends SimpleJobExplorer`, the first call hydrates every past execution with its job instance, step executions and both execution contexts, so the number of statements per launch grows with the number of past executions. Before 6.0 this check lived in `SimpleJobRepository` and went through `jobExecutionDao.findJobExecutions`, which only loaded the job parameters per execution; moving it to the launcher in 90d89595 is where the slope went from one to eight statements per past execution.

This change drops the first read and runs the status checks against the last execution only. A new execution is only created once these checks pass on the previous one, so on the launcher's own path the last execution is the only one that can be running, `UNKNOWN` or `COMPLETED`.

Measured with the reproducer from #5495 (same instance restarted 12 times, statements counted with datasource-proxy on H2), on `main` before and after this change:

```
launch | before | after
     1 |     32 |    32
     2 |     50 |    41
     6 |     82 |    41
    12 |    130 |    41
```

What does change, and I want to be explicit about it: executions that are not the last one are no longer inspected. I built every combination of two past executions (8 statuses in each position) directly through `JobRepository` and compared `main` with this branch. The 35 cases where the older execution is `FAILED` or `STOPPED`, or where there is a single execution, behave identically, including the step status checks, `preventRestart()`, empty identifying parameters and carrying over the last execution context. The 6 cases where the older execution is running, `COMPLETED`, `ABANDONED` or `UNKNOWN` while a newer `FAILED` one exists were rejected on `main` and now proceed. Such a history cannot be produced through the launcher; it takes `abandon` on an older execution after the instance has already been restarted, a direct `JobRepository.createJobExecution` call, or two launches of the same instance racing past the check, which the existing code already only guards against probabilistically (see the comment above `jobRepository.createJobExecution` at the end of the method). If you would rather keep inspecting the full history, the alternative is a repository method that returns executions without hydrating them, which is an API addition I did not want to make on my own. Happy to go that way if you prefer.

Tests added to `TaskExecutorJobOperatorTests` for the last execution being running, being complete, and for a restart after several failed executions; these pass on `main` as well and are there to pin the behaviour. The `spring-batch-core`, `spring-batch-integration` and `spring-batch-test` suites pass. Also removes the now unused `java.util.List` import.

**Update (2026-08-28):** merged `main` to resolve a conflict with eec42cba, which changed the running-execution message inside the loop this PR removes. The improved message is kept (`lastJobExecution` instead of `jobInstance`), and the new `TaskExecutorJobLauncherTests` now stubs `getLastJobExecution` instead of `getJobExecutions`, which `createJobExecution` no longer calls. Its assertions are unchanged.
