### PR TITLE
Fix typos in Javadoc comments

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AbstractApplicationContextFactory.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/configuration/support/AbstractApplicationContextFactory.java
@@ -82,7 +82,7 @@ public abstract class AbstractApplicationContextFactory implements ApplicationCo
 		/*
 		 * Assume that a BeanPostProcessor that is BeanFactoryAware must be specific to
 		 * the parent and remove it from the child (e.g. an AutoProxyCreator will not work
-		 * properly). Unfortunately there might still be a a BeanPostProcessor with a
+		 * properly). Unfortunately there might still be a BeanPostProcessor with a
 		 * dependency that itself is BeanFactoryAware, but we can't legislate for that
 		 * here.
 		 */

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemWriter.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/xml/StaxEventItemWriter.java
@@ -451,7 +451,8 @@ public class StaxEventItemWriter<T> extends AbstractItemStreamItemWriter<T>
 	 * @param writer the {@link Writer} to be used by the {@link XMLEventWriter} for
 	 * writing to character streams.
 	 * @return an xml writer
-	 * @throws XMLStreamException thrown if error occured creating {@link XMLEventWriter}.
+	 * @throws XMLStreamException thrown if error occurred creating
+	 * {@link XMLEventWriter}.
 	 */
 	protected XMLEventWriter createXmlEventWriter(XMLOutputFactory outputFactory, Writer writer)
 			throws XMLStreamException {

--- a/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/person/PersonService.java
+++ b/spring-batch-samples/src/main/java/org/springframework/batch/samples/domain/person/PersonService.java
@@ -26,8 +26,8 @@ import org.springframework.batch.samples.file.patternmatching.Address;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Custom class that contains logic that would normally be be contained in
- * {@link ItemReader} and {@link ItemWriter}.
+ * Custom class that contains logic that would normally be contained in {@link ItemReader}
+ * and {@link ItemWriter}.
  *
  * @author tomas.slanina
  * @author Robert Kasanicky


### PR DESCRIPTION
Fixes a few typos found in Javadoc comments:

- `AbstractApplicationContextFactory`: duplicated "a a" -> "a"                                                                                                                                                                                                                                                      
- `StaxEventItemWriter`: "occured" -> "occurred"                                                                                                                                                                                                                                               
- `PersonService`: duplicated "be be" -> "be" 