### PR TITLE
Add strict() method and deprecate setStrict() in MultiResourceItemReaderBuilder

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilder.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * @author Glenn Renfro
  * @author Drummond Dawson
  * @author Stefano Cordio
+ * @author Usman Ijaz
  * @since 4.0
  * @see MultiResourceItemReader
  */
@@ -110,8 +111,25 @@ public class MultiResourceItemReaderBuilder<T> {
 	 * @param strict false by default.
 	 * @return this instance for method chaining.
 	 * @see MultiResourceItemReader#setStrict(boolean)
+	 * @deprecated as of 6.1.0 in favor of {@link #strict(boolean)}
 	 */
+	@Deprecated(since = "6.1.0", forRemoval = false)
 	public MultiResourceItemReaderBuilder<T> setStrict(boolean strict) {
+		this.strict = strict;
+
+		return this;
+	}
+
+	/**
+	 * In strict mode the reader will throw an exception on
+	 * {@link MultiResourceItemReader#open(ExecutionContext)} if there are no resources to
+	 * read.
+	 * @param strict false by default.
+	 * @return this instance for method chaining.
+	 * @see MultiResourceItemReader#setStrict(boolean)
+	 * @since 6.1.0
+	 */
+	public MultiResourceItemReaderBuilder<T> strict(boolean strict) {
 		this.strict = strict;
 
 		return this;

--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilder.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilder.java
@@ -113,7 +113,7 @@ public class MultiResourceItemReaderBuilder<T> {
 	 * @see MultiResourceItemReader#setStrict(boolean)
 	 * @deprecated as of 6.1.0 in favor of {@link #strict(boolean)}
 	 */
-	@Deprecated(since = "6.1.0", forRemoval = false)
+	@Deprecated(since = "6.1.0", forRemoval = true)
 	public MultiResourceItemReaderBuilder<T> setStrict(boolean strict) {
 		this.strict = strict;
 

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilderTests.java
@@ -90,46 +90,6 @@ class MultiResourceItemReaderBuilderTests extends AbstractItemStreamItemReaderTe
 		multiReader.open(new ExecutionContext());
 	}
 
-	@Test
-	@SuppressWarnings("unchecked")
-	void testStrictMethodWithTrue() {
-		LineMapper<Foo> fooLineMapper = (line, lineNumber) -> {
-			Foo foo = new Foo();
-			foo.setValue(Integer.parseInt(line));
-			return foo;
-		};
-		FlatFileItemReader<Foo> fileReader = new FlatFileItemReader<>(fooLineMapper);
-
-		MultiResourceItemReader<Foo> reader = new MultiResourceItemReaderBuilder<Foo>().delegate(fileReader)
-			.resources(new Resource[] {})
-			.strict(true)
-			.name("TEST")
-			.build();
-
-		Exception exception = assertThrows(IllegalStateException.class, () -> reader.open(new ExecutionContext()));
-		assertEquals("No resources to read. Set strict=false if this is not an error condition.",
-				exception.getMessage());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void testStrictMethodWithFalse() throws Exception {
-		LineMapper<Foo> fooLineMapper = (line, lineNumber) -> {
-			Foo foo = new Foo();
-			foo.setValue(Integer.parseInt(line));
-			return foo;
-		};
-		FlatFileItemReader<Foo> fileReader = new FlatFileItemReader<>(fooLineMapper);
-
-		MultiResourceItemReader<Foo> reader = new MultiResourceItemReaderBuilder<Foo>().delegate(fileReader)
-			.resources(new Resource[] {})
-			.strict(false)
-			.name("TEST")
-			.build();
-
-		// Should not throw with strict=false
-		reader.open(new ExecutionContext());
-	}
 
 	@Test
 	@SuppressWarnings("unchecked")

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilderTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/builder/MultiResourceItemReaderBuilderTests.java
@@ -90,4 +90,89 @@ class MultiResourceItemReaderBuilderTests extends AbstractItemStreamItemReaderTe
 		multiReader.open(new ExecutionContext());
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	void testStrictMethodWithTrue() {
+		LineMapper<Foo> fooLineMapper = (line, lineNumber) -> {
+			Foo foo = new Foo();
+			foo.setValue(Integer.parseInt(line));
+			return foo;
+		};
+		FlatFileItemReader<Foo> fileReader = new FlatFileItemReader<>(fooLineMapper);
+
+		MultiResourceItemReader<Foo> reader = new MultiResourceItemReaderBuilder<Foo>().delegate(fileReader)
+			.resources(new Resource[] {})
+			.strict(true)
+			.name("TEST")
+			.build();
+
+		Exception exception = assertThrows(IllegalStateException.class, () -> reader.open(new ExecutionContext()));
+		assertEquals("No resources to read. Set strict=false if this is not an error condition.",
+				exception.getMessage());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testStrictMethodWithFalse() throws Exception {
+		LineMapper<Foo> fooLineMapper = (line, lineNumber) -> {
+			Foo foo = new Foo();
+			foo.setValue(Integer.parseInt(line));
+			return foo;
+		};
+		FlatFileItemReader<Foo> fileReader = new FlatFileItemReader<>(fooLineMapper);
+
+		MultiResourceItemReader<Foo> reader = new MultiResourceItemReaderBuilder<Foo>().delegate(fileReader)
+			.resources(new Resource[] {})
+			.strict(false)
+			.name("TEST")
+			.build();
+
+		// Should not throw with strict=false
+		reader.open(new ExecutionContext());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testStrictMethodChaining() {
+		LineMapper<Foo> fooLineMapper = (line, lineNumber) -> {
+			Foo foo = new Foo();
+			foo.setValue(Integer.parseInt(line));
+			return foo;
+		};
+		FlatFileItemReader<Foo> fileReader = new FlatFileItemReader<>(fooLineMapper);
+
+		// Test that strict() returns the builder for method chaining
+		MultiResourceItemReader<Foo> reader = new MultiResourceItemReaderBuilder<Foo>().delegate(fileReader)
+			.resources(new Resource[] {})
+			.strict(false)
+			.name("TEST")
+			.saveState(true)
+			.build();
+
+		// If chaining works, build() should succeed
+		assertEquals("TEST", reader.getName());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testSetStrictStillWorks() {
+		LineMapper<Foo> fooLineMapper = (line, lineNumber) -> {
+			Foo foo = new Foo();
+			foo.setValue(Integer.parseInt(line));
+			return foo;
+		};
+		FlatFileItemReader<Foo> fileReader = new FlatFileItemReader<>(fooLineMapper);
+
+		// Test that setStrict() still works for backward compatibility
+		MultiResourceItemReader<Foo> reader = new MultiResourceItemReaderBuilder<Foo>().delegate(fileReader)
+			.resources(new Resource[] {})
+			.setStrict(true)
+			.name("TEST")
+			.build();
+
+		Exception exception = assertThrows(IllegalStateException.class, () -> reader.open(new ExecutionContext()));
+		assertEquals("No resources to read. Set strict=false if this is not an error condition.",
+				exception.getMessage());
+	}
+
 }


### PR DESCRIPTION
## Issue

MultiResourceItemReaderBuilder exposes its strict-mode toggle as setStrict(boolean), while almost every other builder in Spring Batch uses the fluent strict(boolean) naming convention without the set prefix.

## Solution

- Added strict(boolean) method to align with other Spring Batch builder APIs
- Deprecated setStrict(boolean) with @Deprecated(since = "6.1.0", forRemoval = true) for backward compatibility
- Added comprehensive test coverage for both methods

## Changes Made

### MultiResourceItemReaderBuilder.java
- New method: strict(boolean strict) - follows fluent API convention
- Deprecated method: setStrict(boolean strict) with proper version annotation


### MultiResourceItemReaderBuilderTests.java
- testStrictMethodChaining() - verifies fluent API chaining works
- testSetStrictStillWorks() - confirms backward compatibility of deprecated method

## Backward Compatibility
- Old setStrict() method remains fully functional
- Deprecation warnings guide developers to new API
- IDE quick fixes can automate migration

This fix aligns MultiResourceItemReaderBuilder with Spring Batch's consistent builder API pattern, improving developer experience and API consistency across the framework.