### PR TITLE
Allow to use Mongo JobRepository with any PlatformTransactionManager

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableMongoJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/annotation/EnableMongoJobRepository.java
@@ -16,7 +16,7 @@
 package org.springframework.batch.core.configuration.annotation;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.transaction.annotation.Isolation;
 
@@ -34,8 +34,8 @@ import java.lang.annotation.Target;
  * necessary beans for a MongoDB-based infrastructure, including a job repository.
  * <p>
  * The default configuration assumes that a {@link MongoOperations} bean named
- * "mongoTemplate" and a {@link MongoTransactionManager} bean named "transactionManager"
- * are available in the application context.
+ * "mongoTemplate" and a {@link PlatformTransactionManager} bean named
+ * "transactionManager" are available in the application context.
  *
  * @author Mahmoud Ben Hassine
  * @since 6.0
@@ -49,7 +49,7 @@ public @interface EnableMongoJobRepository {
 	String mongoOperationsRef() default "mongoTemplate";
 
 	/**
-	 * Set the {@link MongoTransactionManager} to use in the job repository.
+	 * Set the {@link PlatformTransactionManager} to use in the job repository.
 	 * @return the bean name of the transaction manager to use. Defaults to
 	 * {@literal transactionManager}
 	 */

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/MongoDefaultBatchConfiguration.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/MongoDefaultBatchConfiguration.java
@@ -25,9 +25,9 @@ import org.springframework.batch.core.repository.dao.mongodb.MongoSequenceIncrem
 import org.springframework.batch.core.repository.support.MongoJobRepositoryFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Isolation;
 
 /**
@@ -61,6 +61,7 @@ import org.springframework.transaction.annotation.Isolation;
  * </pre>
  *
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  * @since 6.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -108,20 +109,20 @@ public class MongoDefaultBatchConfiguration extends DefaultBatchConfiguration {
 	}
 
 	@Override
-	protected MongoTransactionManager getTransactionManager() {
-		String errorMessage = " To use the default configuration, a MongoTransactionManager bean named 'transactionManager'"
+	protected PlatformTransactionManager getTransactionManager() {
+		String errorMessage = " To use the default configuration, a PlatformTransactionManager bean named 'transactionManager'"
 				+ " should be defined in the application context but none was found. Override getTransactionManager()"
 				+ " to provide the transaction manager to use for the job repository.";
-		if (this.applicationContext.getBeansOfType(MongoTransactionManager.class).isEmpty()) {
+		if (this.applicationContext.getBeansOfType(PlatformTransactionManager.class).isEmpty()) {
 			throw new BatchConfigurationException(
-					"Unable to find a MongoTransactionManager bean in the application context." + errorMessage);
+					"Unable to find a PlatformTransactionManager bean in the application context." + errorMessage);
 		}
 		else {
 			if (!this.applicationContext.containsBean("transactionManager")) {
 				throw new BatchConfigurationException(errorMessage);
 			}
 		}
-		return this.applicationContext.getBean("transactionManager", MongoTransactionManager.class);
+		return this.applicationContext.getBean("transactionManager", PlatformTransactionManager.class);
 	}
 
 	/**

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/configuration/annotation/BatchRegistrarTests.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
+import org.springframework.batch.core.configuration.support.MongoDefaultBatchConfiguration;
 import org.springframework.batch.core.job.DefaultJobKeyGenerator;
 import org.springframework.batch.core.job.JobKeyGenerator;
 import org.springframework.batch.core.configuration.JobRegistry;
@@ -37,6 +38,7 @@ import org.springframework.batch.core.repository.dao.jdbc.JdbcExecutionContextDa
 import org.springframework.batch.core.repository.dao.jdbc.JdbcJobExecutionDao;
 import org.springframework.batch.core.repository.dao.jdbc.JdbcJobInstanceDao;
 import org.springframework.batch.core.repository.dao.jdbc.JdbcStepExecutionDao;
+import org.springframework.batch.infrastructure.support.transaction.ResourcelessTransactionManager;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,6 +56,7 @@ import org.springframework.transaction.interceptor.TransactionInterceptor;
  * Test class for {@link BatchRegistrar}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Yanming Zhou
  */
 class BatchRegistrarTests {
 
@@ -215,6 +218,30 @@ class BatchRegistrarTests {
 		Assertions.assertNotNull(jobRepository);
 	}
 
+	@Test
+	@DisplayName("Mongo job repository should be configured successfully with @EnableMongoJobRepository and ResourcelessTransactionManager")
+	void testMongoJobRepositoryConfiguredWithEnableMongoJobRepositoryAndResourcelessTransactionManager() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				MongoJobConfigurationWithResourcelessTransactionManager.class);
+
+		JobRepository jobRepository = context.getBean(JobRepository.class);
+
+		Assertions.assertInstanceOf(ResourcelessTransactionManager.class,
+				getTransactionManagerSetOnJobRepository(jobRepository));
+	}
+
+	@Test
+	@DisplayName("Mongo job repository should be configured successfully with ResourcelessTransactionManager")
+	void testMongoJobRepositoryConfiguredWithResourcelessTransactionManager() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				MongoBatchConfigurationWithResourcelessTransactionManager.class);
+
+		JobRepository jobRepository = context.getBean(JobRepository.class);
+
+		Assertions.assertInstanceOf(ResourcelessTransactionManager.class,
+				getTransactionManagerSetOnJobRepository(jobRepository));
+	}
+
 	@Configuration
 	@EnableBatchProcessing
 	public static class JobConfigurationWithUserDefinedInfrastructureBeans {
@@ -348,6 +375,40 @@ class BatchRegistrarTests {
 		@Bean
 		public MongoTransactionManager transactionManager() {
 			return Mockito.mock(MongoTransactionManager.class);
+		}
+
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	@EnableMongoJobRepository
+	public static class MongoJobConfigurationWithResourcelessTransactionManager {
+
+		@Bean
+		public MongoOperations mongoTemplate() {
+			return Mockito.mock(MongoOperations.class);
+		}
+
+		@Bean
+		public ResourcelessTransactionManager transactionManager() {
+			return new ResourcelessTransactionManager();
+		}
+
+	}
+
+	@Configuration
+	@EnableBatchProcessing
+	public static class MongoBatchConfigurationWithResourcelessTransactionManager
+			extends MongoDefaultBatchConfiguration {
+
+		@Override
+		protected MongoOperations getMongoOperations() {
+			return Mockito.mock(MongoOperations.class);
+		}
+
+		@Override
+		protected ResourcelessTransactionManager getTransactionManager() {
+			return new ResourcelessTransactionManager();
 		}
 
 	}


### PR DESCRIPTION
Align to JDBC implementation, it's not required to couple with `MongoTransactionManager`, `ResourcelessTransactionManager` or other custom `PlatformTransactionManager`s should be supported.

See GH-5507
