### PR TITLE
Fix StringIndexOutOfBoundsException for a lone quote field in DelimitedLineTokenizer

### DIFF
--- a/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/transform/DelimitedLineTokenizer.java
+++ b/spring-batch-infrastructure/src/main/java/org/springframework/batch/infrastructure/item/file/transform/DelimitedLineTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,8 +218,7 @@ public class DelimitedLineTokenizer extends AbstractLineTokenizer implements Ini
 
 		String value;
 
-		if ((line.length() >= 2) && isQuoteCharacter(line.charAt(start))
-				&& isQuoteCharacter(line.charAt(start + len - 1))) {
+		if ((len >= 2) && isQuoteCharacter(line.charAt(start)) && isQuoteCharacter(line.charAt(start + len - 1))) {
 			int beginIndex = start + 1;
 			int endIndex = len - 2;
 			value = line.substring(beginIndex, beginIndex + endIndex);

--- a/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/transform/DelimitedLineTokenizerTests.java
+++ b/spring-batch-infrastructure/src/test/java/org/springframework/batch/infrastructure/item/file/transform/DelimitedLineTokenizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -243,6 +243,21 @@ class DelimitedLineTokenizerTests {
 		assertEquals(3, line.getFieldCount());
 		assertEquals("\"b", line.readString(1));
 		assertEquals("c", line.readString(2));
+	}
+
+	@Test
+	void testTokenizeWithLoneQuoteCharacterField() {
+		FieldSet line = tokenizer.tokenize("a,\"");
+		assertEquals(2, line.getFieldCount());
+		assertEquals("a", line.readString(0));
+		assertEquals("\"", line.readString(1));
+	}
+
+	@Test
+	void testTokenizeWithLoneQuoteCharacterLine() {
+		FieldSet line = tokenizer.tokenize("\"");
+		assertEquals(1, line.getFieldCount());
+		assertEquals("\"", line.readString(0));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #5519

The quote-wrapping guard in `substringWithTrimmedWhitespaceAndQuotesIfQuotesPresent` checked the length of the whole line instead of the token, so a one-character token consisting of the quote character itself (e.g. the last field of `a,"`) matched both quote checks with the same character and produced a negative substring range.

This change checks the token length instead, returning a lone quote field literally — consistent with how a lone quote line (`tokenize("\"")`) is already handled.

Two regression tests added; the field-level one fails on `main` with `StringIndexOutOfBoundsException` and passes with the fix. `DelimitedLineTokenizerTests` passes 44/44.