### PR TITLE
Consistently use .version suffix for version properties in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,12 @@
 		<!-- samples dependencies -->
 		<spring-rabbit.version>${spring-amqp.version}</spring-rabbit.version>
 		<quartz.version>2.5.1</quartz.version>
-		<prometheus-metrics-exporter-pushgateway>1.4.2</prometheus-metrics-exporter-pushgateway>
+		<prometheus-metrics-exporter-pushgateway.version>1.4.2</prometheus-metrics-exporter-pushgateway.version>
 		<groovy.version>3.0.25</groovy.version> <!-- change to org.apache.groovy:groovy + update to latest 5.0.2 -->
 		<logback.version>1.5.21</logback.version>
 
 		<!-- documentation dependencies -->
-		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>
+		<io.spring.maven.antora.version>0.0.4</io.spring.maven.antora.version>
 		<antora-maven-plugin.version>1.0.0-alpha.5</antora-maven-plugin.version>
 
 		<!-- plugin versions -->

--- a/spring-batch-docs/pom.xml
+++ b/spring-batch-docs/pom.xml
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>io.spring.maven.antora</groupId>
 				<artifactId>antora-component-version-maven-plugin</artifactId>
-				<version>${io.spring.maven.antora-version}</version>
+				<version>${io.spring.maven.antora.version}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/spring-batch-samples/pom.xml
+++ b/spring-batch-samples/pom.xml
@@ -187,7 +187,7 @@
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>prometheus-metrics-exporter-pushgateway</artifactId>
-			<version>${prometheus-metrics-exporter-pushgateway}</version>
+			<version>${prometheus-metrics-exporter-pushgateway.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Some version properties did not follow the `<name>.version` naming convention used elsewhere in the build.

This PR renames them accordingly and updates their references.