### PR TITLE
Fix open range detection in FixedLengthTokenizer

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/transform/FixedLengthTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/transform/FixedLengthTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2025 the original author or authors.
+ * Copyright 2006-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,9 +85,7 @@ public class FixedLengthTokenizer extends AbstractLineTokenizer {
 			}
 			else {
 				upperBound = range.getMin();
-				if (upperBound > maxRange) {
-					open = true;
-				}
+				open = true;
 			}
 
 			if (upperBound > maxRange) {

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/transform/FixedLengthTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/transform/FixedLengthTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,25 @@ class FixedLengthTokenizerTests {
 		assertEquals(30, exception.getExpectedLength());
 		assertEquals(35, exception.getActualLength());
 		assertEquals(line, exception.getInput());
+	}
+
+	@Test
+	void testLongerLinesSingleOpenRange() {
+		tokenizer.setColumns(new Range(1));
+		line = "H1        12345678       1234567890";
+		FieldSet tokens = tokenizer.tokenize(line);
+		assertEquals(1, tokens.getFieldCount());
+		assertEquals(line.trim(), tokens.readString(0));
+	}
+
+	@Test
+	void testLongerLinesOpenRangeStartingAtFirstColumnMin() {
+		tokenizer.setColumns(new Range(11), new Range(1, 10));
+		line = "H1        12345678       1234567890";
+		FieldSet tokens = tokenizer.tokenize(line);
+		assertEquals(2, tokens.getFieldCount());
+		assertEquals(line.substring(10).trim(), tokens.readString(0));
+		assertEquals(line.substring(0, 10).trim(), tokens.readString(1));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #5518

`calculateMaxRange` only marked the tokenizer as open when the unbounded range's min was strictly greater than the running max, which depends on range order and fails entirely for a single open-ended column (`setColumns(new Range(1))`). Longer lines were then rejected with `IncorrectLineLengthException` in strict mode, contradicting the documented behavior that an open last range reads the rest of the line irrespective of the strict flag.

This change marks the tokenizer as open whenever a range has no max value.

Two regression tests added (single open range; open range listed before a bounded range starting at its min). Both fail on `main` and pass with the fix; `FixedLengthTokenizerTests` passes 18/18.